### PR TITLE
Add Inverto IDLU-UST110-CUO4O-32P

### DIFF
--- a/data/unicable.xml
+++ b/data/unicable.xml
@@ -264,6 +264,9 @@ unicable (version)
 					scr9 ="1128" scr10="1164" scr11="1256" scr12="1292" scr13="1328" scr14="1364" scr15="1458" scr16="1494"
 					scr17="1530" scr18="1566" scr19="1602" scr20="1638" scr21="1716" scr22="1752" scr23="1788" scr24="1824"
 					scr25="1860" scr26="1896" scr27="1932" scr28="1968" scr29="2004" scr30="2076" scr31="2112" scr32="2148"/>
+			<product name="IDLU-UST110-CUO4O-32P" format="EN50607" positions="2" bootuptime="2500"
+					scr1 ="1210" scr2 ="1420" scr3 ="1680" scr4 ="2040" scr5 ="985"  scr6 ="1050" scr7 ="1115" scr8 ="1275"
+					scr9 ="1340" scr10="1485" scr11="1550" scr12="1615" scr13="1745" scr14="1810" scr15="1875" scr16="1940"/>
 			<product name="IDLU-UWT110-CUO10-32P" format="JESS" positions="2" bootuptime="2500"
 					scr1 ="1210" scr2 ="1420" scr3 ="1680" scr4 ="2040" scr5 ="984"  scr6 ="1020" scr7 ="1056" scr8 ="1092"
 					scr9 ="1128" scr10="1164" scr11="1256" scr12="1292" scr13="1328" scr14="1364" scr15="1458" scr16="1494"


### PR DESCRIPTION
Add Inverto IDLU-UST110-CUO4O-32P according to:
http://inverto.tv/multiswitch/308/unicable-ii-cascadable-switch-with-terrestrial-input-and-4x-dcss-scr-legacy-terrestrial-outputs