### PR TITLE
[Timezones.py] Fix incorrectly saved setting

### DIFF
--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -251,7 +251,6 @@ class Timezones:
 			tz = "UTC"
 			file = path.join(TIMEZONE_DATA, tz)
 		print "[Timezones] Setting timezone to '%s'." % tz
-		config.timezone.save()
 		environ["TZ"] = tz
 		try:
 			unlink("/etc/localtime")


### PR DESCRIPTION
Don't save the changed timezone settings until the user exits the settings screen.
