### PR TITLE
TV/Radio toogle button in Octagon SF8008

### DIFF
--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -183,7 +183,7 @@ class InfoBar(InfoBarBase, InfoBarShowHide,
 			self.showTvChannelList(True)
 			self.servicelist.showFavourites()
 	def showTvButton(self):
-		if boxtype.startswith('gb') or boxtype in ('classm', 'genius', 'evo', 'galaxym6'):
+		if boxtype.startswith('gb') or boxtype in ('classm', 'genius', 'evo', 'galaxym6', 'sf8008', 'sf8008m'):
 			self.toogleTvRadio()
 		elif boxtype in ('uniboxhd1', 'uniboxhd2', 'uniboxhd3', 'sezam5000hd', 'mbtwin'):
 			self.showMovies()


### PR DESCRIPTION
Workaround for the TV/Radio toogle button in Octagon SF8008.