### PR TITLE
[sleeptimer] get a quick sleeptimer-function for Power-keys, selectable ...

### DIFF
--- a/PowerTimer.py
+++ b/PowerTimer.py
@@ -63,7 +63,7 @@ class TIMERTYPE:
 
 # please do not translate log messages
 class PowerTimerEntry(timer.TimerEntry, object):
-	def __init__(self, begin, end, disabled = False, afterEvent = AFTEREVENT.NONE, timerType = TIMERTYPE.WAKEUP, checkOldTimers = False):
+	def __init__(self, begin, end, disabled = False, afterEvent = AFTEREVENT.NONE, timerType = TIMERTYPE.WAKEUP, checkOldTimers = False, autosleepdelay = 60):
 		global wakeupEnd
 		timer.TimerEntry.__init__(self, int(begin), int(end))
 		if checkOldTimers:
@@ -83,7 +83,7 @@ class PowerTimerEntry(timer.TimerEntry, object):
 		self.autoincrease = False
 		self.autoincreasetime = 3600 * 24 # 1 day
 		self.autosleepinstandbyonly = 'no'
-		self.autosleepdelay = 60
+		self.autosleepdelay = autosleepdelay
 		self.autosleeprepeat = 'once'
 
 		self.log_entries = []

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -197,15 +197,9 @@ def InitUsageConfig():
 		("intermediate", _("Intermediate")),
 		("expert", _("Expert")) ])
 
-	config.usage.on_long_powerpress = ConfigSelection(default = "show_menu", choices = [
-		("show_menu", _("Show shutdown menu")),
-		("shutdown", _("Immediate shutdown")),
-		("standby", _("Standby")) ] )
-
-	config.usage.on_short_powerpress = ConfigSelection(default = "standby", choices = [
-		("show_menu", _("Show shutdown menu")),
-		("shutdown", _("Immediate shutdown")),
-		("standby", _("Standby")) ] )
+	choicelist = [("show_menu", _("Show shutdown menu")), ("shutdown", _("Immediate shutdown")), ("standby", _("Standby")), ("sleeptimerStandby", _("Sleeptimer Standby")), ("sleeptimerDeepStandby", _("Sleeptimer DeepStandby"))]
+	config.usage.on_long_powerpress = ConfigSelection(default = "show_menu", choices = choicelist)
+	config.usage.on_short_powerpress = ConfigSelection(default = "standby", choices = choicelist)
 
 	choicelist = [("0", "Disabled")]
 	for i in (5, 30, 60, 300, 600, 900, 1200, 1800, 2700, 3600):

--- a/lib/python/Screens/PowerTimerEntry.py
+++ b/lib/python/Screens/PowerTimerEntry.py
@@ -1,5 +1,5 @@
 from Screens.Screen import Screen
-from Components.config import ConfigSelection, ConfigSubList, ConfigDateTime, ConfigClock, ConfigYesNo, ConfigInteger, getConfigListEntry
+from Components.config import ConfigSelection, ConfigSelectionNumber, ConfigSubList, ConfigDateTime, ConfigClock, ConfigYesNo, ConfigInteger, getConfigListEntry
 from Components.ActionMap import NumberActionMap
 from Components.ConfigList import ConfigListScreen
 from Components.MenuList import MenuList
@@ -112,7 +112,7 @@ class TimerEntry(Screen, ConfigListScreen):
 		self.timerentry_type = ConfigSelection(choices = [("once",_("once")), ("repeated", _("repeated"))], default = type)
 
 		self.timerentry_repeated = ConfigSelection(default = repeated, choices = [("daily", _("daily")), ("weekly", _("weekly")), ("weekdays", _("Mon-Fri")), ("user", _("user defined"))])
-		self.timerrntry_autosleepdelay = ConfigInteger(default=autosleepdelay, limits = (10, 300))
+		self.timerrntry_autosleepdelay = ConfigSelectionNumber(default = autosleepdelay, stepwidth = 15, min = 15, max = 300, wraparound = True)
 		self.timerentry_autosleeprepeat = ConfigSelection(choices = [("once",_("once")), ("repeated", _("repeated"))], default = autosleeprepeat)
 		self.timerrntry_autosleepinstandbyonly = ConfigSelection(choices = [("yes",_("Yes")), ("no", _("No"))],default=autosleepinstandbyonly)
 

--- a/mytest.py
+++ b/mytest.py
@@ -389,6 +389,8 @@ class PowerKey:
 		globalActionMap.actions["power_long"]=self.powerlong
 		globalActionMap.actions["deepstandby"]=self.shutdown # frontpanel long power button press
 		globalActionMap.actions["discrete_off"]=self.standby
+		globalActionMap.actions["sleeptimer_standby"]=self.sleepStandby
+		globalActionMap.actions["sleeptimer_deepstandby"]=self.sleepDeepStandby
 		self.standbyblocked = 1
 
 	def MenuClosed(self, *val):
@@ -446,6 +448,12 @@ class PowerKey:
 						return
 		elif action == "standby":
 			self.standby()
+		elif action == "sleeptimerStandby":
+			val = 3
+			self.setSleepTimer(val)
+		elif action == "sleeptimerDeepStandby":
+			val = 4
+			self.setSleepTimer(val)
 
 	def powerdown(self):
 		self.standbyblocked = 0
@@ -460,6 +468,27 @@ class PowerKey:
 	def standby(self):
 		if not Screens.Standby.inStandby and self.session.current_dialog and self.session.current_dialog.ALLOW_SUSPEND and self.session.in_exec:
 			self.session.open(Screens.Standby.Standby)
+
+	def setSleepTimer(self, val):
+		from PowerTimer import PowerTimerEntry
+		sleeptime = 15
+		data = (int(time() + 60), int(time() + 120))
+		self.addSleepTimer(PowerTimerEntry(checkOldTimers = True, *data, timerType = val, autosleepdelay = sleeptime))
+
+	def addSleepTimer(self, timer):
+		from Screens.PowerTimerEntry import TimerEntry
+		self.session.openWithCallback(self.finishedAdd, TimerEntry, timer)
+
+	def finishedAdd(self, answer):
+		if answer[0]:
+			entry = answer[1]
+			simulTimerList = self.session.nav.PowerTimer.record(entry)
+
+	def sleepStandby(self):
+		self.doAction(action = "sleeptimerStandby")
+
+	def sleepDeepStandby(self):
+		self.doAction(action = "sleeptimerDeepStandby")
 
 profile("Scart")
 from Screens.Scart import Scart


### PR DESCRIPTION
...over Setup Remote. Also add calls for keymap.xml for other keys.

Both examples for the keymap.xml:

```
<map context="GlobalActions">
    <key id="KEY_TIMER" mapto="sleeptimer_standby" flags="m" />
    <key id="KEY_SLEEP" mapto="sleeptimer_deepstandby" flags="m" />
</map>
```
