### PR TITLE
[NimManager] Use name in xml file, not position number.

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -2021,10 +2021,10 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.scan_networkid
 		except:
-			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.cablesList)]
+			list = [(x[0], x[0]) for x in nimmgr.cablesList]
 			nim.scan_networkid = ConfigInteger(default = 0, limits = (0, 99999))
 			possible_scan_types = [("bands", _("Frequency bands")), ("steps", _("Frequency steps"))]
-			if n:
+			if list:
 				possible_scan_types.append(("provider", _("Provider")))
 				nim.scan_provider = ConfigSelection(default = "0", choices = list)
 			nim.scan_type = ConfigSelection(default = "provider", choices = possible_scan_types)
@@ -2055,7 +2055,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.terrestrial
 		except:
-			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.terrestrialsList)]
+			list = [(x[0], x[0]) for x in nimmgr.terrestrialsList]
 			nim.terrestrial = ConfigSelection(choices = list)
 			nim.terrestrial_5V = ConfigOnOff()
 
@@ -2063,7 +2063,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.atsc
 		except:
-			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.atscList)]
+			list = [(x[0], x[0]) for x in nimmgr.atscList]
 			nim.atsc = ConfigSelection(choices = list)
 
 	try:

--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -2021,7 +2021,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.scan_networkid
 		except:
-			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.cablesList)]
+			list = [(x[0], x[0]) for x in nimmgr.cablesList]
 			nim.scan_networkid = ConfigInteger(default = 0, limits = (0, 99999))
 			possible_scan_types = [("bands", _("Frequency bands")), ("steps", _("Frequency steps"))]
 			if n:
@@ -2055,7 +2055,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.terrestrial
 		except:
-			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.terrestrialsList)]
+			list = [(x[0], x[0]) for x in nimmgr.terrestrialsList]
 			nim.terrestrial = ConfigSelection(choices = list)
 			nim.terrestrial_5V = ConfigOnOff()
 
@@ -2063,7 +2063,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.atsc
 		except:
-			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.atscList)]
+			list = [(x[0], x[0]) for x in nimmgr.atscList]
 			nim.atsc = ConfigSelection(choices = list)
 
 	try:

--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -2021,7 +2021,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.scan_networkid
 		except:
-			list = [(x[0], x[0]) for x in nimmgr.cablesList]
+			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.cablesList)]
 			nim.scan_networkid = ConfigInteger(default = 0, limits = (0, 99999))
 			possible_scan_types = [("bands", _("Frequency bands")), ("steps", _("Frequency steps"))]
 			if n:
@@ -2055,7 +2055,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.terrestrial
 		except:
-			list = [(x[0], x[0]) for x in nimmgr.terrestrialsList]
+			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.terrestrialsList)]
 			nim.terrestrial = ConfigSelection(choices = list)
 			nim.terrestrial_5V = ConfigOnOff()
 
@@ -2063,7 +2063,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.atsc
 		except:
-			list = [(x[0], x[0]) for x in nimmgr.atscList]
+			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.atscList)]
 			nim.atsc = ConfigSelection(choices = list)
 
 	try:

--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -2021,11 +2021,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.scan_networkid
 		except:
-			list = [ ]
-			n = 0
-			for x in nimmgr.cablesList:
-				list.append((str(n), x[0]))
-				n += 1
+			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.cablesList)]
 			nim.scan_networkid = ConfigInteger(default = 0, limits = (0, 99999))
 			possible_scan_types = [("bands", _("Frequency bands")), ("steps", _("Frequency steps"))]
 			if n:
@@ -2059,11 +2055,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			nim.terrestrial
 		except:
-			list = []
-			n = 0
-			for x in nimmgr.terrestrialsList:
-				list.append((str(n), x[0]))
-				n += 1
+			list = [(str(n), x[0]) for n, x in enumerate(nimmgr.terrestrialsList)]
 			nim.terrestrial = ConfigSelection(choices = list)
 			nim.terrestrial_5V = ConfigOnOff()
 


### PR DESCRIPTION
Deal with issue #759 

At the moment, the entry in settings file uses the position number within the xml file.  As an example, settings file contains ```config.Nims.1.dvbt.terrestrial=70```
If the order changes or another provider is added, the position number obviously changes and users are unwittingly using a different provider.

This is what the pull request will achieve.
```
config.Nims.1.dvbt.terrestrial=Crystal Palace, London (Europe DVB-T/T2)
```

There will be a need to re-save cable/terrestrial config after this commit. Small loss for future robustness.