### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8046,7 +8046,7 @@ msgid "Gabon"
 msgstr "Gabun"
 
 msgid "Gambia"
-msgstr "Gambiau"
+msgstr "Gambia"
 
 msgid "Game Show"
 msgstr ""
@@ -8088,7 +8088,7 @@ msgid "Genre"
 msgstr "Genre"
 
 msgid "Georgia"
-msgstr "Georgienu"
+msgstr "Georgien"
 
 msgid "German"
 msgstr "Deutsch"
@@ -8117,7 +8117,7 @@ msgid "Getting Event Info failed!"
 msgstr "Bezug von Sendungsinformationen fehlgeschlagen!"
 
 msgid "Getting Softcam list. Please wait..."
-msgstr ""
+msgstr "Lade Liste der Softcams..."
 
 #
 msgid "Getting plugin information. Please wait..."
@@ -8281,7 +8281,7 @@ msgid "Grey"
 msgstr "Grau"
 
 msgid "Group:"
-msgstr ""
+msgstr "Gruppe:"
 
 msgid "Grow drop"
 msgstr "Von oben fallend"
@@ -8447,7 +8447,7 @@ msgid "Helps setting up your signal"
 msgstr ""
 
 msgid "Here can set the EPG will alway open at the current channel, the first channel or one of both with primetime. If no primetime selected, the current time is used."
-msgstr "Hier können Sie einstellen, ob der EPG mit dem aktuellem Kanal, dem erstem Kanal oder einem von beiden mit der Primetime geöffnet wird. Wenn keine Primetime ausgewählt ist, wird die aktuelle Zeit verwendet."
+msgstr "Einstellen, ob der EPG mit dem aktuellen Kanal, dem ersten Kanal oder einem von beiden mit der Primetime geöffnet wird. Wenn keine Primetime ausgewählt ist, wird die aktuelle Zeit verwendet."
 
 msgid "Here you can browse (but not modify) the files that are added to the backupfile by default (E2-setup, channels, network)."
 msgstr "Hier können die Dateien durchsucht (aber nicht verändert) werden, die standardmäßig gesichert werden (E2-Einstellungen, Kanäle, Netzwerk)."
@@ -8476,7 +8476,7 @@ msgid "Hide VBI line for this service"
 msgstr "Verstecke VBI Line für diesen Kanal"
 
 msgid "Hide any zap error messages."
-msgstr "Fehlermeldungen beim Umschalten unterdrücken."
+msgstr "Bei 'Ja' werden Fehlermeldungen beim Umschalten (Zappen) unterdrückt."
 
 msgid "Hide known extensions"
 msgstr "Bekannte Dateiendungen ausblenden"
@@ -8599,7 +8599,7 @@ msgid "Hostname:"
 msgstr "Hostname:"
 
 msgid "Hostname: "
-msgstr "Host-Name: "
+msgstr "Hostname: "
 
 msgid "Hotbird 13.0e"
 msgstr ""
@@ -8623,7 +8623,7 @@ msgid "Hours Mins"
 msgstr "Stunden Minuten"
 
 msgid "Hours Mins Secs"
-msgstr "Stunde Minute Sekunde"
+msgstr "Stunden Minuten Sekunden"
 
 msgid "How many minutes do you want to record?"
 msgstr "Wie viele Minuten möchten Sie aufnehmen?"
@@ -8769,7 +8769,7 @@ msgid "If enabled, AIT data is included in recordings."
 msgstr "Wenn aktiviert, sind in den Aufzeichnungen AIT-Daten enthalten."
 
 msgid "If enabled, using a time window to detect a wakeup from deep standby by a timer. Default setting ist disabled and used a special signal from the receiver. But some devices set a wrong or none signal and the wakeup detection can fails."
