### PR TITLE
[timeshift,infobargeneretics] fixes and changes in timeshift function…

### DIFF
--- a/lib/python/Components/Timeshift.py
+++ b/lib/python/Components/Timeshift.py
@@ -82,7 +82,8 @@ class InfoBarTimeshift:
 
 		self["TimeshiftFileActions"] = ActionMap(["InfobarTimeshiftActions"],
 			{
-				"jumpPreviousFile": self.__evSOF,
+				#"jumpPreviousFile": self.__evSOF,
+				"jumpPreviousFile": self.__evSOFjump,
 				"jumpNextFile": self.__evEOF
 			}, prio=-1) # priority over history
 
@@ -112,6 +113,8 @@ class InfoBarTimeshift:
 		self.pts_begintime = 0
 		self.pts_switchtolive = False
 		self.pts_firstplayable = 1
+		self.pts_lastposition = 0
+		self.pts_lastplaying = 1
 		self.pts_currplaying = 1
 		self.pts_nextplaying = 0
 		self.pts_lastseekspeed = 0
@@ -125,6 +128,7 @@ class InfoBarTimeshift:
 		self.checkEvents_value = int(config.timeshift.timeshiftCheckEvents.value)
 		self.pts_starttime = time()
 		self.ptsAskUser_wait = False
+		self.posDiff = 0
 
 		# Init Global Variables
 		self.session.ptsmainloopvalue = 0
@@ -163,15 +167,24 @@ class InfoBarTimeshift:
 		self.pts_StartSeekBackTimer = eTimer()
 		self.pts_StartSeekBackTimer.callback.append(self.ptsStartSeekBackTimer)
 
+		# Init PTS SeekToPos-Timer
+		self.pts_SeekToPos_timer = eTimer()
+		self.pts_SeekToPos_timer.callback.append(self.ptsSeekToPos)
+
 		# Init PTS CheckFileChanged-Timer
+		self.pts_CheckFileChanged_counter = 1
 		self.pts_CheckFileChanged_timer = eTimer()
 		self.pts_CheckFileChanged_timer.callback.append(self.ptsCheckFileChanged)
 
 		# Init Block-Zap Timer
 		self.pts_blockZap_timer = eTimer()
 
+		# Init PTS FileJump-Timer 
+		self.pts_FileJump_timer = eTimer() 
+
 		# Record Event Tracker
 		self.session.nav.RecordTimer.on_state_change.append(self.ptsTimerEntryStateChange)
+
 
 		# Keep Current Event Info for recordings
 		self.pts_eventcount = 0
@@ -193,11 +206,8 @@ class InfoBarTimeshift:
 		self["TimeshiftFileActions"].setEnabled(state)
 		# print ('__seekableStatusChanged - state %s, seekstate %s' % (state, self.seekstate))
 
-		if not state and self.pts_currplaying == self.pts_eventcount:
+		if not state and self.pts_currplaying == self.pts_eventcount and self.timeshiftEnabled() and not self.event_changed:
 			self.setSeekState(self.SEEK_STATE_PLAY)
-		
-		if self.pts_eventcount < self.pts_firstplayable:
-			self.pts_firstplayable = self.pts_eventcount
 
 		self.restartSubtitle()
 
@@ -208,7 +218,7 @@ class InfoBarTimeshift:
 			if int(config.timeshift.startdelay.value):
 				if self.pts_starttime <= (time()-5):
 					self.pts_blockZap_timer.start(3000, True)
-			self.pts_currplaying = self.pts_eventcount
+			self.pts_lastplaying = self.pts_currplaying = self.pts_eventcount
 			self.pts_nextplaying = 0
 			self.pts_file_changed = True
 			self.ptsSetNextPlaybackFile("pts_livebuffer_%s" % self.pts_eventcount)
@@ -225,8 +235,8 @@ class InfoBarTimeshift:
 		if int(config.timeshift.startdelay.value):
 			# print 'TS AUTO START TEST2'
 			self.pts_delay_timer.start(int(config.timeshift.startdelay.value) * 1000, True)
-
-		self.__seekableStatusChanged()
+		self["TimeshiftActions"].setEnabled(True)
+		#self.__seekableStatusChanged()
 
 	def __serviceEnd(self):
 		# print '!!!!! __serviceEnd'
