### PR TITLE
[Timezones.py] Add further improvements

### DIFF
--- a/mytest.py
+++ b/mytest.py
@@ -32,10 +32,6 @@ profile("Geolocation")
 import Tools.Geolocation
 Tools.Geolocation.InitGeolocation()
 
-profile("TimeZones")
-import Components.Timezones
-Components.Timezones.InitTimeZones()
-
 profile("SetupDevices")
 import Components.SetupDevices
 Components.SetupDevices.InitSetupDevices()
@@ -803,6 +799,10 @@ Components.RecordingConfig.InitRecordingConfig()
 profile("UsageConfig")
 import Components.UsageConfig
 Components.UsageConfig.InitUsageConfig()
+
+profile("TimeZones")
+import Components.Timezones
+Components.Timezones.InitTimeZones()
 
 profile("Init:DebugLogCheck")
 import Screens.LogManager


### PR DESCRIPTION
- [Timezones.py] Add further improvements
  - Correct display of UTF-8 areas and zones.
  - Add callbacks for before and after the timezone is set.
  - Separate the AutoTimer code out of the Timezones code.  Move the AutoTimer code to the end of this code and add the hooks as a template until the AutoTimer code is updated to use the new callback code.
  - Enable AutoTimer processing code.
  - Correct a minor spelling error.

- [mytest.py] Move Timezones initialisation

  This change enables the AutoTimer processing to be restored to the Timezones.py code.

  NOTE: The AutoTimer code in the Timezones.py code should be moved into the AutoTimer plugin code.
