### PR TITLE
ImageBackup - backup correct root & kernel for SF8008 type receivers …

### DIFF
--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/ImageBackup.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/ImageBackup.py
@@ -169,6 +169,12 @@ class ImageBackup(Screen):
 						self.MTDROOTFS = "%s" %(self.getImageList[self.SLOT]['part'])
 						if self.SLOT >= 2 and os.path.islink("/dev/block/by-name/userdata"):
 							self.MTDKERNEL = os.readlink("/dev/block/by-name/linuxkernel%s" %self.SLOT)[5:]
+					elif self.EMMCIMG == "usb_update.bin":
+						f = open('/sys/firmware/devicetree/base/chosen/bootargs', 'r').read()
+						if "sda" in f:
+							kern =  (self.SLOT-1)*2
+							self.MTDKERNEL = "sda%s" %(kern-1)
+							self.MTDROOTFS = "sda%s" %(kern)
 					else:
 						try:
 							self.MTDROOTFS = os.readlink("/dev/block/by-name/rootfs%s" %self.SLOT)[5:]


### PR DESCRIPTION
…using multiboot & SD card
Also needs code adding to FlashOnline and ImageBackup to handle flashonline of SD card images back to Emmc slot (different kernel partition size)