### PR TITLE
Speed up insertion of events into EPG

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -28,6 +28,7 @@
 #include <lib/python/python.h>
 #include <lib/base/nconfig.h>
 #include <dvbsi++/descriptor_tag.h>
+#include <unordered_set>
 
 
 /* Interval between "garbage collect" cycles */
@@ -1286,6 +1287,7 @@ void eEPGCache::load()
 		ret = fread( text1, 13, 1, f);
 		if ( !memcmp( text1, "ENIGMA_EPG_V7", 13) )
 		{
+			std::unordered_set<uniqueEPGKey, hash_uniqueEPGKey > overlaps;
 			ret = fread( &size, sizeof(int), 1, f);
 			eventDB.rehash(size); /* Reserve buckets in advance */
 			while(size--)
@@ -1295,6 +1297,15 @@ void eEPGCache::load()
 				ret = fread( &key, sizeof(uniqueEPGKey), 1, f);
 				ret = fread( &size, sizeof(int), 1, f);
 				EventCacheItem& item = eventDB[key]; /* Constructs new entry */
+				bool overlap = false; // Actually overlaps, zero-length event or not time ordered
+				time_t last_end = 0;
+				if (!item.byTime.empty())
+				{
+					timeMap::iterator last_entry = item.byTime.end();
+					--last_entry;
+					last_end = getStartTime(last_entry) + getDuration(last_entry);
+				}
+
 				while(size--)
 				{
 					uint8_t len=0;
@@ -1313,8 +1324,17 @@ void eEPGCache::load()
 					eventData::CacheSize += sizeof(eventData) + event->n_crc * sizeof(uint32_t);
 					item.byEvent[event->getEventID()] = event;
 					item.byTime[event->getStartTime()] = event;
+					time_t this_start = event->getStartTime();
+					time_t this_end = this_start + event->getDuration();
+					if (this_start < last_end || this_start ==  this_end)
+						overlap = true;
+					else
+						last_end = this_end;
+
 					++cnt;
 				}
+				if (overlap)
+					overlaps.insert(key);
 			}
 			eventData::load(f);
 			eDebug("[EPGCache] %d events read from %s", cnt, EPGDAT);
@@ -1355,6 +1375,39 @@ void eEPGCache::load()
 				}
 			}
 #endif // ENABLE_PRIVATE_EPG
+			for (std::unordered_set<uniqueEPGKey, hash_uniqueEPGKey >::iterator it = overlaps.begin();
+				it != overlaps.end();
+				it++)
+			{
+				EventCacheItem &servicemap = eventDB[*it];
+				eventMap &eventmap = servicemap.byEvent;
+				timeMap &timemap = servicemap.byTime;
+				time_t last_end = 0;
+				for (timeMap::iterator It = timemap.begin(); It != timemap.end(); )
+				{
+					time_t start_time = getStartTime(It);
+					time_t end_time = start_time + getDuration(It);
+					if (start_time < last_end || start_time == end_time)
+					{
+#ifdef EPG_DEBUG
+						eDebug("[EPGC] load: svc(%04x:%04x:%04x) delete overlapping/zero-length event %04x at time %ld",
+							it->onid, it->tsid, it->sid,
+							getEventID(It), (long)start_time);
+#endif
+						if (eventmap.erase(getEventID(It)) == 0)
+						{
+							eDebug("[EPGC] Event %04x not found in timeMap at %ld", getEventID(It), start_time);
+						}
+						delete getEventData(It);
+						timemap.erase(It++);
+					}
+					else
+					{
+						last_end = end_time;
+						++It;
+					}
+				}
+			}
 		}
 		else
 			eDebug("[EPGCache] don't read old epg database");

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -849,6 +849,13 @@ void eEPGCache::sectionRead(const uint8_t *data, eit_type_t source, channel_data
 			eventData *new_evt = new eventData(eit_event, eit_event_size, source, (tsid<<16)|onid);
 			time_t new_start = new_evt->getStartTime();
 			time_t new_end = new_start + new_evt->getDuration();
+
+			// Ignore zero-length events
+			if (new_start == new_end)
+			{
+				delete new_evt;
+				goto next;
+			}
 #ifdef EPG_DEBUG
 //			eDebug("[EPGC] created event %04x at %ld", new_evt->getEventID(), new_start);
 #endif
@@ -879,7 +886,19 @@ void eEPGCache::sectionRead(const uint8_t *data, eit_type_t source, channel_data
 				delete data;
 			}
 
-			for (timeMap::iterator it = timemap.begin(); it != timemap.end(); )
+			timeMap::iterator it;
+			if (timemap.empty())
+				it = timemap.begin();
+			else
+			{
+				it = timemap.lower_bound(new_start);
+				if(it == timemap.end() || it != timemap.begin())
+				{
+					--it;
+				}
+			}
+
+			while (it != timemap.end())
 			{
 				time_t old_start = getStartTime(it);
 				time_t old_end = old_start + getDuration(it);


### PR DESCRIPTION
[eEPGCache] Speed up insertion of events into EPG

By taking advantage of the fact that the EPG per-channel list of
events by time is non-overlapping, the check for overlaps when a
new event is added in eEPGCache::sectionRead() can be reduced from
O(N) to O(log N), where N is the number of events in the channel's
EPG.

This improves both the processing speed of EIT EPG data and imported
EPG data (e.g. IceTV), because eEPGCache::sectionRead() is common
to both.

Also drop any zero-length events. Handling them would make
the speedup slightly more complicated.

For Australian IceTV data, it reduces the import time for the EPG
from ~0.67 sec to ~0.14 sec (4.8x), for an 8-day German IceTV EPG
(130+ channels), it reduces the import time from ~16.5 sec to ~2.32
sec (7.1x).

The production German IceTV data is expected to be 14 days, so the
improvement factor for that data should be greater.


[eEPGCache] Ensure that cache loads from file are non-overlapping

In the first loop of eEPGCache::load(), check whether events for a
channel are loaded in time order, non-zero length and are non-overlapping
in time.

A test for non-overlapping that ignores time order would be more
complicated.

For any channel EPGs that may have time overlaps or zero-, loop
over their events and remove overlaps.

Ensuring that the EPG is initially non-overlapping is a prerequisite
for the following commit that significantly speeds up EPG event
import and EIT EPG event processing.

Removing zero-length events slightly simplifies the code for the
speedup.