-msgstr "Wenn aktiviert, wird ein Zeitfenster verwendet, um ein Aufwachen aus dem Deep-Standby durch einen Timer zu erkennen. Standardeinstellung ist deaktiviert und verwendet ein spezielles Signal vom Receiver. Manche Geräte setzen aber ein falsches oder kein Signal und die Erkennung kann fehlschlagen."
+msgstr "Bei 'Ja' kann ein Zeitfenster eingestellt werden, um ein Aufwachen aus dem Deep-Standby durch einen Timer zu erkennen. Standardeinstellung ist 'Nein' und verwendet ein spezielles Signal vom Receiver. Manche Geräte setzen aber ein falsches oder kein Signal und die Erkennung kann fehlschlagen."
 
 msgid "If logs are using the set maximum space used the eldest will be deleted."
 msgstr "Wenn die Log-Dateien zu viel Speicher belegen werden die ältesten Dateien gelöscht."
@@ -8778,58 +8778,58 @@ msgid "If muted, hide mute icon or mute information after few seconds."
 msgstr "Legt fest, ob das Anzeigesymbol oder die Information der Stummschaltung nach wenigen Sekunden ausgeblendet wird."
 
 msgid "If set to 'no', can you save older events even after zapping or interruption of the timeshift."
-msgstr "Wenn 'Nein' eingestellt ist, bleiben Timeshift-Aufnahmen nach dem Umschalten oder Beenden im Timeshift-Verzeichnis erhalten."
+msgstr "Bei 'Nein' bleiben Timeshift-Aufnahmen nach dem Umschalten oder Beenden im Timeshift-Verzeichnis erhalten."
 
 msgid "If set to 'no', timeshift used only one buffer file. It's recommend 'Timeshift checking for older files [in minutes]' and 'Timeshift checking for free space?' to adjust."
-msgstr "Wenn 'Nein' eingestellt ist, wird nur eine Datei als Puffer verwendet. Es wird empfohlen 'Timeshift-Überprüfung auf ältere Dateien (in Minuten)' und 'Timeshift-Überprüfung auf freien Speicherplatz?' anzupassen."
+msgstr "Bei 'Nein' wird nur eine Datei als Puffer verwendet. Es wird empfohlen 'Timeshift-Überprüfung auf ältere Dateien (in Minuten)' und 'Timeshift-Überprüfung auf freien Speicherplatz?' anzupassen."
 
 msgid "If set to 'yes' channels without EPG will not be shown."
-msgstr "Wenn 'Ja' eingestellt ist, werden Sender ohne EPG nicht angezeigt."
+msgstr "Bei 'Ja' werden Sender ohne EPG nicht angezeigt."
 
 msgid "If set to 'yes' it will show the 'PO' packages in browser."
-msgstr "Wenn 'Ja' eingestellt ist, werden auch 'PO'-Pakete angezeigt."
+msgstr "Bei 'Ja' werden auch 'PO'-Pakete angezeigt."
 
 msgid "If set to 'yes' it will show the 'SRC' packages in browser."
-msgstr "Wenn 'Ja' eingestellt ist, werden auch 'SRC'-Pakete angezeigt."
+msgstr "Bei 'Ja' werden auch 'SRC'-Pakete angezeigt."
 
 msgid "If set to 'yes' shows a small TV-screen in the EPG."
-msgstr "Wenn 'Ja' eingestellt ist, wird PiG (kleines TV-Bild) im EPG angezeigt."
+msgstr "Bei 'Ja' wird ein kleines TV-Bild (PiG) im EPG angezeigt."
 
 msgid "If set to 'yes' signal values (SNR, etc) will be calculated from API V3. This is an old API version that has now been superseded."
 msgstr "Bei 'Ja' werden die Signalwerte (SNR usw.) aus API V3 berechnet. Dies ist eine alte API-Version, die jetzt ersetzt wurde."
 
 msgid "If set to 'yes' the bouquets will be shown each time you open the EPG."
-msgstr "Wenn 'Ja' eingestellt ist, werden Favoriten jedes Mal beim Öffnen vom EPG angezeigt."
+msgstr "Bei 'Ja' werden Favoriten jedes Mal beim Öffnen vom EPG angezeigt."
 
 msgid "If set to 'yes' the channel list will be shown after switching between radio and TV modes."
