### PR TITLE
dvbci: properly reset the input source on CI removal

### DIFF
--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -535,7 +535,7 @@ void eDVBCIInterfaces::ciRemoved(eDVBCISlot *slot)
 		if (slot->linked_next)
 			slot->linked_next->setSource(slot->current_source);
 		else // last CI in chain
-			setInputSource(slot->current_tuner, slot->current_source);
+			setInputSource(slot->current_tuner, eDVBCISlot::getTunerLetter(slot->current_tuner));
 		slot->linked_next = 0;
 		slot->use_count=0;
 		slot->plugged=true;
@@ -905,7 +905,7 @@ void eDVBCIInterfaces::removePMTHandler(eDVBServicePMTHandler *pmthandler)
 				if (slot->linked_next)
 					slot->linked_next->setSource(slot->current_source);
 				else
-					setInputSource(slot->current_tuner, slot->current_source);
+					setInputSource(slot->current_tuner, eDVBCISlot::getTunerLetter(slot->current_tuner));
 
 				if (base_slot != slot)
 				{


### PR DESCRIPTION
It seems that removing the CI resets input source to wrong input.
Instead of reseting to tuner leter 0->A,1->B,etc. it resets to A.
Writing the correct input should fix the problem after removing the CI.