### PR TITLE
[Timezones.py] Refactor and optimise the code

### DIFF
--- a/lib/python/Components/SetupDevices.py
+++ b/lib/python/Components/SetupDevices.py
@@ -6,13 +6,6 @@ from Components.Keyboard import keyboard
 
 def InitSetupDevices():
 
-	def timezoneNotifier(configElement):
-		timezones.activateTimezone(configElement.index)
-
-	config.timezone = ConfigSubsection()
-	config.timezone.val = ConfigSelection(default = timezones.getDefaultTimezone(), choices = timezones.getTimezoneList())
-	config.timezone.val.addNotifier(timezoneNotifier)
-
 	def keyboardNotifier(configElement):
 		keyboard.activateKeyboardMap(configElement.index)
 

--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -56,7 +56,7 @@ def InitTimeZones():
 	tz = geolocation.get("timezone", None)
 	if tz is None:
 		area = DEFAULT_AREA
-		zone = timezones.getTimezoneDefault()
+		zone = timezones.getTimezoneDefault(area=area)
 		print "[Timezones] Geolocation not available!  (area='%s', zone='%s')" % (area, zone)
 	elif DEFAULT_AREA == "Classic":
 		area = "Classic"

--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -1,62 +1,315 @@
+import errno
+import time
 import xml.etree.cElementTree
 
-from os import environ, unlink, symlink, path
-import time
+from enigma import eTimer
+from os import environ, path, symlink, unlink, walk
+
+from Components.config import ConfigSelection, ConfigSubsection, config
+from Tools.Geolocation import geolocation
 from Tools.StbHardware import setRTCoffset
-from boxbranding import getMachineBrand
+
+# The DEFAULT_AREA setting is usable by the image maintainers to select the
+# default UI mode and location settings used by their image.  If the value
+# of "Classic" is used then images that use the "Timezone area" and 
+# "Timezone" settings will have the "Timezone area" set to "Classic" and the
+# "Timezone" field will be an expanded version of the classic list of GMT
+# related offsets.  Images that only use the "Timezone" setting should use
+# "Classic" to maintain their chosen UI for timezone selection.  That is,
+# users will only be presented with the list of GMT related offsets.
+#
+# The DEFAULT_ZONE is used to select the default timezone if the "Timezone
+# area" is selected to be "Europe".  This allows OpenViX to have the
+# European default of "London" while OpenATV and OpenPLi can select "Berlin",
+# etc. (These are only examples.)  Images can select any defaults they deem
+# appropriate.
+#
+# NOTE: Even if the DEFAULT_AREA of "Classic" is selected a DEFAULT_ZONE
+# must still be selected.
+#
+# For images that use both the "Timezone area" and "Timezone" configuration
+# options then the DEFAULT_AREA can be set to an area most appropriate for
+# the image.  For example, Beyonwiz would use "Australia", OpenATV, OpenViX
+# and OpenPLi would use "Europe".  If the "Europe" option is selected then
+# the DEFAULT_ZONE can be used to select a more appropriate timezone 
+# selection for the image.  For example, OpenATV and OpenPLi may prefer
+# "Berlin" while OpenViX may prefer "London".
+#
+# Please ensure that any defaults selected are valid, unique and available
+# in the "/usr/share/zoneinfo/" directory tree.
+#
+# This version of Timezones.py now incorporates access to a new Geolocation
+# feature that will try and determine the appropriate timezone for the user
+# based on their WAN IP address.  If the receiver is not connected to the
+# Internet the defaults described above and listed below will be used.
+#
+DEFAULT_AREA = "Classic"  # Use the classic timezone based list of timezones.
+# DEFAULT_AREA = "Australia"  # Beyonwiz
+# DEFAULT_AREA = "Europe"  # OpenATV, OpenPLi, OpenViX
+DEFAULT_ZONE = "Berlin"  # OpenATV, OpenPLi
+# DEFAULT_ZONE = "London"  # OpenViX
+TIMEZONE_FILE = "/etc/timezone.xml"  # This should be SCOPE_TIMEZONES_FILE!  This file moves arond the filesystem!!!  :(
+TIMEZONE_DATA = "/usr/share/zoneinfo/"  # This should be SCOPE_TIMEZONES_DATA!
+AT_POLL_DELAY = 3  # Minutes
+
+def InitTimeZones():
+	tz = geolocation.get("timezone", None)
+	if tz is None:
+		area = DEFAULT_AREA
+		zone = timezones.getTimezoneDefault()
+		print "[Timezones] Geolocation not available!  (area='%s', zone='%s')" % (area, zone)
+	elif DEFAULT_AREA == "Classic":
+		area = "Classic"
+		zone = tz
+		print "[Timezones] Classic mode with geolocation tz='%s', area='%s', zone='%s'." % (tz, area, zone)
+	else:
+		area, zone = tz.split("/", 1)
+		print "[Timezones] Modern mode with geolocation tz='%s', area='%s', zone='%s'." % (tz, area, zone)
+	config.timezone = ConfigSubsection()
+	config.timezone.area = ConfigSelection(default=area, choices=timezones.getTimezoneAreaList())
+	config.timezone.val = ConfigSelection(default=timezones.getTimezoneDefault(), choices=timezones.getTimezoneList())
+	if not config.timezone.area.saved_value:
+		config.timezone.area.value = area
+	if not config.timezone.val.saved_value:
+		config.timezone.val.value = zone
+	config.timezone.save()
+
+	def timezoneAreaChoices(configElement):
+		choices = timezones.getTimezoneList(area=configElement.value)
+		config.timezone.val.setChoices(choices=choices, default=timezones.getTimezoneDefault(area=configElement.value, choices=choices))
+		if config.timezone.val.saved_value and config.timezone.val.saved_value in [x[0] for x in choices]:
+			config.timezone.val.value = config.timezone.val.saved_value
+
+	def timezoneNotifier(configElement):
+		timezones.activateTimezone(configElement.value, config.timezone.area.value)
+
+	config.timezone.area.addNotifier(timezoneAreaChoices, initial_call=False, immediate_feedback=True)
+	config.timezone.val.addNotifier(timezoneNotifier, initial_call=True, immediate_feedback=True)
+	config.timezone.val.callNotifiersOnSaveAndCancel = True
+
 
 class Timezones:
 	def __init__(self):
