### PR TITLE
[Timezones.py] Correct initialisation default

### DIFF
--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -226,7 +226,7 @@ class Timezones:
 	def getTimezoneDefault(self, area=None, choices=None):
 		areaDefaultZone = {
 			"Australia": "Sydney",
-			"Classic": "Europe/London",
+			"Classic": "Europe/%s" % DEFAULT_ZONE,
 			"Etc": "GMT",
 			"Europe": DEFAULT_ZONE,
 			"Generic": "UTC",


### PR DESCRIPTION
The correct timezone default was incorrectly hard coded for the "Classic" mode UI.
