### PR TITLE
[Satconfig.py] fix typo "advanced" / same as line 102 "Advanced"

### DIFF
--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -108,7 +108,7 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				choices["loopthrough"] = _("Loop through to")
 			if isFBCLink(self.nim):
 				choices = { "nothing": _("not configured"),
-						"advanced": _("advanced")}
+						"advanced": _("Advanced")}
 			if self.nim.isMultiType():
 				self.nimConfig.dvbs.configMode.setChoices(choices, default = "nothing")
 			else:


### PR DESCRIPTION
so we don´t need another translation