### PR TITLE
extended range for external subtitle delay

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -665,7 +665,7 @@ def InitUsageConfig():
 	config.subtitles.subtitle_fontsize  = ConfigSelection(choices = ["%d" % x for x in range(16,101) if not x % 2], default = "40")
 
 	subtitle_delay_choicelist = []
-	for i in range(-900000, 1845000, 45000):
+	for i in range(-54000000, 54045000, 45000):
 		if i == 0:
 			subtitle_delay_choicelist.append(("0", _("No delay")))
 		else:

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -544,6 +544,13 @@ class QuickSubtitlesConfigMenu(ConfigListScreen, Screen):
 		{
 			"cancel": self.cancel,
 			"ok": self.ok,
+			"1": self.keyNumber,
+			"3": self.keyNumber,
+			"4": self.keyNumber,
+			"6": self.keyNumber,
+			"7": self.keyNumber,
+			"9": self.keyNumber,
+			"0": self.keyNumber,
 		},-2)
 
 		self.onLayoutFinish.append(self.layoutFinished)
@@ -551,6 +558,36 @@ class QuickSubtitlesConfigMenu(ConfigListScreen, Screen):
 	def layoutFinished(self):
 		if not self["videofps"].text:
 			self.instance.resize(eSize(self.instance.size().width(), self["config"].l.getItemSize().height()*len(self["config"].getList()) + 10))
+
+	def keyNumber(self, number):
+		menuEntry = getConfigMenuItem("config.subtitles.pango_subtitles_delay")
+		if self["config"].getCurrent() != menuEntry:
+			return
+		configItem = menuEntry[1]
+		delay = int(configItem.getValue())
+		minDelay = int(configItem.choices[0])
+		maxDelay = int(configItem.choices[len(configItem.choices) - 1])
+
+		if number == 1:
+			delay -= 45000 # -0.5sec
+		elif number == 3:
+			delay += 45000 # +0.5sec
+		elif number == 4:
+			delay -= 90000 * 5 # -5sec
+		elif number == 6:
+			delay += 90000 * 5 # +5sec
+		elif number == 7:
+			delay -= 90000 * 30 # -30sec
+		elif number == 9:
+			delay += 90000 * 30 # +30sec
+		elif number == 0:
+			delay = 0 # reset to "No delay"
+			
+		delay = min(max(delay, minDelay), maxDelay)
+
+		configItem.setValue(str(delay))
+		self["config"].invalidate(menuEntry)
+		self.wait.start(500, True)
 
 	def changedEntry(self):
 		if self["config"].getCurrent() in [getConfigMenuItem("config.subtitles.pango_subtitles_delay"),getConfigMenuItem("config.subtitles.pango_subtitles_fps")]:


### PR DESCRIPTION
Originally the range for external subtitle delay was “-10..+20 seconds”. When using subtitles from other releases it is sometimes necessary to adjust subtitles using larger offsets. For example releases may or may not include summary of previous episodes, which can easily take one or two minutes at the beginning of episode.

To solve the problem the range for the delay setting was extended to “-600..600 seconds”. Since the change step is just 0.5 seconds it was not comfortable to adjust large delays. In order to cope with such a large range of possible values the “quick subtitle menu”-dialog was extended to process numeric keys to switch between values with larger steps:
- "1" and "3" change delay -0.5 and +0.5 seconds respectively;
- "4" and "6" change delay -5 and +5 seconds;
- "7" and "9" change delay -30 and +30 seconds;
- “0” resets to “No delay”.