-		self.timezones = []
-		self.readTimezonesFromFile()
+		self.timezones = {}
+		self.loadTimezones()
+		self.readTimezones()
+		self.autotimerCheck()
+		if self.autotimerPollDelay is None:
+			self.autotimerPollDelay = AT_POLL_DELAY
+		self.timer = eTimer()
+		self.autotimerUpdate = False
 
-	def readTimezonesFromFile(self):
-		try:
-			file = open('/etc/timezone.xml')
-			root = xml.etree.cElementTree.parse(file).getroot()
-			file.close()
-			for zone in root.findall("zone"):
-				self.timezones.append((zone.get('name',""), zone.get('zone',"")))
-		except:
-			pass
-
+	# Scan the zoneinfo directory tree and all load all timezones found.
+	#
+	def loadTimezones(self):
+		commonTimezoneNames = {
+			"Antarctica/DumontDUrville": "Dumont d'Urville",
+			"Asia/Ho_Chi_Minh": "Ho Chi Minh City",
+			"Australia/LHI": None,  # Exclude
+			"Australia/Lord_Howe": "Lord Howe Island",
+			"Australia/North": "Northern Territory",
+			"Australia/South": "South Australia",
+			"Australia/West": "Western Australia",
+			"Brazil/DeNoronha": "Fernando de Noronha",
+			"Pacific/Chatham": "Chatham Islands",
+			"Pacific/Easter": "Easter Island",
+			"Pacific/Galapagos": "Galapagos Islands",
+			"Pacific/Gambier": "Gambier Islands",
+			"Pacific/Johnston": "Johnston Atoll",
+			"Pacific/Marquesas": "Marquesas Islands",
+			"Pacific/Midway": "Midway Islands",
+			"Pacific/Norfolk": "Norfolk Island",
+			"Pacific/Pitcairn": "Pitcairn Islands",
+			"Pacific/Wake": "Wake Island",
+		}
+		for (root, dirs, files) in walk(TIMEZONE_DATA):
+			base = root[len(TIMEZONE_DATA):]
+			if base in ("posix", "right"):  # Skip these alternate copies of the timezone data if they exist.
+				continue
+			if base == "":
+				base = "Generic"
+			area = None
+			zones = []
+			for file in files:
+				if file[-4:] == ".tab" or file[-2:] == "-0" or file[-1:] == "0" or file[-2:] == "+0":  # No need for ".tab", "-0", "0", "+0" files.
+					continue
+				tz = "%s/%s" % (base, file)
+				area, zone = tz.split("/", 1)
+				name = commonTimezoneNames.get(tz, zone)  # Use the more common name if one is defined.
+				if name is None:
+					continue
+				zones.append((zone, name.replace("_", " ")))
+			if area:
+				if area in self.timezones:
+					zones = self.timezones[area] + zones
+				self.timezones[area] = self.gmtSort(zones)
 		if len(self.timezones) == 0:
-			self.timezones = [("UTC", "UTC")]
+			print "[Timezones] Warning: No areas or zones found in '%s'!" % TIMEZONE_DATA
+			self.timezones["Generic"] = [("UTC", "UTC")]
 
-	def activateTimezone(self, index):
-		if len(self.timezones) <= index:
-			return
+	# Return the list of Zones sorted alphabetically.  If the Zone
+	# starts with "GMT" then those Zones will be sorted in GMT order
+	# with GMT-14 first and GMT+12 last.
+	#
+	def gmtSort(self, zones):
+		data = {}
+		for (zone, name) in zones:
+			if name.startswith("GMT"):
+				try:
+					key = int(name[4:])
+					key = (key * -1) + 15 if name[3:4] == "-" else key + 15
+					key = "GMT%02d" % key
+				except ValueError:
+					key = "GMT15"
+			else:
+				key = name
+			data[key] = (zone, name)
+		return [data[x] for x in sorted(data.keys())]
 
-		environ['TZ'] = self.timezones[index][1]
+	# Read the timezones.xml file and load all timezones found.
+	#
+	def readTimezones(self, filename=TIMEZONE_FILE):
+		root = None
+		try:
+			# This open gets around a possible file handle leak in Python's XML parser.
+			with open(filename, "r") as fd:
+				try:
+					root = xml.etree.cElementTree.parse(fd).getroot()
+				except xml.etree.cElementTree.ParseError as err:
+					root = None
+					fd.seek(0)
+					content = fd.readlines()
+					line, column = err.position
+					print "[Timezones] XML Parse Error: '%s' in '%s'!" % (err, filename)
+					data = content[line - 1].replace("\t", " ").rstrip()
+					print "[Timezones] XML Parse Error: '%s'" % data
+					print "[Timezones] XML Parse Error: '%s^%s'" % ("-" * column, " " * (len(data) - column - 1))
+				except Exception as err:
+					root = None
+					print "[Timezones] Error: Unable to parse timezone data in '%s' - '%s'!" % (filename, err)
+		except (IOError, OSError) as err:
+			if err.errno == errno.ENOENT:  # No such file or directory
+				print "[Timezones] Note: Classic timezones in '%s' are not available." % filename
+			else:
+				print "[Timezones] Error %d: Opening timezone file '%s'! (%s)" % (err.errno, filename, err.strerror)
+		except Exception as err:
+			print "[Timezones] Error: Unexpected error opening timezone file '%s'! (%s)" % (filename, err)
+		zones = []
+		if root is not None:
+			for zone in root.findall("zone"):
+				name = zone.get("name", "")
+				zonePath = zone.get("zone", "")
+				if path.exists(path.join(TIMEZONE_DATA, zonePath)):
+					zones.append((zonePath, name))
+				else:
+					print "[Timezones] Warning: Classic timezone '%s' (%s) is not available in '%s'!" % (name, zonePath, TIMEZONE_DATA)
+				# print "[Timezones] DEBUG: Count=%2d, Name='%-50s', Zone='%s'%s" % (len(zones), name, zonePath)
+			self.timezones["Classic"] = zones
+		if len(zones) == 0:
+			self.timezones["Classic"] = [("UTC", "UTC")]
+
+	# Return a sorted list of all Area entries.
+	#
+	def getTimezoneAreaList(self):
+		return sorted(self.timezones.keys())
+
+	# Return a sorted list of all Zone entries for an Area.
+	#
+	def getTimezoneList(self, area=None):
+		if area is None:
+			area = config.timezone.area.value
+		return self.timezones.get(area, [("UTC", "UTC")])
+
+	# Return a default Zone for any given Area.  If there is no specific
+	# default then the first Zone in the Area will be returned.
+	#
+	def getTimezoneDefault(self, area=None, choices=None):
+		areaDefaultZone = {
+			"Australia": "Sydney",
+			"Classic": "Europe/London",
+			"Etc": "GMT",
+			"Europe": DEFAULT_ZONE,
+			"Generic": "UTC",
+			"Pacific": "Auckland"
+		}
+		if area is None:
+			area = config.timezone.area.value
+		if choices is None:
+			choices = self.getTimezoneList(area=area)
+		return areaDefaultZone.setdefault(area, choices[0][0])
+
+	def activateTimezone(self, zone, area):
+		# print "[Timezones] activateTimezone DEBUG: Area='%s', Zone='%s'" % (area, zone)
+		self.autotimerCheck()
+		if self.autotimerAvailable and config.plugins.autotimer.autopoll.value:
+			print "[Timezones] Trying to stop main AutoTimer poller."
+			if self.autotimerPoller is not None:
+				self.autotimerPoller.stop()
+			self.autotimerUpdate = True
+		tz = zone if area in ("Classic", "Generic") else path.join(area, zone)
+		file = path.join(TIMEZONE_DATA, tz)
+		if not path.isfile(file):
+			print "[Timezones] Error: The timezone '%s' is not available!  Using 'UTC' instead." % tz
+			tz = "UTC"
+			file = path.join(TIMEZONE_DATA, tz)
+		print "[Timezones] Setting timezone to '%s'." % tz
+		environ["TZ"] = tz
 		try:
 			unlink("/etc/localtime")
