### PR TITLE
[Powertimer,Recordtimer,Navigation] some changes and fixes - see decr…

### DIFF
--- a/PowerTimer.py
+++ b/PowerTimer.py
@@ -1,7 +1,8 @@
 import os
 from boxbranding import getMachineBrand, getMachineName
 import xml.etree.cElementTree
-from time import ctime, time
+from datetime import datetime
+from time import ctime, time, strftime, localtime, mktime
 from bisect import insort
 
 from enigma import eActionMap, quitMainloop
@@ -20,18 +21,34 @@ DSsave = False
 RSsave = False
 RBsave = False
 aeDSsave = False
-wasPowerTimerWakeup = False
-wakeupEnd = time()
+wasTimerWakeup = False
 netbytes = 0
-netpackets = 0
+#+++
+debug = False
+#+++
 #global variables end
-
+#----------------------------------------------------------------------------------------------------
+#Timer shutdown, reboot and restart priority
+#1. wakeup
+#2. wakeuptostandby						-> (same as 1.)
+#3. deepstandby							->	DSsave
+#4. deppstandby after event				->	aeDSsave
+#5. reboot system						->	RBsave
+#6. restart gui							->	RSsave
+#7. standby
+#8. autostandby
+#9. nothing (no function, only for suppress autodeepstandby timer)
+#10. autodeepstandby
+#-overlapping timers or next timer start is within 15 minutes, will only the high-order timer executed (at same types will executed the next timer)
+#-autodeepstandby timer is only effective if no other timer is active or current time is in the time window
+#-priority for repeated timer: shift from begin and end time only temporary, end-action priority is higher as the begin-action
+#----------------------------------------------------------------------------------------------------
 #reset wakeupstatus
 def resetTimerWakeup():
-	global wasPowerTimerWakeup
+	global wasTimerWakeup
 	if os.path.exists("/tmp/was_powertimer_wakeup"):
 		os.remove("/tmp/was_powertimer_wakeup")	
-	wasPowerTimerWakeup = False
+	wasTimerWakeup = False
 
 # parses an event, and gives out a (begin, end, name, duration, eit)-tuple.
 # begin and end will be corrected
@@ -45,9 +62,10 @@ class AFTEREVENT:
 		pass
 
 	NONE = 0
-	WAKEUPTOSTANDBY = 1
-	STANDBY = 2
-	DEEPSTANDBY = 3
+	WAKEUP = 1
+	WAKEUPTOSTANDBY = 2
+	STANDBY = 3
+	DEEPSTANDBY = 4
 
 class TIMERTYPE:
 	def __init__(self):
@@ -66,7 +84,6 @@ class TIMERTYPE:
 # please do not translate log messages
 class PowerTimerEntry(timer.TimerEntry, object):
 	def __init__(self, begin, end, disabled = False, afterEvent = AFTEREVENT.NONE, timerType = TIMERTYPE.WAKEUP, checkOldTimers = False, autosleepdelay = 60):
-		global wakeupEnd
 		timer.TimerEntry.__init__(self, int(begin), int(end))
 		if checkOldTimers:
 			if self.begin < time() - 1209600:
@@ -87,27 +104,20 @@ class PowerTimerEntry(timer.TimerEntry, object):
 		self.autosleepinstandbyonly = 'no'
 		self.autosleepdelay = autosleepdelay
 		self.autosleeprepeat = 'once'
+		self.autosleepwindow = 'no'
+		self.autosleepbegin = self.begin
+		self.autosleepend = self.end
 
 		self.log_entries = []
 		self.resetState()
 
 		#check autopowertimer
 		if (self.timerType == TIMERTYPE.AUTOSTANDBY or self.timerType == TIMERTYPE.AUTODEEPSTANDBY) and not self.disabled and time() > 3600 and self.begin > time():
