### PR TITLE
[lcd.py] fix set LCDModeMinitTV at the start of the box

### DIFF
--- a/lib/python/Components/Lcd.py
+++ b/lib/python/Components/Lcd.py
@@ -320,6 +320,7 @@ def InitLcd():
 		if can_lcdmodechecking:
 			def setLCDModeMinitTV(configElement):
 				try:
+					print 'setLCDModeMinitTV',configElement.value
 					f = open("/proc/stb/lcd/mode", "w")
 					f.write(configElement.value)
 					f.close()
@@ -327,6 +328,7 @@ def InitLcd():
 					pass
 			def setMiniTVFPS(configElement):
 				try:
+					print 'setMiniTVFPS',configElement.value
 					f = open("/proc/stb/lcd/fps", "w")
 					f.write("%d \n" % configElement.value)
 					f.close()
@@ -517,7 +519,7 @@ def InitLcd():
 			config.lcd.showTv = ConfigYesNo(default = False)
 			config.lcd.showTv.addNotifier(lcdLiveTvChanged)
 
-		if SystemInfo["LCDMiniTV"]:
+		if SystemInfo["LCDMiniTV"] and config.misc.boxtype.value not in ( 'gbquad', 'gbquadplus', 'gbquad4k', 'gbue4k'):
 			config.lcd.minitvmode = ConfigSelection([("0", _("normal")), ("1", _("MiniTV")), ("2", _("OSD")), ("3", _("MiniTV with OSD"))], "0")
 			config.lcd.minitvmode.addNotifier(setLCDminitvmode)
 			config.lcd.minitvpipmode = ConfigSelection([("0", _("off")), ("5", _("PIP")), ("7", _("PIP with OSD"))], "0")


### PR DESCRIPTION
Damit wird auch beim Starten der Box der richtig LCDMiniTVMode bei den Gigablues gesetzt, bzw. nicht durch den anderen Aufruf
>> config.lcd.minitvmode.addNotifier(setLCDminitvmode) <<
wieder auf "0" gesetzt.