-msgstr "Wenn 'Ja' eingestellt ist, wird die Kanalliste angezeigt, wenn zwischen Fernsehen und Radio gewechselt wird."
+msgstr "Bei 'Ja' wird die Kanalliste angezeigt, wenn zwischen Fernsehen und Radio gewechselt wird."
 
 msgid "If set to 'yes' the channel number will be displayed in the infobar."
-msgstr "Wenn 'Ja' ausgewählt wird, wird die Kanalnummer in der Infoleiste angezeigt."
+msgstr "Bei 'Ja' wird die Kanalnummer in der Infoleiste angezeigt."
 
 msgid "If set to 'yes' the infobar will be displayed when a new event starts."
-msgstr "Wenn 'Ja' eingestellt ist, wird die Infoleiste angezeigt, wenn ein neues Programm anfängt."
+msgstr "Bei 'Ja' wird die Infoleiste angezeigt, wenn ein neues Programm anfängt."
 
 msgid "If set to 'yes' the infobar will be displayed when changing channels."
-msgstr "Wenn 'Ja' eingestellt ist, wird die Infoleiste angezeigt, wenn der Sender gewechselt wird."
+msgstr "Bei 'Ja' wird die Infoleiste angezeigt, wenn der Sender gewechselt wird."
 
 msgid "If set to 'yes' you can preview channels in the EPG list."
-msgstr "Außer bei 'Deaktiviert' erhalten Sie eine Programmvorschau im EPG."
+msgstr "Bei 'Ja' erhalten Sie eine Programmvorschau im EPG."
 
 msgid "If set to 'yes' you can preview channels in the channel list. Press 'OK' to preview the selected channel, press a 2nd 'OK' to exit and zap to that channel, pressing 'EXIT' to return to the channel you started at."
 msgstr "Bei 'Ja' Programmvorschau im EPG. Mit OK die Vorschau, ein zweiter Druck beendet EPG und schaltet zum gewählten Sender, mit EXIT Sender vor Aufruf vom EPG."
 
 msgid "If set to 'yes', allows you use the seekbar to jump to a point within the event."
-msgstr "Wenn 'Ja' eingestellt ist, können Sie innerhalb der Suchleiste zu jedem beliebigen Zeitpunkt vor oder zurück springen."
+msgstr "Bei 'Ja' können Sie innerhalb der Suchleiste zu jedem beliebigen Zeitpunkt vor oder zurück springen."
 
 msgid "If set to 'yes', enable autorecord for automatically background timeshift"
-msgstr "Aktiviert die automatische Aufnahme für Timeshift im Hintergrund."
+msgstr "'Ja' aktiviert die automatische Aufnahme für Timeshift im Hintergrund."
 
 msgid "If set to 'yes; the infobar will be displayed when Fast Forwarding or Rewinding during media playback."
-msgstr "Wenn 'Ja' eingestellt ist, wird die Infoleiste bei schnellem Vor- und Rücklauf in der Medienwiedergabe angezeigt."
+msgstr "Bei 'Ja' wird die Infoleiste bei schnellem Vor- und Rücklauf bei Medienwiedergabe angezeigt."
 
 msgid "If set to 'yes; the infobar will remain shown permanently in 'paused' state (no timeout)."
-msgstr "Wenn 'Ja' eingestellt ist, wird die Infoleiste im pausierten Zustand dauerhaft angezeigt und nicht ausgeblendet."
+msgstr "Bei 'Ja' wird die Infoleiste im pausierten Zustand nicht ausgeblendet sondern dauerhaft angezeigt."
 
 msgid "If the 'deep standby workaround' is enabled, it waits until the system time is synchronized. Depending on the requirement, the devices wake up will continuing after a maximum of 2 minutes."
 msgstr "Wenn der 'Deep-Standby Workaround' aktiviert ist wird gewartet, bis die Systemzeit synchronisiert wurde. Je nach Erfordernis wird das aufwecken der Geräte in maximal 2 Minuten fortgesetzt."
