### PR TITLE
Audio-key fix

### DIFF
--- a/data/keymap.ntr
+++ b/data/keymap.ntr
@@ -266,32 +266,11 @@
 	</map>
 
 	<map context="InfobarAudioSelectionActions">
-		<device name="dreambox advanced remote control (native)">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="dreambox remote control (native)">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="gigablue remote control">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="OPTIMUSS OS2+ remote control (native)">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="OPTIMUSS OS1+ remote control (native)">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="remote control">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<key id="KEY_AUDIO" mapto="audio_key" flags="b" />
-		<key id="KEY_OPTION" mapto="audioSelection" flags="b" />
+		<key id="KEY_YELLOW" mapto="yellow_key" flags="b" />
+		<key id="KEY_YELLOW" mapto="yellow_key" flags="l" />
+		<key id="KEY_AUDIO" mapto="audioSelection" flags="b" />
+		<key id="KEY_AUDIO" mapto="audioSelectionLong" flags="l" />
+		<key id="KEY_OPTION" mapto="audioSelection" flags="m" />
 	</map>
 
 	<map context="InfobarAspectSelectionActions">

--- a/data/keymap.u80
+++ b/data/keymap.u80
@@ -221,9 +221,10 @@
 	</map>
 
 	<map context="InfobarAudioSelectionActions">
-		<key id="KEY_AUDIO" mapto="audio_key" flags="b" />
-		<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-		<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
+		<key id="KEY_YELLOW" mapto="yellow_key" flags="b" />
+		<key id="KEY_YELLOW" mapto="yellow_key" flags="l" />
+		<key id="KEY_AUDIO" mapto="audioSelection" flags="b" />
+		<key id="KEY_AUDIO" mapto="audioSelectionLong" flags="l" />
 	</map>
 
 	<map context="InfobarAspectSelectionActions">

--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -264,31 +264,10 @@
 	</map>
 
 	<map context="InfobarAudioSelectionActions">
-		<device name="dreambox advanced remote control (native)">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="dreambox remote control (native)">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="gigablue remote control">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="OPTIMUSS OS2+ remote control (native)">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="OPTIMUSS OS1+ remote control (native)">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>
-		<device name="remote control">
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="b" />
-			<key id="KEY_YELLOW" mapto="audioSelection" flags="l" />
-		</device>		
-		<key id="KEY_AUDIO" mapto="audio_key" flags="b" />
+		<key id="KEY_YELLOW" mapto="yellow_key" flags="b" />
+		<key id="KEY_YELLOW" mapto="yellow_key" flags="l" />
+		<key id="KEY_AUDIO" mapto="audioSelection" flags="b" />
+		<key id="KEY_AUDIO" mapto="audioSelectionLong" flags="l" />
 		<key id="KEY_OPTION" mapto="audioSelection" flags="m" />
 	</map>
 

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -3900,11 +3900,11 @@ class InfoBarAudioSelection:
 		self["AudioSelectionAction"] = HelpableActionMap(self, "InfobarAudioSelectionActions",
 			{
 				"audioSelection": (self.audioSelection, _("Audio options...")),
-				"audio_key": (self.audio_key, _("Audio options...")),
+				"yellow_key": (self.yellow_key, _("Audio options...")),
 				"audioSelectionLong": (self.audioSelectionLong, _("Toggle Digital downmix...")),
 			})
 
-	def audioSelection(self):
+	def yellow_key(self):
 		if not hasattr(self, "LongButtonPressed"):
 			self.LongButtonPressed = False
 		if not self.LongButtonPressed:
@@ -3938,7 +3938,7 @@ class InfoBarAudioSelection:
 				except:
 					pass
 				
-	def audio_key(self):
+	def audioSelection(self):
 		from Screens.AudioSelection import AudioSelection
 		self.session.openWithCallback(self.audioSelected, AudioSelection, infobar=self)
 


### PR DESCRIPTION
Fixed two things:

1.  audio-key in “audio selection screen” were supposed to switch between pages “audio selection” and “subtitle selection” but that did not work. The code for that was there but the key mapping was incorrect. Fixed:
 ![1_0_19_1b1d_802_2_11a0000_0_0_0](https://cloud.githubusercontent.com/assets/3368402/16531567/4db93ef2-3fcd-11e6-8b2f-a479b75f762d.png)

2. Long press on audio-key were supposed to toggle digital audio downmix, but that did not work either, for the same reason (key mapping issue), now it does:
 ![1_0_19_1b1c_802_2_11a0000_0_0_0](https://cloud.githubusercontent.com/assets/3368402/16531614/a21d49b6-3fcd-11e6-96f5-a6085d2bd9bb.png)