### PR TITLE
SecondInfoBarECM available in all skins

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -294,7 +294,7 @@ class SecondInfoBar(Screen):
 
 	def __init__(self, session):
 		Screen.__init__(self, session)
-		if config.usage.show_second_infobar.value == "3" and (config.skin.primary_skin.value == "DMConcinnity-HD/skin.xml" or config.skin.primary_skin.value.startswith('MetrixHD/')):
+		if config.usage.show_second_infobar.value == "3":
 			self.skinName = "SecondInfoBarECM"
 		else:
 			self.skinName = "SecondInfoBar"


### PR DESCRIPTION
Allows any skin to use SecondInfoBarECM.
![1_0_19_1b1c_802_2_11a0000_0_0_0 1](https://cloud.githubusercontent.com/assets/9438117/14053768/f0637e8e-f2d3-11e5-947d-d097092f1b06.jpg)