@@ -8945,10 +8945,10 @@ msgid "In addition to the check at an event start, a repetitive check can be use
 msgstr "Zusätzlich zu der Überprüfung bei einem Event-Start kann diese Einstellung genutzt werden. Damit wird die Bedingung 'Puffer Limit in Stunden' oder 'Überprüfung auf freien Speicherplatz' eher erkannt."
 
 msgid "In expert mode, configure which tuners will be preferred for recordings, when more than one tuner is available."
-msgstr "Konfigurieren Sie im Expertenmodus, welche Tuner für Aufnahmen bevorzugt werden sollen, wenn mehr als ein Tuner verfügbar ist."
+msgstr "Im Expertenmodus einstellen, welche Tuner für Aufnahmen bevorzugt werden sollen, wenn mehr als ein Tuner verfügbar ist."
 
 msgid "In expert mode, configure which tuners will be preferred, when more than one tuner is available."
-msgstr "Konfigurieren Sie im Expertenmodus, welche von mehreren Tunern bevorzugt benutzt werden sollen."
+msgstr "Im Expertenmodus einstellen, welche von mehreren Tunern bevorzugt benutzt werden sollen, wenn mehr als ein Tuner verfügbar ist."
 
 msgid "In most cases this should be set to No. Only enable if you have a very specific need."
 msgstr "In den meisten Fällen sollte dies auf 'Nein' eingestellt sein. Nur aktivieren, wenn Sie einen ganz bestimmten Bedarf haben."
@@ -8974,7 +8974,7 @@ msgid "In progress"
 msgstr "In Arbeit"
 
 msgid "In the Standby Record on the LCD Display"
-msgstr "Gerätedisplay bei Aufnahmen im Standby"
+msgstr "Bei 'Ja' wird das blinkende REC Symbol im Gerätedisplay im Standby aktiviert (nicht alle Receiver unterstützen das)."
 
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -9343,7 +9343,7 @@ msgid "Invert"
 msgstr "Invertieren"
 
 msgid "Inverts the button function."
-msgstr "Invertiert die Tastenfunktion."
+msgstr "Bei 'Ja' werden die Funktionen der Kanaltasten umgekehrt."
 
 #
 msgid "Ipkg"
@@ -9722,7 +9722,7 @@ msgid "Latvian"
 msgstr "Lettisch"
 
 msgid "Leave DVD player?"
-msgstr ""
+msgstr "DVD Player verlassen?"
 
 msgid "Leave File Commander"
 msgstr "Verlassen Sie den File Commander"
@@ -10077,7 +10077,7 @@ msgid "Mainmenu"
 msgstr "Hauptmenü"
 
 msgid "Maintain old EPG data for"
-msgstr "Halte alte EPG-Daten für (X) Minuten"
+msgstr "Alte EPG-Daten für x Minuten halten"
 
 msgid "Make File Commander accessible from the Extensions menu."
 msgstr "File Commander über das Erweiterungsmenü zugänglich machen."
@@ -10200,7 +10200,7 @@ msgid "Max memory positions"
 msgstr "Max. Speicherpositionen"
 
 msgid "Max. bitrate: "
-msgstr ""
+msgstr "Max. Bitrate: "
 
 msgid "Maxdown +"
 msgstr "Maxdown +"
@@ -10250,7 +10250,7 @@ msgid "Media player"
 msgstr "Media Player"
 
 msgid "Media scanner"
-msgstr ""
+msgstr "Media Scanner"
 
 #
 msgid "MediaPlayer"
@@ -10273,7 +10273,7 @@ msgid "Medium is not empty!"
 msgstr "Das Medium ist nicht leer!"
 
 msgid "Medium toolbox"
-msgstr ""
+msgstr "Medium Toolbox"
 
 # InfoPanel
 msgid "MemInfo"
@@ -10314,7 +10314,7 @@ msgid "MessageBox Functions"
 msgstr "Funktionen der virtuellen Tastatur"
 
 msgid "Metadata changed:"
-msgstr ""
+msgstr "Metadaten geändert:"
 
 msgid "Mexico"
 msgstr "Mexiko"
@@ -10343,7 +10343,7 @@ msgstr "MiniTV mit OSD"
 
 #, python-format
 msgid "Minimum age %d years"
