### PR TITLE
Convert and import EPG data channel at a time

### DIFF
--- a/lib/python/Plugins/SystemPlugins/IceTV/API.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/API.py
@@ -16,7 +16,7 @@ from socket import socket, create_connection, AF_INET, SOCK_DGRAM, SHUT_RDWR, er
 from . import config, saveConfigFile, getIceTVDeviceType
 from boxbranding import getMachineBrand, getMachineName, getImageBuild
 
-_version_string = "20191018"
+_version_string = "20191020"
 _protocol = "http://"
 _device_type_id = getIceTVDeviceType()
 _debug_level = 0  # 1 = request/reply, 2 = 1+headers, 3 = 2+partial body, 4 = 2+full body


### PR DESCRIPTION
Change EPGFetcher.makeChanShowMap() to construct the map over
the Pythonised JSON data instead of converting it all into Python input
form in one go.

Move the conversion of the Pythonised JSON into the new method
EPGFetcher.convertChanShows() that does that conversion over a single channel.

Change the EPGFetcher.processShowsBatched() to call convertChanShows()
on each channel entry in channel_show_map.

This saves 20-30% of maximum memory use during EPG processing.

Bump version number.