### PR TITLE
Minor IceTV fixups

### DIFF
--- a/lib/python/Plugins/SystemPlugins/IceTV/API.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/API.py
@@ -16,7 +16,7 @@ from socket import socket, create_connection, AF_INET, SOCK_DGRAM, SHUT_RDWR, er
 from . import config, saveConfigFile, getIceTVDeviceType
 from boxbranding import getMachineBrand, getMachineName, getImageBuild
 
-_version_string = "20191107"
+_version_string = "20191108"
 _protocol = "http://"
 _device_type_id = getIceTVDeviceType()
 _debug_level = 0  # 1 = request/reply, 2 = 1+headers, 3 = 2+partial body, 4 = 2+full body

--- a/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
@@ -343,7 +343,7 @@ class EPGFetcher(object):
         _session.nav.RecordTimer.onTimerRemoved.append(self.onTimerRemoved)
         _session.nav.RecordTimer.onTimerChanged.append(self.onTimerChanged)
         _session.nav.record_event.append(self.gotRecordEvent)
-        self.addLog(_("IceTV started"))
+        self.addLog("IceTV started")
 
     def shouldProcessTimer(self, entry):
         if entry.isAutoTimer:
@@ -351,7 +351,7 @@ class EPGFetcher(object):
         if config.plugins.icetv.configured.value and config.plugins.icetv.enable_epg.value:
             global password_requested
             if password_requested:
-                self.addLog(_("Can not proceed - you need to login first"))
+                self.addLog("Can not proceed - you need to login first")
                 return False
             else:
                 return True
@@ -482,7 +482,7 @@ class EPGFetcher(object):
         if config.plugins.icetv.configured.value and config.plugins.icetv.enable_epg.value:
             global password_requested
             if password_requested:
-                self.addLog(_("Can not proceed - you need to login first"))
+                self.addLog("Can not proceed - you need to login first")
                 return
             # print "[IceTV] Create fetch job"
             self.send_scans = self.send_scans or send_scans
@@ -490,13 +490,13 @@ class EPGFetcher(object):
 
     def doWork(self):
         global password_requested
-        self.addLog(_("Start update"))
+        self.addLog("Start update")
         if password_requested:
-            self.addLog(_("Can not proceed - you need to login first"))
+            self.addLog("Can not proceed - you need to login first")
             return False
         if not ice.haveCredentials():
             password_requested = True
-            self.addLog(_("No token, requesting password..."))
+            self.addLog("No token, requesting password...")
             _session.open(IceTVNeedPassword)
             if not ice.haveCredentials():
                 return False
@@ -514,13 +514,13 @@ class EPGFetcher(object):
             self.deferredPostStatus(None)
             self.statusCleanup()
             if res:  # Timers fetched in non-batched show fetch
-                self.addLog(_("End update"))
+                self.addLog("End update")
                 return res
             res = True  # Reset res ready for a separate timer download
         except (IOError, RuntimeError) as ex:
             if hasattr(ex, "response") and hasattr(ex.response, "status_code") and ex.response.status_code == 404:
                 # Ignore 404s when there are no EPG updates - buggy server
-                self.addLog(_("No EPG updates"))
+                self.addLog("No EPG updates")
             else:
                 _logResponseException(self, _("Can not download EPG"), ex)
                 res = False
@@ -533,9 +533,9 @@ class EPGFetcher(object):
             res = False
         if not ice.haveCredentials() and not password_requested:
             password_requested = True
-            self.addLog(_("No token, requesting password..."))
+            self.addLog("No token, requesting password...")
             _session.open(IceTVNeedPassword)
-        self.addLog(_("End update"))
+        self.addLog("End update")
         self.deferredPostStatus(None)
         self.statusCleanup()
         return res
@@ -687,7 +687,7 @@ class EPGFetcher(object):
                             timer.eit = eit
                             timer_updated = True
                     if timer_updated:
-                        self.addLog(_("Update timer details from EPG '") + timer.name + "'")
+                        self.addLog("Update timer details from EPG '" + timer.name + "'")
                     updated |= timer_updated
         return updated
 
@@ -719,7 +719,7 @@ class EPGFetcher(object):
             res = self.processTimers(shows["timers"])
         config.plugins.icetv.last_update_time.value = last_update_time
         epgcache.save()
-        self.addLog(_("EPG download OK"))
+        self.addLog("EPG download OK")
         return res
 
     def processTimers(self, timers):
