### PR TITLE
Quickmenu, make submenus wider

### DIFF
--- a/lib/python/Plugins/Extensions/Infopanel/QuickMenu.py
+++ b/lib/python/Plugins/Extensions/Infopanel/QuickMenu.py
@@ -633,7 +633,7 @@ class QuickMenu(Screen, ProtectedScreen):
 
 
 ######## Create MENULIST format #######################
-def QuickMenuEntryComponent(name, description, long_description = None, width=540):
+def QuickMenuEntryComponent(name, description, long_description = None, width=680):
 	pngname = name.replace(" ","_") 
 	png = LoadPixmap("/usr/lib/enigma2/python/Plugins/Extensions/Infopanel/icons/" + pngname + ".png")
 	if png is None:
@@ -648,7 +648,7 @@ def QuickMenuEntryComponent(name, description, long_description = None, width=54
 		MultiContentEntryText(pos=(0, 0), size=(0, 0), font=0, text = _(long_description))
 	]
 
-def QuickSubMenuEntryComponent(name, description, long_description = None, width=540):
+def QuickSubMenuEntryComponent(name, description, long_description = None, width=700):
 	sf = getSkinFactor()
 	return [
 		_(name),


### PR DESCRIPTION
When using  a language other than English, strings in menus and submenus of Quickmenu will not fit. This cosmetic fix will settle this nicely!