### PR TITLE
Modified resolution recognised as 4K

### DIFF
--- a/lib/python/Components/Converter/ServiceInfo.py
+++ b/lib/python/Components/Converter/ServiceInfo.py
@@ -170,7 +170,7 @@ class ServiceInfo(Converter, object):
 		elif self.type == self.IS_SD:
 			return video_height < 720
 		elif self.type == self.IS_HD:
-			return video_height >= 720 and video_height < 2160
+			return video_height >= 720 and video_height < 2151
 		elif self.type == self.IS_1080:
 			return video_height > 1000 and video_height <= 1080
 		elif self.type == self.IS_720:
@@ -180,7 +180,7 @@ class ServiceInfo(Converter, object):
 		elif self.type == self.IS_480:
 			return video_height > 0 and video_height <= 480
 		elif self.type == self.IS_4K:
-			return video_height >= 2160
+			return video_height > 2152 and video_height <= 2160
 		return False
 
 	boolean = property(getBoolean)


### PR DESCRIPTION
Would it be acceptable to allow 2152-2160 as 4K?
On Astra1 19.2 is a UHD channel broadcasting in 3840x2152. Currently its not recognised as a 4K channel.
http://www.satindex.de/frequenz/10714/