-		except OSError:
+		except (IOError, OSError) as err:
+			if err.errno != errno.ENOENT:  # No such file or directory
+				print "[Directories] Error %d: Unlinking '/etc/localtime'! (%s)" % (err.errno, err.strerror)
 			pass
 		try:
-			symlink("/usr/share/zoneinfo/%s" %(self.timezones[index][1]), "/etc/localtime")
-		except OSError:
+			symlink(file, "/etc/localtime")
+		except (IOError, OSError) as err:
+			print "[Directories] Error %d: Linking '%s' to '/etc/localtime'! (%s)" % (err.errno, file, err.strerror)
 			pass
 		try:
 			time.tzset()
-		except:
+		except Exception:
 			from enigma import e_tzset
 			e_tzset()
-
 		if path.exists("/proc/stb/fp/rtc_offset"):
 			setRTCoffset()
+		if self.autotimerAvailable and config.plugins.autotimer.autopoll.value:
+			if self.autotimerUpdate:
+				self.timer.stop()
+			if self.autotimeQuery not in self.timer.callback:
+				self.timer.callback.append(self.autotimeQuery)
+			print "[Timezones] AutoTimer poller will be run in %d minutes." % AT_POLL_DELAY
+			self.timer.startLongTimer(AT_POLL_DELAY * 60)
 
-	def getTimezoneList(self):
-		return [ str(x[0]) for x in self.timezones ]
+	def autotimerCheck(self):
+		try:
+			# Create attributes autotimer & autopoller for backwards compatibility.
+			# Their use is deprecated.
+			from Plugins.Extensions.AutoTimer.plugin import autotimer, autopoller
+			self.autotimerPoller = autopoller
+			self.autotimerTimer = autotimer
+			self.autotimerAvailable = True
+		except ImportError:
+			self.autotimerPoller = None
+			self.autotimerTimer = None
+			self.autotimerAvailable = False
+		try:
+			self.autotimerPollDelay = config.plugins.autotimer.delay.value
+		except AttributeError:
+			self.autotimerPollDelay = None
 
-	def getDefaultTimezone(self):
-		# TODO return something more useful - depending on country-settings?
-		if getMachineBrand() == "Beyonwiz":
-			t = "(GMT+10:00) Australia: Sydney"
-		else:
-			t = "(GMT+01:00) Germany: Berlin"
-		for (a,b) in self.timezones:
-			if a == t:
-				return a
-		return self.timezones[0][0]
+	def autotimeQuery(self):
+		print "[Timezones] AutoTimer poll is running."
+		self.autotimerUpdate = False
+		if self.autotimeQuery in self.timer.callback:
+			self.timer.callback.remove(self.autotimeQuery)
+		self.timer.stop()
+		self.autotimerCheck()
+		if self.autotimerAvailable:
+			if self.autotimerTimer is not None:
+				print "[Timezones] AutoTimer is parseing the EPG."
+				self.autotimerTimer.parseEPG(autoPoll=True)
+			if self.autotimerPoller is not None:
+				self.autotimerPoller.start()
+
 
 timezones = Timezones()

--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -281,6 +281,9 @@ class Timezones:
 			self.timer.startLongTimer(AT_POLL_DELAY * 60)
 
 	def autotimerCheck(self):
+		self.autotimerAvailable = False
+		self.autotimerPollDelay = None
+		return None
 		try:
 			# Create attributes autotimer & autopoller for backwards compatibility.
 			# Their use is deprecated.

