### PR TITLE
[setup.xml] Enable area and timezone UI

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -1,7 +1,8 @@
 <!--suppress XmlUnboundNsPrefix -->
 <setupxml>
 	<setup key="time" title="Time settings">
-		<item level="0" text="Timezone" description="Setup your timezone.">config.timezone.val</item>
+		<item level="0" text="Timezone area" description="Setup your timezone area.">config.timezone.area</item>
+		<item level="0" text="Timezone" description="Your timezone in the area.">config.timezone.val</item>
 		<item level="0" text="Sync time using" description="Synchronize systemtime using transponder or internet.">config.misc.SyncTimeUsing</item>
 		<item level="0" text="NTP server" description="Configure your NTP server.">config.misc.NTPserver</item>
 		<item level="0" text="Sync NTP every (minutes)" description="Setup network time synchronization interval." requires="config.misc.SyncTimeUsing" >config.misc.useNTPminutes</item>


### PR DESCRIPTION
This change enables the area / region and timezone in that region Timezone UI.  Users can now select their area or region of the world and then can select from a significantly shorter list of timezones that apply to that area or region.

If users prefer they can still select the "Classic" area and the Timezone list will then offer the traditional comprehensive list of timezones by GMT offsets.
