### PR TITLE
hotkey for subtitle quick menu

### DIFF
--- a/lib/python/Screens/ButtonSetup.py
+++ b/lib/python/Screens/ButtonSetup.py
@@ -172,6 +172,7 @@ def getButtonSetupFunctions():
 	ButtonSetupFunctions.append((_("Start teletext"), "Infobar/startTeletext", "InfoBar"))
 	ButtonSetupFunctions.append((_("Show subservice selection"), "Infobar/subserviceSelection", "InfoBar"))
 	ButtonSetupFunctions.append((_("Show subtitle selection"), "Infobar/subtitleSelection", "InfoBar"))
+	ButtonSetupFunctions.append((_("Show subtitle quick menu"), "Infobar/subtitleQuickMenu", "InfoBar"))
 	ButtonSetupFunctions.append((_("Letterbox zoom"), "Infobar/vmodeSelection", "InfoBar"))
 	if SystemInfo["PIPAvailable"]:
 		ButtonSetupFunctions.append((_("Show PIP"), "Infobar/showPiP", "InfoBar"))

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -4770,6 +4770,16 @@ class InfoBarSubtitleSupport(object):
 		else:
 			return 0
 
+	def subtitleQuickMenu(self):
+		service = self.session.nav.getCurrentService()
+		subtitle = service and service.subtitle()
+		subtitlelist = subtitle and subtitle.getSubtitleList()
+		if self.selected_subtitle and self.selected_subtitle != (0,0,0,0):
+			from Screens.AudioSelection import QuickSubtitlesConfigMenu
+			self.session.open(QuickSubtitlesConfigMenu, self)
+		else:
+			self.subtitleSelection()
+
 	def __serviceChanged(self):
 		if self.selected_subtitle:
 			self.selected_subtitle = None


### PR DESCRIPTION
New function “Show subtitle quick menu” is now available in Hotkey setup. It shows subtitle quick menu directly. This menu is otherwise accessible via “Subtitle selection (Text-button) -> Subtitle Quickmenu (Red-button)” which requires more button clicks and shows unnecessary intermediate dialog. The subtitle quick menu is often useful to sync external subtitles in movie player and being able to show the quick menu directly is a big advantage.

Special case: if no subtitle stream is selected the function shows subtitle stream selection dialog.

**New function in hotkey dialog:**
![show-subtitle-quick-menu](https://cloud.githubusercontent.com/assets/3368402/15892091/2859b23e-2d78-11e6-9799-5199a0f7bdff.png)

**Subtitle quick menu:**
![subtitle-quick-menu](https://cloud.githubusercontent.com/assets/3368402/15892075/18455dd0-2d78-11e6-9fa9-b03bd11c2f8f.png)

### Usage example
I personally assigned the **Text-button** to the new function. The text-button by default shows **Subtitle selection**. Now if no subtitle stream is selected the "Subtitle selection"-dialog is shown too (as mentioned in the "special case" above) and I can choose subtitle stream, if necessary. Once a subtitle stream is selected the text-button works for "subtitle quick menu" where I can adjust subtitle delay; this is often necessary multiple times during watching movies as the external subtitles are sometimes go out of sync. In a rare case when I need the "subtile selection dialog" again (to choose another stream of disable subtitles) I use audio-button which brings "Audio selection dialog", then "Right" or "Left" buttons to switch to "Subtitle selection dialog". Therefore I don't miss the function which were previously assigned to Text-button.

It is of course possible to use another button for "Quick subtitle menu" and leave the standard function to Text-button.

----

As a side note: hotkeys do not work in EMC, therefore you should use default Movie Center, if you want the new function for quick subtitle menu.