### PR TITLE
Revert "radiotext - fixed lossy encoding"

### DIFF
--- a/lib/dvb/radiotext.cpp
+++ b/lib/dvb/radiotext.cpp
@@ -411,13 +411,13 @@ void eDVBRdsDecoder::gotAncillaryData(const uint8_t *buf, int len)
 					switch (c)
 					{
 						case 0 ... 0x7f: break;
-						case 0x8d: c='ÃŸ'; break;
-						case 0x91: c='Ã¤'; break;
-						case 0xd1: c='Ã„'; break;
-						case 0x97: c='Ã¶'; break;
-						case 0xd7: c='Ã–'; break;
-						case 0x99: c='Ã¼'; break;
-						case 0xd9: c='Ãœ'; break;
+						case 0x8d: c='ß'; break;
+						case 0x91: c='ä'; break;
+						case 0xd1: c='Ä'; break;
+						case 0x97: c='ö'; break;
+						case 0xd7: c='Ö'; break;
+						case 0x99: c='ü'; break;
+						case 0xd9: c='Ü'; break;
 						default: c=' '; break;  // convert all unknown to space
 					}
 					message[msgPtr++]=c;


### PR DESCRIPTION
Reverts openatv/enigma2#1521
need more rework if transformed from iso 8859-15 to utf-8.