### PR TITLE
HDMI CEC :  FIX EPG_KEY

### DIFF
--- a/lib/driver/hdmi_cec.cpp
+++ b/lib/driver/hdmi_cec.cpp
@@ -469,7 +469,7 @@ long eHdmiCEC::translateKey(unsigned char code)
 			key = 0xd0;
 			break;
 		case 0x53:
-			key = 0x166;
+			key = 0x16d;
 			break;
 		case 0x54:
 			key = 0x16a;


### PR DESCRIPTION
EPG hdmi command is wrongly set to KEY_INFO 
		case 0x53: should be set to	key = 0x16d;
accordingly to input_fake.h
lib/driver/input_fake.h
#define KEY_INFO         0x166
#define KEY_TIME         0x167
#define KEY_EPG          0x16d