--- a/lib/python/Tools/Geolocation.py
+++ b/lib/python/Tools/Geolocation.py
@@ -1,0 +1,64 @@
+from json import loads
+from urllib2 import URLError, urlopen
+
+# Data available from http://ip-api.com/json/:
+#
+# 	Name		Description				Example			Type
+# 	--------------	--------------------------------------	----------------------	------
+# 	status		success or fail				success			string
+# 	message		Included only when status is fail. Can
+# 			be one of the following: private range,
+# 			reserved range, invalid query		invalid query		string
+# 	continent	Continent name				North America		string
+# 	continentCode	Two-letter continent code		NA			string
+# 	country		Country name				United States		string
+# 	countryCode	Two-letter country code
+# 			ISO 3166-1 alpha-2			US			string
+# 	region		Region/state short code (FIPS or ISO)	CA or 10		string
+# 	regionName	Region/state				California		string
+# 	city		City					Mountain View		string
+# 	district	District (subdivision of city)		Old Farm District	string
+# 	zip		Zip code				94043			string
+# 	lat		Latitude				37.4192			float
+# 	lon		Longitude				-122.0574		float
+# 	timezone	City timezone				America/Los_Angeles	string
+# 	currency	National currency			USD			string
+# 	isp		ISP name				Google			string
+# 	org		Organization name			Google			string
+# 	as		AS number and organization, separated
+# 			by space (RIR). Empty for IP blocks 
+# 			not being announced in BGP tables.	AS15169 Google Inc.	string
+# 	asname		AS name (RIR). Empty for IP blocks not
+# 			being announced in BGP tables.		GOOGLE			string
+# 	reverse		Reverse DNS of the IP
+# 			(Not fetched as it delays response)	wi-in-f94.1e100.net	string
+# 	mobile		Mobile (cellular) connection		true			bool
+# 	proxy		Proxy, VPN or Tor exit address		true			bool
+# 	hosting		Hosting, colocated or data center	true			bool
+# 	query		IP used for the query			173.194.67.94		string
+
+geolocation = {}
+
+def InitGeolocation():
+	global geolocation
+	if len(geolocation) == 0:
+		try:
+			response = urlopen("http://ip-api.com/json/?fields=33288191", data=None, timeout=10).read()
+			# print "[Geolocation] DEBUG:", response
+			if response:
+				geolocation = loads(response)
+			status = geolocation.get("status", None)
+			if status and status == "success":
+				print "[Geolocation] Geolocation data initialised."
+			else:
+				print "[Geolocation] Error: Geolocation lookup returned a '%s' status!  Message '%s' returned." % (status, geolocation.get("message", None))
+		except URLError as err:
+			if hasattr(err, 'code'):
+				print "[Geolocation] Error : Geolocation data not available! (Code: %s)" % err.code
+			if hasattr(err, 'reason'):
+				print "[Geolocation] Error : Geolocation data not available! (Reason: %s)" % err.reason
+
+def RefreshGeolocation():
+	global geolocation
+	geolocation = {}
+	InitGeolocation()

--- a/mytest.py
+++ b/mytest.py
@@ -28,6 +28,10 @@ if getImageArch() in ("aarch64"):
 
 from traceback import print_exc
 
+profile("Geolocation")
+import Tools.Geolocation
+Tools.Geolocation.InitGeolocation()
+
 profile("SetupDevices")
 import Components.SetupDevices
 Components.SetupDevices.InitSetupDevices()

--- a/mytest.py
+++ b/mytest.py
@@ -32,6 +32,10 @@ profile("Geolocation")
 import Tools.Geolocation
 Tools.Geolocation.InitGeolocation()
 
+profile("TimeZones")
+import Components.Timezones
+Components.Timezones.InitTimeZones()
+
 profile("SetupDevices")
 import Components.SetupDevices
 Components.SetupDevices.InitSetupDevices()


### PR DESCRIPTION
- [Timezones.py] Refactor and optimise the code
  - Clean up and optimise the code.
  - Add access to geolocation data to establish the initial guess of the user's timezone.
  - Don't change the default timezone when navigating through available timezone lists.
  - Ignore the existence of alternate txdata from "posix" or "right" packages.
  - Improve the configuration comments.
  - Correct name display of "Dumont d'Urville".
  - Use the 2019c version of "timezone.xml" file to offer users a classic view of timezone selections.  This list is the default for OpenATV and is available under the "Timezone area" of "Classic" if the new "timezone area" and "Timezone" style UI is adopted by OpenATV.

- [Geolocation.py] New tool to provide geolocation data

- [mytest.py] Activate geolocation initialisation

- [mytest.py] Create separate timezone initialisation

- [SetupDevices.py] Remove partial timezone initialisation

- [Timezones.py] Disable AutoTimer synchronisation

  OpenATV appears to have enough differences from the other images that it is easier to simply disable this feature.  It wasn't previously available so nothing has been lost.