@@ -766,7 +766,7 @@ class EPGFetcher(object):
                                         iceTimer["state"] = "failed"
                                         iceTimer["message"] = "Failed to update timer '%s'" % name
                                         update_queue.append(iceTimer)
-                                        self.addLog(_("Failed to update timer '%s") % name)
+                                        self.addLog("Failed to update timer '%s" % name)
                                 else:
                                     iceTimer["state"] = "pending"
                                     iceTimer["message"] = "Timer already up to date '%s'" % name
@@ -800,7 +800,7 @@ class EPGFetcher(object):
                                     iceTimer["state"] = "failed"
                                     iceTimer["message"] = "Timer conflict: '%s'" % "', '".join(names)
                                     # print "[IceTV] Timer conflict:", conflicts
-                                    self.addLog(_("Timer '%s' conflicts with %s") % (name, "', '".join([n for n in names if n != name])))
+                                    self.addLog("Timer '%s' conflicts with %s" % (name, "', '".join([n for n in names if n != name])))
                     if not completed and not updated and not created:
                         iceTimer["state"] = "failed"
                         update_queue.append(iceTimer)
@@ -814,7 +814,7 @@ class EPGFetcher(object):
         res = True
         try:
             self.putTimers(update_queue)
-            self.addLog(_("Timers updated OK"))
+            self.addLog("Timers updated OK")
         except KeyError as ex:
             print "[IceTV] ", str(ex)
             res = False
@@ -923,7 +923,7 @@ class EPGFetcher(object):
             req = ice.Timer(local_timer.ice_timer_id)
             timer = {}
             if not local_timer.eit:
-                self.addLog(_("Timer '%s' has no event id; update not sent to IceTV") % local_timer.name)
+                self.addLog("Timer '%s' has no event id; update not sent to IceTV" % local_timer.name)
                 return
             timer["id"] = local_timer.ice_timer_id
             timer["eit_id"] = local_timer.eit
@@ -943,7 +943,7 @@ class EPGFetcher(object):
                 timer["message"] = "Will record on %s" % config.plugins.icetv.device.label.value
             req.data["timers"] = [timer]
             res = req.put().json()
-            self.addLog(_("Timer '%s' updated OK") % local_timer.name)
+            self.addLog("Timer '%s' updated OK" % local_timer.name)
         except (IOError, RuntimeError, KeyError) as ex:
             _logResponseException(self, _("Can not update timer"), ex)
 
@@ -958,7 +958,7 @@ class EPGFetcher(object):
             try:
                 # print "[IceTV] uploading new timer"
                 if not local_timer.eit:
-                    self.addLog(_("Timer '%s' has no event id; not sent to IceTV") % local_timer.name)
+                    self.addLog("Timer '%s' has no event id; not sent to IceTV" % local_timer.name)
                     return
                 channel_id = self.serviceToIceChannelId(local_timer.service_ref)
                 req = ice.Timers()
@@ -977,12 +977,12 @@ class EPGFetcher(object):
                 res = req.post()
                 try:
                     local_timer.ice_timer_id = res.json()["timers"][0]["id"].encode("utf-8")
-                    self.addLog(_("Timer '%s' created OK") % local_timer.name)
+                    self.addLog("Timer '%s' created OK" % local_timer.name)
                     if local_timer.ice_timer_id is not None:
                         NavigationInstance.instance.RecordTimer.saveTimer()
                         self.deferredPostStatus(local_timer)
                 except:
-                    self.addLog(_("Couldn't get IceTV timer id for timer '%s'") % local_timer.name)
+                    self.addLog("Couldn't get IceTV timer id for timer '%s'" % local_timer.name)
 
             except (IOError, RuntimeError, KeyError) as ex:
                 _logResponseException(self, _("Can not upload timer"), ex)
@@ -995,7 +995,7 @@ class EPGFetcher(object):
             # print "[IceTV] deleting timer:", ice_timer_id
             req = ice.Timer(ice_timer_id)
             req.delete()
-            self.addLog(_("Timer deleted OK"))
+            self.addLog("Timer deleted OK")
         except (IOError, RuntimeError, KeyError) as ex:
             _logResponseException(self, _("Can not delete timer"), ex)
 
@@ -1139,7 +1139,7 @@ class IceTVMain(ChoiceBox):
                 _session.open(MessageBox, _("IceTV update completed OK"), type=MessageBox.TYPE_INFO, timeout=5)
                 return
         except (Exception) as ex:
