### PR TITLE
[PowerTimerEdit] add summary-descriptions("name", "after")

### DIFF
--- a/lib/python/Components/PowerTimerList.py
+++ b/lib/python/Components/PowerTimerList.py
@@ -9,6 +9,28 @@ from timer import TimerEntry
 from Tools.Directories import resolveFilename, SCOPE_ACTIVE_SKIN
 from PowerTimer import AFTEREVENT, TIMERTYPE
 
+def gettimerType(timer):
+	timertype = {
+		TIMERTYPE.WAKEUP: _("Wake Up"),
+		TIMERTYPE.WAKEUPTOSTANDBY: _("Wake Up To Standby"),
+		TIMERTYPE.STANDBY: _("Standby"),
+		TIMERTYPE.AUTOSTANDBY: _("Auto Standby"),
+		TIMERTYPE.AUTODEEPSTANDBY: _("Auto Deep Standby"),
+		TIMERTYPE.DEEPSTANDBY: _("Deep Standby"),
+		TIMERTYPE.REBOOT: _("Reboot"),
+		TIMERTYPE.RESTART: _("Restart GUI")
+		}[timer.timerType]
+	return timertype
+
+def getafterEvent(timer):
+	afterevent = {
+		AFTEREVENT.NONE: _("Nothing"),
+		AFTEREVENT.WAKEUPTOSTANDBY: _("Wake Up To Standby"),
+		AFTEREVENT.STANDBY: _("Standby"),
+		AFTEREVENT.DEEPSTANDBY: _("Deep Standby")
+		}[timer.afterEvent]
+	return afterevent
+
 
 class PowerTimerList(HTMLComponent, GUIComponent, object):
 #
@@ -16,29 +38,11 @@ class PowerTimerList(HTMLComponent, GUIComponent, object):
 #  | <start, end>              <state>  |
 #
 	def buildTimerEntry(self, timer, processed):
-		timertype = {
-			TIMERTYPE.WAKEUP: _("Wake Up"),
-			TIMERTYPE.WAKEUPTOSTANDBY: _("Wake Up To Standby"),
-			TIMERTYPE.STANDBY: _("Standby"),
-			TIMERTYPE.AUTOSTANDBY: _("Auto Standby"),
-			TIMERTYPE.AUTODEEPSTANDBY: _("Auto Deep Standby"),
-			TIMERTYPE.DEEPSTANDBY: _("Deep Standby"),
-			TIMERTYPE.REBOOT: _("Reboot"),
-			TIMERTYPE.RESTART: _("Restart GUI")
-			}[timer.timerType]
-
-		afterevent = {
-			AFTEREVENT.NONE: _("Nothing"),
-			AFTEREVENT.WAKEUPTOSTANDBY: _("Wake Up To Standby"),
-			AFTEREVENT.STANDBY: _("Standby"),
-			AFTEREVENT.DEEPSTANDBY: _("Deep Standby")
-			}[timer.afterEvent]
-
 		height = self.l.getItemSize().height()
 		width = self.l.getItemSize().width()
 		res = [ None ]
 		x = width / 2
-		res.append((eListboxPythonMultiContent.TYPE_TEXT, 26, 4, width, 25, 0, RT_HALIGN_LEFT|RT_VALIGN_BOTTOM, timertype))
+		res.append((eListboxPythonMultiContent.TYPE_TEXT, 26, 4, width, 25, 0, RT_HALIGN_LEFT|RT_VALIGN_BOTTOM, gettimerType(timer)))
 		if timer.timerType == TIMERTYPE.AUTOSTANDBY or timer.timerType == TIMERTYPE.AUTODEEPSTANDBY:
 			if self.iconRepeat and timer.autosleeprepeat != "once":
 				res.append((eListboxPythonMultiContent.TYPE_PIXMAP_ALPHATEST, 2, 27, 20, 20, self.iconRepeat))
@@ -61,7 +65,7 @@ class PowerTimerList(HTMLComponent, GUIComponent, object):
 				icon = self.iconDone
 			res.append((eListboxPythonMultiContent.TYPE_TEXT, 148, 27, width-150, 23, 1, RT_HALIGN_RIGHT|RT_VALIGN_BOTTOM, _("Delay:") + " " + str(timer.autosleepdelay) + "(" + _("mins") + ")"))
 		else:
-			res.append((eListboxPythonMultiContent.TYPE_TEXT, x+24, 2, x-2-24, 25, 1, RT_HALIGN_RIGHT|RT_VALIGN_BOTTOM, _('At End:') + ' ' + afterevent))
+			res.append((eListboxPythonMultiContent.TYPE_TEXT, x+24, 2, x-2-24, 25, 1, RT_HALIGN_RIGHT|RT_VALIGN_BOTTOM, _('At End:') + ' ' + getafterEvent(timer)))
 			days = ( _("Mon"), _("Tue"), _("Wed"), _("Thu"), _("Fri"), _("Sat"), _("Sun") )
 			begin = FuzzyTime(timer.begin)
 			if timer.repeated:

--- a/lib/python/Screens/PowerTimerEdit.py
+++ b/lib/python/Screens/PowerTimerEdit.py
@@ -2,7 +2,7 @@ from Components.ActionMap import ActionMap
 from Components.Button import Button
 from Components.Label import Label
 from Components.config import config
-from Components.PowerTimerList import PowerTimerList
+from Components.PowerTimerList import PowerTimerList, gettimerType, getafterEvent
 from Components.Sources.StaticText import StaticText
 from PowerTimer import PowerTimerEntry, AFTEREVENT
 from Screens.Screen import Screen
@@ -167,6 +167,11 @@ class PowerTimerEditList(Screen):
 		timer = self['timerlist'].getCurrent()
 
 		if timer:
+			name = gettimerType(timer)
+			if getafterEvent(timer) == "Nothing":
+				after = ""
+			else:
+				after = getafterEvent(timer)
 			time = "%s %s ... %s" % (FuzzyTime(timer.begin)[0], FuzzyTime(timer.begin)[1], FuzzyTime(timer.end)[1])
 			duration = ("(%d " + _("mins") + ")") % ((timer.end - timer.begin) / 60)
 
@@ -181,11 +186,13 @@ class PowerTimerEditList(Screen):
 			else:
 				state = _("<unknown>")
 		else:
+			name = ""
+			after = ""
 			time = ""
 			duration = ""
 			state = ""
 		for cb in self.onChangedEntry:
-			cb(time, duration, state)
+			cb(name, after, time, duration, state)
 
 	def fillTimerList(self):
 		#helper function to move finished timers to end of list
@@ -291,6 +298,8 @@ class PowerTimerEditList(Screen):
 class PowerTimerEditListSummary(Screen):
 	def __init__(self, session, parent):
 		Screen.__init__(self, session, parent = parent)
+		self["name"] = StaticText("")
+		self["after"] = StaticText("")
 		self["time"] = StaticText("")
 		self["duration"] = StaticText("")
 		self["state"] = StaticText("")
@@ -304,7 +313,9 @@ class PowerTimerEditListSummary(Screen):
 	def removeWatcher(self):
 		self.parent.onChangedEntry.remove(self.selectionChanged)
 
-	def selectionChanged(self, time, duration, state):
+	def selectionChanged(self, name, after, time, duration, state):
+		self["name"].text = name
+		self["after"].text = after
 		self["time"].text = time
 		self["duration"].text = duration
 		self["state"].text = state


### PR DESCRIPTION
Example for skinners for the screen(with all possible entrys):

```
<screen name="PowerTimerEditListSummary" position="0,0" size="256,64">
    <widget source="parent.Title" render="Label" position="120,0" size="136,40" font="FdLcD;17" halign="center" valgin="bottom" />
    <widget source="name" render="Label" position="0,42" size="256,22" zPosition="1" font="FdLcD;20" halign="center" valign="center" />
    <!--widget source="after" render="Label" position="0,42" size="256,22" zPosition="1" font="FdLcD;20" halign="center" valign="center" /-->
    <!--widget source="time" render="Label" position="0,42" size="256,22" zPosition="1" font="FdLcD;20" halign="center" valign="center" /-->
    <!--widget source="duration" render="Label" position="0,42" size="256,22" zPosition="1" font="FdLcD;20" halign="center" valign="center" /-->
    <!--widget source="state" render="Label" position="0,42" size="256,22" zPosition="1" font="FdLcD;20" halign="center" valign="center" /-->
</screen>
```
