### PR TITLE
discrete commands to on/off digital downmix

### DIFF
--- a/lib/python/Screens/ButtonSetup.py
+++ b/lib/python/Screens/ButtonSetup.py
@@ -160,6 +160,8 @@ def getButtonSetupFunctions():
 	ButtonSetupFunctions.append((_("Show single service EPG"), "Infobar/openSingleServiceEPG", "EPG"))
 	ButtonSetupFunctions.append((_("Show multi channel EPG"), "Infobar/openMultiServiceEPG", "EPG"))
 	ButtonSetupFunctions.append((_("Show Audioselection"), "Infobar/audioSelection", "InfoBar"))
+	ButtonSetupFunctions.append((_("Enable digital downmix"), "Infobar/audioDownmixOn", "InfoBar"))
+	ButtonSetupFunctions.append((_("Disable digital downmix"), "Infobar/audioDownmixOff", "InfoBar"))
 	ButtonSetupFunctions.append((_("Switch to radio mode"), "Infobar/showRadio", "InfoBar"))
 	ButtonSetupFunctions.append((_("Switch to TV mode"), "Infobar/showTv", "InfoBar"))
 	ButtonSetupFunctions.append((_("Show servicelist or movies"), "Infobar/showServiceListOrMovies", "InfoBar"))

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -3945,7 +3945,7 @@ class InfoBarAudioSelection:
 	def audioSelected(self, ret=None):
 		print "[infobar::audioSelected]", ret
 
-	def audioSelectionLong(self):
+	def audioSelectionLong(self, popup = True):
 		if SystemInfo["CanDownmixAC3"] and self.LongButtonPressed:
 			if config.av.downmix_ac3.value:
 				message = _("Dolby Digital downmix is now") + " " + _("disabled")
@@ -3955,7 +3955,16 @@ class InfoBarAudioSelection:
 				config.av.downmix_ac3.setValue(True)
 				message = _("Dolby Digital downmix is now") + " " + _("enabled")
 				print '[Audio] Dolby Digital downmix is now enabled'
-			Notifications.AddPopup(text = message, type = MessageBox.TYPE_INFO, timeout = 5, id = "DDdownmixToggle")
+			if popup:
+				Notifications.AddPopup(text = message, type = MessageBox.TYPE_INFO, timeout = 5, id = "DDdownmixToggle")
+
+	def audioDownmixOn(self):
+		if not config.av.downmix_ac3.value:
+			self.audioSelectionLong(False)
+
+	def audioDownmixOff(self):
+		if config.av.downmix_ac3.value:
+			self.audioSelectionLong(False)
 
 class InfoBarSubserviceSelection:
 	def __init__(self):


### PR DESCRIPTION
Added two commands for hotkeys setup:

1. Enable digital downmix;

2. Disable digital downmix.

![1_0_19_1b1d_802_2_11a0000_0_0_0-2](https://cloud.githubusercontent.com/assets/3368402/16541945/a0cc3e38-4094-11e6-8869-fd61e8d98465.png)

These are discrete commands which change state of digital downmix setting when necessary or do nothing if the setting were in required state already.

### Usage example
I use these commands on an universal remote control in macro sequences **watch tv** (which among other things enables downmix; audio comes from TV) and **watch movie** (which among other things powers on AV-receiver and disables downmix). Discrete commands are required to ensure the downmix option is set correctly regardless of its previous state.