-msgstr ""
+msgstr "Mindestalter %d Jahre"
 
 msgid "Minimum send interval"
 msgstr "Minimaler Sendeintervall"
@@ -10355,7 +10355,7 @@ msgid "Mins Secs"
 msgstr "Minuten Sekunden"
 
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Sonstiges"
 
 msgid "Misconfiguration in channel allocation"
 msgstr "Fehlkonfiguration bei der Kanalzuweisung"
@@ -10554,10 +10554,10 @@ msgid "Move folder"
 msgstr "Ordner verschieben"
 
 msgid "Move mode off"
-msgstr "Move-Modus aus"
+msgstr "Verschiebemodus aus"
 
 msgid "Move mode on"
-msgstr "Move-Modus an"
+msgstr "Verschiebemodus an"
 
 #
 msgid "Move the text buffer cursor left"
@@ -10730,7 +10730,7 @@ msgid "Music"
 msgstr "Musik"
 
 msgid "Music/Ballet/Dance"
-msgstr ""
+msgstr "Musik/Ballet/Tanz"
 
 #, fuzzy
 msgid "Musical"
@@ -10769,7 +10769,7 @@ msgid "NEXT"
 msgstr "NÄCHSTE"
 
 msgid "NFI image flashing"
-msgstr ""
+msgstr "Flashe NFI Image"
 
 msgid "NFI image flashing completed. Press Yellow to Reboot!"
 msgstr ""
@@ -11036,7 +11036,7 @@ msgstr ""
 
 #, fuzzy
 msgid "News/Current Affairs"
-msgstr "Nachrichten (allgemein)"
+msgstr "Aktuelle Nachrichten"
 
 msgid "Next"
 msgstr "Nächstes"
@@ -11226,7 +11226,7 @@ msgid "No standby"
 msgstr "Kein Standby"
 
 msgid "No suitable sat tuner found!"
-msgstr ""
+msgstr "Keinen passenden SAT Tuner gefunden!"
 
 #
 msgid "No tags are set on these movies."
@@ -11278,7 +11278,7 @@ msgid "No update required!"
 msgstr "Kein Update erforderlich!"
 
 msgid "No updates available. Please try again later."
-msgstr ""
+msgstr "Keine Updates vorhanden. Bitte später erneut versuchen."
 
 msgid "No valid region details were foind"
 msgstr ""
@@ -11363,7 +11363,7 @@ msgid "Norfolk Island"
 msgstr "Norfolkinsel"
 
 msgid "Normal mode"
-msgstr ""
+msgstr "Normaler Modus"
 
 #
 msgid "North"
@@ -11399,7 +11399,7 @@ msgstr "Nicht verknüpft"
 
 #, python-format
 msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Nicht genug Speicherplatz. Bitte machen Sie etwas Speicher frei und versuchen Sie es erneut. (%d MB benötigt, %d MB verfügbar)"
+msgstr "Nicht genug Speicherplatz! %d MB benötigt, %d MB verfügbar. Bitte machen Sie etwas Speicher frei und versuchen es dann erneut."
 
 #, python-format
 msgid ""
@@ -11543,7 +11543,7 @@ msgid "OSD Position"
 msgstr "OSD Kalibrieren"
 
 msgid "OSD Settings"
-msgstr ""
+msgstr "OSD Einstellungen"
 
 # Quick Menue
 msgid "OSD Setup"
@@ -11609,7 +11609,7 @@ msgid "On reaching the end of a file during playback, you can choose the box's b
 msgstr "Am Ende einer Filmwiedergabe kann das Verhalten der Box bestimmt werden."
 
 msgid "On valid ONIDs, ignore frequency sub network part"
-msgstr "Ignoriere Subnetzwerk Frequenzen bei gültigen ONIDs"
+msgstr "Bei 'Ja' werden Subnetzwerk Frequenzen bei gültigen ONIDs ignoriert."
 
 msgid "Once per day"
 msgstr "Einmal pro Tag"
@@ -11693,14 +11693,14 @@ msgid "Open service list and select next channel"
 msgstr "Öffne Kanalliste und wähle nächsten Kanal"
 
 msgid "Open service list and select next channel for PiP"
