### PR TITLE
EPGSelection - fix indentionError introduced in #478

### DIFF
--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -1774,4 +1774,4 @@ class EPGSelection(Screen, HelpableScreen):
 class SingleEPG(EPGSelection):
 	def __init__(self, session, service, EPGtype="single"):
 		EPGSelection.__init__(self, session, service=service, EPGtype=EPGtype)
-               self.skinName = 'EPGSelection'
+		self.skinName = 'EPGSelection'


### PR DESCRIPTION
17:38:16.784 Traceback (most recent call last):
17:38:16.784   File "/usr/lib/enigma2/python/mytest.py", line 26, in <module>
17:38:16.785     from Screens import InfoBar
17:38:16.785   File "/usr/lib/enigma2/python/Screens/InfoBar.py", line 4, in <module>
17:38:16.785   File "/usr/lib/enigma2/python/Screens/MovieSelection.py", line 342, in <module>
17:38:16.785   File "/usr/lib/enigma2/python/Screens/ParentalControlSetup.py", line 10, in <module>
17:38:16.786   File "/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 21, in <module>
17:38:16.786   File "/usr/lib/enigma2/python/Screens/EpgSelection.py", line 1777
17:38:16.786     self.skinName = 'EPGSelection'
17:38:16.787                                  ^
17:38:16.787 IndentationError: unindent does not match any outer indentation level