### PR TITLE
addition to #401: fix for short key presses

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -3901,7 +3901,7 @@ class InfoBarAudioSelection:
 			{
 				"audioSelection": (self.audioSelection, _("Audio options...")),
 				"yellow_key": (self.yellow_key, _("Audio options...")),
-				"audioSelectionLong": (self.audioSelectionLong, _("Toggle Digital downmix...")),
+				"audioSelectionLong": (self.audioDownmixToggle, _("Toggle Digital downmix...")),
 			})
 
 	def yellow_key(self):
@@ -3945,8 +3945,8 @@ class InfoBarAudioSelection:
 	def audioSelected(self, ret=None):
 		print "[infobar::audioSelected]", ret
 
-	def audioSelectionLong(self, popup = True):
-		if SystemInfo["CanDownmixAC3"] and self.LongButtonPressed:
+	def audioDownmixToggle(self, popup = True):
+		if SystemInfo["CanDownmixAC3"]:
 			if config.av.downmix_ac3.value:
 				message = _("Dolby Digital downmix is now") + " " + _("disabled")
 				print '[Audio] Dolby Digital downmix is now disabled'
@@ -3960,11 +3960,11 @@ class InfoBarAudioSelection:
 
 	def audioDownmixOn(self):
 		if not config.av.downmix_ac3.value:
-			self.audioSelectionLong(False)
+			self.audioDownmixToggle(False)
 
 	def audioDownmixOff(self):
 		if config.av.downmix_ac3.value:
-			self.audioSelectionLong(False)
+			self.audioDownmixToggle(False)
 
 class InfoBarSubserviceSelection:
 	def __init__(self):


### PR DESCRIPTION
This is a follow-up to #401.

Fixed: hotkeys with short key presses did not work with new discrete commands for digital downmix on/off.