-            fetcher.addLog(_("Error trying to fetch: %s") % str(ex))
+            fetcher.addLog("Error trying to fetch: %s" % str(ex))
         _session.open(MessageBox, _("IceTV update completed with errors.\n\nPlease check the log for details."), type=MessageBox.TYPE_ERROR, timeout=15)
 
     def login(self, res=None):
@@ -1619,7 +1619,7 @@ class IceTVNeedPassword(ConfigListScreen, Screen):
             self.close()
             global password_requested
             password_requested = False
-            fetcher.addLog(_("Login OK"))
+            fetcher.addLog("Login OK")
             fetcher.createFetchJob()
         except (IOError, RuntimeError) as ex:
             msg = _logResponseException(fetcher, _("Login failure"), ex)

--- a/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
@@ -643,17 +643,17 @@ class EPGFetcher(object):
             for g in show.get("category", []):
                 name = g['name'].encode("utf-8")
                 if name in category_cache:
-                        eit = category_cache[name]
+                    eit = category_cache[name]
                 else:
-                        eit = int(g.get("eit", "0"), 0) or 0x01
-                        eit_remap = genre_remaps.get(country_code, {}).get(name, eit)
-                        mapped_name = getGenreStringSub((eit_remap >> 4) & 0xf, eit_remap & 0xf, country=country_code)
-                        if mapped_name == name:
-                                genres.append(eit_remap)
-                                category_cache[name] = eit
-                        elif name not in mapping_errors:
-                            print '[EPGFetcher] ERROR: lookup of 0x%02x%s "%s" returned \"%s"' % (eit, (" (remapped to 0x%02x)" % eit_remap) if eit != eit_remap else "", name, mapped_name)
-                            mapping_errors.add(name)
+                    eit = int(g.get("eit", "0"), 0) or 0x01
+                    eit_remap = genre_remaps.get(country_code, {}).get(name, eit)
+                    mapped_name = getGenreStringSub((eit_remap >> 4) & 0xf, eit_remap & 0xf, country=country_code)
+                    if mapped_name == name:
+                        genres.append(eit_remap)
+                        category_cache[name] = eit
+                    elif name not in mapping_errors:
+                        print '[EPGFetcher] ERROR: lookup of 0x%02x%s "%s" returned \"%s"' % (eit, (" (remapped to 0x%02x)" % eit_remap) if eit != eit_remap else "", name, mapped_name)
+                        mapping_errors.add(name)
             p_rating = ((country_code, parental_ratings.get(show.get("rating", "").encode("utf-8"), 0x00)),)
             res.append((start, duration, title, short, extended, genres, event_id, p_rating))
         return res

--- a/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
@@ -643,14 +643,15 @@ class EPGFetcher(object):
             for g in show.get("category", []):
                 name = g['name'].encode("utf-8")
                 if name in category_cache:
-                    eit = category_cache[name]
+                    eit_remap = category_cache[name]
+                    genres.append(eit_remap)
                 else:
                     eit = int(g.get("eit", "0"), 0) or 0x01
                     eit_remap = genre_remaps.get(country_code, {}).get(name, eit)
                     mapped_name = getGenreStringSub((eit_remap >> 4) & 0xf, eit_remap & 0xf, country=country_code)
                     if mapped_name == name:
                         genres.append(eit_remap)
-                        category_cache[name] = eit
+                        category_cache[name] = eit_remap
                     elif name not in mapping_errors:
                         print '[EPGFetcher] ERROR: lookup of 0x%02x%s "%s" returned \"%s"' % (eit, (" (remapped to 0x%02x)" % eit_remap) if eit != eit_remap else "", name, mapped_name)
                         mapping_errors.add(name)


### PR DESCRIPTION
Sorry, I know that having unrelated commits in a single PR is not good practice, but I needed to get these finished today, and they would be likely to cause merge problems if they were all branched from the same base.

[IceTV] Fix inconsistent indenting

Fixed some indenting that was done on an 8-character indent instead
of a 4-character indent.


[IceTV] Fix bug in genre mapping caching

Cached genre mappings weren't being added to the list of genres,
and the unmapped eit code was being added to cache instead of the
remapped value.

So little code... so many bugs.

Bump version number.


[IceTV] No translation of addLog messages

Remove the translation of addLog() mesages, to make things easier
for developers who don't know the user's selected language.
