### PR TITLE
Long button press emulation

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -311,6 +311,7 @@
 		<item level="0" text="Select Yellow Key Action" description="Select what you want the YELLOW button to activate:">config.plugins.infopanel_yellowkey.list</item>
 		<item level="0" text="Select Yellow Key Action long" description="Select what you want the YELLOW-Long button to activate:">config.plugins.infopanel_yellowkey.listLong</item>
 		<item level="0" text="BlueSwitch: Blue-Short/Blue-Long" description="Switch Blue-Short (QuickMenu) with Blue-Long (Extensions)">config.workaround.blueswitch</item>
+		<item level="0" text="Long press emulation with button" description="Press this button to emulate a long press on a button pressed afterwards (this also overrides any other actions assigned to emulation button).">config.usage.long_press_emulation_key</item>
 		</setup>
 	<setup level="2" key="softcamsetup" title="Softcam settings">
 		<item level="2" text="Show CCcam in extensions ?" description="Allows you to show/hide CCcam in extensions (blue button).">config.cccaminfo.showInExtensions</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -11,6 +11,7 @@ from Components.ServiceList import refreshServiceList
 from SystemInfo import SystemInfo
 from Tools.HardwareInfo import HardwareInfo
 from boxbranding import getBoxType
+from keyids import KEYIDS
 
 def InitUsageConfig():
 	config.misc.useNTPminutes = ConfigSelection(default = "30", choices = [("30", "30" + " " +_("minutes")), ("60", _("Hour")), ("1440", _("Once per day"))])
@@ -229,6 +230,20 @@ def InitUsageConfig():
 	choicelist = [("show_menu", _("Show shutdown menu")), ("shutdown", _("Immediate shutdown")), ("standby", _("Standby")), ("sleeptimer", _("SleepTimer")), ("powertimerStandby", _("PowerTimer Standby")), ("powertimerDeepStandby", _("PowerTimer DeepStandby"))]
 	config.usage.on_long_powerpress = ConfigSelection(default = "show_menu", choices = choicelist)
 	config.usage.on_short_powerpress = ConfigSelection(default = "standby", choices = choicelist)
+
+	config.usage.long_press_emulation_key = ConfigSelection(default = "0", choices = [
+		("0", _("None")),
+		(str(KEYIDS["KEY_TV"]), _("TV")),
+		(str(KEYIDS["KEY_RADIO"]), _("Radio")),
+		(str(KEYIDS["KEY_AUDIO"]), _("Audio")),
+		(str(KEYIDS["KEY_VIDEO"]), _("List/Fav")),
+		(str(KEYIDS["KEY_HOME"]), _("Home")),
+		(str(KEYIDS["KEY_END"]), _("End")),
+		(str(KEYIDS["KEY_HELP"]), _("Help")),
+		(str(KEYIDS["KEY_INFO"]), _("Info (EPG)")),
+		(str(KEYIDS["KEY_TEXT"]), _("Teletext")),
+		(str(KEYIDS["KEY_SUBTITLE"]), _("Subtitle")),
+		(str(KEYIDS["KEY_FAVORITES"]), _("Favorites")) ])
 
 	choicelist = [("0", "Disabled")]
 	for i in (5, 30, 60, 300, 600, 900, 1200, 1800, 2700, 3600):

--- a/main/enigma.cpp
+++ b/main/enigma.cpp
@@ -16,6 +16,7 @@
 #include <lib/base/eerror.h>
 #include <lib/base/init.h>
 #include <lib/base/init_num.h>
+#include <lib/base/nconfig.h>
 #include <lib/gdi/gmaindc.h>
 #include <lib/gdi/glcddc.h>
 #include <lib/gdi/grc.h>
@@ -64,12 +65,34 @@ void keyEvent(const eRCKey &key)
 {
 	static eRCKey last(0, 0, 0);
 	static int num_repeat;
+	static int long_press_emulation_pushed = false;
+	static time_t long_press_emulation_start = 0;
 
 	ePtr<eActionMap> ptr;
 	eActionMap::getInstance(ptr);
 	/*eDebug("key.code : %02x \n", key.code);*/
 
-	if ((key.code == last.code) && (key.producer == last.producer) && key.flags & eRCKey::flagRepeat)
+	int flags = key.flags;
+	int long_press_emulation_key = eConfigManager::getConfigIntValue("config.usage.long_press_emulation_key");
+	if ((long_press_emulation_key > 0) && (key.code == long_press_emulation_key))
+	{
+		long_press_emulation_pushed = true;
+		long_press_emulation_start = time(NULL);
+		last = key;
+		return;
+	}
+
+	if (long_press_emulation_pushed && (time(NULL) - long_press_emulation_start < 10) && (key.producer == last.producer))
+	{
+		// emit make-event first
+		ptr->keyPressed(key.producer->getIdentifier(), key.code, key.flags);
+		// then setup condition for long-event
+		num_repeat = 3;
+		last = key;
+		flags = eRCKey::flagRepeat;
+	}
+
+	if ((key.code == last.code) && (key.producer == last.producer) && flags & eRCKey::flagRepeat)
 		num_repeat++;
 	else
 	{
@@ -89,7 +112,9 @@ void keyEvent(const eRCKey &key)
 		ptr->keyPressed(key.producer->getIdentifier(), 510 /* faked KEY_ASCII */, 0);
 	}
 	else
-		ptr->keyPressed(key.producer->getIdentifier(), key.code, key.flags);
+		ptr->keyPressed(key.producer->getIdentifier(), key.code, flags);
+
+	long_press_emulation_pushed = false;
 }
 
 /************************************************/


### PR DESCRIPTION
### What's this about
When setting up an universal remote control I've faced an inability of using long button presses in macros. Why would I want this? Because there is a number of functions (to setup by editing of keymap.xml or via Hotkey setup screen) which can be useful in macro sequences, such as "discrete power on" and "discrete power off" commands. Sacrificing one physical button for each function isn't practical. It's better to assign such functions to long presses. Only if we could execute them from macro sequences...

### Solution
To work around this problem I've added an emulation of long button presses via two normal (short) presses. One button on the remote must be defined for the long press emulation purpose (for example a rarely used `TV` or `Radio`). Then a normal (short) press on the emulation button followed by a normal (short) press on a second button emulates the long press on the second button.

There is a new setting “Long press emulation with button” on button setup screen to define the button for that purpose:

![1_0_1_2010_24b8_13e_820000_0_0_0](https://cloud.githubusercontent.com/assets/3368402/16506438/a4cc2d0e-3f22-11e6-989d-bdc8e954ac2c.png)

By default the setting is disabled (set to `None`).

If after pressing on the long emulation button no other button is pressed within 10 seconds the emulation state is canceled and a button pressed afterwards will be registered as a normal (short) press.

### Usage examples
In my case I've defined button `Radio` (which I didn't use anyway). Now to emulate a long click on blue button I can press (and release) `Radio`, then short press (and release) `Blue`. This sequence of two key presses can now be used in macros on the remote control.

A better (real life) example. By editing of keymap.xml I've defined two separate keys for "power on" and "power off". Since we are in shortage of remote keys defining of two separate buttons for the purpose were not a good idea. Instead I configured button `Home-long` to "power on" and `End-long` to "power off" and I use them in macros which start or shutdown all devices. The buttons `Home` and `End` can be used like before (or I can use them for other things).

### Summary
This feature significantly increases the number of commands which can be used in macros.