### PR TITLE
Add possibility to set custom epgpid from whitch to grab epg data.

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -394,6 +394,31 @@ eEPGCache::eEPGCache()
 	         onid_blacklist.insert(onid_blacklist.end(),1,tmp_onid);
 	onid_file.close();
 
+	std::ifstream pid_file ("/etc/enigma2/epgpids.custom");
+	if (pid_file.is_open())
+	{
+		eDebug("[eEPGCache] Custom pidfile found, parsing ...");
+		std::string line;
+		char tmp_optsidonid[12];
+		int op, tsid, onid, eitpid;
+		while (!pid_file.eof())
+		{
+			getline(pid_file,line);
+			if (line[0] == '#' || sscanf(line.c_str(), "%i %i %i %i", &op, &tsid, &onid, &eitpid) != 4)
+				continue;
+			if (op < 0)
+				op += 3600;
+			if (eitpid != 0)
+			{
+				sprintf (tmp_optsidonid, "%x%04x%04x", op, tsid, onid);
+				customeitpids[std::string(tmp_optsidonid)] = eitpid;
+				eDebug("[eEPGCache] %s --> %#x", tmp_optsidonid, eitpid);
+			}
+		}
+		pid_file.close();
+		eDebug("[eEPGCache] Done");
+	}
+
 	ePtr<eDVBResourceManager> res_mgr;
 	eDVBResourceManager::getInstance(res_mgr);
 	if (!res_mgr)
@@ -1588,6 +1613,18 @@ void eEPGCache::channel_data::startEPG()
 #endif
 	mask.pid = 0x12;
 	mask.flags = eDVBSectionFilterMask::rfCRC;
+
+	eDVBChannelID chid = channel->getChannelID();
+	char optsidonid[8];
+	sprintf (optsidonid,"%x", chid.dvbnamespace.get());
+	optsidonid [strlen(optsidonid) - 4] = '\0';
+	sprintf (optsidonid, "%s%04x%04x", optsidonid, chid.transport_stream_id.get(), chid.original_network_id.get());
+	std::map<std::string,int>::iterator it = cache->customeitpids.find(std::string(optsidonid));
+	if (it != cache->customeitpids.end())
+	{
+		mask.pid = it->second;
+		eDebug("[eEPGCache] Using non standart pid %#x", mask.pid);
+	}
 
 	if (eEPGCache::getInstance()->getEpgSources() & eEPGCache::NOWNEXT)
 	{

--- a/lib/dvb/epgcache.h
+++ b/lib/dvb/epgcache.h
@@ -258,6 +258,7 @@ private:
 	unsigned int historySeconds;
 
 	std::vector<int> onid_blacklist;
+	std::map<std::string,int> customeitpids;
 	eventCache eventDB;
 	updateMap channelLastUpdated;
 	std::string m_filename;


### PR DESCRIPTION
This is very useful if epg data is send on 2 or more different pids or use non stardart one.

Usage:
Create a file "/etc/enigma2/epgpids.cusom" and fill in the format

Orbital position | TSID | ONID | Custom pid to use

The values ​​can be decimal or hexadecimal (0x ...), and combined
For orbital position using integers where 1 means 0,1 ° (19,2°E -> 192)
For orbital position can be used as negative numbers (0,8°W -> -8 or 3592)

examples:
390 17 28 299 # 39°E 12688V, epgpid to use: 299
0x186 0x11 0x1c 0x12b # Same, but in hexadecimal format
390 17 28 0x12b # Or combined