### PR TITLE
[Timezones.py] Patch to avoid /etc/localtime issues

### DIFF
--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -86,12 +86,12 @@ def InitTimeZones():
 		msgs = []
 		if config.timezone.area.value != tzArea:
 			msgs.append("area '%s' != '%s'" % (tzArea, config.timezone.area.value))
-			config.timezone.area.value = tzArea
+			# config.timezone.area.value = tzArea
 		if config.timezone.val.value != tzVal:
 			msgs.append("zone '%s' != '%s'" % (tzVal, config.timezone.val.value))
-			config.timezone.val.value = tzVal
+			# config.timezone.val.value = tzVal
 		if len(msgs):
-			print "[Timezones] Warning: System timezone does not match Enigma2 timezone (%s), setting Enigma2 to system timezone!" % ",".join(msgs)
+			print "[Timezones] Warning: System timezone does not match Enigma2 timezone (%s)!" % ",".join(msgs)
 	except (IOError, OSError):
 		pass
 


### PR DESCRIPTION
This patch disables the code that tried to synchronise the Enigma2 time zone with that defined in the Operating System.  For now the difference will be logged but Enigma2 will no longer be synchronized.

I hope this patch can be removed as soon as the code that is unexpectedly changing /etc/localtime can be found and fixed.
