### PR TITLE
Update Common Interface Assignment

### DIFF
--- a/lib/python/Plugins/SystemPlugins/CommonInterfaceAssignment/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/CommonInterfaceAssignment/plugin.py
@@ -640,7 +640,7 @@ def main(session, **kwargs):
 	session.open(CIselectMainMenu)
 
 def menu(menuid, **kwargs):
-	if menuid == "cam" and eDVBCIInterfaces.getInstance().getNumOfSlots():
+	if menuid == "setup" and eDVBCIInterfaces.getInstance().getNumOfSlots():
 		return [(_("Common Interface Assignment"), main, "ci_assign", 11)]
 	return [ ]
 


### PR DESCRIPTION
As there is no menuid=cam in openatv, changed to menuid=setup.

Now Common Interface Assignment is shown:
MENU->Settings->Common Interface Assignment
