### PR TITLE
[Volume.py] Add VolumeText screen variable

### DIFF
--- a/lib/python/Screens/Volume.py
+++ b/lib/python/Screens/Volume.py
@@ -1,14 +1,15 @@
-from Screens.Screen import Screen
+from Components.Label import Label
 from Components.VolumeBar import VolumeBar
+from Screens.Screen import Screen
 
 class Volume(Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
-
 		self.volumeBar = VolumeBar()
-
 		self["Volume"] = self.volumeBar
+		self["VolumeText"] = Label("")
 
 	def setValue(self, vol):
-		print "setValue", vol
+		print "[Volume] Volume set to %d." % vol
 		self.volumeBar.setValue(vol)
+		self["VolumeText"].text = str(vol)


### PR DESCRIPTION
Add the VolumeText variable to allow skins to also display the current volume as a numeric value.

(Also improve the volume log message.)
