### PR TITLE
[Timezones.py] Update default timezone

### DIFF
--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -42,9 +42,9 @@ from Tools.StbHardware import setRTCoffset
 # based on their WAN IP address.  If the receiver is not connected to the
 # Internet the defaults described above and listed below will be used.
 #
-DEFAULT_AREA = "Classic"  # Use the classic timezone based list of timezones.
+# DEFAULT_AREA = "Classic"  # Use the classic timezone based list of timezones.
 # DEFAULT_AREA = "Australia"  # Beyonwiz
-# DEFAULT_AREA = "Europe"  # OpenATV, OpenPLi, OpenViX
+DEFAULT_AREA = "Europe"  # OpenATV, OpenPLi, OpenViX
 # DEFAULT_ZONE = "Amsterdam"  # OpenPLi
 DEFAULT_ZONE = "Berlin"  # OpenATV
 # DEFAULT_ZONE = "London"  # OpenViX


### PR DESCRIPTION
With the new area / region and timezone UI being enabled in "setup.xml" the default time zone in "Timezones.py" needs to be updated to "Europe/Berlin" to provide a better user experience when setting the timezone.
