### PR TITLE
A lot of extra changes.

### DIFF
--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -308,6 +308,7 @@ private:
 	bool m_subtitles_paused;
 	bool m_use_prefillbuffer;
 	bool m_paused;
+	bool m_first_paused;
 	/* cuesheet load check */
 	bool m_cuesheet_loaded;
 	/* servicemMP3 chapter TOC support CVR */
@@ -315,7 +316,6 @@ private:
 	bool m_use_chapter_entries;
 	/* last used seek position gst-1 only */
 	gint64 m_last_seek_pos;
-	gint64 m_last_play_pos;
 	gint64 m_media_lenght;
 #endif
 	bufferInfo m_bufferInfo;


### PR DESCRIPTION
 Adapted to use new properties e2-asyn and e2-sync.
 Stopped the unneeded flush at media start after async completed.
 Corrected subtitle dificult start up on suvtitle change.
 Corrected use of cuts file. Now 100 % ok without emc.
 Emc can now be adapted to not use cuts file anymore for,
 resumepoints .
 Requires the very last dvbmediasink openatv-dev

	modified:   lib/service/servicemp3.cpp
	modified:   lib/service/servicemp3.h