@@ -239,22 +249,45 @@ class InfoBarTimeshift:
 		self.service_changed = 0
 		if not config.timeshift.isRecording.value:
 			self.__seekableStatusChanged()
+		self["TimeshiftActions"].setEnabled(False)
+
+	def __evSOFjump(self):
+		if not self.timeshiftEnabled() or self.pts_CheckFileChanged_timer.isActive() or self.pts_SeekBack_timer.isActive() or self.pts_StartSeekBackTimer.isActive() or self.pts_SeekToPos_timer.isActive():
+			return
+		if self.pts_FileJump_timer.isActive():
+			self.__evSOF()
+		else:
+			self.pts_FileJump_timer.start(5000, True)
+			self.setSeekState(self.SEEK_STATE_PLAY)
+			self.doSeek(0)
+			self.posDiff = 0
+
+	def evSOF(self, posDiff = 0):  #called from InfoBarGenerics.py
+		self.posDiff = posDiff
+		self.__evSOF()
 
 	def __evSOF(self):
 		# print '!!!!! jumpToPrevTimeshiftedEvent'
-		if not self.timeshiftEnabled() or self.pts_CheckFileChanged_timer.isActive():
+		if not self.timeshiftEnabled() or self.pts_CheckFileChanged_timer.isActive() or self.pts_SeekBack_timer.isActive() or self.pts_StartSeekBackTimer.isActive() or self.pts_SeekToPos_timer.isActive():
 			return
 
 		# print ('[TIMESHIFT] - pts_currplaying %s, pts_nextplaying %s, pts_eventcount %s, pts_firstplayable %s' % (self.pts_currplaying, self.pts_nextplaying, self.pts_eventcount, self.pts_firstplayable))
 
 		self.pts_switchtolive = False
 
+		self.pts_lastplaying = self.pts_currplaying
 		self.pts_nextplaying = 0
 		if self.pts_currplaying > self.pts_firstplayable:
 			self.pts_currplaying -= 1
 		else:
 			self.setSeekState(self.SEEK_STATE_PLAY)
 			self.doSeek(0)
+			self.posDiff = 0
+			if self.pts_FileJump_timer.isActive():
+				self.pts_FileJump_timer.stop()
+				Notifications.AddNotification(MessageBox, _("First playable timeshift file!"), MessageBox.TYPE_INFO, timeout=5)
+			if not self.pts_FileJump_timer.isActive():
+				self.pts_FileJump_timer.start(5000, True)
 			return
 
 		# Switch to previous TS file by seeking forward to next file
@@ -264,6 +297,7 @@ class InfoBarTimeshift:
 			self.ptsSetNextPlaybackFile("pts_livebuffer_%s" % self.pts_currplaying)
 			self.setSeekState(self.SEEK_STATE_PLAY)
 			self.doSeek(3600 * 24 * 90000)
+			self.pts_CheckFileChanged_counter = 1
 			self.pts_CheckFileChanged_timer.start(1000, False)
 			self.pts_file_changed = False
 		else:
@@ -272,17 +306,23 @@ class InfoBarTimeshift:
 			self.pts_firstplayable += 1
 			self.setSeekState(self.SEEK_STATE_PLAY)
 			self.doSeek(0)
-		
+			self.posDiff = 0
+
 		# print ('[TIMESHIFT] - pts_currplaying %s, pts_nextplaying %s, pts_eventcount %s, pts_firstplayable %s' % (self.pts_currplaying, self.pts_nextplaying, self.pts_eventcount, self.pts_firstplayable))
+
+	def evEOF(self, posDiff = 0):  #called from InfoBarGenerics.py
+		self.posDiff = posDiff
+		self.__evEOF()
 
 	def __evEOF(self):
 		# print '!!!!! jumpToNextTimeshiftedEvent'
-		if not self.timeshiftEnabled() or self.pts_CheckFileChanged_timer.isActive():
+		if not self.timeshiftEnabled() or self.pts_CheckFileChanged_timer.isActive() or self.pts_SeekBack_timer.isActive() or self.pts_StartSeekBackTimer.isActive() or self.pts_SeekToPos_timer.isActive():
 			return
 		# print ('[TIMESHIFT] - pts_currplaying %s, pts_nextplaying %s, pts_eventcount %s, pts_firstplayable %s' % (self.pts_currplaying, self.pts_nextplaying, self.pts_eventcount, self.pts_firstplayable))
 		
 		self.pts_switchtolive = False
