### PR TITLE
epgcache.cpp: do not save cache on MHW2

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -4541,10 +4541,7 @@ void eEPGCache::channel_data::readMHWData(const uint8_t *data)
 	if ( m_MHWReader )
 		m_MHWReader->stop();
 	if (haveData)
-	{
 		finishEPG();
-		cache->save();
-	}
 }
 
 void eEPGCache::channel_data::readMHWData2(const uint8_t *data)
@@ -4971,10 +4968,7 @@ abort:
 	if ( m_MHWReader2 )
 		m_MHWReader2->stop();
 	if (haveData)
-	{
 		finishEPG();
-		cache->save();
-	}
 }
 
 void eEPGCache::channel_data::readMHWData2_old(const uint8_t *data)


### PR DESCRIPTION
Save mhw(new)-epg after update can cause segfault.
Cache must be saved on exit or by external call.

It solves segfault when try to update mhw-epg from SID 30150
and EPG is set to 4 or more days.