### PR TITLE
Option to stop movie player with exit-button

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -210,7 +210,7 @@ def InitUsageConfig():
 	config.usage.next_movie_msg = ConfigYesNo(default = True)
 	config.usage.last_movie_played = ConfigText()
 	config.usage.leave_movieplayer_onExit = ConfigSelection(default = "no", choices = [
-		("no", _("No")), ("popup", _("With popup")), ("without popup", _("Without popup")) ])
+		("no", _("No")), ("popup", _("With popup")), ("without popup", _("Without popup")), ("stop", _("Behave like stop-button")) ])
 
 	config.usage.setup_level = ConfigSelection(default = "expert", choices = [
 		("simple", _("Simple")),

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -585,6 +585,8 @@ class MoviePlayer(InfoBarAspectSelection, InfoBarSimpleEventView, InfoBarBase, I
 			self.session.openWithCallback(self.leavePlayerOnExitCallback, MessageBox, _("Exit movie player?"), simple=True)
 		elif config.usage.leave_movieplayer_onExit.value == "without popup":
 			self.leavePlayerOnExitCallback(True)
+		elif config.usage.leave_movieplayer_onExit.value == "stop":
+			self.leavePlayer()
 
 	def leavePlayerOnExitCallback(self, answer):
 		if answer:


### PR DESCRIPTION
Option “Allow quit movie player with exit” was extended with new possible value “Behave like stop-button”. This allows to use exit-button just like stop-button. In particular when option “Behavior when a movie is stopped” is set to “Return to movie list” the button “Exit” returns to movie list too, which was not possible before (it could be configured to return to previous service but not to movie list). That's similar to how EMC behaves.

![leave_movieplayer_onexit_like-stop](https://cloud.githubusercontent.com/assets/3368402/15866971/5a9a4746-2ce1-11e6-8837-aa3659b2761b.png)