-
+		self.pts_lastposition = self.ptsGetPosition()
+		self.pts_lastplaying = self.pts_currplaying
 		self.pts_nextplaying = 0
 		self.pts_currplaying += 1
 
@@ -293,14 +333,23 @@ class InfoBarTimeshift:
 			self.ptsSetNextPlaybackFile("pts_livebuffer_%s" % self.pts_currplaying)
 			self.setSeekState(self.SEEK_STATE_PLAY)
 			self.doSeek(3600 * 24 * 90000)
-		else:
-			self.pts_switchtolive = True
-			self.pts_currplaying -= 1
-			self.ptsSetNextPlaybackFile("")
-			self.setSeekState(self.SEEK_STATE_PLAY)
-			self.doSeek(3600 * 24 * 90000)
+			self.pts_CheckFileChanged_counter = 1
 			self.pts_CheckFileChanged_timer.start(1000, False)
 			self.pts_file_changed = False
+		else:
+			if not int(config.timeshift.startdelay.value):
+				Notifications.AddNotification(MessageBox, _("Switching to live TV - timeshift is still active!"), MessageBox.TYPE_INFO, timeout=5)
+			self.posDiff = 0
+			self.pts_lastposition = 0
+			self.pts_currplaying -= 1
+			self.pts_switchtolive = True 
+			self.ptsSetNextPlaybackFile("") 
+			self.setSeekState(self.SEEK_STATE_PLAY) 
+			self.doSeek(3600 * 24 * 90000) 
+			self.pts_CheckFileChanged_counter = 1
+			self.pts_CheckFileChanged_timer.start(1000, False) 
+			self.pts_file_changed = False 
+
 		# print ('[TIMESHIFT] - pts_currplaying %s, pts_nextplaying %s, pts_eventcount %s, pts_firstplayable %s' % (self.pts_currplaying, self.pts_nextplaying, self.pts_eventcount, self.pts_firstplayable))
 
 	def __evInfoChanged(self):
@@ -358,7 +407,6 @@ class InfoBarTimeshift:
 					self.pts_delay_timer.start(1000, True)
 
 	def getTimeshift(self):
-
 		if self.ts_disabled:
 			return None
 
@@ -406,20 +454,24 @@ class InfoBarTimeshift:
 		# print ' answer', answer
 		if answer and int(config.timeshift.startdelay.value) and self.switchToLive and self.isSeekable():
 			# print 'TEST4'
+			self.posDiff = 0
+			self.pts_lastposition = 0
+			if self.pts_currplaying != self.pts_eventcount:
+				self.pts_lastposition = self.ptsGetPosition()
+			self.pts_lastplaying = self.pts_currplaying
 			self.ptsStop = False
 			self.pts_nextplaying = 0
 			self.pts_switchtolive = True
 			self.setSeekState(self.SEEK_STATE_PLAY)
 			self.ptsSetNextPlaybackFile("")
 			self.doSeek(3600 * 24 * 90000)
-			self.__seekableStatusChanged()
+			self.pts_CheckFileChanged_counter = 1
+			self.pts_CheckFileChanged_timer.start(1000, False)
+			self.pts_file_changed = False
+			#self.__seekableStatusChanged()
 			return 0
 
-		was_enabled = False
 		ts = self.getTimeshift()
-		if ts and ts.isTimeshiftEnabled():
-			# print 'TEST5'
-			was_enabled = ts.isTimeshiftEnabled()
 		if answer and ts:
 			# print 'TEST6'
 			if int(config.timeshift.startdelay.value):
@@ -448,7 +500,7 @@ class InfoBarTimeshift:
 			if getBrandOEM() == 'xtrend':
 				self.ts_rewind_timer.start(1000, 1)
 			else:
-				self.ts_rewind_timer.start(100, 1)
+				self.ts_rewind_timer.start(500, 1)
 
 	def rewindService(self):
 		if getBrandOEM() in ('gigablue', 'xp'):
