### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -2880,7 +2880,7 @@ msgid ""
 msgstr ""
 "Sind Sie sicher, dass die Einstellungen Ihrer %s %s wiederhergestellt werden sollen?\n"
 "\n"
-"Ihr Receiver wird neu gestartet, nachdem die Einstellungen wiederhergestellt wurden"
+"Ihr Receiver wird neu gestartet, nachdem die Einstellungen wiederhergestellt wurden."
 
 #
 msgid ""
@@ -2889,7 +2889,7 @@ msgid ""
 msgstr ""
 "Sind Sie sicher, dass die Einstellungen Ihres Receivers wiederhergestellt werden sollen?\n"
 "\n"
-"Ihr Receiver wird neu gestartet, nachdem die Einstellungen wiederhergestellt wurden"
+"Ihr Receiver wird neu gestartet, nachdem die Einstellungen wiederhergestellt wurden."
 
 msgid "Are you sure you want to save the EPG Cache to:\n"
 msgstr "Die EPG-Daten hier speichern:\n"
@@ -7256,7 +7256,7 @@ msgstr "Sendungsinformation:"
 
 #
 msgid "Everyday"
-msgstr "Jeder Tag"
+msgstr "Täglich"
 
 msgid "Everywhere"
 msgstr "Überall"
@@ -12555,7 +12555,7 @@ msgid "Please wait while scanning is in progress..."
 msgstr "Der Suchvorgang läuft. Bitte warten..."
 
 msgid "Please wait while the list downloads..."
-msgstr "Bitte warten während die Liste heruntergeladen wird ..."
+msgstr "Bitte warten während die Liste heruntergeladen wird..."
 
 msgid "Please wait while we check your installed plugins..."
 msgstr "Bitte warten, es werden die installierten Plugins geprüft..."
@@ -15442,7 +15442,7 @@ msgid "Setup your Channel selection configuration"
 msgstr "Stellen Sie Ihre Kanallistenkonfiguration ein."
 
 msgid "Setup your Device mounts (USB, HDD, others...)"
-msgstr "Einstellungen der Laufwerk-Mounts (USB, HDD, andere...)"
+msgstr "Einstellungen der Laufwerk-Mounts (USB, HDD etc.)"
 
 # Quick Menue
 msgid "Setup your EPG config"
@@ -20146,10 +20146,10 @@ msgid "When enabled the online checker will also check for experimental versions
 msgstr "Wenn aktiviert, werden auch experimentelle Updates gesucht."
 
 msgid "When enabled, AIT data will be included in http streams. This allows a client receiver to use HbbTV."
-msgstr "Wenn aktiviert, werden AIT Daten in HTTP Streams eingebettet. Dies erlaubt es Klienten HbbTV zu benutzen."
+msgstr "Bei 'Ja' werden AIT Daten in HTTP Streams eingebettet. Dies erlaubt es Klienten HbbTV zu benutzen."
 
 msgid "When enabled, EIT data will be included in http streams. This allows a client receiver to show EPG."
-msgstr "Wenn aktiviert, werden EIT Daten in HTTP Streams eingebettet. Dies erlaubt es Klienten einen EPG anzuzeigen."
+msgstr "Bei 'Ja' werden EIT Daten in HTTP Streams eingebettet. Dies erlaubt es Klienten einen EPG anzuzeigen."
 
 # channelselection 5.1
 msgid "When enabled, Enigma2 will load unlinked bouquets. This means that bouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
@@ -20313,7 +20313,7 @@ msgid ""
 "\n"
 "Really do a factory reset?"
 msgstr ""
-"Wenn Sie die Werkseinstellungen wiederherstellen, verlieren Sie sämtliche Konfigurationsdateien (einschließlich Kanalliste, Tuner-Konfiguration...)\n"
+"Wenn Sie die Werkseinstellungen wiederherstellen, verlieren Sie sämtliche Konfigurationsdateien (einschließlich Kanalliste, Tuner-Konfiguration etc.).\n"
 "\n"
 "Nach der Wiederherstellung wird die %s %s automatisch neu starten.\n"
 "\n"
@@ -20888,7 +20888,7 @@ msgid ""
 "This may take a few minutes"
 msgstr ""
 "Der Frontprozessor wird jetzt aktualisiert.\n"
-"Bitte warten bis die %s %s neu startet,\n"
+"Bitte warten Sie bis die %s %s neu startet,\n"
 "es dauert einige Minuten..."
 
 # SoftwareManager
@@ -21447,7 +21447,7 @@ msgid "create directory"
 msgstr "Verzeichnis erstellen"
 
 msgid "create symlink ..."
-msgstr "erzeuge Symlink ..."
+msgstr "erzeuge Symlink..."
 
 #
 msgid "current affairs (general)"


### PR DESCRIPTION
Eigentlich sollte (fast immer) vor die drei Punkte ("...") ein Leerzeichen. So ist die aktuelle Rechtschreibung.
Aber 1. Sieht es dann machmal 'blöd' aus.
Aber 2. Kann es bei längeren Texten passieren, dass die Punkte dann allein in der nächsten Zeile stehen.
Aber 3. Sind nur zwei Texte mit " ..." zu ändern, im Gegensatz zu 'hunderten' mit "..."
Änderungen in Timerübersicht und MENU - Einstellungen - EPG - Einstellungen
---
ab Zeile 2913 - Mal so "&" - mal so "/" ?
msgid "Arts & Culture"
msgstr "Kunst/Kultur"

msgid "Arts/Culture"
msgstr "Kunst/Kultur

Welches ist 'richtig' ?

Gruß - Makumbo