### PR TITLE
 Invalid ONID/TSID (126/30300) on 7.0E

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -113,8 +113,8 @@ int eDVBScan::isValidONIDTSID(int orbital_position, eOriginalNetworkID onid, eTr
 	case 32: // NSS 806 (40.5W) 4059R, 3774L
 		ret = orbital_position != 3195 || tsid != 21;
 		break;
-	case 126:  // 11221H and 11387H on Utelsat 7.0E with same ONID/TSID (126/40700)
-		ret = orbital_position != 70 || tsid != 40700;
+	case 126:  // 11221H and 11387H on Utelsat 7.0E with same ONID/TSID (126/40700) and 11304H, 11262H (126/30300) 
+		ret = orbital_position != 70 || (tsid != 40700 && tsid !=30300);
 		break;
 	case 3622:  // 11881H and 12284V on Badr 26.0E with same ONID/TSID (3622/100)
 		ret = orbital_position != 260 || tsid != 100;


### PR DESCRIPTION
Adding another invalid ONID/TSID (126/30300) for TPs 11304H and 11262H on 7.0E to overcome the TPscan overwrite.