### PR TITLE
Fix crash in IceTV plugin on recording write error

### DIFF
--- a/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
@@ -458,7 +458,7 @@ class EPGFetcher(object):
                     del self.failed[id(event)]
         elif event in self.ERROR_EVENTS:
             state = "failed"
-            if event == evRecordWriteError and id(event) not in self.failed:
+            if event == iRecordableService.evRecordWriteError and id(event) not in self.failed:
                 # use same structure as deferred_status to simplify cleanup
                 # Hold otherwise unused reference to entry so
                 # that id(entry) remains valid


### PR DESCRIPTION
Add class name to reference to evRecordWriteError to prevent
crash when there is a disk write error during recording.