### PR TITLE
File size in GB with 2 digits when file is +1024MB

### DIFF
--- a/lib/python/Components/Converter/MovieInfo.py
+++ b/lib/python/Components/Converter/MovieInfo.py
@@ -55,6 +55,8 @@ class MovieInfo(Converter, object):
 				if filesize is not None:
 					if filesize >= 100000*1024*1024:
 						return _("%.0f GB") % (filesize / (1024.0*1024.0*1024.0))
+					elif filesize >= 100000*1024:
+						return _("%.2f GB") % (filesize / (1024.0*1024.0*1024.0))
 					else:
 						return _("%.0f MB") % (filesize / (1024.0*1024.0))
 		return ""


### PR DESCRIPTION
Shows the size of the file in gigabytes (with two digits for megabytes) when it is higher than 1024 MB. (E.g. 4.35GB)