### PR TITLE
new setting to cleanup hearing impaired subtitles

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -125,6 +125,7 @@
 		<item level="2" text="External subtitle color" description="Configure the color of the external subtitles, alternative (normal in white, italic in yellow, bold in cyan, underscore in green), white or yellow.">config.subtitles.pango_subtitle_colors</item>
 		<item level="2" text="Delay for external subtitles" description="Configure an additional delay to improve external subtitle synchronisation.">config.subtitles.pango_subtitles_delay</item>
 		<item level="2" text="Set fps for external subtitles" description="Can be used for different fps between external subtitles and video.">config.subtitles.pango_subtitles_fps</item>
+		<item level="2" text="HI-cleanup for external subtitles" description="Remove texts for the hearing impaired from external subtitles (instrumental music or environmental sounds, e.g., when a doorbell rings or a gun shot is heard).">config.subtitles.pango_subtitle_removehi</item>
 		<item level="2" text="Automatically turn on external subtitles" description="When enabled, external subtitles will be always turned on for playback movie.">config.subtitles.pango_autoturnon</item>
 	</setup>
 	<setup key="autolanguagesetup" title="Auto language selection">

--- a/lib/gui/esubtitle.cpp
+++ b/lib/gui/esubtitle.cpp
@@ -294,6 +294,10 @@ int eSubtitleWidget::event(int event, void *data, void *data2)
 				face = Subtitle_Regular;
 				ePangoSubtitlePageElement &element = m_pango_page.m_elements[i];
 				std::string text = element.m_pango_line;
+
+				if (eConfigManager::getConfigBoolValue("config.subtitles.pango_subtitle_removehi", false))
+					removeHearingImpaired(text);
+
 				text = replace_all(text, "&apos;", "'");
 				text = replace_all(text, "&quot;", "\"");
 				text = replace_all(text, "&amp;", "&");
@@ -357,3 +361,58 @@ void eSubtitleWidget::setFontStyle(subfont_t face, gFont *font, int haveColor, c
 	subtitleStyles[face].border_color = borderCol;
 	subtitleStyles[face].border_width = borderWidth;
 }
+
+void eSubtitleWidget::removeHearingImpaired(std::string& str)
+{
+	// remove texts in round brackets
+	while (true)
+	{
+		std::string::size_type loc = str.find('(');
+		if (loc == std::string::npos)
+			break;
+		std::string::size_type enp = str.find(')');
+		if (enp == std::string::npos)
+			break;
+		str.erase(loc, enp - loc + 1);
+	}
+
+	// remove texts in square brackets
+	while (true)
+	{
+		std::string::size_type loc = str.find('[');
+		if (loc == std::string::npos)
+			break;
+		std::string::size_type enp = str.find(']');
+		if (enp == std::string::npos)
+			break;
+		str.erase(loc, enp - loc + 1);
+	}
+
+	// cleanup: remove empty lines (consisting of spaces and hyphens only)
+	std::string::size_type line_start = 0;
+	bool empty_line = true;
+	for (std::string::size_type p = 0; p < str.length(); p++)
+	{
+		unsigned char ch = str[p];
+
+		if (ch != ' ' && ch != '-' && ch != '\n')
+			empty_line = false;
+
+		if (ch == '\n' || p == str.length() - 1)
+		{
+			if (empty_line)
+			{
+				// remove line
+				str.erase(line_start, p - line_start + 1);
+				p = line_start - 1;
+			}
+			line_start = p + 1;
+			empty_line = true;
+		}
+	}
+
+	// cleanup: remove trailing line breaks
+	while (str[str.length() - 1] == '\n')
+		str.erase(str.length() - 1, 1);
+}
+

--- a/lib/gui/esubtitle.h
+++ b/lib/gui/esubtitle.h
@@ -66,6 +66,7 @@ public:
 
 protected:
 	int event(int event, void *data=0, void *data2=0);
+	void removeHearingImpaired(std::string& str);
 private:
 	int m_page_ok;
 	eDVBTeletextSubtitlePage m_page;

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -653,6 +653,7 @@ def InitUsageConfig():
 		("25000", _("25")),
 		("29970", _("29.97")),
 		("30000", _("30"))])
+	config.subtitles.pango_subtitle_removehi = ConfigYesNo(default = False)
 	config.subtitles.pango_autoturnon = ConfigYesNo(default = True)
 
 	config.autolanguage = ConfigSubsection()

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -505,6 +505,7 @@ class QuickSubtitlesConfigMenu(ConfigListScreen, Screen):
 				getConfigMenuItem("config.subtitles.subtitle_position"),
 				getConfigMenuItem("config.subtitles.subtitle_alignment"),
 				getConfigMenuItem("config.subtitles.subtitle_rewrap"),
+				getConfigMenuItem("config.subtitles.pango_subtitle_removehi"),
 				getConfigMenuItem("config.subtitles.subtitle_borderwidth"),
 				getConfigMenuItem("config.subtitles.pango_subtitles_fps"),
 			]


### PR DESCRIPTION
- added new setting "HI-cleanup for external subtitles (yes/no)" under "Main menu -> Setup -> System -> Extended System -> Subtitle settings";
- when active the parts of subtitles intended for the hearing impaired are automatically removed (e. g. "(THUNDER RUMBLING)" or "[GRUNTS]") making the subtitles to better suite the needs of people without hearing difficulties watching with audio in a foreign language;
- the quick subtitles menu (activated via "Subtitles-key -> Red-key") was also extended with the new setting;
- the subtitles are cleaned up when pushed to screen; changing the setting has an immediate effect and doesn't require restart of the video.