### PR TITLE
Standby.py - Add possibility to run a Script when Entering/Leaving Standby

### DIFF
--- a/lib/python/Screens/Standby.py
+++ b/lib/python/Screens/Standby.py
@@ -9,9 +9,11 @@ from enigma import eDVBVolumecontrol, eTimer, eDVBLocalTimeHandler, eServiceRefe
 from boxbranding import getMachineBrand, getMachineName, getBoxType, getBrandOEM
 from Tools import Notifications
 from time import localtime, time
+from os import path, system
 import Screens.InfoBar
 from gettext import dgettext
 import Components.RecordingConfig
+import os
 
 inStandby = None
 
@@ -26,6 +28,10 @@ def setLCDModeMinitTV(value):
 class Standby2(Screen):
 	def Power(self):
 		print "[Standby] leave standby"
+		
+		if os.path.exists("/usr/script/StandbyLeave.sh"):
+			os.system("/usr/script/StandbyLeave.sh &")
+
 		if (getBrandOEM() in ('fulan')):
 			open("/proc/stb/hdmi/output", "w").write("on")
 		#set input to encoder
@@ -57,6 +63,9 @@ class Standby2(Screen):
 		self.avswitch = AVSwitch()
 
 		print "[Standby] enter standby"
+
+		if os.path.exists("/usr/script/StandbyEnter.sh"):
+			os.system("/usr/script/StandbyEnter.sh &")
 
 		self["actions"] = ActionMap( [ "StandbyActions" ],
 		{


### PR DESCRIPTION
Scripts must be located under /usr/script and Scripts must have permissions to execute (chmod 755).

/usr/script/StandbyLeave.sh (Script is used, when leaving Standby)
/usr/script/StandbyEnter.sh (Script is used, when entering Standby)

Thanks to arn354 for the code/changes in OpenMips:
https://github.com/openmips/stbgui/commit/53bd3ef93bbd6e264ee572ce9ff0a2ae27d4681f