-			self.begin = time()						#the begin is in the future -> set to current time = no start delay of this timer
-
-		#check startuptimer
-		if self.timerType == TIMERTYPE.WAKEUP or self.timerType == TIMERTYPE.WAKEUPTOSTANDBY:
-			if abs(time() - self.begin) <= 300:		#begin within 5 minutes -> this is wakeuptimer
-				if self.end > time():
-					wakeupEnd = self.end
-				else:
-					wakeupEnd = time() + 3600		#no endtime listed, 1hour suppression of autodeepstandby and other overlapping powertimer
-		wuEnd = time () + 43200						#limitation to 12hours  suppression of ...
-		if wakeupEnd > wuEnd:
-			wakeupEnd = wuEnd
+			self.begin = int(time())						#the begin is in the future -> set to current time = no start delay of this timer
 
 	def __repr__(self):
 		timertype = {
+			TIMERTYPE.NONE: "nothing",
 			TIMERTYPE.WAKEUP: "wakeup",
 			TIMERTYPE.WAKEUPTOSTANDBY: "wakeuptostandby",
 			TIMERTYPE.AUTOSTANDBY: "autostandby",
@@ -126,42 +136,59 @@ class PowerTimerEntry(timer.TimerEntry, object):
 		self.log_entries.append((int(time()), code, msg))
 
 	def do_backoff(self):
-		if Screens.Standby.inStandby:
+		if Screens.Standby.inStandby and not wasTimerWakeup or RSsave or RBsave or aeDSsave or DSsave:
 			self.backoff = 300
 		else:
 			if self.backoff == 0:
-				self.backoff = 5*60
+				self.backoff = 300
 			else:
-				self.backoff *= 2
-				if self.backoff > 1800:
-					self.backoff = 1800
-		self.log(10, "backoff: retry in %d minuets" % (int(self.backoff)/60))
+				self.backoff += 300
+				if self.backoff > 900:
+					self.backoff = 900
+		self.log(10, "backoff: retry in %d minutes" % (int(self.backoff)/60))
 
 	def activate(self):
-		global DSsave, RSsave, RBsave, aeDSsave, wasPowerTimerWakeup, wakeupEnd
-
+		global RSsave, RBsave, DSsave, aeDSsave, wasTimerWakeup
+		breakPT = shiftPT = False
+		now = time()
 		next_state = self.state + 1
 		self.log(5, "activating state %d" % next_state)
-
-		if next_state == 1 and (self.timerType == TIMERTYPE.AUTOSTANDBY or self.timerType == TIMERTYPE.AUTODEEPSTANDBY):
+		if next_state == self.StatePrepared and (self.timerType == TIMERTYPE.AUTOSTANDBY or self.timerType == TIMERTYPE.AUTODEEPSTANDBY):
+			if self.autosleepwindow == 'yes':
+				ltm = localtime(now)
+				asb = strftime("%H:%M", localtime(self.autosleepbegin)).split(':')
+				ase = strftime("%H:%M", localtime(self.autosleepend)).split(':')
+				self.autosleepbegin = int(mktime(datetime(ltm.tm_year, ltm.tm_mon, ltm.tm_mday, int(asb[0]), int(asb[1])).timetuple()))
+				self.autosleepend = int(mktime(datetime(ltm.tm_year, ltm.tm_mon, ltm.tm_mday, int(ase[0]), int(ase[1])).timetuple()))
+				if self.autosleepend <= self.autosleepbegin:
+					self.autosleepbegin -= 86400
+			if self.getAutoSleepWindow():
+				self.begin = self.end = int(now) + int(self.autosleepdelay)*60
 			eActionMap.getInstance().bindAction('', -0x7FFFFFFF, self.keyPressed)
-			self.begin = time() + int(self.autosleepdelay)*60
-			if self.end <= self.begin:
-				self.end = self.begin
+
+		if (next_state == self.StateRunning or next_state == self.StateEnded) and NavigationInstance.instance.PowerTimer is None:
+			#TODO: running/ended timer at system start has no nav instance
+			#First fix: crash in getPriorityCheck (NavigationInstance.instance.PowerTimer...)
+			#Second fix: suppress the message (A finished powertimer wants to ...)
+			if debug: print "*****NavigationInstance.instance.PowerTimer is None*****", self.timerType, self.state, ctime(self.begin), ctime(self.end)
+			return True
+		elif next_state == self.StateRunning and abs(self.begin - now) >= 60: return True 
+		elif next_state == self.StateEnded and abs(self.end - now) >= 60: return True 
 
 		if next_state == self.StatePrepared:
 			self.log(6, "prepare ok, waiting for begin")
-			self.next_activation = self.begin
+			if self.begin <= now:
+				self.next_activation = int(now) + 20
+			else:
+				self.next_activation = self.begin
 			self.backoff = 0
 			return True
 
 		elif next_state == self.StateRunning:
-
-			if os.path.exists("/tmp/was_powertimer_wakeup") and not wasPowerTimerWakeup:
-				wasPowerTimerWakeup = int(open("/tmp/was_powertimer_wakeup", "r").read()) and True or False
-
-			if wasPowerTimerWakeup and time() >= wakeupEnd:
-				resetTimerWakeup()
+			if os.path.exists("/tmp/was_powertimer_wakeup") and not wasTimerWakeup:
+				wasTimerWakeup = int(open("/tmp/was_powertimer_wakeup", "r").read()) and True or False
+			elif os.path.exists("/tmp/was_rectimer_wakeup") and not wasTimerWakeup:
+				wasTimerWakeup = int(open("/tmp/was_rectimer_wakeup", "r").read()) and True or False
 
 			# if this timer has been cancelled, just go to "end" state.
 			if self.cancelled:
@@ -170,7 +197,10 @@ class PowerTimerEntry(timer.TimerEntry, object):
 			if self.failed:
 				return True
 
-			if self.timerType == TIMERTYPE.WAKEUP:
+			if self.timerType == TIMERTYPE.NONE:
+				return True
+
+			elif self.timerType == TIMERTYPE.WAKEUP:
 				if Screens.Standby.inStandby:
 					Screens.Standby.inStandby.Power()
 				return True
@@ -179,34 +209,40 @@ class PowerTimerEntry(timer.TimerEntry, object):
 				return True
 
 			elif self.timerType == TIMERTYPE.STANDBY:
-				if not Screens.Standby.inStandby: # not already in standby
+				if debug: print "self.timerType == TIMERTYPE.STANDBY:"
+				prioPT = [TIMERTYPE.WAKEUP,TIMERTYPE.RESTART,TIMERTYPE.REBOOT,TIMERTYPE.DEEPSTANDBY]
+				prioPTae = [AFTEREVENT.WAKEUP,AFTEREVENT.DEEPSTANDBY]
+				shiftPT,breakPT = self.getPriorityCheck(prioPT,prioPTae)
+				if not Screens.Standby.inStandby and not breakPT: # not already in standby
 					Notifications.AddNotificationWithCallback(self.sendStandbyNotification, MessageBox, _("A finished powertimer wants to set your\n%s %s to standby. Do that now?") % (getMachineBrand(), getMachineName()), timeout = 180)
 				return True
 
 			elif self.timerType == TIMERTYPE.AUTOSTANDBY:
+				if debug: print "self.timerType == TIMERTYPE.AUTOSTANDBY:"
+				if not self.getAutoSleepWindow():
+					return False
 				if not Screens.Standby.inStandby: # not already in standby
 					Notifications.AddNotificationWithCallback(self.sendStandbyNotification, MessageBox, _("A finished powertimer wants to set your\n%s %s to standby. Do that now?") % (getMachineBrand(), getMachineName()), timeout = 180)
 					if self.autosleeprepeat == "once":
 						eActionMap.getInstance().unbindAction('', self.keyPressed)
 						return True
 					else:
-						self.begin = time() + int(self.autosleepdelay)*60
-						if self.end <= self.begin:
-							self.end = self.begin
+						self.begin = self.end = int(now) + int(self.autosleepdelay)*60
 				else:
-					self.begin = time() + int(self.autosleepdelay)*60
-					if self.end <= self.begin:
-						self.end = self.begin
+					self.begin = self.end = int(now) + int(self.autosleepdelay)*60
 
 			elif self.timerType == TIMERTYPE.AUTODEEPSTANDBY:
-				if self.getNetworkTraffic() or wasPowerTimerWakeup or (NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - time()) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - time()) <= 900) or ((self.autosleepinstandbyonly == 'yesNWno' or self.autosleepinstandbyonly == 'yes') and not Screens.Standby.inStandby):
+				if debug: print "self.timerType == TIMERTYPE.AUTODEEPSTANDBY:"
+				if not self.getAutoSleepWindow():
+					return False
+				if self.getNetworkTraffic() or NavigationInstance.instance.PowerTimer.isProcessing() or abs(NavigationInstance.instance.PowerTimer.getNextPowerManagerTime() - now) <= 900 \
+					or NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - now) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - now) <= 900 \
+					or ((self.autosleepinstandbyonly == 'yesACnetwork' or self.autosleepinstandbyonly == 'yes') and not Screens.Standby.inStandby):
 					self.do_backoff()
 					# retry
-					self.begin = time() + self.backoff
-					if self.end <= self.begin:
-						self.end = self.begin
+					self.begin = self.end = int(now) + self.backoff
 					return False
-				if not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
+				elif not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
 					if self.autosleeprepeat == "once":
 						self.disabled = True
 					if Screens.Standby.inStandby: # in standby
@@ -219,119 +255,257 @@ class PowerTimerEntry(timer.TimerEntry, object):
 							eActionMap.getInstance().unbindAction('', self.keyPressed)
 							return True
 						else:
-							self.begin = time() + int(self.autosleepdelay)*60
-							if self.end <= self.begin:
-								self.end = self.begin
-
-			elif self.timerType == TIMERTYPE.DEEPSTANDBY:
-				if wasPowerTimerWakeup or NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - time()) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - time()) <= 900:
-					if int(self.repeated) > 0 and not DSsave:
-						self.DSbegin = self.begin
-						self.DSend = self.end
-						DSsave = True
-					self.do_backoff()
-					# retry
-					self.begin = time() + self.backoff
-					if self.end <= self.begin:
-						self.end = self.begin
-					return False
-				if not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
-					if DSsave:
-						DSsave = False
-						self.begin = self.DSbegin
-						self.end = self.DSend
-					if Screens.Standby.inStandby: # in standby
-						print "[PowerTimer] quitMainloop #2"
-						quitMainloop(1)
-					else:
-						Notifications.AddNotificationWithCallback(self.sendTryQuitMainloopNotification, MessageBox, _("A finished powertimer wants to shutdown your %s %s.\nDo that now?") % (getMachineBrand(), getMachineName()), timeout = 180)
-				return True
-
-			elif self.timerType == TIMERTYPE.REBOOT:
-				if wasPowerTimerWakeup or NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - time()) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - time()) <= 900:
-					if int(self.repeated) > 0 and not RBsave:
-						self.RBbegin = self.begin
-						self.RBend = self.end
-						RBsave = True
-					self.do_backoff()
-					# retry
-					self.begin = time() + self.backoff
-					if self.end <= self.begin:
-						self.end = self.begin
-					return False
-				if not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
-					if RBsave:
-						RBsave = False
-						self.begin = self.RBbegin
-						self.end = self.RBend
-					if Screens.Standby.inStandby: # in standby
-						print "[PowerTimer] quitMainloop #3"
-						quitMainloop(2)
-					else:
-						Notifications.AddNotificationWithCallback(self.sendTryToRebootNotification, MessageBox, _("A finished powertimer wants to reboot your %s %s.\nDo that now?") % (getMachineBrand(), getMachineName()), timeout = 180)
-				return True
+							self.begin = self.end = int(now) + int(self.autosleepdelay)*60
 
 			elif self.timerType == TIMERTYPE.RESTART:
-				if wasPowerTimerWakeup or NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - time()) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - time()) <= 900:
-					if int(self.repeated) > 0 and not RSsave:
-						self.RSbegin = self.begin
-						self.RSend = self.end
+				if debug: print "self.timerType == TIMERTYPE.RESTART:"
+				#check priority
+				prioPT = [TIMERTYPE.RESTART,TIMERTYPE.REBOOT,TIMERTYPE.DEEPSTANDBY]
+				prioPTae = [AFTEREVENT.DEEPSTANDBY]
+				shiftPT,breakPT = self.getPriorityCheck(prioPT,prioPTae)
+				#a timer with higher priority was shifted - no execution of current timer
+				if RBsave or aeDSsave or DSsave:
+					if debug: print "break#1"
+					breakPT = True
+				#a timer with lower priority was shifted - shift now current timer and wait for restore the saved time values from other timer
+				if False:
+					if debug: print "shift#1"
+					breakPT = False
+					shiftPT = True
+				#shift or break
+				if shiftPT or breakPT \
+					or NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - now) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - now) <= 900:
+					if self.repeated and not RSsave:
+						self.savebegin = self.begin
+						self.saveend = self.end
 						RSsave = True
-					self.do_backoff()
-					# retry
-					self.begin = time() + self.backoff
-					if self.end <= self.begin:
-						self.end = self.begin
-					return False
-				if not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
-					if RSsave:
+					if not breakPT:
+						self.do_backoff()
+						#check difference begin to end before shift begin time
+						if RSsave and self.end - self.begin > 3 and self.end - now - self.backoff <= 240: breakPT = True
+					#breakPT
+					if breakPT:
+						if self.repeated and RSsave:
+							try:
+								self.begin = self.savebegin
+								self.end = self.saveend
+							except:
+								pass
 						RSsave = False
-						self.begin = self.RSbegin
-						self.end = self.RSend
+						return True
+					# retry
+					oldbegin = self.begin
+					self.begin = int(now) + self.backoff
+					if abs(self.end - oldbegin) <= 3:
+						self.end = self.begin
+					else:
+						if not self.repeated and self.end < self.begin + 300:
+							self.end = self.begin + 300
+					return False
+				elif not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
+					if self.repeated and RSsave:
+						try:
+							self.begin = self.savebegin
+							self.end = self.saveend
+						except:
+							pass
 					if Screens.Standby.inStandby: # in standby
 						print "[PowerTimer] quitMainloop #4"
 						quitMainloop(3)
 					else:
 						Notifications.AddNotificationWithCallback(self.sendTryToRestartNotification, MessageBox, _("A finished powertimer wants to restart the user interface.\nDo that now?"), timeout = 180)
+				RSsave = False
+				return True
+
+			elif self.timerType == TIMERTYPE.REBOOT:
+				if debug: print "self.timerType == TIMERTYPE.REBOOT:"
+				#check priority
+				prioPT = [TIMERTYPE.REBOOT,TIMERTYPE.DEEPSTANDBY]
+				prioPTae = [AFTEREVENT.DEEPSTANDBY]
+				shiftPT,breakPT = self.getPriorityCheck(prioPT,prioPTae)
+				#a timer with higher priority was shifted - no execution of current timer
+				if aeDSsave or DSsave:
+					if debug: print "break#1"
+					breakPT = True
+				#a timer with lower priority was shifted - shift now current timer and wait for restore the saved time values from other timer
+				if RSsave:
+					if debug: print "shift#1"
+					breakPT = False
+					shiftPT = True
+				#shift or break
+				if shiftPT or breakPT \
+					or NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - now) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - now) <= 900:
+					if self.repeated and not RBsave:
+						self.savebegin = self.begin
+						self.saveend = self.end
+						RBsave = True
+					if not breakPT:
+						self.do_backoff()
+						#check difference begin to end before shift begin time
+						if RBsave and self.end - self.begin > 3 and self.end - now - self.backoff <= 240: breakPT = True
+					#breakPT
+					if breakPT:
+						if self.repeated and RBsave:
+							try:
+								self.begin = self.savebegin
+								self.end = self.saveend
+							except:
+								pass
+						RBsave = False
+						return True
+					# retry
+					oldbegin = self.begin
+					self.begin = int(now) + self.backoff
+					if abs(self.end - oldbegin) <= 3:
+						self.end = self.begin
+					else:
+						if not self.repeated and self.end < self.begin + 300:
+							self.end = self.begin + 300
+					return False
+				elif not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
+					if self.repeated and RBsave:
+						try:
+							self.begin = self.savebegin
+							self.end = self.saveend
+						except:
+							pass
+					if Screens.Standby.inStandby: # in standby
+						print "[PowerTimer] quitMainloop #3"
+						quitMainloop(2)
+					else:
+						Notifications.AddNotificationWithCallback(self.sendTryToRebootNotification, MessageBox, _("A finished powertimer wants to reboot your %s %s.\nDo that now?") % (getMachineBrand(), getMachineName()), timeout = 180)
+				RBsave = False
+				return True
+
+			elif self.timerType == TIMERTYPE.DEEPSTANDBY:
+				if debug: print "self.timerType == TIMERTYPE.DEEPSTANDBY:"
+				#check priority
+				prioPT = [TIMERTYPE.WAKEUP,TIMERTYPE.WAKEUPTOSTANDBY,TIMERTYPE.DEEPSTANDBY]
+				prioPTae = [AFTEREVENT.WAKEUP,AFTEREVENT.WAKEUPTOSTANDBY,AFTEREVENT.DEEPSTANDBY]
+				shiftPT,breakPT = self.getPriorityCheck(prioPT,prioPTae)
+				#a timer with higher priority was shifted - no execution of current timer
+				if False:
+					if debug: print "break#1"
+					breakPT = True
+				#a timer with lower priority was shifted - shift now current timer and wait for restore the saved time values from other timer
+				if RSsave or RBsave or aeDSsave:
+					if debug: print "shift#1"
+					breakPT = False
+					shiftPT = True
+				#shift or break
+				if shiftPT or breakPT \
+					or NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - now) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - now) <= 900:
+					if self.repeated and not DSsave:
+						self.savebegin = self.begin
+						self.saveend = self.end
+						DSsave = True
+					if not breakPT:
+						self.do_backoff()
+						#check difference begin to end before shift begin time
+						if DSsave and self.end - self.begin > 3 and self.end - now - self.backoff <= 240: breakPT = True
+					#breakPT
+					if breakPT:
+						if self.repeated and DSsave:
+							try:
+								self.begin = self.savebegin
+								self.end = self.saveend
+							except:
+								pass
+						DSsave = False
+						return True
+					# retry
+					oldbegin = self.begin
+					self.begin = int(now) + self.backoff
+					if abs(self.end - oldbegin) <= 3:
+						self.end = self.begin
+					else:
+						if not self.repeated and self.end < self.begin + 300:
+							self.end = self.begin + 300
+					return False
+				elif not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
+					if self.repeated and DSsave:
+						try:
+							self.begin = self.savebegin
+							self.end = self.saveend
+						except:
+							pass
+					if Screens.Standby.inStandby: # in standby
+						print "[PowerTimer] quitMainloop #2"
+						quitMainloop(1)
+					else:
+						Notifications.AddNotificationWithCallback(self.sendTryQuitMainloopNotification, MessageBox, _("A finished powertimer wants to shutdown your %s %s.\nDo that now?") % (getMachineBrand(), getMachineName()), timeout = 180)
+				DSsave = False
 				return True
 
 		elif next_state == self.StateEnded:
-			resetTimerWakeup()
-			NavigationInstance.instance.PowerTimer.saveTimer()
-			if self.afterEvent == AFTEREVENT.STANDBY:
+			if self.afterEvent == AFTEREVENT.WAKEUP:
+				if Screens.Standby.inStandby:
+					Screens.Standby.inStandby.Power()
+			elif self.afterEvent == AFTEREVENT.STANDBY:
 				if not Screens.Standby.inStandby: # not already in standby
 					Notifications.AddNotificationWithCallback(self.sendStandbyNotification, MessageBox, _("A finished powertimer wants to set your\n%s %s to standby. Do that now?") % (getMachineBrand(), getMachineName()), timeout = 180)
 			elif self.afterEvent == AFTEREVENT.DEEPSTANDBY:
-				if NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - time()) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - time()) <= 900:
-					if int(self.repeated) > 0 and not aeDSsave:
-						self.aeDSbegin = self.begin
-						self.aeDSend = self.end
+				if debug: print "self.afterEvent == AFTEREVENT.DEEPSTANDBY:"
+				#check priority
+				prioPT = [TIMERTYPE.WAKEUP,TIMERTYPE.WAKEUPTOSTANDBY,TIMERTYPE.DEEPSTANDBY]
+				prioPTae = [AFTEREVENT.WAKEUP,AFTEREVENT.WAKEUPTOSTANDBY,AFTEREVENT.DEEPSTANDBY]
+				shiftPT,breakPT = self.getPriorityCheck(prioPT,prioPTae)
+				#a timer with higher priority was shifted - no execution of current timer
+				if DSsave:
+					if debug: print "break#1"
+					breakPT = True
+				#a timer with lower priority was shifted - shift now current timer and wait for restore the saved time values
+				if RSsave or RBsave:
+					if debug: print "shift#1"
+					breakPT = False
+					shiftPT = True
+				#shift or break
+				runningPT = False
+				#option: check other powertimer is running (current disabled)
+				#runningPT = NavigationInstance.instance.PowerTimer.isProcessing(exceptTimer = TIMERTYPE.NONE, endedTimer = self.timerType)
+				if shiftPT or breakPT or runningPT \
+					or NavigationInstance.instance.RecordTimer.isRecording() or abs(NavigationInstance.instance.RecordTimer.getNextRecordingTime() - now) <= 900 or abs(NavigationInstance.instance.RecordTimer.getNextZapTime() - now) <= 900:
+					if self.repeated and not aeDSsave:
+						self.savebegin = self.begin
+						self.saveend = self.end
 						aeDSsave = True
-					self.do_backoff()
-					# retry
-					self.begin = time() + self.backoff
-					if self.end <= self.begin:
-						self.end = self.begin
-					return False
-				if not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
-					if aeDSsave:
+					if not breakPT: self.do_backoff()
+					#breakPT
+					if breakPT:
+						if self.repeated and aeDSsave:
+							try:
+								self.begin = self.savebegin
+								self.end = self.saveend
+							except:
+								pass
 						aeDSsave = False
-						self.begin = self.aeDSbegin
-						self.end = self.aeDSend
+						return True
+					# retry
+					self.end = int(now) + self.backoff
+					return False
+				elif not Screens.Standby.inTryQuitMainloop: # not a shutdown messagebox is open
+					if self.repeated and aeDSsave:
+						try:
+							self.begin = self.savebegin
+							self.end = self.saveend
+						except:
+							pass
 					if Screens.Standby.inStandby: # in standby
 						print "[PowerTimer] quitMainloop #5"
 						quitMainloop(1)
 					else:
-						Notifications.AddNotificationWithCallback(self.sendTryQuitMainloopNotification, MessageBox, _("A finished power timer wants to shut down\nyour %s %s. Shutdown now?") % (getMachineBrand(), getMachineName()), timeout = 180)
+						Notifications.AddNotificationWithCallback(self.sendTryQuitMainloopNotification, MessageBox, _("A finished powertimer wants to shutdown your %s %s.\nDo that now?") % (getMachineBrand(), getMachineName()), timeout = 180)
+				aeDSsave = False
+			NavigationInstance.instance.PowerTimer.saveTimer()
 			return True
 
 	def setAutoincreaseEnd(self, entry = None):
 		if not self.autoincrease:
 			return False
 		if entry is None:
-			new_end =  int(time()) + self.autoincreasetime
+			new_end = int(time()) + self.autoincreasetime
 		else:
-			new_end = entry.begin -30
+			new_end = entry.begin - 30
 
 		dummyentry = PowerTimerEntry(self.begin, new_end, disabled=True, afterEvent = self.afterEvent, timerType = self.timerType)
 		dummyentry.disabled = self.disabled
@@ -363,9 +537,50 @@ class PowerTimerEntry(timer.TimerEntry, object):
 			Notifications.AddNotification(Screens.Standby.TryQuitMainloop, 3)
 
 	def keyPressed(self, key, tag):
