### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -4331,15 +4331,23 @@ msgstr "Wählen Sie das CI Protokoll, für CI Normal oder CI Plus Module."
 
 msgid "Choose the display formatting style for dates. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin."
 msgstr ""
+"Wählen Sie das Format für das Datum. 'D'/'DD' ist das Datum, 'M'/'MM' der Monat. Bei 'DD' und 'MM' wird einstelligen Werten eine '0' vorangestellt.\n"
+"Nicht jeder Skin unterstützt jede Einstellung."
 
 msgid "Choose the display formatting style for times. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes and 'ss' is the seconds.  ('HH' and 'hh' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin."
 msgstr ""
+"Wählen Sie das Format für die Uhrzeit. 'H'/'HH' zeigt sie im 24-Stunden-Format, 'h'/'hh' im 12-Stunden-Format an. Bei 'HH' oder 'hh' wird einstelligen Werten eine '0' vorangestellt.\n"
+"Nicht jeder Skin unterstützt jede Einstellung."
 
 msgid "Choose the front panel display formatting style for dates. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin."
-msgstr "Wählen Sie, ob und wie das Datum im Display angezeigt werden soll. 'Keine Anzeige' zeigt es gar nicht an. 'T'/'TT' ist das Datum und 'M'/'MM' der Monat. Bei 'TT' oder 'MM' wird einstelligen Werten eine '0' vorangestellt. Nicht jeder Skin unterstützt jede Einstellung."
+msgstr ""
+"Wählen Sie, ob und wie das Datum im Display angezeigt werden soll. 'Keine Anzeige' zeigt es gar nicht an. 'T'/'TT' ist das Datum und 'M'/'MM' der Monat. Bei 'TT' oder 'MM' wird einstelligen Werten eine '0' vorangestellt.\n"
+"Nicht jeder Skin unterstützt jede Einstellung."
 
 msgid "Choose the front panel display formatting style for times. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes.  ('HH' and 'hh' have leading zeros for single digit values.) The front panel display will be based on your choice but can be influenced any applicable skin."
-msgstr "Wählen Sie, ob und wie die Uhrzeit im Display angezeigt werden soll. 'Keine Anzeige' zeigt sie gar nicht an, 'H'/'HH' im 24-Stunden-Format, 'h'/'hh' im 12-Stunden-Format. Bei 'HH' oder 'hh' wird einstelligen Werten eine '0' vorangestellt. Nicht jeder Skin unterstützt jede Einstellung."
+msgstr ""
+"Wählen Sie, ob und wie die Uhrzeit im Display angezeigt werden soll. 'Keine Anzeige' zeigt sie gar nicht an, 'H'/'HH' im 24-Stunden-Format, 'h'/'hh' im 12-Stunden-Format. Bei 'HH' oder 'hh' wird einstelligen Werten eine '0' vorangestellt.\n"
+"Nicht jeder Skin unterstützt jede Einstellung."
 
 msgid "Choose the location for crash and debuglogs."
 msgstr "Wählen Sie den Speicherort für Crash- und Debug-Logs."
@@ -15831,7 +15839,7 @@ msgid "Show VCR scart on main menu"
 msgstr "Zeige Scart-Videorekorder im Hauptmenü"
 
 msgid "Show Vertical EPG"
-msgstr "Zeige vertikales EPG"
+msgstr "Zeige vertikalen EPG"
 
 #
 msgid "Show WLAN status"
@@ -16120,7 +16128,7 @@ msgid "Show single epg for current channel (setup in menu)"
 msgstr "Zeige Einzel-EPG für den aktuellen Kanal (Einstellung im Menü)"
 
 msgid "Show single service EPG"
-msgstr "Einfaches EPG anzeigen"
+msgstr "Einfachen EPG anzeigen"
 
 msgid "Show source packages"
 msgstr "Zeige Quellpakete"


### PR DESCRIPTION
"Zeige vertikales EPG" und "Einfaches EPG anzeigen" in "Zeige vertikalen EPG" und "Einfachen EPG anzeigen" geändert (es ist ja DER EPG).
Format für Datum / Uhrzeit in deutsch und neu formatiert, so dass die Erklärung "Nicht jeder Skin unterstützt jede Einstellung." eine eigene Zeile bekommt.
Gruß - Makumbo