### PR TITLE
[MediaPlayer] fixes a crash when activating the dvb-subtitles

### DIFF
--- a/lib/python/Plugins/Extensions/MediaPlayer/plugin.py
+++ b/lib/python/Plugins/Extensions/MediaPlayer/plugin.py
@@ -103,6 +103,7 @@ class MediaPlayerInfoBar(Screen):
 class MediaPlayer(Screen, InfoBarBase, InfoBarScreenSaver, InfoBarSeek, InfoBarAudioSelection, InfoBarAspectSelection, InfoBarCueSheetSupport, InfoBarNotifications, InfoBarSubtitleSupport, HelpableScreen, InfoBarResolutionSelection):
 	ALLOW_SUSPEND = True
 	ENABLE_RESUME_SUPPORT = True
+	FLAG_CENTER_DVB_SUBS = 2048
 
 	def __init__(self, session, args = None):
 		Screen.__init__(self, session)


### PR DESCRIPTION
11:02:22.4455 {   } Screens/Screen.py:151 show [SCREENNAME]  SubtitleDisplay
11:02:22.4465 { D } Traceback (most recent call last):
11:02:22.4466 { D }   File "/usr/lib/enigma2/python/Components/ActionMap.py", line 68, in action
11:02:22.4470 { D }   File "/usr/lib/enigma2/python/Components/ActionMap.py", line 48, in action
11:02:22.4472 { D }   File "/usr/lib/enigma2/python/Screens/AudioSelection.py", line 477, in keyOk
11:02:22.4473 { D }   File "/usr/lib/enigma2/python/Screens/AudioSelection.py", line 299, in enableSubtitle
11:02:22.4474 { D }   File "/usr/lib/enigma2/python/Screens/InfoBarGenerics.py", line 4918, in enableSubtitle
11:02:22.4476 { D }   File "/usr/lib/enigma2/python/Screens/InfoBarGenerics.py", line 4883, in doCenterDVBSubs
11:02:22.4478 { D } AttributeError: 'MediaPlayer' object has no attribute 'FLAG_CENTER_DVB_SUBS'
11:02:22.4478 [ E ] python/python.cpp:209 call [ePyObject] (PyObject_CallObject(<bound method NumberActionMap.action of <Components.ActionMap.NumberActionMap instance at 0xae330fa8>>,('OkCancelActions', 'ok')) failed)