### PR TITLE
Update hu.po, enigma2.pot, ClockToText.py

### DIFF
--- a/lib/python/Components/Converter/ClockToText.py
+++ b/lib/python/Components/Converter/ClockToText.py
@@ -17,6 +17,7 @@ class ClockToText(Converter, object):
 	AS_LENGTHHOURS = 11
 	AS_LENGTHSECONDS = 12
 	FULL_DATE = 13
+	HOUR_MIN = 14
 
 	# add: date, date as string, weekday, ...
 	# (whatever you need!)
@@ -55,6 +56,8 @@ class ClockToText(Converter, object):
 		elif "Format" in type:
 			self.type = self.FORMAT
 			self.fmt_string = type[7:]
+		elif type == "HourMin":
+			self.type = self.HOUR_MIN
 		else:
 			self.type = self.DEFAULT
 
@@ -89,6 +92,19 @@ class ClockToText(Converter, object):
 			return "%d:%02d:%02d" % (time / 3600, time / 60 % 60, time % 60)
 		elif self.type == self.TIMESTAMP:
 			return str(time)
+		elif self.type == self.HOUR_MIN:
+			mins = time / 60
+			if not isinstance(mins, int):
+				return '{0}{1}'.format(0, _("time_min_ct"))
+			if mins <= 0:
+				return '{0}{1}'.format(0, _("time_min_ct"))
+			vhour, vmins = mins // 60, mins % 60
+			if vhour and vmins:
+				return '{0}{1}{2}{3}'.format(vhour, _("time_hour_ct"), vmins, _("time_min_ct"))
+			elif vhour and not vmins:
+				return '{0}{1}'.format(vhour, _("time_hour_ct"))
+			else:
+				return '{0}{1}'.format(vmins, _("time_min_ct"))
 
 		t = localtime(time)
 

--- a/po/enigma2.pot
+++ b/po/enigma2.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: openATV / enigma2\n"
-"POT-Creation-Date: 2018-05-12 18:29+0200\n"
+"POT-Creation-Date: 2018-06-11 17:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME\n"
 "Language-Team: TEAM <EMAIL@ADDRESS>\n"
@@ -125,6 +125,12 @@ msgstr ""
 msgid "time_min"
 msgstr ""
 
+msgid "time_hour_ct"
+msgstr ""
+
+msgid "time_min_ct"
+msgstr ""
+
 msgid "%02d.%02d."
 msgstr ""
 
@@ -156,6 +162,9 @@ msgid "%A %e %B %Y"
 msgstr ""
 
 msgid "%a %e %B %Y"
+msgstr ""
+
+msgid "%A %B %d, %Y"
 msgstr ""
 
 msgid "%a %e/%m"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,10 +4,10 @@
 # Automatically generated, 2005.
 msgid ""
 msgstr ""
-"Project-Id-Version: enigma2 v2.6\n"
+"Project-Id-Version: enigma2 v2.7\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2018-06-09 22:10+0200\n"
+"PO-Revision-Date: 2018-06-11 17:30+0200\n"
 "Last-Translator: Alec <alex1vagyok@gmail.com>\n"
 "Language-Team: alec <alex1vagyok@gmail.com>\n"
 "Language: hu_HU\n"
@@ -148,6 +148,12 @@ msgstr " óra "
 msgid "time_min"
 msgstr " perc"
 
+msgid "time_hour_ct"
+msgstr " óra "
+
+msgid "time_min_ct"
+msgstr " perc"
+
 msgid "%02d.%02d."
 msgstr "%02d.%02d."
 
@@ -257,6 +263,9 @@ msgstr "%d-%m"
 
 msgid "%d.%B %Y"
 msgstr "%Y. %B %d."
+
+msgid "%A %B %d, %Y"
+msgstr "%Y, %B %d. - %A"
 
 msgid "%d.%m.   "
 msgstr "%m/%d   "
@@ -18875,6 +18884,3 @@ msgstr "Zambia"
 
 msgid "Zimbabwe"
 msgstr "Zimbabwe"
-
-#~ msgid "History Zap..."
-#~ msgstr "Utoljára nézett csatornák..."


### PR DESCRIPTION
v2.7  hu.po

The hour, min display option in ClockToText.py.

The [language].po files must be set as follows (for example):

msgid "time_hour_ct"
msgstr " hour "

msgid "time_min_ct"
msgstr " min"

The hour,min can be displayed: (for example):  "1h24m" or "1 hour 24 min" or "1h:24m" or ...