-msgstr ""
+msgstr "Öffne Kanalliste und wähle nächsten Kanal für Bild im Bild (PiP)"
 
 #
 msgid "Open service list and select previous channel"
 msgstr "Öffne Kanalliste und wähle vorherigen Kanal"
 
 msgid "Open service list and select previous channel for PiP"
-msgstr ""
+msgstr "Öffne Kanalliste und wähle vorherigen Kanal für Bild im Bild (PiP)"
 
 msgid "Open settings/actions menu"
 msgstr "Menü Einstellungen / Aktionen öffnen"
@@ -11744,11 +11744,11 @@ msgstr "Option lang"
 
 # Menue Anpassungen OSD
 msgid "Option to disable picons on the Infobar"
-msgstr "Hiermit kann man die Anzeige von Senderlogos in der Infoleiste einschalten"
+msgstr "Bei 'Ja' werden Senderlogos (Picons) (falls vorhanden) in der Infoleiste angezeigt."
 
 # HDD Standby
 msgid "Option to enable the Hardware Standby Timer"
-msgstr "Option zum Auswählen des internen Standby-Timers der HDD"
+msgstr "Internen Standby-Timer der HDD auswählen."
 
 msgid "Orbital position"
 msgstr "Orbitposition"
@@ -12137,7 +12137,7 @@ msgid "Picon and Service Name"
 msgstr "Picon und Sendername"
 
 msgid "Picon and service name"
-msgstr ""
+msgstr "Picon und Sendername"
 
 #
 msgid "Picon width"
@@ -12262,7 +12262,7 @@ msgstr "Aufnahmeendzeit ändern"
 
 # ImageBackup.py
 msgid "Please check the manual of the receiver"
-msgstr "schauen Sie in die Bedienungsanleitung Ihres Receivers,"
+msgstr "in die Bedienungsanleitung Ihres Receivers,"
 
 #
 msgid "Please check your network settings!"
@@ -12287,7 +12287,7 @@ msgid ""
 "Please configure or verify your Nameservers by filling out the required values.\n"
 "When you are ready press OK to continue."
 msgstr ""
-"Konfigurieren Sie Ihre DNS-Server durch Ausfüllen der entsprechenden Werte.\n"
+"Stellen Sie Ihre DNS-Server durch Ausfüllen der entsprechenden Werte ein.\n"
 "\n"
 "OK drücken zum Fortfahren."
 
@@ -12359,7 +12359,7 @@ msgid "Please enter your email address. This is required for us to send you serv
 msgstr "Geben Sie bitte Ihre Email-Adresse ein. Die Email wird verwendet für Status Meldungen, Programm-Informationen, Werbeangebote und einer Willkommensmail."
 
 msgid "Please enter your personal feed URL"
-msgstr "Hier können Sie die persönliche FEED URL eintragen"
+msgstr "Tragen Sie Ihre eigene Feed URL ein."
 
 #
 msgid "Please follow the instructions on the TV"
@@ -12598,7 +12598,7 @@ msgstr ""
 
 #
 msgid "Please use the UP and DOWN keys to select your language. Afterwards press the OK button."
-msgstr "Für Sprachauswahl Hoch/Runter-Tasten nutzen. Danach OK drücken."
+msgstr "Für Sprachauswahl die Hoch/Runter-Tasten nutzen. Danach OK drücken."
 
 msgid "Please wait"
 msgstr "Bitte warten"
@@ -12762,7 +12762,7 @@ msgid "Position of finished Timers in Timerlist"
 msgstr "Position beendeter Timeraufnahmen in der Timerliste"
 
 msgid "Position of recording icons"
-msgstr "Ausrichtung der Aufnahme-Symbole"
+msgstr "Position der Aufnahme-Symbole"
 
 msgid "Position stored at index"
 msgstr ""
@@ -13248,7 +13248,7 @@ msgid "Quick Menu..."
 msgstr "Schnellstartmenü..."
 
 msgid "Quick zap"
