### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -12918,7 +12918,7 @@ msgstr "Wiederholungen"
 
 # Subtitle neu 5.1
 msgid "Replace `- ` in dialogs with colored text per speaker (like teletext subtitles for the hearing impaired)"
-msgstr "Diese Option ersetzt `- ` durch farbigen Text je Sprecher in Dialogen (so wie bei Teletext Untertiteln für Hörgeschädigte)."
+msgstr "Diese Option ersetzt '- ' durch farbigen Text je Sprecher in Dialogen (so wie bei Teletext Untertiteln für Hörgeschädigte)."
 
 msgid "Require authentication for http streams"
 msgstr "Verlange Authentifizierung für HTTP-Streams"
@@ -13795,7 +13795,7 @@ msgid "Select how the satellite dish is set up. i.e. fixed dish, single LNB, DiS
 msgstr "Wählen Sie, wie die Satellitenschüssel eingerichtet ist. Feste Schüssel, einzelner LNB, DiSEqC-Schalter, Positionierer usw."
 
 msgid "Select how to activate the Quick EPG mode:"
-msgstr "Wählen Sie, wie der grafische Infoleisten-EPG aktiviert werden soll."
+msgstr "Einstellen, wie der grafische Infoleisten-EPG aktiviert werden soll."
 
 #
 msgid "Select how your box will upgrade."
@@ -16879,7 +16879,7 @@ msgid "This allows you change the number of rows shown."
 msgstr "Einstellen, wie viele Zeilen angezeigt werden sollen."
 
 msgid "This allows you to set the number of digits to 5, if you have more than 9999 channels."
-msgstr "Hier können Sie die Anzahl der Stellen auf 5 setzen, wenn Sie mehr als 9999 Kanäle haben."
+msgstr "Stellen Sie die Anzahl der Stellen auf 5, wenn Sie mehr als 9999 Kanäle haben."
 
 msgid "This allows you to show drivers modules in downloads"
 msgstr "Treiber im Downloadbereich anzeigen."
@@ -16940,16 +16940,16 @@ msgid "This line is not editable!"
 msgstr "Diese Zeile kann nicht bearbeitet werden!"
 
 msgid "This option allows to reduce the block-noise in the picture. Obviously this is at the cost of the picture's sharpness."
-msgstr "Diese Option erlaubt es, Block-Rauschen im Bild zu reduzieren, was aber auf Kosten der Bildschärfe geht."
+msgstr "Block-Rauschen im Bild kann reduziert werden, was aber auf Kosten der Bildschärfe geht."
 
 msgid "This option allows to set the level of dynamic contrast of the picture."
-msgstr "Diese Option erlaubt es, den Wert für den dynamischen Kontrast des Bildes zu setzen."
+msgstr "Den Wert für den dynamischen Kontrast des Bildes setzen."
 
 msgid "This option allows you can config the Colordepth for UHD"
 msgstr "Stellen Sie die Farbtiefe im UHD Modus ein."
 
 msgid "This option allows you can config the Colorimetry for HDR"
-msgstr "Diese Option erlaubt die Farbprofile Steuerung im HDR Modus"
+msgstr "Farbprofile Steuerung im HDR Modus einstellen."
 
 msgid "This option allows you can config the Colorspace from Auto to RGB"
 msgstr "Stellen Sie den Farbraum ein."
@@ -17025,36 +17025,36 @@ msgid "This option allows you to choose from the two channel lists that are avai
 msgstr "Diese Option gibt Ihnen die Wahl zwischen den beiden verfügbaren Kanallisten."
 
 msgid "This option allows you to choose how to display 1080p 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "Hiermit können Sie einstellen, wie 1080p 24Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
+msgstr "Einstellen, wie 1080p 24Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
 
 msgid "This option allows you to choose how to display 1080p 25Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "Hiermit können Sie einstellen, wie 1080p 25Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
+msgstr "Einstellen, wie 1080p 25Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
 
 msgid "This option allows you to choose how to display 1080p 30Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "Hiermit können Sie einstellen, wie 1080p 30Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
+msgstr "Einstellen, wie 1080p 30Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
 
 msgid "This option allows you to choose how to display 2160p 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "Hiermit können Sie einstellen, wie 2160p 24Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
+msgstr "Einstellen, wie 2160p 24Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
 
 msgid "This option allows you to choose how to display 2160p 25Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "Hiermit können Sie einstellen, wie 2160p 25Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
+msgstr "Einstellen, wie 2160p 25Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
 
 msgid "This option allows you to choose how to display 2160p 30Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "Hiermit können Sie einstellen, wie 2160p 30Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
+msgstr "Einstellen, wie 2160p 30Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
 
 msgid "This option allows you to choose how to display 720p 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "Hiermit können Sie einstellen, wie 720p 24 Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
+msgstr "Einstellen, wie 720p 24 Hz angezeigt werden soll (einige Fernseher unterstützen diese Auflösung nicht)."
 
 msgid "This option allows you to choose how to display SD progressive 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "Diese Option erlaubt es, einzustellen wie ein 480/576p 24Hz Video angezeigt wird (einige Fernseher unterstützen nicht alle Formate)."
+msgstr "Einstellen, wie ein 480/576p 24Hz Video angezeigt wird (einige Fernseher unterstützen nicht alle Formate)."
 
 msgid "This option allows you to choose how to display standard definition video on your TV."
-msgstr "Hiermit können Sie einstellen, mit welcher Auflösung SD-Video angezeigt werden soll."
+msgstr "Einstellen, mit welcher Auflösung SD-Video angezeigt werden soll."
 
 msgid "This option allows you to choose what the first button press jumps to in channel list screen, (so pressing '2' jumps to 'A' or '2' first), when 'Quick Actions' preset actions are performed. "
 msgstr ""
-"Diese Option erlaubt es Ihnen zu wählen,\n"
-"was der erste Tastendruck in der Kanalliste bewirkt ('2' springt zu '2' oder 'A' zuerst)."
+"Einstellen, was der erste Tastendruck in der Kanalliste bewirken soll.\n"
+"'2' zum Beispiel springt zu '2' wenn es Kanalnummern gibt, oder, wenn nicht, zum ersten Kanal der mit 'A' anfängt."
 
 msgid "This option allows you to disable show Restart Network in Extensions list."
 msgstr "Bei 'Ja' wird ein Netzwerk-Neustart im Erweiterungsmenü angezeigt."
@@ -17068,7 +17068,7 @@ msgstr "Bei 'Ja' werden Einstellungseinträge in allen Menüs alphabetisch sorti
 
 # A/V Settings
 msgid "This option allows you to enable 3D Surround Sound."
-msgstr "Diese Option konfiguriert die 3D Surround Sound Ausgabe."
+msgstr "Einstellen der 3D Surround Sound Ausgabe."
 
 msgid "This option allows you to hide and sorting of the menus"
 msgstr "Einstellen, wie Menüeinträge sortiert oder versteckt werden sollen."
@@ -18227,7 +18227,7 @@ msgstr "Virgin EPG Informationen verwenden, wenn sie verfügbar sind."
 
 #
 msgid "Use a gateway"
-msgstr "Einen Gateway verwenden"
+msgstr "Ein Gateway verwenden"
 
 msgid "Use as HDD"
 msgstr "Mount HDD"


### PR DESCRIPTION
Einstellen, einstellen und einstellen.

Mir ist aufgefallen, dass für die 6.4 Version der de.po Datei eine ältere Version der 6.3 Datei verwendet wird.
Ist das gewollt oder versehentlich?
Ich könnte die 6.4er Version auch - wenn ich darf - auf den neuesten Stand bringen...
Gruß - Makumbo