### PR TITLE
Add fixes from opendreambox git

### DIFF
--- a/lib/dvb/sec.h
+++ b/lib/dvb/sec.h
@@ -315,7 +315,7 @@ public:
 private:
 #ifndef SWIG
 	static eDVBSatelliteEquipmentControl *instance;
-	eDVBSatelliteLNBParameters m_lnbs[144]; // i think its enough
+	eDVBSatelliteLNBParameters m_lnbs[512]; // at the moment we have max 2 FBC Tuners.. a 8 channels... max 32 LNB per channel
 	int m_lnbidx; // current index for set parameters
 	std::multimap<int, eDVBSatelliteSwitchParameters>::iterator m_curSat;
 	eSmartPtrList<eDVBRegisteredFrontend> &m_avail_frontends, &m_avail_simulate_frontends;

--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -780,7 +780,7 @@ class EPGList(HTMLComponent, GUIComponent):
 				begin = localtime(beginTime)
 				end = localtime(beginTime+duration)
 				res.extend((
-					(eListboxPythonMultiContent.TYPE_TEXT, r4.x, r4.y, r4.w, r4.h, 1, RT_HALIGN_CENTER|RT_VALIGN_CENTER, _("%02d.%02d - %02d.%02d")%(begin[3],begin[4],end[3],end[4])),
+					(eListboxPythonMultiContent.TYPE_TEXT, r4.x, r4.y, r4.w, r4.h, 1, RT_HALIGN_CENTER|RT_VALIGN_CENTER, _("%02d:%02d - %02d:%02d")%(begin[3],begin[4],end[3],end[4])),
 					(eListboxPythonMultiContent.TYPE_TEXT, r3.x, r3.y, fact1, r3.h, 1, RT_HALIGN_RIGHT|RT_VALIGN_CENTER, _("%d min") % (duration / 60))
 				))
 			else:

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -662,7 +662,10 @@ class ConfigSequence(ConfigElement):
 		return str(v)
 
 	def fromstring(self, value):
-		return [int(x) for x in value.split(self.seperator)]
+		try:
+			return [int(x) for x in value.split(self.seperator)]
+		except:
+			return self.default
 
 	def onDeselect(self, session):
 		if self.last_value != self._value:


### PR DESCRIPTION
Fix issues reported in opendreambox git
---------------------------------------

- use colon as hour delimiter instead of a single point in multiepg
- fixed some tuner config related issues
- fixed crash when more than 4 satellites are configured with multiple fbc tuners