@@ -467,7 +519,7 @@ class InfoBarTimeshift:
 		# print 'self.switchToLive',self.switchToLive
 		if self.ptsStop:
 			returnFunction(True)
-		elif (self.isSeekable() and self.timeshiftEnabled() or self.save_current_timeshift) and config.usage.check_timeshift.value:
+		elif (self.isSeekable() or (self.timeshiftEnabled() and not int(config.timeshift.startdelay.value)) or self.save_current_timeshift) and config.usage.check_timeshift.value:
 			# print 'TEST1'
 			if config.timeshift.favoriteSaveAction.value == "askuser":
 				# print 'TEST2'
@@ -534,7 +586,7 @@ class InfoBarTimeshift:
 
 	def autostartAutorecordTimeshift(self):
 		# print '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!autostartAutorecordTimeshift'
-		self["TimeshiftActions"].setEnabled(True)
+		#self["TimeshiftActions"].setEnabled(True)
 		ts = self.getTimeshift()
 		if ts is None:
 			# print '[TimeShift] tune lock failed, so could not start.'
@@ -557,18 +609,24 @@ class InfoBarTimeshift:
 		if self.ptsCheckTimeshiftPath() is False or self.session.screen["Standby"].boolean is True or self.ptsLiveTVStatus() is False or (config.timeshift.stopwhilerecording.value and self.pts_record_running):
 			return
 
-		# setNextPlaybackFile() on event change while timeshifting
-		if self.isSeekable():
-			self.pts_nextplaying = self.pts_currplaying + 1
-			self.ptsSetNextPlaybackFile("pts_livebuffer_%s" % self.pts_nextplaying)
-			# Do not switch back to LiveTV while timeshifting
-			self.switchToLive = False
-		else:
-			self.switchToLive = True
-
 		# (Re)start Timeshift now
 		if config.timeshift.filesplitting.value:
+			# setNextPlaybackFile() on event change while timeshifting
+			if self.isSeekable():
+				self.pts_nextplaying = self.pts_currplaying + 1
+				self.ptsSetNextPlaybackFile("pts_livebuffer_%s" % self.pts_nextplaying)
+				# Do not switch back to LiveTV while timeshifting
+				self.switchToLive = False
+			else:
+				self.switchToLive = True
 			self.stopTimeshiftcheckTimeshiftRunningCallback(True)
+		else:
+			if self.pts_currplaying < self.pts_eventcount:
+				self.pts_nextplaying = self.pts_currplaying + 1
+				self.ptsSetNextPlaybackFile("pts_livebuffer_%s" % self.pts_nextplaying)
+			else:
+				self.pts_nextplaying = 0
+				self.ptsSetNextPlaybackFile("")
 		self.event_changed = False
 
 		ts = self.getTimeshift()
@@ -603,6 +661,9 @@ class InfoBarTimeshift:
 				self.session.open(MessageBox, _("Timeshift not possible!"), MessageBox.TYPE_ERROR, timeout=2)
 			except:
 				print '[TIMESHIFT] Failed to open MessageBox, Timeshift not possible, probably another MessageBox was active.'
+
+		if self.pts_eventcount < self.pts_firstplayable:
+			self.pts_firstplayable = self.pts_eventcount
 		# print ('[TIMESHIFT] - pts_currplaying %s, pts_nextplaying %s, pts_eventcount %s, pts_firstplayable %s' % (self.pts_currplaying, self.pts_nextplaying, self.pts_eventcount, self.pts_firstplayable))
 
 	def createTimeshiftFolder(self):
@@ -865,14 +926,19 @@ class InfoBarTimeshift:
 	def ptsAskUser(self, what):
 		if self.ptsAskUser_wait:
 			return
