### PR TITLE
Renaming Channel to Audio Channel in AudioSelection

### DIFF
--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -133,7 +133,7 @@ class AudioSelection(Screen, ConfigListScreen):
 					choicelist = [("0",_("left")), ("1",_("stereo")), ("2", _("right"))]
 					self.settings.channelmode = ConfigSelection(choices = choicelist, default = str(self.audioChannel.getCurrentChannel()))
 					self.settings.channelmode.addNotifier(self.changeMode, initial_call = False)
-					conflist.append(getConfigListEntry(_("Channel"), self.settings.channelmode, None))
+					conflist.append(getConfigListEntry(_("Audio Channel"), self.settings.channelmode, None))
 				selectedAudio = self.audioTracks.getCurrentTrack()
 				for x in range(n):
 					number = str(x + 1)


### PR DESCRIPTION
Renaming `Channel` to `Audio Channel` as its badly named, because the naming is used for more than 1 function.
For example this `Channel`  refers to the `Audio Channel`, and in the add Timer section it refers to the `TV channel`.

(Another alternative would be to add a space at the end of the name to allow 2 translation strings, but i think `Audio Channel` better reflects the function anyway.)