### PR TITLE
[Infopanel] add summary-descriptions for Infopanel and QuickMenu

### DIFF
--- a/lib/python/Plugins/Extensions/Infopanel/QuickMenu.py
+++ b/lib/python/Plugins/Extensions/Infopanel/QuickMenu.py
@@ -3,6 +3,7 @@ from enigma import eListboxPythonMultiContent, gFont, eEnv
 from boxbranding import getMachineBrand, getMachineName, getBoxType, getBrandOEM
 from Components.ActionMap import ActionMap
 from Components.Label import Label
+from Components.Sources.StaticText import StaticText
 from Components.Pixmap import Pixmap
 from Components.MenuList import MenuList
 from Components.MultiContent import MultiContentEntryText, MultiContentEntryPixmapAlphaTest
@@ -128,6 +129,7 @@ class QuickMenu(Screen):
 		self["key_yellow"] = Label(_("Devices"))
 		self["key_blue"] = Label()
 		self["description"] = Label()
+		self["summary_description"] = StaticText("")
 
 		self.menu = 0
 		self.list = []
@@ -163,6 +165,9 @@ class QuickMenu(Screen):
 		self.selectionChanged()
 		self.onLayoutFinish.append(self.layoutFinished)
 
+	def createSummary(self):
+		pass
+
 	def layoutFinished(self):
 		self["sublist"].selectionEnabled(0)
 
@@ -171,6 +176,7 @@ class QuickMenu(Screen):
 			item = self["list"].getCurrent()
 			if item:
 				self["description"].setText(_(item[4]))
+				self["summary_description"].text = item[0]
 				self.okList()
 
 	def selectionSubChanged(self):
@@ -178,6 +184,7 @@ class QuickMenu(Screen):
 			item = self["sublist"].getCurrent()
 			if item:
 				self["description"].setText(_(item[3]))
+				self["summary_description"].text = item[0]
 
 	def goLeft(self):
 		if self.menu <> 0:

--- a/lib/python/Plugins/Extensions/Infopanel/plugin.py
+++ b/lib/python/Plugins/Extensions/Infopanel/plugin.py
@@ -312,6 +312,7 @@ class Infopanel(Screen, InfoBarPiP):
 			}, 1)
 		
 		self["label1"] = Label(INFO_Panel_Version)
+		self["summary_description"] = StaticText("")
 
 		self.Mlist = []
 		if Check_Softcam():
@@ -331,9 +332,13 @@ class Infopanel(Screen, InfoBarPiP):
 		menu = 0
 		self["Mlist"].onSelectionChanged.append(self.selectionChanged)
 
+	def createSummary(self):
+		pass
+
 	def getCurrentEntry(self):
 		if self['Mlist'].l.getCurrentSelection():
 			selection = self['Mlist'].l.getCurrentSelection()[0]
+			self["summary_description"].text = selection[1]
 			if (selection[0] is not None):
 				return selection[0]
 
@@ -342,6 +347,7 @@ class Infopanel(Screen, InfoBarPiP):
 
 	def setWindowTitle(self):
 		self.setTitle(_("Info Panel"))
+		self.selectionChanged()
 
 	def up(self):
 		#self["Mlist"].up()


### PR DESCRIPTION
Example for skinners in the "skin_display.xml" for this two screens:

<!-- QuickMenu -->

```
<screen name="QuickMenu_summary" position="0,0" size="256,64">
    <widget source="parent.Title" render="Label" position="120,0" size="136,40" font="FdLcD;17" halign="center" valgin="bottom" />
    <widget source="parent.summary_description" render="Label" position="0,42" size="256,22" zPosition="1" font="FdLcD;20" halign="center" valign="center" />
</screen>
```

<!-- Infopanel -->

```
<screen name="Infopanel_summary" position="0,0" size="256,64">
    <widget source="parent.Title" render="Label" position="120,0" size="136,40" font="FdLcD;17" halign="center" valgin="bottom" />
    <widget source="parent.summary_description" render="Label" position="0,42" size="256,22" zPosition="1" font="FdLcD;20" halign="center" valign="center" />
</screen>
```
