### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3938,7 +3938,7 @@ msgid "Channel list on mode change"
 msgstr "Kanalliste bei Moduswechsel"
 
 msgid "Channel list preview"
-msgstr "Vorschau"
+msgstr "Kanal Vorschaumodus"
 
 msgid "Channel list service mode*"
 msgstr "Servicemodus *"
@@ -8287,10 +8287,10 @@ msgid "If set to 'yes' the infobar will be displayed when changing channels."
 msgstr "Bei 'Ja' wird die Infoleiste angezeigt, wenn der Sender gewechselt wird."
 
 msgid "If set to 'yes' you can preview channels in the EPG list."
-msgstr "Bei 'Ja' erhalten Sie eine Programmvorschau im EPG."
+msgstr "Wenn aktiviert, erhalten Sie eine Programmvorschau im EPG."
 
 msgid "If set to 'yes' you can preview channels in the channel list. Press 'OK' to preview the selected channel, press a 2nd 'OK' to exit and zap to that channel, pressing 'EXIT' to return to the channel you started at."
-msgstr "Bei 'Ja' Programmvorschau im EPG. Mit OK die Vorschau, ein zweiter Druck beendet EPG und schaltet zum gewählten Sender, mit EXIT Sender vor Aufruf vom EPG."
+msgstr "Bei 'Ja' wird in der Kanalliste mit OK im Hintergrund auf den markierten Sender geschaltet. Ein zweites OK beendet die Kanalliste und zeigt diesen Sender, EXIT dagegen beendet die Kanalliste und schaltet zum ursprünglichen Sender zurück."
 
 msgid "If set to 'yes', allows you use the seekbar to jump to a point within the event."
 msgstr "Bei 'Ja' können Sie innerhalb der Suchleiste zu jedem beliebigen Zeitpunkt vor oder zurück springen."
@@ -18015,7 +18015,7 @@ msgid "Unknown user: %d"
 msgstr ""
 
 msgid "Unless set to 'disabled' you get a preview of channels inside the EPG list."
-msgstr "Außer bei 'Deaktiviert' erhalten Sie eine Programmvorschau im EPG."
+msgstr "Bei 'Ja' erhalten Sie eine Programmvorschau im EPG."
 
 #
 msgid "Unmark service as dedicated 3D service"


### PR DESCRIPTION
Was zum Geier war beim ersten Mal falsch?
Der Text in Zeile 8392 "Bei 'Ja' wird in der Kanalliste mit OK im Hintergrund auf den markierten Sender geschaltet. Ein zweites OK beendet die Kanalliste und zeigt diesen Sender, EXIT dagegen beendet die Kanalliste und schaltet zum ursprünglichen Sender zurück."
eventuell zu lang?
Dann könnte man ihn vielleicht in "Bei 'Ja' wird in der Kanalliste mit OK im Hintergrund auf den markierten Sender geschaltet. Ein zweites OK beendet die Kanalliste und zeigt diesen Sender, EXIT dagegen schaltet zum ursprünglichen Sender zurück."
Gruß - Makumbo