-		self.begin = time() + int(self.autosleepdelay)*60
-		if self.end <= self.begin:
-			self.end = self.begin
+		if self.getAutoSleepWindow():
+			self.begin = self.end = int(time()) + int(self.autosleepdelay)*60
+
+	def getAutoSleepWindow(self):
+		now = time()
+		if self.autosleepwindow == 'yes':
+			if now < self.autosleepbegin and now < self.autosleepend:
+				self.begin = self.autosleepbegin + int(self.autosleepdelay)*60
+				self.end = self.autosleepend
+				return False
+			elif now > self.autosleepbegin and now > self.autosleepend:
+				while self.autosleepbegin < now:
+					self.autosleepbegin += 86400
+				while self.autosleepend <= self.autosleepbegin:
+					self.autosleepend += 86400
+				self.begin = self.autosleepbegin + int(self.autosleepdelay)*60
+				self.end = self.autosleepend
+				return False
+		return True
+
+	def getPriorityCheck(self,prioPT,prioPTae):
+		shiftPT = breakPT = False
+		nextPTlist = NavigationInstance.instance.PowerTimer.getNextPowerManagerTime(getNextTimerTyp = True)
+		for entry in nextPTlist:
+			#check timers within next 15 mins will started or ended
+			if abs(entry[0] - time()) > 900:
+				continue
+			#faketime
+			if entry[1] is None and entry[2] is None and entry[3] is None:
+				if debug: print "shift#2 - entry is faketime", ctime(entry[0]), entry
+				shiftPT = True
+				continue
+			#is timer in list itself?
+			if entry[0] == self.begin and entry[1] == self.timerType and entry[2] is None and entry[3] == self.state \
+				or entry[0] == self.end and entry[1] is None and entry[2] == self.afterEvent and entry[3] == self.state:
+				if debug: print "entry is itself", ctime(entry[0]), entry
+				nextPTitself = True
+			else:
+				nextPTitself = False
+			if (entry[1] in prioPT or entry[2] in prioPTae) and not nextPTitself:
+				if debug: print "break#2 <= 900", ctime(entry[0]), entry
+				breakPT = True
+				break
+		return shiftPT, breakPT
 
 	def getNextActivation(self):
 		if self.state == self.StateEnded or self.state == self.StateFailed:
@@ -377,18 +592,42 @@ class PowerTimerEntry(timer.TimerEntry, object):
 				self.StateRunning: self.begin,
 				self.StateEnded: self.end }[next_state]
 
-	def getNextWakeup(self):
+	def getNextWakeup(self, getNextStbPowerOn = False):
+		next_state = self.state + 1
+		if getNextStbPowerOn:
+			if next_state == 3 and (self.timerType == TIMERTYPE.WAKEUP or self.timerType == TIMERTYPE.WAKEUPTOSTANDBY or self.afterEvent == AFTEREVENT.WAKEUP or  self.afterEvent == AFTEREVENT.WAKEUPTOSTANDBY):
+				if self.begin > time() and (self.timerType == TIMERTYPE.WAKEUP or self.timerType == TIMERTYPE.WAKEUPTOSTANDBY): #timer start time is later as now - begin time was changed while running timer
+					return self.begin
+				if self.afterEvent == AFTEREVENT.WAKEUP or self.afterEvent == AFTEREVENT.WAKEUPTOSTANDBY:
+					return self.end
+				next_day = 0
+				count_day = 0
+				wd_timer = datetime.fromtimestamp(self.begin).isoweekday()*-1
+				wd_repeated = bin(128+self.repeated)
+				for s in range(wd_timer-1,-8,-1):
+					count_day +=1
+					if int(wd_repeated[s]):
+						next_day = s
+						break
+				if next_day == 0:
+					for s in range(-1,wd_timer-1,-1):
+						count_day +=1
+						if int(wd_repeated[s]):
+							next_day = s
+							break
+				return self.begin + 86400 * count_day
+			elif next_state < 3 and (self.timerType == TIMERTYPE.WAKEUP or self.timerType == TIMERTYPE.WAKEUPTOSTANDBY):
+				return self.begin
+			elif next_state < 3 and (self.afterEvent == AFTEREVENT.WAKEUP or self.afterEvent == AFTEREVENT.WAKEUPTOSTANDBY):
+				return self.end
+			else:
+				return -1
+
 		if self.state == self.StateEnded or self.state == self.StateFailed:
 			return self.end
-
-		if self.timerType != TIMERTYPE.WAKEUP and self.timerType != TIMERTYPE.WAKEUPTOSTANDBY and not self.afterEvent:
-			return -1
-		elif self.timerType != TIMERTYPE.WAKEUP and self.timerType != TIMERTYPE.WAKEUPTOSTANDBY and self.afterEvent:
-			return self.end
-		next_state = self.state + 1
 		return {self.StatePrepared: self.start_prepare,
 				self.StateRunning: self.begin,
-				self.StateEnded: self.end }[next_state]
+				self.StateEnded: self.end}[next_state]
 
 	def timeChanged(self):
 		old_prepare = self.start_prepare
@@ -399,12 +638,10 @@ class PowerTimerEntry(timer.TimerEntry, object):
 			self.log(15, "time changed, start prepare is now: %s" % ctime(self.start_prepare))
 
 	def getNetworkTraffic(self):
-		global netbytes, netpackets
+		global netbytes
 		oldbytes = netbytes
-		oldpackets = netpackets
 		newbytes = 0
-		newpackets = 0
-		if Screens.Standby.inStandby and self.autosleepinstandbyonly == 'yesNWno':
+		if Screens.Standby.inStandby and self.autosleepinstandbyonly == 'yesACnetwork':
 			try:
 				if os.path.exists('/proc/net/dev'):
 					f = open('/proc/net/dev', 'r')
@@ -414,20 +651,18 @@ class PowerTimerEntry(timer.TimerEntry, object):
 						lisp = lines.split()
 						if lisp[0].endswith(':') and (lisp[0].startswith('eth') or lisp[0].startswith('wlan')):
 							newbytes += int(lisp[1]) + int(lisp[9])
-							newpackets += int(lisp[2]) + int(lisp[10])
 					netbytes = newbytes
-					netpackets = newpackets
 					print '[PowerTimer] Receive/Transmit Bytes : ', str(newbytes - oldbytes), '(' + str(int((newbytes - oldbytes)/1024/1024)) + ' MBytes)'
-					#print '[PowerTimer] Receive/Transmit Packets : ', str(newpackets - oldpackets)
-					if (newbytes - oldbytes) > 1000000:	# or (newpackets - oldpackets) > 3000:	#packets deactivated
+					if (newbytes - oldbytes) > 1048576:
 						return True
 			except:
