### PR TITLE
UTF-8 special characters now working

### DIFF
--- a/lib/python/Components/Converter/TextCase.py
+++ b/lib/python/Components/Converter/TextCase.py
@@ -18,9 +18,9 @@ class TextCase(Converter):
 	def getText(self):
 		originaltext = self.source.getText()
 		if self.type == self.UPPER:
-			return originaltext.upper()
+			return originaltext.decode('utf-8').upper().encode('utf-8')
 		elif self.type == self.LOWER:
-			return originaltext.lower()
+			return originaltext.decode('utf-8').lower().encode('utf-8')
 		else:
 			return originaltext
 


### PR DESCRIPTION
This allows UTF-8 special characters (é, ç, ñ, etc...) to be turned into upper or lower case.