### PR TITLE
[IceTV] Allow sending of IceTV logs to the IceTV server

### DIFF
--- a/lib/python/Plugins/SystemPlugins/IceTV/API.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/API.py
@@ -16,7 +16,7 @@ from socket import socket, create_connection, AF_INET, SOCK_DGRAM, SHUT_RDWR, er
 from . import config, saveConfigFile, getIceTVDeviceType
 from boxbranding import getMachineBrand, getMachineName, getImageBuild
 
-_version_string = "20191108"
+_version_string = "20191127"
 _protocol = "http://"
 _device_type_id = getIceTVDeviceType()
 _debug_level = 0  # 1 = request/reply, 2 = 1+headers, 3 = 2+partial body, 4 = 2+full body
@@ -306,6 +306,28 @@ class Timer(AuthRequest):
 class Scans(AuthRequest):
     def __init__(self):
         super(Scans, self).__init__("/scans")
+
+    def post(self):
+        return self.send("post")
+
+
+class Settings(AuthRequest):
+    def __init__(self):
+        super(Settings, self).__init__("/user/settings")
+
+    def get(self):
+        return self.send("get")
+
+    def post(self):
+        return self.send("post")
+
+
+class PvrLogs(AuthRequest):
+    def __init__(self):
+        super(PvrLogs, self).__init__("/user/pvr_logs")
+
+    def get(self):
+        return self.send("get")
 
     def post(self):
         return self.send("post")

--- a/lib/python/Plugins/SystemPlugins/IceTV/__init__.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/__init__.py
@@ -33,6 +33,7 @@ config.plugins.icetv.member.token = ConfigText()
 config.plugins.icetv.member.id = ConfigNumber()
 config.plugins.icetv.member.region_id = ConfigNumber()
 config.plugins.icetv.member.country = ConfigText(default="AUS")
+config.plugins.icetv.member.send_logs = ConfigYesNo(default=True)
 
 config.plugins.icetv.member.password = NoSave(ConfigPassword(censor="●", show_help=False, fixed_size=False))
 

--- a/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
@@ -358,6 +358,8 @@ class EPGFetcher(object):
         # returns NoError (for example, evRecordWriteError).
         self.failed = {}
 
+        self.settings = {}
+
         # Update status for timers that are already running at startup
         # Use id(None) for their key to differentiate them from deferred
         # updates for specific timers
@@ -530,9 +532,21 @@ class EPGFetcher(object):
                 return False
         res = True
         try:
+            self.settings = dict((s["name"], s["value"].encode("utf-8") if s["type"] == 2 else s["value"]) for s in self.getSettings())
+            print "[EPGFetcher] settings", self.settings
+        except (Exception) as ex:
+            self.settings = {}
+            _logResponseException(self, _("Can not retrieve IceTV settings"), ex)
+        send_logs = config.plugins.icetv.member.send_logs and self.settings.get("send_pvr_logs", False)
+        print "[EPGFetcher] send_logs", send_logs
+        if send_logs:
+            self.postPvrLogs()
+        try:
             self.channel_service_map = self.makeChanServMap(self.getChannels())
         except (Exception) as ex:
             _logResponseException(self, _("Can not retrieve channel map"), ex)
+            if send_logs:
+                self.postPvrLogs()
             return False
         if self.send_scans:
             self.postScans()
@@ -543,6 +557,8 @@ class EPGFetcher(object):
             self.statusCleanup()
             if res:  # Timers fetched in non-batched show fetch
                 self.addLog("End update")
+                if send_logs:
+                    self.postPvrLogs()
                 return res
             res = True  # Reset res ready for a separate timer download
         except (IOError, RuntimeError) as ex:
@@ -566,6 +582,8 @@ class EPGFetcher(object):
         self.addLog("End update")
         self.deferredPostStatus(None)
         self.statusCleanup()
+        if send_logs:
+            self.postPvrLogs()
         return res
 
     def getTriplets(self):
@@ -912,6 +930,11 @@ class EPGFetcher(object):
             _session.nav.RecordTimer.timeChanged(timer)
         return success
 
+    def getSettings(self):
+        req = ice.Settings()
+        res = req.get().json()
+        return res.get("settings", [])
+
     def getShows(self, chan_list=None, fetch_timers=True):
         req = ice.Shows()
         last_update = config.plugins.icetv.last_update_time.value
@@ -1051,6 +1074,21 @@ class EPGFetcher(object):
             print "[EPGFetcher] postScans", res
         except (IOError, RuntimeError, KeyError) as ex:
             _logResponseException(self, _("Can not post scan information"), ex)
+
+    def postPvrLogs(self):
+        log_list = [l for l in self.log if not l.sent]
+        print "[EPGFetcher] postPvrLogs", len(log_list)
+        if not log_list:
+            return
+        try:
+            req = ice.PvrLogs()
+            req.data["logs"] = log_list
+            res = req.post()
+            print "[EPGFetcher] postPvrLogs", res, res.json()["count_of_log_entries"]
+            for l in log_list:
+                l.sent = True
+        except (IOError, RuntimeError, KeyError) as ex:
+            _logResponseException(self, _("Can not post PVR log information"), ex)
 
 
 fetcher = None


### PR DESCRIPTION
[IceTV] Prepare log for sending to IceTV

Save the log information in a form suitable for sending to IceTV,
and format it as needed for user display.

Use strftime() instead of datetime for date/time formatting for consistency
with other date/time formatting in the code.

[IceTV] Allow sending of IceTV logs to the IceTV server

Helps support remote debugging by IceTV staff.

Fetch IceTV server user settings, and if sending debug logging to
the server is enabled in the settings send IceTV logging information to
the IceTV server.

Only log information in EPGFetcher.log is sent.

Setting config.plugins.icetv.member.send_logs to False will prevent
any debug logs from being sent to the server, but tere is currently
no UI to change the config variable.

Bump IceTV plugin version.
