### PR TITLE
HDMICEC - additional key mappings for RegzaLink

### DIFF
--- a/lib/driver/hdmi_cec.cpp
+++ b/lib/driver/hdmi_cec.cpp
@@ -239,7 +239,7 @@ void eHdmiCEC::hdmiEvent(int what)
 			static unsigned char pressedkey = 0;
 			static unsigned int data_idx = 0;
 
-			eDebugNoNewLineStart("eHdmiCEC_: received message");
+			eDebugNoNewLineStart("eHdmiCEC: received message");
 			for (int i = 0; i < rxmessage.length; i++)
 			{
 				eDebugNoNewLine(" %02X", rxmessage.data[i]);

--- a/lib/driver/hdmi_cec.cpp
+++ b/lib/driver/hdmi_cec.cpp
@@ -237,21 +237,31 @@ void eHdmiCEC::hdmiEvent(int what)
 		{
 			bool keypressed = false;
 			static unsigned char pressedkey = 0;
+			static unsigned int data_idx = 0;
 
 			eDebugNoNewLineStart("eHdmiCEC_: received message");
 			for (int i = 0; i < rxmessage.length; i++)
 			{
 				eDebugNoNewLine(" %02X", rxmessage.data[i]);
+				switch (rxmessage.data[i])
+				{
+					case 0x44: /* key pressed */
+						data_idx = i;
+						break;
+					case 0x45: /* key released */
+						data_idx = i;
+						break;	
+				}
 			}
 			eDebugNoNewLineEnd(" ");
 			bool hdmicec_report_active_menu = eConfigManager::getConfigBoolValue("config.hdmicec.report_active_menu", false);
 			if (hdmicec_report_active_menu)
 			{
-				switch (rxmessage.data[0])
+				switch (rxmessage.data[data_idx])
 				{
 					case 0x44: /* key pressed */
 						keypressed = true;
-						pressedkey = rxmessage.data[1];
+						pressedkey = rxmessage.data[data_idx+1];
 					case 0x45: /* key released */
 					{
 						long code = translateKey(pressedkey);
@@ -264,7 +274,7 @@ void eHdmiCEC::hdmiEvent(int what)
 					}
 				}
 			}
-			ePtr<iCECMessage> msg = new eCECMessage(rxmessage.address, rxmessage.data[0], (char*)&rxmessage.data[1], rxmessage.length);
+			ePtr<iCECMessage> msg = new eCECMessage(rxmessage.address, rxmessage.data[data_idx], (char*)&rxmessage.data[data_idx+1], rxmessage.length);
 			messageReceived(msg);
 		}
 	}

--- a/lib/driver/hdmi_cec.cpp
+++ b/lib/driver/hdmi_cec.cpp
@@ -411,6 +411,9 @@ long eHdmiCEC::translateKey(unsigned char code)
 		case 0x4a:		/* KEY_EJECTCD */
 			key = 0x172;
 			break;
+		case 0x0b:		/* KEY_CONTEXT_MENU */
+			key = 0x1b6;
+			break;
 		default:
 			key = 0x8b;
 			break;

--- a/lib/driver/hdmi_cec.cpp
+++ b/lib/driver/hdmi_cec.cpp
@@ -412,7 +412,7 @@ long eHdmiCEC::translateKey(unsigned char code)
 	}
 	return key;
 }
-int eHdmiCEC::getPressedIndex(struct rxmessage)
+int eHdmiCEC::getPressedIndex(rxmessage)
 {
 	for (int i = 0; i < rxmessage.length; i++)
 	{

--- a/lib/driver/hdmi_cec.cpp
+++ b/lib/driver/hdmi_cec.cpp
@@ -380,8 +380,26 @@ long eHdmiCEC::translateKey(unsigned char code)
 		case 0x74:
 			key = 0x190;
 			break;
-		case 0x40:
+		case 0x40:		/* KEY_POWER */
 			key = 0x74;
+			break;
+		case 0x11:		/* KEY_DVD_MENU */
+			key = 0x8b;
+			break;
+		case 0x10:		/* KEY_TOP_MENU */
+			key = 0x16d;
+			break;
+		case 0x0a:		/* KEY_SETUP */
+			key = 0x8d;
+			break;
+		case 0x33:		/* KEY_SOUND */
+			key = 0xd5;
+			break;
+		case 0x35:		/* KEY_INFO */
+			key = 0x166;
+			break;
+		case 0x4a:		/* KEY_EJECTCD */
+			key = 0x172;
 			break;
 		default:
 			key = 0x8b;

--- a/lib/driver/hdmi_cec.cpp
+++ b/lib/driver/hdmi_cec.cpp
@@ -243,20 +243,12 @@ void eHdmiCEC::hdmiEvent(int what)
 			for (int i = 0; i < rxmessage.length; i++)
 			{
 				eDebugNoNewLine(" %02X", rxmessage.data[i]);
-				switch (rxmessage.data[i])
-				{
-					case 0x44: /* key pressed */
-						data_idx = i;
-						break;
-					case 0x45: /* key released */
-						data_idx = i;
-						break;	
-				}
 			}
 			eDebugNoNewLineEnd(" ");
 			bool hdmicec_report_active_menu = eConfigManager::getConfigBoolValue("config.hdmicec.report_active_menu", false);
 			if (hdmicec_report_active_menu)
 			{
+				data_idx = getPressedIndex(rxmessage);
 				switch (rxmessage.data[data_idx])
 				{
 					case 0x44: /* key pressed */
@@ -420,7 +412,24 @@ long eHdmiCEC::translateKey(unsigned char code)
 	}
 	return key;
 }
-
+int eHdmiCEC::getPressedIndex(struct rxmessage)
+{
+	for (int i = 0; i < rxmessage.length; i++)
+	{
+		if(rxmessage.data[i] == 0x44)
+		{
+			idx = i;
+			break;
+		}
+		
+		if(rxmessage.data[i] == 0x45)
+		{
+			idx = i;
+			break;
+		}
+	}
+	return idx;
+}
 void eHdmiCEC::sendMessage(struct cec_message &message)
 {
 	if (hdmiFd >= 0)

--- a/lib/driver/hdmi_cec.cpp
+++ b/lib/driver/hdmi_cec.cpp
@@ -238,7 +238,7 @@ void eHdmiCEC::hdmiEvent(int what)
 			bool keypressed = false;
 			static unsigned char pressedkey = 0;
 
-			eDebugNoNewLineStart("eHdmiCEC: received message");
+			eDebugNoNewLineStart("eHdmiCEC_: received message");
 			for (int i = 0; i < rxmessage.length; i++)
 			{
 				eDebugNoNewLine(" %02X", rxmessage.data[i]);
@@ -379,6 +379,9 @@ long eHdmiCEC::translateKey(unsigned char code)
 			break;
 		case 0x74:
 			key = 0x190;
+			break;
+		case 0x40:
+			key = 0x74;
 			break;
 		default:
 			key = 0x8b;


### PR DESCRIPTION
I've added few more key mappings recorded by my RegzaLink remote. I guess that some of them are part of a standard. 

To handle messages like: A0 00 00 39 44 10 (eHdmiCEC_: received message A0 00 00 39 44 10) I have to modified couple of lines with hardcoded index. Please check them as I don't know C++ ;-)