### PR TITLE
[Picon] Different IPTV/Service types 

### DIFF
--- a/lib/python/Components/Renderer/LcdPicon.py
+++ b/lib/python/Components/Renderer/LcdPicon.py
@@ -88,7 +88,7 @@ def getLcdPiconName(serviceName):
 		fields = sname.split('_', 3)
 		if len(fields) > 2 and fields[2] != '1': #fallback to 1 for services with different service types
 			fields[2] = '1'
-		if len(fields) > 0 and fields[0] == '4097': #fallback to 1 for IPTV streams
+		if len(fields) > 0 and fields[0] != '1': #fallback to 1 for IPTV streams
 			fields[0] = '1'
 		pngname = findLcdPicon('_'.join(fields))
 	if not pngname: # picon by channel name

--- a/lib/python/Components/Renderer/LcdPicon.py
+++ b/lib/python/Components/Renderer/LcdPicon.py
@@ -86,7 +86,7 @@ def getLcdPiconName(serviceName):
 	pngname = findLcdPicon(sname)
 	if not pngname:
 		fields = sname.split('_', 3)
-		if len(fields) > 2 and fields[2] != '2': #fallback to 1 for tv services with nonstandard servicetypes
+		if len(fields) > 2 and fields[2] != '1': #fallback to 1 for services with different service types
 			fields[2] = '1'
 		if len(fields) > 0 and fields[0] == '4097': #fallback to 1 for IPTV streams
 			fields[0] = '1'

--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -81,7 +81,7 @@ def getPiconName(serviceName):
 	pngname = findPicon(sname)
 	if not pngname:
 		fields = sname.split('_', 3)
-		if len(fields) > 2 and fields[2] != '2': #fallback to 1 for tv services with nonstandard servicetypes
+		if len(fields) > 2 and fields[2] != '1': #fallback to 1 for services with different service types
 			fields[2] = '1'
 		if len(fields) > 0 and fields[0] == '4097': #fallback to 1 for IPTV streams
 			fields[0] = '1'

--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -83,7 +83,7 @@ def getPiconName(serviceName):
 		fields = sname.split('_', 3)
 		if len(fields) > 2 and fields[2] != '1': #fallback to 1 for services with different service types
 			fields[2] = '1'
-		if len(fields) > 0 and fields[0] == '4097': #fallback to 1 for IPTV streams
+		if len(fields) > 0 and fields[0] != '1': #fallback to 1 for IPTV streams
 			fields[0] = '1'
 		pngname = findPicon('_'.join(fields))
 	if not pngname: # picon by channel name


### PR DESCRIPTION
Flexibility with service types in picons. In essence radio

This also allows for IPTV services starting with something different to 4097, ( more correctly different to 1).  

This will partly address following issue:
https://github.com/openatv/enigma2/issues/707

 