### PR TITLE
Icetv batch fetch

### DIFF
--- a/lib/python/Plugins/SystemPlugins/IceTV/API.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/API.py
@@ -150,6 +150,17 @@ class Channels(Request):
         return self.send("get")
 
 
+class UserChannels(AuthRequest):
+    def __init__(self, region=None):
+        if region is None:
+            super(UserChannels, self).__init__("/regions/channels")
+        else:
+            super(UserChannels, self).__init__("/regions/" + str(int(region)) + "/channels")
+
+    def get(self):
+        return self.send("get")
+
+
 class Login(Request):
     def __init__(self, email, password, region=None):
         super(Login, self).__init__("/login")

--- a/lib/python/Plugins/SystemPlugins/IceTV/API.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/API.py
@@ -16,7 +16,7 @@ from socket import socket, create_connection, AF_INET, SOCK_DGRAM, SHUT_RDWR, er
 from . import config, saveConfigFile, getIceTVDeviceType
 from boxbranding import getMachineBrand, getMachineName, getImageBuild
 
-_version_string = "20191013"
+_version_string = "20191018"
 _protocol = "http://"
 _device_type_id = getIceTVDeviceType()
 _debug_level = 0  # 1 = request/reply, 2 = 1+headers, 3 = 2+partial body, 4 = 2+full body

--- a/lib/python/Plugins/SystemPlugins/IceTV/__init__.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/__init__.py
@@ -10,7 +10,8 @@ License: Proprietary / Commercial - contact enigma.licensing (at) urbanec.net
 from enigma import eEPGCache
 from boxbranding import getMachineBrand, getMachineName, getImageDistro
 from Components.config import config, ConfigSubsection, ConfigNumber, ConfigText, \
-    ConfigPassword, ConfigSelection, NoSave, configfile, ConfigYesNo
+    ConfigPassword, ConfigSelection, NoSave, configfile, ConfigYesNo, \
+    ConfigSelectionNumber
 
 def getIceTVDeviceType():
     if getImageDistro() == "openatv":
@@ -75,6 +76,11 @@ checktimes = [
 ]
 
 config.plugins.icetv.refresh_interval = ConfigSelection(default="%d" % int(minute * 15), choices=checktimes)
+
+# Fetch EPG in batches of channels no larger than this size.
+# 0 disables batching - fetch EPG for all channels in 1 batch
+
+config.plugins.icetv.batchsize = ConfigSelectionNumber(0, 50, 1, default=30)
 
 def saveConfigFile():
     config.plugins.icetv.save()

--- a/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
@@ -861,6 +861,11 @@ class EPGFetcher(object):
         return req.get().json()
 
     def getChannels(self):
+        req = ice.UserChannels(config.plugins.icetv.member.region_id.value)
+        res = req.get().json()
+        return res.get("channels", [])
+
+    def getAllChannels(self):
         req = ice.Channels(config.plugins.icetv.member.region_id.value)
         res = req.get().json()
         return res.get("channels", [])


### PR DESCRIPTION
Fetch only user's selected channels to the IceTV channel map

- Add UserChannels class to the IceTV API. UserChannels is an AuthRequest that requests only the user's enabled channels.
- Make EPGFetcher.getChannels() return only the user's selected channels. Rename the old getChannels() to getAllChannels().
- Precursor to allowing batching of show requests to channel groups.


Allow batching of EPG fetches to limit memory use

- Allow the EPG to be fetched in batches of channels.
- The aim is to reduce the maximum memory requirement when downloding and processing the EPG. The larger (~140 channels, 14 days) German EPG appeared to be causing OOM problems on some boxes.
- config.plugins.icetv.batchsize controls the maximum size of the batch.  When set to 0, the EPG is loaded in a single fetch as before. Defaults to 30.
- Bump version number.
