### PR TITLE
frontend: fix DTV_ENUM_DELSYS fallback logic

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -778,15 +778,16 @@ int eDVBFrontend::openFrontend()
 					if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[delsys]) < 0)
 						eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
 				}
+				ioctlMeasureEval("DTV_ENUM_DELSYS");
 			}
 			else
+			{
 				eWarning("[eDVBFrontend] ioctl FE_GET_PROPERTY/DTV_ENUM_DELSYS failed: %m");
-			ioctlMeasureEval("DTV_ENUM_DELSYS");
 #else
 			/* no DTV_ENUM_DELSYS support */
 			if (1)
-#endif
 			{
+#endif
 				/* old DVB API, fill delsys map with some defaults */
 				switch (fe_info.type)
 				{


### PR DESCRIPTION
restore the original logic of eec6ad54811373f42920343213c42896401f7c2d,
which was to:
-use DTV_ENUM_DELSYS on recent DVB_API versions
-use FE_GET_INFO.type on older DVB_API versions
-fallback to FE_GET_INFO.type when DTV_ENUM_DELSYS fails

commit 7e9e38e9ad641161abbc9e0d2ed5a97f27478074 and
436fb8d36a19c2a3045de388ecb832aa54c21a0b break the fallback logic by
introducing debug log after the 'else' clause.
As a result, the fallback was always executed, even when DTV_ENUM_DELSYS
produced valid results.

On multitype frontends, where the initial value of FE_GET_INFO.type is
not necessarily equal to the current value of FE_GET_INFO.type after
having iterated through all delsys, this could mean that frontend info
was stored to the wrong m_delsys entry. (e.g. DVB-T frequency_min/max
overwriting DVB-S2 frequency_min/max)

This commit restores the original logic and tries to avoid similar
mistakes in the future by moving the opening bracket directly under the
'else' clause.