-		message_time =  _("The buffer time for timeshift exceeds the specified limit in the settings.\nWhat do you want to do ?")
-		message_space =  _("The available disk space for timeshift is less than specified in the settings.\nWhat do you want to do ?")
-		choice_restart = [(_("Delete the current timeshift buffer and restart timeshift"), "restarttimeshift"),
+		message_time = _("The buffer time for timeshift exceeds the specified limit in the settings.\nWhat do you want to do ?")
+		message_space = _("The available disk space for timeshift is less than specified in the settings.\nWhat do you want to do ?")
+		message_livetv = _("Can't going to live TV!\nSwitch to live TV and restart Timeshift ?")
+		message_nextfile = _("Can't play the next Timeshift file!\nSwitch to live TV and restart Timeshift ?")
+		choice_restart =[(_("Delete the current timeshift buffer and restart timeshift"), "restarttimeshift"),
 						(_("Nothing, just leave this menu"), "no")]
 		choice_save = [(_("Stop timeshift and save timeshift buffer as movie and start recording of current event"), "savetimeshiftandrecord"),
 					(_("Stop timeshift and save timeshift buffer as movie"), "savetimeshift"),
 					(_("Stop timeshift"), "noSave"),
 					(_("Nothing, just leave this menu"), "no")]
+		choice_livetv = [(_("No"), "nolivetv"),
+						(_("Yes"), "golivetv")]
+
 		if what == "time":
 			message = message_time
 			choice = choice_restart
@@ -885,6 +951,12 @@ class InfoBarTimeshift:
 		elif what == "space_and_save":
 			message = message_space
 			choice = choice_save
+		elif what == "livetv":
+			message = message_livetv
+			choice = choice_livetv
+		elif what == "nextfile":
+			message = message_nextfile
+			choice = choice_livetv
 		else:
 			return
 		self.ptsAskUser_wait = True
@@ -906,6 +978,14 @@ class InfoBarTimeshift:
 				self.ptsEventCleanTimerSTOP()
 				self.save_current_timeshift = True
 				InfoBarTimeshift.saveTimeshiftActions(self, answer, self.stopTimeshiftAskUserCallback)
+			elif answer == "golivetv":
+				self.ptsEventCleanTimerSTOP(True)
+				self.stopTimeshiftAskUserCallback(True)
+				self.restartTimeshift()
+			elif answer == "nolivetv":
+				if self.pts_lastposition: 
+					self.setSeekState(self.SEEK_STATE_PLAY)
+					self.doSeek(self.pts_lastposition)
 
 	def stopTimeshiftAskUserCallback(self, answer):
 		ts = self.getTimeshift()
@@ -1420,9 +1500,33 @@ class InfoBarTimeshift:
 		# print ('[TIMESHIFT] - pts_currplaying %s, pts_nextplaying %s, pts_eventcount %s, pts_firstplayable %s' % (self.pts_currplaying, self.pts_nextplaying, self.pts_eventcount, self.pts_firstplayable))
 		# print 'self.pts_file_changed',self.pts_file_changed
 
-		if self.pts_file_changed or not self.timeshiftEnabled():
+		if not self.timeshiftEnabled():
 			self.pts_CheckFileChanged_timer.stop()
-			if not self.pts_currplaying == self.pts_eventcount:
+			return
+
+		if self.pts_CheckFileChanged_counter >= 5 and not self.pts_file_changed:
+			if self.pts_switchtolive:
+				self.ptsAskUser("livetv")
+			elif self.pts_lastplaying <= self.pts_currplaying:
+				self.ptsAskUser("nextfile")
+			else:
+				Notifications.AddNotification(MessageBox, _("Can't play the previous timeshift file! You can try again."), MessageBox.TYPE_INFO, timeout=5)
+				self.doSeek(0)
+				self.setSeekState(self.SEEK_STATE_PLAY)
+				#self.pts_firstplayable = self.pts_lastplaying
+
+			self.pts_currplaying = self.pts_lastplaying
+			self.pts_CheckFileChanged_timer.stop()
+			return
+
+		self.pts_CheckFileChanged_counter += 1
+		if self.pts_file_changed:
+			self.pts_CheckFileChanged_timer.stop()
+			if self.posDiff:
+				self.pts_SeekToPos_timer.start(1000, True)
+			elif self.pts_FileJump_timer.isActive():
+				self.pts_FileJump_timer.stop()
+			elif self.pts_lastplaying > self.pts_currplaying:
 				self.pts_SeekBack_timer.start(1000, True)
 		else:
 			self.doSeek(3600 * 24 * 90000)
@@ -1430,7 +1534,7 @@ class InfoBarTimeshift:
 	def ptsTimeshiftFileChanged(self):
 		# print '!!!!! ptsTimeshiftFileChanged'
 		# print ('[TIMESHIFT] - pts_currplaying %s, pts_nextplaying %s, pts_eventcount %s, pts_firstplayable %s' % (self.pts_currplaying, self.pts_nextplaying, self.pts_eventcount, self.pts_firstplayable))
-		
+
 		self.pts_file_changed = True
 
 		# Reset Seek Pointer
@@ -1466,7 +1570,27 @@ class InfoBarTimeshift:
 		if ts is None:
 			return
 		# print ("!!! SET NextPlaybackFile%s%s" % (config.usage.timeshift_path.value,nexttsfile))
-		ts.setNextPlaybackFile("%s%s" % (config.usage.timeshift_path.value,nexttsfile))
+		if nexttsfile:
+			ts.setNextPlaybackFile("%s%s" % (config.usage.timeshift_path.value,nexttsfile))
+		else:
+			ts.setNextPlaybackFile("")
+
+	def ptsSeekToPos(self):
+		#print '!!!!! ptsSeekToPos', self.posDiff
+		length = self.ptsGetLength()
+		if length is None:
+			return
+		if self.posDiff < 0:
+			if length <= abs(self.posDiff):
+				self.posDiff = 0
+		else:
+			if length <= abs(self.posDiff):
+				tmp = length - 90000*10
+				if tmp < 0: tmp = 0
+				self.posDiff = tmp
+		self.setSeekState(self.SEEK_STATE_PLAY)
+		self.doSeek(self.posDiff)
+		self.posDiff = 0
 
 	def ptsSeekBackTimer(self):
 		# print '!!!!! ptsSeekBackTimer RUN'

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -2473,7 +2473,8 @@ class InfoBarSeek:
 
 	def unPauseService(self):
 		if self.seekstate == self.SEEK_STATE_PLAY:
-			return 0
+			#return 0 # if 'return 0', plays timeshift again from the beginning
+			return
 		self.setSeekState(self.SEEK_STATE_PLAY)
 
 	def doPause(self, pause):
@@ -2512,6 +2513,24 @@ class InfoBarSeek:
 		self.doSeekRelative(pts)
 
 	def doSeekRelative(self, pts):
+		try:
+			if "<class 'Screens.InfoBar.InfoBar'>" in `self`:
+				if InfoBarTimeshift.timeshiftEnabled(self):
+					length = InfoBarTimeshift.ptsGetLength(self)
+					position = InfoBarTimeshift.ptsGetPosition(self)
+					if length is None or position is None:
+						return
+					if position + pts >= length:
+						InfoBarTimeshift.evEOF(self, position + pts - length)
+						return
+					elif position + pts < 0:
+						InfoBarTimeshift.evSOF(self, position + pts)
+						self.showAfterSeek()
+						return
+		except:
+			from sys import exc_info
+			print "[InfoBarGeneretics] error in 'def doSeekRelative'", exc_info()[:2]
+
 		seekable = self.getSeek()
 		if seekable is None and int(self.seek.getLength()[1]) < 1:
 			return

--- a/po/de.po
+++ b/po/de.po
@@ -10024,10 +10024,11 @@ msgid "Zap mode"
 msgstr "Umschaltmodus"
 
 msgid "[TimeShift] - Merging records failed!"
-msgstr "[TimeShift] - Zusammenführen der Aufnahmen fehlgeschlagen!"
+msgstr "TimeShift - Zusammenführen der Aufnahmen fehlgeschlagen!"
 
 msgid "[TimeShift] - Restarting Timeshift!"
-msgstr "[TimeShift] - Timeshift-Neustart!"
+msgstr "Timeshift wird erneut gestartet !"
+
 
 msgid "Zap to selected channel"
 msgstr "Schalte zum ausgewählten Sender um"
@@ -10039,10 +10040,25 @@ msgid "Zoom Off..."
 msgstr "Zoom aus..."
 
 msgid "[TimeShift] Restarting Timeshift!"
-msgstr "[Timeshift] Timeshift erneut starten!"
+msgstr "Timeshift wird erneut gestartet !"
 
 msgid "[Timeshift] Merging records failed!"
-msgstr "[Timeshift] Zusammenfügen der Aufnahmen fehlgeschlagen!"
+msgstr "Timeshift - Zusammenfügen der Aufnahmen fehlgeschlagen!"
+
+msgid "Switching to live TV - timeshift is still active!"
+msgstr "Schalte auf Live-TV um - Timeshift bleibt weiterhin aktiv !"
+
+msgid "First playable timeshift file!"
+msgstr "Sie befinden sich am Anfang der ersten abspielbaren Timeshift-Datei !"
+
+msgid "Can't going to live TV!\nSwitch to live TV and restart Timeshift ?"
+msgstr "Es kann nicht zum Live-TV geschaltet werden !\nZum Live-TV schalten und Timeshift erneut starten ?"
+
+msgid "Can't play the next Timeshift file!\nSwitch to live TV and restart Timeshift ?"
+msgstr "Die nächste Timeshift-Datei kann nicht abgespielt werden !\nZum Live-TV schalten und Timeshift erneut starten ?"
+
+msgid "Can't play the previous timeshift file! You can try again."
+msgstr "Die vorherige Timeshift-Datei kann nicht abgespielt werden !\nSie können es noch einmal versuchen."
 
 msgid "[alternative edit]"
 msgstr "[Alternativen-Bearbeitung]"


### PR DESCRIPTION
…s, update de.po

---fixes---
- jump to live tv with number keys when config value 'event based file
splitting' is off and an event has changed
- enable manual start timehift before delay time for auto start
timeshift is over
- changed seek state when next event starts on some boxes
- frozen screen by endless timer loop when file change check fails
(driver or box problems)
- if timeshift activ and press 2 times key 'OK' playing again from the
beginning

---changed---
- jump with number keys in previous / next events and approximate
compliance of the jump distance
-> is the previous file length shorter than the jump, jump to the
beginning, at the next file jump to 10s before end
- jump to previous file with jump-key is new logic implement (similar to
marker in movie player)
-> first jump to begin of current file, press within 5 secs again jumps
to begin the previous file
-> the old method (jump and then seeking backwards) is only active when
seek from current in previous file
- if timeshift active (not permanent timeshift) and current in live tv -
comes message when switch to another service (if enabled in the options)
- state messages and ask user if a problem occurred (e.g. after 5 times
try to change file or switch to live tv)

++++++++++++++++++++

---Fehlerbehebung---
- Sprung zum live TV mit den Zahlentasten wenn die Option
'Sendungsbasierte Dateitrennung' auf aus steht und ein Sendungswechsel
stattgefunden hat
- man kann jetzt unabhängig der eingestellten Zeit 'Timeshift
automatisch starten in ...' manuell sofort starten
- bei machen Boxen änderte sich der Widergabestatus (von Pause auf Play)
bei einem Sendungswechsel
- eingefrorenes Bild durch wiederholende Versuche ins Live TV oder zu
vorherigen bzw. zur nächsten Datei zu springen (Treiber oder Box
Probleme)
- wenn Timeshift aktiv ist und 2 mal die 'OK' Taste gedrückt wurde
beginnt die Wiedergabe von vorn

---Änderungen---
- Dateiübergreifendens Springen mit den Nummertasten und ungefährer
Einhaltung der Sprungweite
-> ist die vorherige Datei kürzer als der Sprung wird zum Anfang
gesprungen, bei der nachfolgenden Datei wird bis 10s vor das Ende
gesprungen
- Änderung der Sprunglogik mit den Spungtasten ('<''>'), speziell der
Rücksprungfunktion (ähnlich wie bei den Markern im Movie-Player)
-> der erste Sprung führt zum Anfang der aktuellen Datei, wird innerhalb
von 5s erneut gesprungen kommt man an den Anfang der vorherigen Datei
-> die alte Methode (springen und dann zurückspulen) ist nur aktiv wenn
von der aktuellen in die vorherige Datei zurückgespult wird
- ist Timeshift aktiv (nicht permanet Timeshift) und man sich im live TV
befindet erfolgt auch die Abfrage ob Timeshift beendet werden soll wenn
auf ein anderes Programm geschaltet wird (sofern die Abfrage in den
Einstellungen aktiviert ist)
- Informationen und Benutzerrückfrage wenn ein Problem festgestellt wird
(z.Bsp. wenn nach 5 Versuchen kein Dateiwechsel oder der Sprung zum live
TV abgeschlossen ist)