### PR TITLE
[PowerTimerEntry.py] add summary-description for Timer-Entry, works now ...

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -118,6 +118,14 @@ class ConfigList(HTMLComponent, GUIComponent, object):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageDown)
 
+	def moveUp(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveUp)
+
+	def moveDown(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveDown)
+
 class ConfigListScreen:
 	def __init__(self, list, session = None, on_change = None):
 		self["config_actions"] = NumberActionMap(["SetupActions", "InputAsciiActions", "KeyboardInputActions"],

--- a/lib/python/Screens/PowerTimerEntry.py
+++ b/lib/python/Screens/PowerTimerEntry.py
@@ -5,6 +5,7 @@ from Components.ConfigList import ConfigListScreen
 from Components.MenuList import MenuList
 from Components.Button import Button
 from Components.Label import Label
+from Components.Sources.StaticText import StaticText
 from Components.Pixmap import Pixmap
 from Components.SystemInfo import SystemInfo
 from PowerTimer import AFTEREVENT, TIMERTYPE
@@ -26,6 +27,7 @@ class TimerEntry(Screen, ConfigListScreen):
 		self["canceltext"] = Label(_("Cancel"))
 		self["ok"] = Pixmap()
 		self["cancel"] = Pixmap()
+		self["summary_description"] = StaticText("")
 
 		self.createConfig()
 
@@ -37,7 +39,9 @@ class TimerEntry(Screen, ConfigListScreen):
 			"volumeUp": self.incrementStart,
 			"volumeDown": self.decrementStart,
 			"size+": self.incrementEnd,
-			"size-": self.decrementEnd
+			"size-": self.decrementEnd,
+			"up": self.keyUp,
+			"down": self.keyDown
 		}, -2)
 
 		self.list = []
@@ -187,6 +191,13 @@ class TimerEntry(Screen, ConfigListScreen):
 
 		self[widget].list = self.list
 		self[widget].l.setList(self.list)
+		self.checkSummary()
+
+	def createSummary(self):
+		pass
+
+	def checkSummary(self):
+		self["summary_description"].text = self["config"].getCurrent()[0]
 
 	def newConfig(self):
 		if self["config"].getCurrent() in (self.timerType, self.timerTypeEntry, self.frequencyEntry, self.entryShowEndTime):
@@ -203,6 +214,14 @@ class TimerEntry(Screen, ConfigListScreen):
 	def keySelect(self):
 		cur = self["config"].getCurrent()
 		self.keyGo()
+
+	def keyUp(self):
+		self["config"].moveUp()
+		self.checkSummary()
+
+	def keyDown(self):
+		self["config"].moveDown()
+		self.checkSummary()
 
 	def getTimestamp(self, date, mytime):
 		d = localtime(date)


### PR DESCRIPTION
...also on/for default TimerEntry

TODO: translated Title is needed(DE) for that at the moment. This is the entry:
self.setTitle(_("PowerManager entry"))
it's  in the enigma2.pot at line 14902.

Example for skinners:

```
<screen name="TimerEntry_summary" position="0,0" size="256,64">
    <widget source="parent.Title" render="Label" position="120,0" size="136,40" font="FdLcD;17" halign="center" valgin="bottom" />
    <widget source="parent.summary_description" render="Label" position="0,42" size="256,22" zPosition="1" font="FdLcD;20" halign="center" valign="center" />       
</screen>
```
