### PR TITLE
Fix SNR for Vuplus DVB-S NIM(AVL6222) (DVB-S2)

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -996,6 +996,8 @@ void eDVBFrontend::calculateSignalQuality(int snr, int &signalquality, int &sign
 		) // VU+
 	{
 		ret = (int)((((double(snr) / (65536.0 / 100.0)) * 0.1244) + 2.5079) * 100);
+		if (!strcmp(m_description, "Vuplus DVB-S NIM(AVL6222)"))
+			sat_max = 1490;
 	}
 	else if (!strcmp(m_description, "BCM7356 DVB-S2 NIM (internal)")) // VU+ Solo2
 	{


### PR DESCRIPTION
SNR fix for Vuplus DVB-S NIM(AVL6222) (DVB-S2) with a maximum of 14.9 dB.