### PR TITLE
Invalid ONID/TSID on 26.0E & 7.0E

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -113,6 +113,12 @@ int eDVBScan::isValidONIDTSID(int orbital_position, eOriginalNetworkID onid, eTr
 	case 32: // NSS 806 (40.5W) 4059R, 3774L
 		ret = orbital_position != 3195 || tsid != 21;
 		break;
+	case 126:  // 11221H and 11387H on Utelsat 7.0E with same ONID/TSID (126/40700)
+		ret = orbital_position != 70 || tsid != 40700;
+		break;
+	case 3622:  // 11881H and 12284V on Badr 26.0E with same ONID/TSID (3622/100)
+		ret = orbital_position != 260 || tsid != 100;
+		break;
 	default:
 		ret = onid.get() < 0xFF00;
 		break;


### PR DESCRIPTION
To overcome scanning conflict on TPs with same onid/tsid