### PR TITLE
[UsageConfig.py] workaround to show Cover in LCD-Displays

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -85,6 +85,10 @@ def InitUsageConfig():
 	config.usage.numberzap_show_servicename = ConfigYesNo(default = False)
 #####################################################
 
+#########  Workaround for Cover in LCD-Displays   ##############
+	config.usage.movielist_show_cover = ConfigYesNo(default = True)
+################################################################
+
 	config.usage.panicbutton = ConfigYesNo(default = False)
 	config.usage.panicchannel = ConfigInteger(default = 1, limits=(1,5000) )
 	config.usage.quickzap_bouquet_change = ConfigYesNo(default = False)


### PR DESCRIPTION
https://github.com/openatv/enigma2/blob/DEV/lib/python/Components/Renderer/Cover.py#L21