-				print '[PowerTimer] Receive/Transmit Bytes or Packets : Error reading values! Use "cat /proc/net/dev" for testing on command line.'
+				print '[PowerTimer] Receive/Transmit Bytes: Error reading values! Use "cat /proc/net/dev" for testing on command line.'
 		return False
 
 def createTimer(xml):
 	timertype = str(xml.get("timertype") or "wakeup")
 	timertype = {
+		"nothing": TIMERTYPE.NONE,
 		"wakeup": TIMERTYPE.WAKEUP,
 		"wakeuptostandby": TIMERTYPE.WAKEUPTOSTANDBY,
 		"autostandby": TIMERTYPE.AUTOSTANDBY,
@@ -444,6 +679,7 @@ def createTimer(xml):
 	afterevent = str(xml.get("afterevent") or "nothing")
 	afterevent = {
 		"nothing": AFTEREVENT.NONE,
+		"wakeup": AFTEREVENT.WAKEUP,
 		"wakeuptostandby": AFTEREVENT.WAKEUPTOSTANDBY,
 		"standby": AFTEREVENT.STANDBY,
 		"deepstandby": AFTEREVENT.DEEPSTANDBY
@@ -451,12 +687,18 @@ def createTimer(xml):
 	autosleepinstandbyonly = str(xml.get("autosleepinstandbyonly") or "no")
 	autosleepdelay = str(xml.get("autosleepdelay") or "0")
 	autosleeprepeat = str(xml.get("autosleeprepeat") or "once")
+	autosleepwindow = str(xml.get("autosleepwindow") or "no")
+	autosleepbegin = int(xml.get("autosleepbegin") or begin)
+	autosleepend = int(xml.get("autosleepend") or end)
 
 	entry = PowerTimerEntry(begin, end, disabled, afterevent, timertype)
 	entry.repeated = int(repeated)
 	entry.autosleepinstandbyonly = autosleepinstandbyonly
 	entry.autosleepdelay = int(autosleepdelay)
 	entry.autosleeprepeat = autosleeprepeat
+	entry.autosleepwindow = autosleepwindow
+	entry.autosleepbegin = autosleepbegin
+	entry.autosleepend = autosleepend
 
 	for l in xml.findall("log"):
 		ltime = int(l.get("time"))
@@ -555,6 +797,7 @@ class PowerTimer(timer.Timer):
 				continue
 			list.append('<timer')
 			list.append(' timertype="' + str(stringToXML({
+				TIMERTYPE.NONE: "nothing",
 				TIMERTYPE.WAKEUP: "wakeup",
 				TIMERTYPE.WAKEUPTOSTANDBY: "wakeuptostandby",
 				TIMERTYPE.AUTOSTANDBY: "autostandby",
@@ -569,6 +812,7 @@ class PowerTimer(timer.Timer):
 			list.append(' repeated="' + str(int(timer.repeated)) + '"')
 			list.append(' afterevent="' + str(stringToXML({
 				AFTEREVENT.NONE: "nothing",
+				AFTEREVENT.WAKEUP: "wakeup",
 				AFTEREVENT.WAKEUPTOSTANDBY: "wakeuptostandby",
 				AFTEREVENT.STANDBY: "standby",
 				AFTEREVENT.DEEPSTANDBY: "deepstandby"
@@ -577,6 +821,9 @@ class PowerTimer(timer.Timer):
 			list.append(' autosleepinstandbyonly="' + str(timer.autosleepinstandbyonly) + '"')
 			list.append(' autosleepdelay="' + str(timer.autosleepdelay) + '"')
 			list.append(' autosleeprepeat="' + str(timer.autosleeprepeat) + '"')
+			list.append(' autosleepwindow="' + str(timer.autosleepwindow) + '"')
+			list.append(' autosleepbegin="' + str(int(timer.autosleepbegin)) + '"')
+			list.append(' autosleepend="' + str(int(timer.autosleepend)) + '"')
 			list.append('>\n')
 
 			for ltime, code, msg in timer.log_entries:
@@ -601,6 +848,15 @@ class PowerTimer(timer.Timer):
 		file.close()
 		os.rename(self.Filename + ".writing", self.Filename)
 
+	def isProcessing(self, exceptTimer = None, endedTimer = None):
+		isRunning = False
+		for timer in self.timer_list:
+			if timer.timerType != TIMERTYPE.AUTOSTANDBY and timer.timerType != TIMERTYPE.AUTODEEPSTANDBY and timer.timerType != exceptTimer and timer.timerType != endedTimer:
+				if timer.isRunning():
+					isRunning = True
+					break
+		return isRunning
+
 	def getNextZapTime(self):
 		now = time()
 		for timer in self.timer_list:
@@ -609,26 +865,69 @@ class PowerTimer(timer.Timer):
 			return timer.begin
 		return -1
 
-	def getNextPowerManagerTimeOld(self):
-		now = time()
+	def getNextPowerManagerTimeOld(self, getNextStbPowerOn = False):
+		now = int(time())
+		nextPTlist = [(-1,None,None,None)]
 		for timer in self.timer_list:
 			if timer.timerType != TIMERTYPE.AUTOSTANDBY and timer.timerType != TIMERTYPE.AUTODEEPSTANDBY:
-				next_act = timer.getNextWakeup()
-				if next_act < now:
+				next_act = timer.getNextWakeup(getNextStbPowerOn)
+				if next_act + 3 < now:
 					continue
-				return next_act
-		return -1
+				if getNextStbPowerOn and debug:
+					print "[powertimer] next stb power up", strftime("%a, %Y/%m/%d %H:%M", localtime(next_act))
+				next_timertype = next_afterevent = None
+				if nextPTlist[0][0] == -1:
+					if abs(next_act - timer.begin) <= 30:
+						next_timertype = timer.timerType
+					elif abs(next_act - timer.end) <= 30:
+						next_afterevent = timer.afterEvent
+					nextPTlist = [(next_act,next_timertype,next_afterevent,timer.state)]
+				else:
+					if abs(next_act - timer.begin) <= 30:
+						next_timertype = timer.timerType
+					elif abs(next_act - timer.end) <= 30:
+						next_afterevent = timer.afterEvent
+					nextPTlist.append((next_act,next_timertype,next_afterevent,timer.state))
+		nextPTlist.sort()
+		return nextPTlist
 
-	def getNextPowerManagerTime(self):
-		nextrectime = self.getNextPowerManagerTimeOld()
-		faketime = time()+300
-		if config.timeshift.isRecording.value:
-			if 0 < nextrectime < faketime:
-				return nextrectime
+	def getNextPowerManagerTime(self, getNextStbPowerOn = False, getNextTimerTyp = False):
+		global DSsave, RSsave, RBsave, aeDSsave
+		nextrectime = self.getNextPowerManagerTimeOld(getNextStbPowerOn)
+		faketime = int(time()) + 300
+		if getNextTimerTyp:
+			#check entrys and plausibility of shift state (manual canceled timer has shift/save state not reset)
+			tt = ae = []
+			now = time()
+			if debug: print "+++++++++++++++"
+			for entry in nextrectime:
+				if entry[0] < now + 900: tt.append(entry[1])
+				if entry[0] < now + 900: ae.append(entry[2])
+				if debug: print ctime(entry[0]), entry
+			if not TIMERTYPE.RESTART in tt: RSsave = False
+			if not TIMERTYPE.REBOOT in tt: RBsave = False
+			if not TIMERTYPE.DEEPSTANDBY in tt: DSsave = False
+			if not AFTEREVENT.DEEPSTANDBY in ae: aeDSsave = False
+			if debug: print "RSsave=%s, RBsave=%s, DSsave=%s, aeDSsave=%s, wasTimerWakeup=%s" %(RSsave, RBsave, DSsave, aeDSsave, wasTimerWakeup)
+			if debug: print "+++++++++++++++"
+			###
+			if config.timeshift.isRecording.value:
+				if 0 < nextrectime[0][0] < faketime:
+					return nextrectime
+				else:
+					nextrectime.append((faketime,None,None,None))
+					nextrectime.sort()
+					return nextrectime
 			else:
-				return faketime
+				return nextrectime
 		else:
-			return nextrectime
+			if config.timeshift.isRecording.value:
+				if 0 < nextrectime[0][0] < faketime:
+					return nextrectime[0][0]
+				else:
+					return faketime
+			else:
+				return nextrectime[0][0]
 
 	def isNextPowerManagerAfterEventActionAuto(self):
 		now = time()

--- a/lib/python/Components/PowerTimerList.py
+++ b/lib/python/Components/PowerTimerList.py
@@ -11,6 +11,7 @@ from PowerTimer import AFTEREVENT, TIMERTYPE
 
 def gettimerType(timer):
 	timertype = {
+		TIMERTYPE.NONE: _("Nothing"),
 		TIMERTYPE.WAKEUP: _("Wake Up"),
 		TIMERTYPE.WAKEUPTOSTANDBY: _("Wake Up To Standby"),
 		TIMERTYPE.STANDBY: _("Standby"),
@@ -25,6 +26,7 @@ def gettimerType(timer):
 def getafterEvent(timer):
 	afterevent = {
 		AFTEREVENT.NONE: _("Nothing"),
+		AFTEREVENT.WAKEUP: _("Wake Up"),
 		AFTEREVENT.WAKEUPTOSTANDBY: _("Wake Up To Standby"),
 		AFTEREVENT.STANDBY: _("Standby"),
 		AFTEREVENT.DEEPSTANDBY: _("Deep Standby")
@@ -69,10 +71,13 @@ class PowerTimerList(HTMLComponent, GUIComponent, object):
 			else:
 				state = _("done!")
 				icon = self.iconDone
+			autosleepwindow = ""
+			if timer.autosleepwindow == 'yes':
+				autosleepwindow = _("Time range:") + " " + FuzzyTime(timer.autosleepbegin)[1] + " ... " + FuzzyTime(timer.autosleepend)[1] + ", "
 			if screenwidth and screenwidth == 1920:
-				res.append((eListboxPythonMultiContent.TYPE_TEXT, 225, 38, width-225, 35, 3, RT_HALIGN_RIGHT|RT_VALIGN_BOTTOM, _("Delay:") + " " + str(timer.autosleepdelay) + "(" + _("mins") + ")"))
+				res.append((eListboxPythonMultiContent.TYPE_TEXT, 225, 38, width-225, 35, 3, RT_HALIGN_RIGHT|RT_VALIGN_BOTTOM, autosleepwindow + _("Delay:") + " " + str(timer.autosleepdelay) + "(" + _("mins") + ")"))
 			else:
-				res.append((eListboxPythonMultiContent.TYPE_TEXT, 150, 26, width-150, 23, 1, RT_HALIGN_RIGHT|RT_VALIGN_BOTTOM, _("Delay:") + " " + str(timer.autosleepdelay) + "(" + _("mins") + ")"))
+				res.append((eListboxPythonMultiContent.TYPE_TEXT, 150, 26, width-150, 23, 1, RT_HALIGN_RIGHT|RT_VALIGN_BOTTOM, autosleepwindow + _("Delay:") + " " + str(timer.autosleepdelay) + "(" + _("mins") + ")"))
 		else:
 			if screenwidth and screenwidth == 1920:
 				res.append((eListboxPythonMultiContent.TYPE_TEXT, x+36, 3, x-3-36, 35, 3, RT_HALIGN_RIGHT|RT_VALIGN_BOTTOM, _('At End:') + ' ' + getafterEvent(timer)))

--- a/mytest.py
+++ b/mytest.py
@@ -653,27 +653,29 @@ def runScreenTest():
 		setRTCtime(nowTime)
 
 	wakeupList = [
-		x for x in ((session.nav.RecordTimer.getNextRecordingTime(), 0, session.nav.RecordTimer.isNextRecordAfterEventActionAuto()),
+		x for x in ((session.nav.RecordTimer.getNextRecordingTime(getNextStbPowerOn = True), 0, session.nav.RecordTimer.isNextRecordAfterEventActionAuto()),
 					(session.nav.RecordTimer.getNextZapTime(), 1),
 					(plugins.getNextWakeupTime(), 2),
-					(session.nav.PowerTimer.getNextPowerManagerTime(), 3, session.nav.PowerTimer.isNextPowerManagerAfterEventActionAuto()))
+					(session.nav.PowerTimer.getNextPowerManagerTime(getNextStbPowerOn = True), 3, session.nav.PowerTimer.isNextPowerManagerAfterEventActionAuto()))
 		if x[0] != -1
 	]
 	wakeupList.sort()
 	recordTimerWakeupAuto = False
 	if wakeupList and wakeupList[0][1] != 3:
 		startTime = wakeupList[0]
-		if (startTime[0] - nowTime) < 270: # no time to switch box back on
-			wptime = nowTime + 30  # so switch back on in 30 seconds
+		if (startTime[0] - nowTime) < 300: # no time to switch box back on
+			wptime = nowTime + 60  # so switch back on in 60 seconds
 		else:
-			if boxtype.startswith("gb"):
+			if config.workaround.deeprecord.value:
+				wptime = startTime[0] - 240
+			elif boxtype.startswith("gb"):
 				wptime = startTime[0] - 120 # Gigaboxes already starts 2 min. before wakeup time
 			else:
-				wptime = startTime[0] - 240
+				wptime = startTime[0] - 180
 #		if not config.misc.SyncTimeUsing.value == "0" or boxtype.startswith('gb'):
 #			print "dvb time sync disabled... so set RTC now to current linux time!", strftime("%Y/%m/%d %H:%M", localtime(nowTime))
 #			setRTCtime(nowTime)
-		print "set wakeup time to", strftime("%Y/%m/%d %H:%M", localtime(wptime))
+		print "set wakeup time to", strftime("%a, %Y/%m/%d %H:%M", localtime(wptime))
 		setFPWakeuptime(wptime)
 		recordTimerWakeupAuto = startTime[1] == 0 and startTime[2]
 		print 'recordTimerWakeupAuto',recordTimerWakeupAuto
@@ -684,17 +686,19 @@ def runScreenTest():
 	PowerTimerWakeupAuto = False
 	if wakeupList and wakeupList[0][1] == 3:
 		startTime = wakeupList[0]
-		if (startTime[0] - nowTime) < 60: # no time to switch box back on
-			wptime = nowTime + 30  # so switch back on in 30 seconds
+		if (startTime[0] - nowTime) < 300: # no time to switch box back on
+			wptime = nowTime + 60  # so switch back on in 60 seconds
 		else:
 			if config.workaround.deeprecord.value:
-				wptime = startTime[0] - 240 # Gigaboxes already starts 2 min. before wakeup time
+				wptime = startTime[0] - 240
+			elif boxtype.startswith("gb"):
+				wptime = startTime[0] - 120 # Gigaboxes already starts 2 min. before wakeup time
 			else:
-				wptime = startTime[0]
+				wptime = startTime[0] - 180
 #		if not config.misc.SyncTimeUsing.value == "0" or getBrandOEM() == 'gigablue':
 #			print "dvb time sync disabled... so set RTC now to current linux time!", strftime("%Y/%m/%d %H:%M", localtime(nowTime))
 #			setRTCtime(nowTime)
-		print "set wakeup time to", strftime("%Y/%m/%d %H:%M", localtime(wptime+60))
+		print "set wakeup time to", strftime("%a, %Y/%m/%d %H:%M", localtime(wptime))
 		setFPWakeuptime(wptime)
 		PowerTimerWakeupAuto = startTime[1] == 3 and startTime[2]
 		print 'PowerTimerWakeupAuto',PowerTimerWakeupAuto

--- a/po/de.po
+++ b/po/de.po
@@ -8464,8 +8464,8 @@ msgid ""
 "A finished powertimer wants to set your\n"
 "%s %s to standby. Do that now?"
 msgstr ""
-"Ein Powertimer will Ihren Receiver ausschalten.\n"
-"Ihre %s %s jetzt ausschalten?"
+"Ein Powertimer will Ihren Receiver in den Standby schalten.\n"
+"Ihre %s %s jetzt in den Standby schalten?"
 
 # /usr/lib/enigma2/python/PowerTimer.py
 msgid ""
@@ -15421,3 +15421,23 @@ msgstr "Zeitsprünge: Hängenbleiben vermeiden"
 
 msgid "Avoid getting stuck (at the expense of some stuttering) when the jump time is smaller than the time between I-frames."
 msgstr "Verhindert ein Hängenbleiben beim Spulen, wenn die Sprungdistanz kleiner ist als der Abstand zwischen I-Frames (ein gewisses Ruckeln ist dabei unvermeidbar)."
+
+# PowerTimerEntry.py
+msgid "Difference between timer begin and end must be equal or greater than 5 minutes.\nEnd Action was disabled !"
+msgstr "Die Differenz zwischen Timer Startzeit und Endzeit muss größer oder gleich 5 Minuten sein.\nDie Endaktion wurde deaktiviert !"
+
+# PowerTimerEntry.py
+msgid "Yes, additional condition: No network data traffic"
+msgstr "Ja, außerdem: keine Netzwerkdatenübertragung"
+
+# PowerTimerEntry.py
+msgid "Restrict the active time range?"
+msgstr "Den aktiven Zeitbereich einschränken?"
+
+# PowerTimerList.py
+msgid "Delay:"
+msgstr "Verzögerung:"
+
+# PowerTimerList.py
+msgid "Time range:"
+msgstr "Zeitbereich:"


### PR DESCRIPTION
…iption

new: timer type "nothing" can use for suppress the "autodeepstandby" timer (was a first simple way before time window added ...)
new: timer afterevent "wakeup" for shutdown and wakeup in one timer entry, respectively more combinations possible
new: "autodeepstandby" timer will not executed while others timer is active(except "autostandby timer")
new: a optional adjustable active time window for autodeepstandby and autostandby timer
new: after recordtimer will not shutdown when a powertimer is running(except "autostandby", "autodeepstandby" and "nothing" timer)
new: time difference between timer begin and end must equal or greater 5 minutes, otherwise is end action disabled
new: more time values for autodeepstandby and autostandby timer
new: timer execution after priority(1.wakeup,wakeuptostandby,2.deepstandby,3.reboot,4.restart,5.standby,6.autostandby,7.autodeepstandby)
-overlapping timers or next timer start is within 15 minutes, will only the high-order timer executed (at same types will executed the next timer)
-priority for repeated timer: save the original times - shift from begin and end time only temporary (begin time never over the original end time -> end-action priority is higher as the begin-action
fix: setting the next stb start time when shutting down and a timer is active (stb start time was set to end time of current timer)
fix: possible bs by overlapping timer same typs
fix: after timerstart goes box only to standby, when timertype or afterevent wakeuptostandby is enabled
fix: after systemstart suppress the message (A finished powertimer wants to...) when the timer is running
fix: verify wakeup-state by timer type and time so that not after restart(every) the box going in standby (for boxes where "/proc/stb/fp/was_timer_wakeup" is not writable
(clearFPWasTimerWakeup() in StbHardware.py has no effect -> after x hours and restart/reboot is wasTimerWakeup = True)
fix: save and restore original begin/end time at repeated timers (current not when time is
shifted and manually box shutdown or timer abort)
and some more ...

neu: timertyp "nothing", kann benutzt werden um den "autodeepstandby" timer zu unterdrücken (war der erste weg vor dem zeitfenster...)
neu: afterevent "wakeup" damit ein timer ausschalten und aufwachen kann, und für mehr kombinationsmöglichkeiten
neu: "autodeepstandby" timer wird nur ausgeführt wenn kein anderer timer aktiv ist (außer "autostandby")
neu: "autodeepstandby" und "autostandby" haben ein optionales einstellbares zeitfenster in dem sie aktiv sind/werden
neu: nach der aufnahme wird nicht abgeschaltet wenn noch ein powertimer läuft
neu: die zeitdifferenz zwischen timerstart und -ende muß größer gleich 5 minuten sein, andernfalls wird die endaktion deaktiviert
neu: mehr zeitwerte für autostandby und autodeepstandby timer
neu: timer ausführung nach priorität
(1.wakeup,wakeuptostandby,2.deepstandby,3.reboot,4.restart,5.standby,6.autostandby,7.autodeepstandby)
-bei überlappenden timern oder der nächste timer startet innerhalb 15 minten wird nur der höherwertige ausgeführt(bei gleichem typ wird der nächste ausgeführt)
-priorität für wiederholende timer: sichere die originalzeiten - verschiebung der start/endzeit ist nur temporär (startzeit niemals über die originale endzeit -> die endaktion hat eine
höhere priorität als die startaktion)
fix: setzen der weckzeit bei laufendem timer (wurde bisher die endzeit des timers verwendet)
fix: möglichen bs bei der überlappung von timern gleichen typs
fix: nach einem timerstart wird nur in den standby gegangen wenn "wakeuptostandby"
ausgewählt wurde
fix: uberprüfung des wakeup-status mit zeit und timertyp damit die box nicht nach jedem neustart in den standby geht (für geräte wo "/proc/stb/fp/was_timer_wakeup" nicht beschreibbar ist (clearFPWasTimerWakeup() in StbHardware.py hat keine Wirkung -> nach
x stunden und einem restart/reboot ist wasTimerWakeup = True)
fix: sicherung und wiederherstellung der original start/end zeiten bei wiederholenden timern (aktuell funktioniert das nicht wenn der timer manuell abgebochen oder die box neu gestartet wird)
und einiges mehr ...