### PR TITLE
fixed external subtitle resync

### DIFF
--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -497,6 +497,9 @@ class QuickSubtitlesConfigMenu(ConfigListScreen, Screen):
 		self.wait = eTimer()
 		self.wait.timeout.get().append(self.resyncSubtitles)
 
+		self.resume = eTimer()
+		self.resume.timeout.get().append(self.resyncSubtitlesResume)
+
 		self["videofps"] = Label("")
 
 		sub = self.infobar.selected_subtitle
@@ -595,6 +598,9 @@ class QuickSubtitlesConfigMenu(ConfigListScreen, Screen):
 
 	def resyncSubtitles(self):
 		self.infobar.setSeekState(self.infobar.SEEK_STATE_PAUSE)
+		self.resume.start(100, True)
+
+	def resyncSubtitlesResume(self):
 		self.infobar.setSeekState(self.infobar.SEEK_STATE_PLAY)
 
 	def getFps(self):


### PR DESCRIPTION
After upgrading from OpenATV 4.2 to 5.3 I've found that changing of external subtitle delay (via quick subtitle menu) causes pausing of playback. That's how the effect appeared:
- make one change to delay - the playback pauses;
- make another change - the playback resumes;
- and go on.

When the delay is changed a special resync-routine pauses and then immediately resumes the player (this is necessary to reread subtitles):
```python
 	def resyncSubtitles(self):
 		self.infobar.setSeekState(self.infobar.SEEK_STATE_PAUSE)
 		self.infobar.setSeekState(self.infobar.SEEK_STATE_PLAY)
```
This code wasn't changed since v4.2, where it worked flawlessly. I guess the change of behavior is caused by the upgrade of GStreamer (from 0.10 to 1.x), which now probably cannot process pause and resume commands at once. 

I was able to fix the issue by introducing a small delay of 100 msec between the commands. A simple `time.pause(0.100)` in-between didn't work, even a larger delay of one second didn't work with "time.pause". The fix works however when using a timer object for the delay (see the code).

### Rationale
AFAIK GStreamer works on a low level with device drivers. Therefore it's is possible that not all devices are affected by the issue but my "Vu+ duo (first generation)" sure is. If other devices are not affected we could make the fix active only for specific devices but who have a list of all affected devices? Even for not affected devices the fix doesn't break things. It merely adds a small glitch (due to 100 sec delay) but it's totally OK and in any case a big improvement to the old v4.2 where the changing of subtitle delay caused a small rewind of 0.5-1 sec which was much more noticeable (but again that could be only on my device).