### PR TITLE
FullDescription widget in SecondInfobar

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -503,6 +503,7 @@ class SecondInfoBar(Screen):
 		text = description + extended
 		self.setTitle(event.getEventName())
 		self["epg_description"].setText(text)
+		self["FullDescription"].setText(extended)
 		serviceref = self.currentService
 		eventid = self.event.getEventId()
 		refstr = serviceref.ref.toString()


### PR DESCRIPTION
This commit allows to use "FullDescription" widget in SecondInfobar screen.
e.g. <widget name="FullDescription"...