-msgstr ""
+msgstr "Quickzap"
 
 msgid "QuickEPG mode"
 msgstr "Grafischen Infoleisten-EPG aufrufen"
@@ -13269,7 +13269,7 @@ msgid "REC"
 msgstr ""
 
 msgid "REC Symbol"
-msgstr "REC Zeichen"
+msgstr "REC Symbol"
 
 msgid "REC Symbol in Standby"
 msgstr "REC Symbol im Standby"
@@ -13330,19 +13330,19 @@ msgstr "Reader-Statistik"
 
 #, python-format
 msgid "Ready to install \"%s\" ?"
-msgstr ""
+msgstr "Wollen Sie '%s' installieren?"
 
 #, python-format
 msgid "Ready to install %s ?"
-msgstr "Wollen Sie - %s - installieren?"
+msgstr "Wollen Sie '%s' installieren?"
 
 #, python-format
 msgid "Ready to remove \"%s\" ?"
-msgstr "Wollen Sie - %s - de-installieren?"
+msgstr "Wollen Sie '%s' de-installieren?"
 
 #, python-format
 msgid "Ready to remove %s ?"
-msgstr "Wollen Sie - %s - de-installieren?"
+msgstr "Wollen Sie '%s' de-installieren?"
 
 msgid "Real Life"
 msgstr ""
@@ -13573,7 +13573,7 @@ msgstr "Bildwiederholrate für 'Niedrigster Modus'"
 
 #
 msgid "Refresh rate selection."
-msgstr "Auswahl der Bildwiederholungsrate."
+msgstr "Auswahl der Bildwiederholrate."
 
 msgid "Refresh screen"
 msgstr "Anzeige aktualisieren"
@@ -13811,7 +13811,7 @@ msgstr "Wiederholungen"
 
 # Subtitle neu 5.1
 msgid "Replace `- ` in dialogs with colored text per speaker (like teletext subtitles for the hearing impaired)"
-msgstr "Diese Option ersetzt `- ` durch farbigen Text je Sprecher in Dialogen (so wie bei Teletext Untertiteln für Hörgeschädigte)."
+msgstr "Diese Option ersetzt '- ' durch farbigen Text je Sprecher in Dialogen (so wie bei Teletext Untertiteln für Hörgeschädigte)."
 
 #, fuzzy
 msgid "Reportage"
@@ -13828,7 +13828,7 @@ msgid "Rereading partition table"
 msgstr ""
 
 msgid "Reserved"
-msgstr ""
+msgstr "Reserviert"
 
 msgid "Reserved for future use"
 msgstr ""
@@ -13856,7 +13856,7 @@ msgid "Reset video enhancement settings to your last configuration?"
 msgstr "Video-Optimierungs-Einstellungen auf letzte Konfiguration zurücksetzen?"
 
 msgid "Reshare"
-msgstr ""
+msgstr "Re-Share"
 
 msgid "Reshare:"
 msgstr "Re-Share:"
@@ -14239,7 +14239,7 @@ msgid "San Marino"
 msgstr "San Marino"
 
 msgid "Sao Tome and Principe"
-msgstr "S&atilde;o Tom&eacute; und Pr&iacute;ncipe"
+msgstr "São Tomé und Príncipe"
 
 #
 msgid "Sat"
@@ -14266,7 +14266,7 @@ msgid "Satellite equipment setup"
 msgstr "Einstellungen der Sat-Ausrüstung"
 
 msgid "Satellite longitude:"
-msgstr ""
+msgstr "Satellit Längengrad:"
 
 #
 msgid "Satellites"


### PR DESCRIPTION
Erste Anpassungen an den aktuellen (Text) Stand der 6.3 Version.

In Zeile 11283 heißt es msgid "No valid region details were foind"
Da ist wohl "found" gemeint?
Ich traue mich aber nicht, "msgid"s zu ändern.

Apropos "msgid": Es gibt viele, die deutschen Text enthalten, z.B. ab Zeile 9579:
msgid "Krieg"
msgstr ""

msgid "Krimi"
msgstr ""

Ist das so OK? Und wenn ja, warum? ;)

Gruß - Makumbo