### PR TITLE
Overhaul skin processing engine

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -348,7 +348,6 @@
 		<item level="0" requires="ConfigDisplay" text="Power On Display" description="This option allows you to Power Off the display.">config.lcd.power</item>
 		<item level="0" requires="ConfigDisplay" text="Show HDMI-Output Res" description="Show HDMI Output Resolution">config.lcd.showoutputresolution</item>
 		<item level="0" requires="ConfigDisplay" text="Show HDD progress" description="Disable the HDD Process on VFD">config.lcd.hdd</item>
-		<item level="0" requires="ConfigDisplay" text="Show on Display" description="Disable all VFD Symbols">config.vfd.show</item>
 		<item level="1" requires="ConfigDisplay" text="Scrolling speed (software renderer)" description="Set the scrolling speed of text on the front display, this is used by software renderer in some skins.">config.lcd.scroll_speed</item>
 		<item level="1" requires="ConfigDisplay" text="Scrolling delay (software renderer)" description="Set the delay time between repeated loops, this is used by software renderer in some skins.">config.lcd.scroll_delay</item>
 		<item level="0" requires="config.usage.date.enabled_display" text="Date style" description="Choose the front panel display formatting style for dates. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin." >config.usage.date.display</item>

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -11,7 +11,7 @@ class ConfigList(HTMLComponent, GUIComponent, object):
 	def __init__(self, list, session = None):
 		GUIComponent.__init__(self)
 		self.l = eListboxPythonConfigContent()
-		seperation, = skin.parameters.get("ConfigListSeperator", (350, ))
+		seperation = skin.parameters.get("ConfigListSeperator", 350)
 		self.l.setSeperation(seperation)
 		height, space = skin.parameters.get("ConfigListSlider",(17, 0))
 		self.l.setSlider(height, space)

--- a/skin.py
+++ b/skin.py
@@ -1,1046 +1,847 @@
-from Tools.Profile import profile
-profile("LOAD:ElementTree")
+import errno
 import xml.etree.cElementTree
-import os
 
-profile("LOAD:enigma_skin")
-from enigma import eSize, ePoint, eRect, gFont, eWindow, eLabel, ePixmap, eWindowStyleManager, addFont, gRGB, eWindowStyleSkinned, getDesktop
-from Components.config import ConfigSubsection, ConfigText, config, ConfigYesNo, ConfigSelection, ConfigNothing
-from Components.Converter.Converter import Converter
-from Components.Sources.Source import Source, ObsoleteSource
+from boxbranding import getBoxType
+from enigma import addFont, eLabel, ePixmap, ePoint, eRect, eSize, eWindow, eWindowStyleManager, eWindowStyleSkinned, getDesktop, gFont, getFontFaces, gRGB
+from os.path import basename, dirname, isfile
+
+from Components.config import ConfigNothing, ConfigSelection, ConfigSubsection, ConfigText, config
+from Components.RcModel import rc_model
+from Components.Sources.Source import ObsoleteSource
 from Components.SystemInfo import SystemInfo
-from Tools.Directories import resolveFilename, SCOPE_SKIN, SCOPE_SKIN_IMAGE, SCOPE_FONTS, SCOPE_CURRENT_SKIN, SCOPE_CURRENT_LCDSKIN, SCOPE_CONFIG, fileExists
+from Tools.Directories import SCOPE_CONFIG, SCOPE_CURRENT_LCDSKIN, SCOPE_CURRENT_SKIN, SCOPE_FONTS, SCOPE_SKIN, SCOPE_SKIN_IMAGE, pathExists, resolveFilename
 from Tools.Import import my_import
 from Tools.LoadPixmap import LoadPixmap
-from Components.RcModel import rc_model
-from boxbranding import getBoxType
 
-config.vfd = ConfigSubsection()
-config.vfd.show = ConfigSelection([("skin_text.xml", _("Channel Name")), ("skin_text_clock.xml", _("Clock"))], "skin_text.xml")
-if not os.path.exists("/usr/share/enigma2/skin_text.xml"):
-	config.vfd.show = ConfigNothing()
-
-colorNames = {}
-colorNamesHuman = {}
-switchPixmap = {}
-# Predefined fonts, typically used in built-in screens and for components like
-# the movie list and so.
-fonts = {
-	"Body": ("Regular", 18, 22, 16),
-	"ChoiceList": ("Regular", 20, 24, 18),
-}
-
-parameters = {}
-constant_widgets = {}
-variables = {}
 DEFAULT_SKIN = "MetrixHD/skin.xml"
-DEFAULT_DISPLAY_SKIN = "skin_display.xml"
-if SystemInfo["grautec"]:
-	DEFAULT_DISPLAY_SKIN = "skin_display_grautec.xml"
-isVTISkin = False
+EMERGENCY_SKIN = "skin_default.xml"
+DEFAULT_DISPLAY_SKIN = "skin_display_grautec.xml" if SystemInfo["grautec"] else "skin_display.xml"
+USER_SKIN = "skin_user.xml"
+USER_SKIN_TEMPLATE = "skin_user_%s.xml"
+SUBTITLE_SKIN = "skin_subtitles.xml"
 
-def dump(x, i=0):
-	print " " * i + str(x)
-	try:
-		for n in x.childNodes:
-			dump(n, i + 1)
-	except:
-		None
+GUI_SKIN_ID = 0  # Main frame-buffer.
+DISPLAY_SKIN_ID = 2 if getBoxType().startswith("dm") else 1  # Front panel / display / LCD.
 
+domScreens = {}  # Dictionary of skin based screens.
+colors = {  # Dictionary of skin color names.
+	"key_back": gRGB(0x00313131),
+	"key_blue": gRGB(0x0018188b),
+	"key_green": gRGB(0x001f771f),
+	"key_red": gRGB(0x009f1313),
+	"key_text": gRGB(0x00ffffff),
+	"key_yellow": gRGB(0x00a08500)
+}
+colorNames = colors  # Temporary until OverlayHD is updated.
+fonts = {  # Dictionary of predefined and skin defined font aliases.
+	"Body": ("Regular", 18, 22, 16),
+	"ChoiceList": ("Regular", 20, 24, 18)
+}
+menus = {}  # Dictionary of images associated with menu entries.
+parameters = {}  # Dictionary of skin parameters used to modify code behavior.
+setups = {}  # Dictionary of images associated with setup menus.
+switchPixmap = {}  # Dictionary of switch images.
 skinfactor = 0
-def getSkinFactor(refresh = False):
-	global skinfactor
-	if refresh or not skinfactor:
-		try:
-			skinfactor = getDesktop(0).size().width() / 1280.0
-			if not skinfactor in [1, 1.5, 3]:
-				print '[SKIN] getSkinFactor unknown result (%s) -> set skinfactor to 1' %skinfactor
-				skinfactor = 1
-		except Exception, err:
-			skinfactor = 1
-			print '[SKIN] getSkinFactor failed: ', err
-	return skinfactor
+isVTISkin = False  # Temporary flag to suppress errors in OpenATV.
+
+config.skin = ConfigSubsection()
+skin = resolveFilename(SCOPE_SKIN, DEFAULT_SKIN)
+if not pathExists(skin) or not isfile(skin):
+	print "[Skin] Error: Default skin '%s' is not readable or is not a file!  Using emergency skin." % skin
+	DEFAULT_SKIN = EMERGENCY_SKIN
+config.skin.primary_skin = ConfigText(default=DEFAULT_SKIN)
+config.skin.display_skin = ConfigText(default=DEFAULT_DISPLAY_SKIN)
+
+currentPrimarySkin = None
+currentDisplaySkin = None
+callbacks = []
+runCallbacks = False
+
+# Skins are loaded in order of priority.  Skin with highest priority is
+# loaded last.  This is usually the user-specified skin.  In this way
+# any duplicated screens will be replaced by a screen of the same name
+# with a higher priority.
+#
+# GUI skins are saved in the settings file as the path relative to
+# SCOPE_SKIN.  The full path is NOT saved.  E.g. "MySkin/skin.xml"
+#
+# Display skins are saved in the settings file as the path relative to
+# SCOPE_CURRENT_LCDSKIN.  The full path is NOT saved.
+# E.g. "MySkin/skin_display.xml"
+#
+def InitSkins():
+	global currentPrimarySkin, currentDisplaySkin
+	runCallbacks = False
+	# Add the emergency skin.  This skin should provide enough functionality
+	# to enable basic GUI functions to work.
+	loadSkin(EMERGENCY_SKIN, scope=SCOPE_CURRENT_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID)
+	# Add the subtitle skin.
+	loadSkin(SUBTITLE_SKIN, scope=SCOPE_CURRENT_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID)
+	# Add the front panel / display / lcd skin.
+	result = []
+	for skin, name in [(config.skin.display_skin.value, "current"), (DEFAULT_DISPLAY_SKIN, "default")]:
+		if skin in result:  # Don't try to add a skin that has already failed.
+			continue
+		config.skin.display_skin.value = skin
+		if loadSkin(config.skin.display_skin.value, scope=SCOPE_CURRENT_LCDSKIN, desktop=getDesktop(DISPLAY_SKIN_ID), screenID=DISPLAY_SKIN_ID):
+			currentDisplaySkin = config.skin.display_skin.value
+			break
+		print "[Skin] Error: Adding %s display skin '%s' has failed!" % (name, config.skin.display_skin.value)
+		result.append(skin)
+	# Add the main GUI skin.
+	result = []
+	for skin, name in [(config.skin.primary_skin.value, "current"), (DEFAULT_SKIN, "default")]:
+		if skin in result:  # Don't try to add a skin that has already failed.
+			continue
+		config.skin.primary_skin.value = skin
+		if loadSkin(config.skin.primary_skin.value, scope=SCOPE_CURRENT_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID):
+			currentPrimarySkin = config.skin.primary_skin.value
+			break
+		print "[Skin] Error: Adding %s GUI skin '%s' has failed!" % (name, config.skin.primary_skin.value)
+		result.append(skin)
+	# Add an optional skin related user skin "user_skin_<SkinName>.xml".  If there is
+	# not a skin related user skin then try to add am optional generic user skin.
+	result = None
+	if isfile(resolveFilename(SCOPE_SKIN, config.skin.primary_skin.value)):
+		name = USER_SKIN_TEMPLATE % dirname(config.skin.primary_skin.value)
+		if pathExists(resolveFilename(SCOPE_CURRENT_SKIN, name)):
+			result = loadSkin(name, scope=SCOPE_CURRENT_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID)
+	if result is None:
+		loadSkin(USER_SKIN, scope=SCOPE_CURRENT_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID)
+	runCallbacks = True
+
+# Temporary entry point for older versions of mytest.py.
+#
+def loadSkinData(desktop):
+	InitSkins()
+
+# Now a utility for plugins to add skin data to the screens.
+#
+def loadSkin(filename, scope=SCOPE_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID):
+	filename = resolveFilename(scope, filename)
+	print "[Skin] Loading skin file '%s'." % filename
+	try:
+		with open(filename, "r") as fd:  # This open gets around a possible file handle leak in Python's XML parser.
+			try:
+				domSkin = xml.etree.cElementTree.parse(fd).getroot()
+				# print "[Skin] DEBUG: Extracting non screen blocks from '%s'.  (scope='%s')" % (filename, scope)
+				# For loadSingleSkinData colors, bordersets etc. are applied one after
+				# the other in order of ascending priority.
+				loadSingleSkinData(desktop, screenID, domSkin, filename, scope=scope)
+				for element in domSkin:
+					if element.tag == "screen":  # If non-screen element, no need for it any longer.
+						name = element.attrib.get("name", None)
+						if name:  # Without a name, it's useless!
+							sid = element.attrib.get("id", None)
+							if sid is None or sid == screenID:  # If there is a screen ID is it for this display.
+								# print "[Skin] DEBUG: Extracting screen '%s' from '%s'.  (scope='%s')" % (name, filename, scope)
+								domScreens[name] = (element, "%s/" % dirname(filename))
+				print "[Skin] Loading skin file '%s' complete." % filename
+				if runCallbacks:
+					for method in self.callbacks:
+						if method:
+							method()
+				return True
+			except xml.etree.cElementTree.ParseError as err:
+				fd.seek(0)
+				content = fd.readlines()
+				line, column = err.position
+				print "[Skin] XML Parse Error: '%s' in '%s'!" % (err, filename)
+				data = content[line - 1].replace("\t", " ").rstrip()
+				print "[Skin] XML Parse Error: '%s'" % data
+				print "[Skin] XML Parse Error: '%s^%s'" % ("-" * column, " " * (len(data) - column - 1))
+			except Exception as err:
+				print "[Skin] Error: Unable to parse skin data in '%s' - '%s'!" % (filename, err)
+	except (IOError, OSError) as err:
+		if err.errno == errno.ENOENT:  # No such file or directory
+			print "[Skin] Warning: Skin file '%s' does not exist!" % filename
+		else:
+			print "[Skin] Error %d: Opening skin file '%s'! (%s)" % (err.errno, filename, err.strerror)
+	except Exception as err:
+		print "[Skin] Error: Unexpected error opening skin file '%s'! (%s)" % (filename, err)
+	return False
+
+def reloadSkins():
+	domScreens.clear()
+	colors.clear()
+	colors = {
+		"key_back": gRGB(0x00313131),
+		"key_blue": gRGB(0x0018188b),
+		"key_green": gRGB(0x001f771f),
+		"key_red": gRGB(0x009f1313),
+		"key_text": gRGB(0x00ffffff),
+		"key_yellow": gRGB(0x00a08500)
+	}
+	fonts.clear()
+	fonts = {
+		"Body": ("Regular", 18, 22, 16),
+		"ChoiceList": ("Regular", 20, 24, 18)
+	}
+	menus.clear()
+	parameters.clear()
+	setups.clear()
+	switchPixmap.clear()
+	InitSkins()
+
+def addCallback(callback):
+	if callback not in callbacks:
+		callbacks.append(callback)
+
+def removeCallback(callback):
+	if callback in self.callbacks:
+		callbacks.remove(callback)
+
 
 class SkinError(Exception):
 	def __init__(self, message):
 		self.msg = message
+
 	def __str__(self):
-		return "{%s}: %s. Please contact the skin's author!" % (config.skin.primary_skin.value, self.msg)
+		return "[Skin] {%s}: %s!  Please contact the skin's author!" % (config.skin.primary_skin.value, self.msg)
 
-class DisplaySkinError(Exception):
-	def __init__(self, message):
-		self.msg = message
-	def __str__(self):
-		return "{%s}: %s. Please contact the skin's author!" % (config.skin.display_skin.value, self.msg)
-
-dom_skins = [ ]
-
-def addSkin(name, scope = SCOPE_SKIN):
-	# read the skin
-	if name is None or not len(name):
-		print "[SKIN ERROR] attempt to add a skin without filename"
-		return False
-	filename = resolveFilename(scope, name)
-	if fileExists(filename):
-		mpath = os.path.dirname(filename) + "/"
-		try:
-			dom_skins.append((mpath, xml.etree.cElementTree.parse(filename).getroot()))
-		except:
-			print "[SKIN ERROR] error in %s" % filename
-			return False
-		else:
-			return True
-	return False
-
-def get_modular_files(name, scope = SCOPE_SKIN):
-	dirname = resolveFilename(scope, name + 'mySkin/')
-	file_list = []
-	if fileExists(dirname) and config.skin.primary_skin.value != DEFAULT_SKIN:
-		skin_files = (os.listdir(dirname))
-		if len(skin_files):
-			for f in skin_files:
-				if f.startswith('skin_') and f.endswith('.xml'):
-					file_list.append(("mySkin/" + f))
-	file_list = sorted(file_list, key=str.lower)
-	return file_list
-
-# get own skin_user_skinname.xml file, if exist
-def skin_user_skinname():
-	name = "skin_user_" + config.skin.primary_skin.value[:config.skin.primary_skin.value.rfind('/')] + ".xml"
-	filename = resolveFilename(SCOPE_CONFIG, name)
-	if fileExists(filename):
-		return name
-	return None
-
-# we do our best to always select the "right" value
-# skins are loaded in order of priority: skin with
-# highest priority is loaded last, usually the user-provided
-# skin.
-
-# currently, loadSingleSkinData (colors, bordersets etc.)
-# are applied one-after-each, in order of ascending priority.
-# the dom_skin will keep all screens in descending priority,
-# so the first screen found will be used.
-
-# example: loadSkin("nemesis_greenline/skin.xml")
-config.skin = ConfigSubsection()
-config.skin.primary_skin = ConfigText(default = DEFAULT_SKIN)
-config.skin.display_skin = ConfigText(default = DEFAULT_DISPLAY_SKIN)
-
-##################################################################################################
-if fileExists('/etc/.restore_skins'):
-	os.unlink('/etc/.restore_skins')
-	import glob
-	lastpath = ''
-	for skin in sorted(glob.glob('/usr/lib/enigma2/python/Plugins/Extensions/*/ActivateSkinSettings.py*')):
-		try:
-			print '[RESTORE_SKIN] restore skin from "%s" ...' % skin
-			skinpath, ext = os.path.splitext(skin)
-			if skinpath == lastpath or not ext in '.pyo':
-				print '[RESTORE_SKIN] ...skip!'
-				continue
-			lastpath = skinpath
-			if getattr(__import__(skin.replace('/usr/lib/enigma2/python/','').replace(ext,'').replace('/','.'), fromlist=['ActivateSkinSettings']), 'ActivateSkinSettings')().WriteSkin(True):
-				print '[RESTORE_SKIN] ... failed!'
-			else:
-				print '[RESTORE_SKIN] ... done!'
-		except Exception, err:
-			print '[RESTORE_SKIN] ...error occurred: ', err
-##################################################################################################
-
-def skinExists(skin = False):
-	if not skin or not isinstance(skin, skin):
-		skin = config.skin.primary_skin.value
-	skin =  resolveFilename(SCOPE_SKIN, skin)
-	if not fileExists(skin):
-		if fileExists(resolveFilename(SCOPE_SKIN, DEFAULT_SKIN)):
-			config.skin.primary_skin.value = DEFAULT_SKIN
-		else:
-			config.skin.primary_skin.value = "skin.xml"
-		config.skin.primary_skin.save()
-skinExists()
-
-def getSkinPath():
-	#primary_skin_path = config.skin.primary_skin.value.replace('skin.xml', '')
-	p = config.skin.primary_skin.value
-	primary_skin_path = p[:p.rfind('/')+1]
-	if not primary_skin_path.endswith('/'):
-		primary_skin_path = primary_skin_path + '/'
-	return primary_skin_path
-	
-primary_skin_path = getSkinPath()
-
-profile("LoadSkin")
-res = None
-name = skin_user_skinname()
-if name:
-	res = addSkin(name, SCOPE_CONFIG)
-if not name or not res:
-	addSkin('skin_user.xml', SCOPE_CONFIG)
-
-# some boxes lie about their dimensions
-addSkin('skin_box.xml')
-# add optional discrete second infobar
-addSkin('skin_second_infobar.xml')
-display_skin_id = 1
-if getBoxType().startswith('dm'):
-	display_skin_id = 2
-try:
-	if not addSkin(os.path.join('display', config.skin.display_skin.value)):
-		raise DisplaySkinError, "display skin not found"
-except Exception, err:
-	print "SKIN ERROR:", err
-	skin = DEFAULT_DISPLAY_SKIN
-	if config.skin.display_skin.value == skin:
-		skin = 'skin_display.xml'
-	print "defaulting to standard display skin...", skin
-	config.skin.display_skin.value = skin
-	skin = os.path.join('display', skin)
-	addSkin(skin)
-	del skin
-
-# Add Skin for Display
-try:
-	addSkin(config.vfd.show.value)
-except:
-	addSkin('skin_text.xml')
-
-addSkin('skin_subtitles.xml')
-
-if config.skin.primary_skin.value != DEFAULT_SKIN:
-	skinpath = resolveFilename(SCOPE_SKIN, primary_skin_path)
-	if os.path.isdir(skinpath):
-		for file in sorted(os.listdir(skinpath)):
-			if file.startswith('skin_user_') and file.endswith('.xml'):
-				try:
-					addSkin(primary_skin_path + file, SCOPE_SKIN)
-					print "[SKIN] loading user defined %s skin file: %s" %(file.replace('skin_user_','')[:-4], primary_skin_path + file)
-				except (SkinError, IOError, OSError, AssertionError), err:
-					print "[SKIN] not loading user defined %s skin file: %s - error: %s" %(file.replace('skin_user_','')[:-4], primary_skin_path + file, err)
-
-def load_modular_files():
-	modular_files = get_modular_files(primary_skin_path, SCOPE_SKIN)
-	if len(modular_files):
-		for f in modular_files:
-			try:
-				addSkin(primary_skin_path + f, SCOPE_SKIN)
-				print "[SKIN] loading modular skin file : ", (primary_skin_path + f)
-			except (SkinError, IOError, AssertionError), err:
-				print "[SKIN] failed to load modular skin file : ", err
-load_modular_files()
-
-try:
-	if not addSkin(config.skin.primary_skin.value):
-		raise SkinError, "primary skin not found"
-except Exception, err:
-	print "SKIN ERROR:", err
-	skin = DEFAULT_SKIN
-	if config.skin.primary_skin.value == skin:
-		skin = 'skin.xml'
-	print "defaulting to standard skin...", skin
-	config.skin.primary_skin.value = skin
-	addSkin(skin)
-	del skin
-
-addSkin('skin_default.xml')
-profile("LoadSkinDefaultDone")
-
+# Convert a coordinate string into a number.  Used to convert object position and
+# size attributes into a number.
+#    s is the input string.
+#    e is the the parent object size to do relative calculations on parent
+#    size is the size of the object size (e.g. width or height)
+#    font is a font object to calculate relative to font sizes
+# Note some constructs for speeding up simple cases that are very common.
+#
+# Can do things like:  10+center-10w+4%
+# To center the widget on the parent widget,
+#    but move forward 10 pixels and 4% of parent width
+#    and 10 character widths backward
+# Multiplication, division and subexpressions are also allowed: 3*(e-c/2)
+#
+# Usage:  center : Center the object on parent based on parent size and object size.
+#         e      : Take the parent size/width.
+#         c      : Take the center point of parent size/width.
+#         %      : Take given percentage of parent size/width.
+#         w      : Multiply by current font width.
+#         h      : Multiply by current font height.
+#
 def parseCoordinate(s, e, size=0, font=None):
 	s = s.strip()
-	if s == "center":
-		if not size:
-			val = 0
-		else:
-			val = (e - size)/2
-	elif s == '*':
+	if s == "center":  # For speed as this can be common case.
+		val = 0 if not size else (e - size) / 2
+	elif s == "*":
 		return None
 	else:
-		if s[0] is 'e':
-			val = e
-			s = s[1:]
-		elif s[0] is 'c':
-			val = e/2
-			s = s[1:]
-		else:
-			val = 0
-		if s:
-			if s[-1] is '%':
-				val += e * int(s[:-1]) / 100
-			elif s[-1] is 'w':
-				val += fonts[font][3] * int(s[:-1])
-			elif s[-1] is 'h':
-				val += fonts[font][2] * int(s[:-1])
-			else:
-				val += int(s)
+		try:
+			val = int(s)  # For speed try a simple number first.
+		except ValueError:
+			if "t" in s:
+				s = s.replace("center", str((e - size) / 2.0))
+			if "e" in s:
+				s = s.replace("e", str(e))
+			if "c" in s:
+				s = s.replace("c", str(e / 2.0))
+			if "w" in s:
+				s = s.replace("w", "*%s" % str(fonts[font][3]))
+			if "h" in s:
+				s = s.replace("h", "*%s" % str(fonts[font][2]))
+			if "%" in s:
+				s = s.replace("%", "*%s" % str(e / 100.0))
+			try:
+				val = int(s)  # For speed try a simple number first.
+			except ValueError:
+				val = int(eval(s))
+	# print "[Skin] DEBUG: parseCoordinate s='%s', e='%s', size=%s, font='%s', val='%s'." % (s, e, size, font, val)
 	if val < 0:
 		val = 0
 	return val
 
-
-
 def getParentSize(object, desktop):
-	size = eSize()
 	if object:
 		parent = object.getParent()
-		# For some widgets (e.g. ScrollLabel) the skin attributes are applied to
-		# a child widget, instead of to the widget itself. In that case, the parent
-		# we have here is not the real parent, but it is the main widget.
-		# We have to go one level higher to get the actual parent.
-		# We can detect this because the 'parent' will not have a size yet
-		# (the main widget's size will be calculated internally, as soon as the child
-		# widget has parsed the skin attributes)
+		# For some widgets (e.g. ScrollLabel) the skin attributes are applied to a
+		# child widget, instead of to the widget itself.  In that case, the parent
+		# we have here is not the real parent, but it is the main widget.  We have
+		# to go one level higher to get the actual parent.  We can detect this
+		# because the 'parent' will not have a size yet.  (The main widget's size
+		# will be calculated internally, as soon as the child widget has parsed the
+		# skin attributes.)
 		if parent and parent.size().isEmpty():
 			parent = parent.getParent()
 		if parent:
-			size = parent.size()
+			return parent.size()
 		elif desktop:
-			#widget has no parent, use desktop size instead for relative coordinates
-			size = desktop.size()
-	return size
+			return desktop.size()  # Widget has no parent, use desktop size instead for relative coordinates.
+	return eSize()
 
-def parsePosition(s, scale, object = None, desktop = None, size = None):
-	if s in variables:
-		s = variables[s]
-	x, y = s.split(',')
+def parseValuePair(s, scale, object=None, desktop=None, size=None):
+	x, y = s.split(",")
 	parentsize = eSize()
-	if object and (x[0] in ('c', 'e') or y[0] in ('c', 'e')):
+	if object and ("c" in x or "c" in y or "e" in x or "e" in y or "%" in x or "%" in y):  # Need parent size for ce%
 		parentsize = getParentSize(object, desktop)
-	xval = parseCoordinate(x, parentsize.width(), size and size.width())
-	yval = parseCoordinate(y, parentsize.height(), size and size.height())
-	return ePoint(xval * scale[0][0] / scale[0][1], yval * scale[1][0] / scale[1][1])
+	xval = parseCoordinate(x, parentsize.width(), size and size.width() or 0)
+	yval = parseCoordinate(y, parentsize.height(), size and size.height() or 0)
+	return (xval * scale[0][0] / scale[0][1], yval * scale[1][0] / scale[1][1])
 
-def parseSize(s, scale, object = None, desktop = None):
-	if s in variables:
-		s = variables[s]
-	x, y = s.split(',')
-	parentsize = eSize()
-	if object and (x[0] in ('c', 'e') or y[0] in ('c', 'e')):
-		parentsize = getParentSize(object, desktop)
-	xval = parseCoordinate(x, parentsize.width())
-	yval = parseCoordinate(y, parentsize.height())
-	return eSize(xval * scale[0][0] / scale[0][1], yval * scale[1][0] / scale[1][1])
+def parsePosition(s, scale, object=None, desktop=None, size=None):
+	return ePoint(*parseValuePair(s, scale, object, desktop, size))
 
-def parseFont(s, scale):
+def parseSize(s, scale, object=None, desktop=None):
+	return eSize(*parseValuePair(s, scale, object, desktop))
+
+def parseFont(s, scale=((1, 1), (1, 1))):
+	if ";" in s:
+		name, size = s.split(";")
+	else:
+		name = s
+		size = None
 	try:
-		f = fonts[s]
+		f = fonts[name]
 		name = f[0]
-		size = f[1]
-	except:
-		name, size = s.split(';')
+		size = f[1] if size is None else size
+	except KeyError:
+		if name not in getFontFaces():
+			f = fonts["Body"]
+			print "[Skin] Error: Font '%s' (in '%s') is not defined!  Using 'Body' font ('%s') instead." % (name, s, f[0])
+			name = f[0]
+			size = f[1] if size is None else size
 	return gFont(name, int(size) * scale[0][0] / scale[0][1])
 
 def parseColor(s):
-	if s[0] != '#':
+	if s[0] != "#":
 		try:
-			return colorNames[s]
-		except:
-			raise SkinError("color '%s' must be #aarrggbb or valid named color" % s)
+			return colors[s]
+		except KeyError:
+			raise SkinError("Color '%s' must be #aarrggbb or valid named color" % s)
 	return gRGB(int(s[1:], 0x10))
 
 def parseParameter(s):
-	"""This function is responsible for parsing parameters in the skin, it can parse integers, floats, hex colors, hex integers, named colors and strings."""
-	if s[0] == '#':
+	"""This function is responsible for parsing parameters in the skin, it can parse integers, floats, hex colors, hex integers, named colors, fonts and strings."""
+	if s[0] == "*":  # String.
+		return s[1:]
+	elif s[0] == "#":  # HEX Color.
 		return int(s[1:], 16)
-	elif s[:2] == '0x':
+	elif s[:2] == "0x":  # HEX Integer.
 		return int(s, 16)
-	elif '.' in s:
+	elif "." in s:  # Float number.
 		return float(s)
-	elif s in colorNames:
-		return colorNames[s].argb()
-	else:
+	elif s in colors:  # Named color.
+		return colors[s].argb()
+	elif s.find(";") != -1:  # Font.
+		font, size = [x.strip() for x in s.split(";", 1)]
+		return [font, int(size)]
+	else:  # Integer.
 		return int(s)
 
-def collectAttributes(skinAttributes, node, context, skin_path_prefix=None, ignore=(), filenames=frozenset(("pixmap", "pointer", "seek_pointer", "backgroundPixmap", "selectionPixmap", "sliderPixmap", "scrollbarbackgroundPixmap"))):
-	# walk all attributes
+def loadPixmap(path, desktop):
+	option = path.find("#")
+	if option != -1:
+		path = path[:option]
+	if rc_model.rcIsDefault() is False and basename(path) in ("rc.png", "rc0.png", "rc1.png", "rc2.png", "oldrc.png"):
+		path = rc_model.getRcImg()
+	pixmap = LoadPixmap(path, desktop)
+	if pixmap is None:
+		raise SkinError("Pixmap file '%s' not found" % path)
+	return pixmap
+
+def collectAttributes(skinAttributes, node, context, skinPath=None, ignore=(), filenames=frozenset(("pixmap", "pointer", "seek_pointer", "backgroundPixmap", "selectionPixmap", "sliderPixmap", "scrollbarSliderPicture", "scrollbarbackgroundPixmap", "scrollbarBackgroundPicture"))):
 	size = None
 	pos = None
 	font = None
-	for attrib, value in node.items():
+	for attrib, value in node.items():  # Walk all attributes.
 		if attrib not in ignore:
 			if attrib in filenames:
-				pngfile = resolveFilename(SCOPE_CURRENT_SKIN, value, path_prefix=skin_path_prefix)
-				if not fileExists(pngfile) and fileExists(resolveFilename(SCOPE_CURRENT_LCDSKIN, value, path_prefix=skin_path_prefix)):
-					pngfile = resolveFilename(SCOPE_CURRENT_LCDSKIN, value, path_prefix=skin_path_prefix)
+				# DEBUG: Why does a SCOPE_CURRENT_LCDSKIN image replace the GUI image?!?!?!
+				pngfile = resolveFilename(SCOPE_CURRENT_SKIN, value, path_prefix=skinPath)
+				if not pathExists(pngfile) and pathExists(resolveFilename(SCOPE_CURRENT_LCDSKIN, value, path_prefix=skinPath)):
+					pngfile = resolveFilename(SCOPE_CURRENT_LCDSKIN, value, path_prefix=skinPath)
 				value = pngfile
-			# Bit of a hack this, really. When a window has a flag (e.g. wfNoBorder)
+			# Bit of a hack this, really.  When a window has a flag (e.g. wfNoBorder)
 			# it needs to be set at least before the size is set, in order for the
 			# window dimensions to be calculated correctly in all situations.
-			# If wfNoBorder is applied after the size has been set, the window will fail to clear the title area.
-			# Similar situation for a scrollbar in a listbox; when the scrollbar setting is applied after
-			# the size, a scrollbar will not be shown until the selection moves for the first time
-			if attrib == 'size':
+			# If wfNoBorder is applied after the size has been set, the window will
+			# fail to clear the title area.  Similar situation for a scrollbar in a
+			# listbox; when the scrollbar setting is applied after the size, a scrollbar
+			# will not be shown until the selection moves for the first time.
+			if attrib == "size":
 				size = value.encode("utf-8")
-			elif attrib == 'position':
+			elif attrib == "position":
 				pos = value.encode("utf-8")
-			elif attrib == 'font':
+			elif attrib == "font":
 				font = value.encode("utf-8")
 				skinAttributes.append((attrib, font))
 			else:
 				skinAttributes.append((attrib, value.encode("utf-8")))
 	if pos is not None:
 		pos, size = context.parse(pos, size, font)
-		skinAttributes.append(('position', pos))
+		skinAttributes.append(("position", pos))
 	if size is not None:
-		skinAttributes.append(('size', size))
-
-def morphRcImagePath(value):
-	if rc_model.rcIsDefault() is False and os.path.basename(value) in ("rc.png", "rc0.png", "rc1.png", "rc2.png", "oldrc.png"):
-		value = rc_model.getRcImg()
-	return value
-
-def loadPixmap(path, desktop):
-	cached = False
-	option = path.find("#")
-	if option != -1:
-		options = path[option+1:].split(',')
-		path = path[:option]
-		cached = "cached" in options
-	ptr = LoadPixmap(morphRcImagePath(path), desktop, cached)
-	if ptr is not None:
-		return ptr
-	print("pixmap file %s not found!" % path)
-
-
-
-pngcache = []
-def cachemenu():
-	pixmaplist = []
-	for (path, skin) in dom_skins:
-		for x in skin.findall("screen"):
-			if x.attrib.get('name') == 'menu_mainmenu':
-				print x.attrib.get('name')
-				for s in x.findall("ePixmap"):
-					if s.attrib.get('pixmap','') is not '':
-						pixmaplist.append(s.attrib.get('pixmap',''))
-				for s in x.findall('widget'):
-					if s.attrib.get('pixmap','') is not '':
-						pixmaplist.append(s.attrib.get('pixmap',''))
-	desktop = getDesktop(0)
-	for s in pixmaplist:
-		value ='/usr/share/enigma2/'+s
-		ptr = loadPixmap(value, desktop)
-		pngcache.append((value,ptr))
-try:
-	if config.skin.primary_skin.value == "MetrixHD/skin.xml" or config.skin.primary_skin.value == DEFAULT_SKIN:
-		cachemenu()
-except:
-	print "fail cache main menu"
+		skinAttributes.append(("size", size))
 
 
 class AttributeParser:
-	def __init__(self, guiObject, desktop, scale=((1,1),(1,1))):
+	def __init__(self, guiObject, desktop, scale=((1, 1), (1, 1))):
 		self.guiObject = guiObject
 		self.desktop = desktop
 		self.scaleTuple = scale
+
 	def applyOne(self, attrib, value):
 		try:
 			getattr(self, attrib)(value)
 		except AttributeError:
-			print "[SKIN] Attribute \"%s\" with value \"%s\" in object of type \"%s\" is not implemented" % (attrib, value, self.guiObject.__class__.__name__)
-		except SkinError, ex:
-			print "\033[91m[SKIN] Error:", ex,
-			print "\033[0m"
-		except:
-			print "[Skin] attribute \"%s\" with wrong (or unknown) value \"%s\" in object of type \"%s\"" % (attrib, value, self.guiObject.__class__.__name__)
+			print "[Skin] Attribute '%s' (with value of '%s') in object of type '%s' is not implemented!" % (attrib, value, self.guiObject.__class__.__name__)
+		except SkinError as err:
+			print "[Skin] Error:", err
+		except Exception:
+			print "[Skin] Attribute '%s' with wrong (or unknown) value '%s' in object of type '%s'!" % (attrib, value, self.guiObject.__class__.__name__)
 
 	def applyAll(self, attrs):
 		for attrib, value in attrs:
-			try:
-				getattr(self, attrib)(value)
-			except AttributeError:
-				print "[SKIN] Attribute \"%s\" with value \"%s\" in object of type \"%s\" is not implemented" % (attrib, value, self.guiObject.__class__.__name__)
-			except SkinError, ex:
-				print "\033[91m[Skin] Error:", ex,
-				print "\033[0m"
-			except:
-				print "[Skin] attribute \"%s\" with wrong (or unknown) value \"%s\" in object of type \"%s\"" % (attrib, value, self.guiObject.__class__.__name__)
+			self.applyOne(attrib, value)
 
 	def conditional(self, value):
 		pass
+
 	def objectTypes(self, value):
 		pass
+
 	def position(self, value):
 		if isinstance(value, tuple):
 			self.guiObject.move(ePoint(*value))
 		else:
 			self.guiObject.move(parsePosition(value, self.scaleTuple, self.guiObject, self.desktop, self.guiObject.csize()))
+
 	def size(self, value):
 		if isinstance(value, tuple):
 			self.guiObject.resize(eSize(*value))
 		else:
 			self.guiObject.resize(parseSize(value, self.scaleTuple, self.guiObject, self.desktop))
+
 	def animationPaused(self, value):
 		pass
-	def NoAnimationAfter(self, value):
-		pass
-	def Animation(self, value):
-		self.guiObject.setAnimationMode(
-			{ "disable": 0x00,
-				"off": 0x00,
-				"offshow": 0x10,
-				"offhide": 0x01,
-				"onshow": 0x01,
-				"onhide": 0x10,
-				"disable_onshow": 0x10,
-				"disable_onhide": 0x01,
-			}[value])
+
 	def animationMode(self, value):
-		self.guiObject.setAnimationMode(
-			{ "disable": 0x00,
+		try:
+			self.guiObject.setAnimationMode({
+				"disable": 0x00,
 				"off": 0x00,
 				"offshow": 0x10,
 				"offhide": 0x01,
 				"onshow": 0x01,
 				"onhide": 0x10,
 				"disable_onshow": 0x10,
-				"disable_onhide": 0x01,
+				"disable_onhide": 0x01
 			}[value])
+		except KeyError:
+			print "[Skin] Error: Invalid animationMode '%s'!  Must be one of 'disable', 'off', 'offshow', 'offhide', 'onshow' or 'onhide'." % value
+
 	def title(self, value):
-		global isVTISkin
-		if value[:3].lower() == "vti":
-			isVTISkin = True
 		self.guiObject.setTitle(_(value))
+
 	def text(self, value):
 		self.guiObject.setText(_(value))
+
 	def font(self, value):
 		self.guiObject.setFont(parseFont(value, self.scaleTuple))
+
 	def secondfont(self, value):
 		self.guiObject.setSecondFont(parseFont(value, self.scaleTuple))
+
 	def zPosition(self, value):
 		self.guiObject.setZPosition(int(value))
+
 	def itemHeight(self, value):
 		self.guiObject.setItemHeight(int(value))
+
 	def pixmap(self, value):
-		global pngcache
-		ptr = None
-		for cvalue, cptr in pngcache:
-			if cvalue== value:
-				ptr=cptr
-		if ptr is None:
-			if not fileExists(value):
-				ptr = loadPixmap(resolveFilename(SCOPE_SKIN_IMAGE, value), self.desktop)
-			else:
-				ptr = loadPixmap(value, self.desktop)
-		self.guiObject.setPixmap(ptr)
+		self.guiObject.setPixmap(loadPixmap(value, self.desktop))
+
 	def backgroundPixmap(self, value):
-		global pngcache
-		ptr = None
-		for cvalue, cptr in pngcache:
-			if cvalue== value:
-				ptr=cptr
-		if ptr is None:
-			if not fileExists(value):
-				ptr = loadPixmap(resolveFilename(SCOPE_SKIN_IMAGE, value), self.desktop)
-			else:
-				ptr = loadPixmap(value, self.desktop)
-		self.guiObject.setBackgroundPicture(ptr)
+		self.guiObject.setBackgroundPicture(loadPixmap(value, self.desktop))
+
 	def selectionPixmap(self, value):
-		global pngcache
-		ptr = None
-		for cvalue, cptr in pngcache:
-			if cvalue== value:
-				ptr=cptr
-		if ptr is None:
-			if not fileExists(value):
-				ptr = loadPixmap(resolveFilename(SCOPE_SKIN_IMAGE, value), self.desktop)
-			else:
-				ptr = loadPixmap(value, self.desktop)
-		self.guiObject.setSelectionPicture(ptr)
+		self.guiObject.setSelectionPicture(loadPixmap(value, self.desktop))
+
 	def sliderPixmap(self, value):
-		global pngcache
-		ptr = None
-		for cvalue, cptr in pngcache:
-			if cvalue== value:
-				ptr=cptr
-		if ptr is None:
-			if not fileExists(value):
-				ptr = loadPixmap(resolveFilename(SCOPE_SKIN_IMAGE, value), self.desktop)
-			else:
-				ptr = loadPixmap(value, self.desktop)
-		self.guiObject.setSliderPicture(ptr)
+		self.guiObject.setSliderPicture(loadPixmap(value, self.desktop))
+
 	def scrollbarbackgroundPixmap(self, value):
-		global pngcache
-		ptr = None
-		for cvalue, cptr in pngcache:
-			if cvalue== value:
-				ptr=cptr
-		if ptr is None:
-			if not fileExists(value):
-				ptr = loadPixmap(resolveFilename(SCOPE_SKIN_IMAGE, value), self.desktop)
-			else:
-				ptr = loadPixmap(value, self.desktop)
-		self.guiObject.setScrollbarBackgroundPicture(ptr)
-	def scrollbarSliderPicture(self, value):
-		global pngcache
-		ptr = None
-		for cvalue, cptr in pngcache:
-			if cvalue== value:
-				ptr=cptr
-		if ptr is None:
-			if not fileExists(value):
-				ptr = loadPixmap(resolveFilename(SCOPE_SKIN_IMAGE, value), self.desktop)
-			else:
-				ptr = loadPixmap(value, self.desktop)
-		self.guiObject.setScrollbarSliderPicture(ptr)
-	def scrollbarBackgroundPicture(self, value):
-		global pngcache
-		ptr = None
-		for cvalue, cptr in pngcache:
-			if cvalue== value:
-				ptr=cptr
-		if ptr is None:
-			if not fileExists(value):
-				ptr = loadPixmap(resolveFilename(SCOPE_SKIN_IMAGE, value), self.desktop)
-			else:
-				ptr = loadPixmap(value, self.desktop)
-		self.guiObject.setScrollbarBackgroundPicture(ptr)
+		self.guiObject.setScrollbarBackgroundPicture(loadPixmap(value, self.desktop))
+
+	def scrollbarSliderPicture(self, value):  # For compatibility same as sliderPixmap.
+		self.guiObject.setSliderPicture(loadPixmap(value, self.desktop))
+
+	def scrollbarBackgroundPicture(self, value):  # For compatibility same as scrollbarbackgroundPixmap.
+		self.guiObject.setScrollbarBackgroundPicture(loadPixmap(value, self.desktop))
+
 	def alphatest(self, value):
-		self.guiObject.setAlphatest(
-			{ "on": 1,
-			  "off": 0,
-			  "blend": 2,
-			}[value])
-	def scale(self, value):
-		self.guiObject.setScale(1)
-	def orientation(self, value): # used by eSlider
 		try:
-			self.guiObject.setOrientation(*
-				{ "orVertical": (self.guiObject.orVertical, False),
-					"orTopToBottom": (self.guiObject.orVertical, False),
-					"orBottomToTop": (self.guiObject.orVertical, True),
-					"orHorizontal": (self.guiObject.orHorizontal, False),
-					"orLeftToRight": (self.guiObject.orHorizontal, False),
-					"orRightToLeft": (self.guiObject.orHorizontal, True),
-				}[value])
+			self.guiObject.setAlphatest({
+				"on": 1,
+				"off": 0,
+				"blend": 2
+			}[value])
 		except KeyError:
-			print "oprientation must be either orVertical or orHorizontal!, not %s. Please contact the skin's author!" % value
+			print "[Skin] Error: Invalid alphatest '%s'!  Must be one of 'on', 'off' or 'blend'." % value
+
+	def scale(self, value):
+		value = 1 if value.lower() in ("1", "enabled", "on", "scale", "true", "yes") else 0
+		self.guiObject.setScale(value)
+
+	def orientation(self, value):  # Used by eSlider.
+		try:
+			self.guiObject.setOrientation(*{
+				"orVertical": (self.guiObject.orVertical, False),
+				"orTopToBottom": (self.guiObject.orVertical, False),
+				"orBottomToTop": (self.guiObject.orVertical, True),
+				"orHorizontal": (self.guiObject.orHorizontal, False),
+				"orLeftToRight": (self.guiObject.orHorizontal, False),
+				"orRightToLeft": (self.guiObject.orHorizontal, True)
+			}[value])
+		except KeyError:
+			print "[Skin] Error: Invalid orientation '%s'!  Must be one of 'orVertical', 'orTopToBottom', 'orBottomToTop', 'orHorizontal', 'orLeftToRight' or 'orRightToLeft'." % value
+
 	def valign(self, value):
 		try:
-			self.guiObject.setVAlign(
-				{ "top": self.guiObject.alignTop,
-					"center": self.guiObject.alignCenter,
-					"bottom": self.guiObject.alignBottom
-				}[value])
+			self.guiObject.setVAlign({
+				"top": self.guiObject.alignTop,
+				"center": self.guiObject.alignCenter,
+				"bottom": self.guiObject.alignBottom
+			}[value])
 		except KeyError:
-			print "valign must be either top, center or bottom!, not %s. Please contact the skin's author!" % value
+			print "[Skin] Error: Invalid valign '%s'!  Must be one of 'top', 'center' or 'bottom'." % value
+
 	def halign(self, value):
 		try:
-			self.guiObject.setHAlign(
-				{ "left": self.guiObject.alignLeft,
-					"center": self.guiObject.alignCenter,
-					"right": self.guiObject.alignRight,
-					"block": self.guiObject.alignBlock
-				}[value])
+			self.guiObject.setHAlign({
+				"left": self.guiObject.alignLeft,
+				"center": self.guiObject.alignCenter,
+				"right": self.guiObject.alignRight,
+				"block": self.guiObject.alignBlock
+			}[value])
 		except KeyError:
-			print "halign must be either left, center, right or block!, not %s. Please contact the skin's author!" % value
+			print "[Skin] Error: Invalid halign '%s'!  Must be one of 'left', 'center', 'right' or 'block'." % value
+
 	def textOffset(self, value):
-		global isVTISkin
-		if value in variables:
-			value = variables[value]
-		x, y = value.split(',')
+		x, y = value.split(",")
 		self.guiObject.setTextOffset(ePoint(int(x) * self.scaleTuple[0][0] / self.scaleTuple[0][1], int(y) * self.scaleTuple[1][0] / self.scaleTuple[1][1]))
-		if isVTISkin:
-			self.guiObject.setUseVTIWorkaround()
+
 	def flags(self, value):
-		if value in variables:
-			value = variables[value]
-		flags = value.split(',')
+		flags = value.split(",")
 		for f in flags:
 			try:
 				fv = eWindow.__dict__[f]
 				self.guiObject.setFlag(fv)
 			except KeyError:
-				print "illegal flag %s!" % f
+				print "[Skin] Error: Invalid flag '%s'!" % f
+
 	def backgroundColor(self, value):
 		self.guiObject.setBackgroundColor(parseColor(value))
+
 	def backgroundColorSelected(self, value):
 		self.guiObject.setBackgroundColorSelected(parseColor(value))
+
 	def foregroundColor(self, value):
 		self.guiObject.setForegroundColor(parseColor(value))
+
 	def foregroundColorSelected(self, value):
 		self.guiObject.setForegroundColorSelected(parseColor(value))
+
 	def foregroundNotCrypted(self, value):
 		self.guiObject.setForegroundColor(parseColor(value))
+
 	def backgroundNotCrypted(self, value):
 		self.guiObject.setBackgroundColor(parseColor(value))
+
 	def foregroundCrypted(self, value):
 		self.guiObject.setForegroundColor(parseColor(value))
+
 	def backgroundCrypted(self, value):
 		self.guiObject.setBackgroundColor(parseColor(value))
+
 	def foregroundEncrypted(self, value):
 		self.guiObject.setForegroundColor(parseColor(value))
+
 	def backgroundEncrypted(self, value):
 		self.guiObject.setBackgroundColor(parseColor(value))
+
 	def shadowColor(self, value):
 		self.guiObject.setShadowColor(parseColor(value))
+
 	def selectionDisabled(self, value):
 		self.guiObject.setSelectionEnable(0)
+
 	def transparent(self, value):
 		self.guiObject.setTransparent(int(value))
+
 	def borderColor(self, value):
 		self.guiObject.setBorderColor(parseColor(value))
+
 	def borderWidth(self, value):
 		self.guiObject.setBorderWidth(int(value))
+
 	def scrollbarSliderBorderWidth(self, value):
 		self.guiObject.setScrollbarSliderBorderWidth(int(value))
+
 	def scrollbarWidth(self, value):
 		self.guiObject.setScrollbarWidth(int(value))
+
 	def scrollbarSliderBorderColor(self, value):
 		self.guiObject.setSliderBorderColor(parseColor(value))
+
 	def scrollbarSliderForegroundColor(self, value):
 		self.guiObject.setSliderForegroundColor(parseColor(value))
+
 	def scrollbarMode(self, value):
-		self.guiObject.setScrollbarMode(getattr(self.guiObject, value))
-		#	{ "showOnDemand": self.guiObject.showOnDemand,
-		#		"showAlways": self.guiObject.showAlways,
-		#		"showNever": self.guiObject.showNever,
-		#		"showLeft": self.guiObject.showLeft
-		#	}[value])
+		try:
+			self.guiObject.setScrollbarMode({
+				"showOnDemand": self.guiObject.showOnDemand,
+				"showAlways": self.guiObject.showAlways,
+				"showNever": self.guiObject.showNever,
+				"showLeft": self.guiObject.showLeft
+			}[value])
+		except KeyError:
+			print "[Skin] Error: Invalid scrollbarMode '%s'!  Must be one of 'showOnDemand', 'showAlways', 'showNever' or 'showLeft'." % value
+
 	def enableWrapAround(self, value):
-		self.guiObject.setWrapAround(True)
+		value = True if value.lower() in ("1", "enabled", "enablewraparound", "on", "true", "yes") else False
+		self.guiObject.setWrapAround(value)
+
+	def itemHeight(self, value):
+		self.guiObject.setItemHeight(int(value))
+
 	def pointer(self, value):
-		(name, pos) = value.split(':')
+		(name, pos) = value.split(":")
 		pos = parsePosition(pos, self.scaleTuple)
 		ptr = loadPixmap(name, self.desktop)
 		self.guiObject.setPointer(0, ptr, pos)
+
 	def seek_pointer(self, value):
-		(name, pos) = value.split(':')
+		(name, pos) = value.split(":")
 		pos = parsePosition(pos, self.scaleTuple)
 		ptr = loadPixmap(name, self.desktop)
 		self.guiObject.setPointer(1, ptr, pos)
+
 	def shadowOffset(self, value):
 		self.guiObject.setShadowOffset(parsePosition(value, self.scaleTuple))
-	def noWrap(self, value):
-		self.guiObject.setNoWrap(int(value))
-	def linelength(self, value):
-		pass
-	def OverScan(self, value):
-		self.guiObject.setOverscan(value)
 
-def applySingleAttribute(guiObject, desktop, attrib, value, scale = ((1,1),(1,1))):
-	# Someone still using applySingleAttribute?
+	def noWrap(self, value):
+		value = 1 if value.lower() in ("1", "enabled", "nowrap", "on", "true", "yes") else 0
+		self.guiObject.setNoWrap(value)
+
+def applySingleAttribute(guiObject, desktop, attrib, value, scale=((1, 1), (1, 1))):
+	# Is anyone still using applySingleAttribute?
 	AttributeParser(guiObject, desktop, scale).applyOne(attrib, value)
 
 def applyAllAttributes(guiObject, desktop, attributes, scale):
 	AttributeParser(guiObject, desktop, scale).applyAll(attributes)
 
-def loadSingleSkinData(desktop, skin, path_prefix):
-	"""loads skin data like colors, windowstyle etc."""
-	assert skin.tag == "skin", "root element in skin must be 'skin'!"
-	for c in skin.findall("output"):
-		id = c.attrib.get('id')
+def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_CURRENT_SKIN):
+	"""Loads skin data like colors, windowstyle etc."""
+	assert domSkin.tag == "skin", "root element in skin must be 'skin'!"
+	global colors, fonts, menus, parameters, setups, switchPixmap
+	for tag in domSkin.findall("output"):
+		id = tag.attrib.get("id")
 		if id:
 			id = int(id)
 		else:
-			id = 0
-		if id == 0: # framebuffer
-			for res in c.findall("resolution"):
-				get_attr = res.attrib.get
-				xres = get_attr("xres")
-				if xres:
-					xres = int(xres)
-				else:
-					xres = 720
-				yres = get_attr("yres")
-				if yres:
-					yres = int(yres)
-				else:
-					yres = 576
-				bpp = get_attr("bpp")
-				if bpp:
-					bpp = int(bpp)
-				else:
-					bpp = 32
-				#print "Resolution:", xres,yres,bpp
+			id = GUI_SKIN_ID
+		if id == GUI_SKIN_ID:
+			for res in tag.findall("resolution"):
+				xres = res.attrib.get("xres")
+				xres = int(xres) if xres else 720
+				yres = res.attrib.get("yres")
+				yres = int(yres) if yres else 576
+				bpp = res.attrib.get("bpp")
+				bpp = int(bpp) if bpp else 32
+				# print "[Skin] DEBUG: Resolution xres=%d, yres=%d, bpp=%d." % (xres, yres, bpp)
 				from enigma import gMainDC
 				gMainDC.getInstance().setResolution(xres, yres)
 				desktop.resize(eSize(xres, yres))
 				if bpp != 32:
-					# load palette (not yet implemented)
-					pass
-
-	for skininclude in skin.findall("include"):
-		filename = skininclude.attrib.get("filename")
+					pass  # Load palette (Not yet implemented!)
+	for tag in domSkin.findall("include"):
+		filename = tag.attrib.get("filename")
 		if filename:
-			skinfile = resolveFilename(SCOPE_CURRENT_SKIN, filename, path_prefix=path_prefix)
-			if fileExists(skinfile):
-				print "[SKIN] loading include:", skinfile
-				loadSkin(skinfile)
-
-	for c in skin.findall('switchpixmap'):
-		for pixmap in c.findall('pixmap'):
-			get_attr = pixmap.attrib.get
-			name = get_attr('name')
+			filename = resolveFilename(scope, filename, path_prefix=pathSkin)
+			if pathExists(filename):
+				loadSkin(filename, scope=scope, desktop=desktop, screenID=screenID)
+			else:
+				raise SkinError("Included file '%s' not found" % filename)
+	for tag in domSkin.findall("switchpixmap"):
+		for pixmap in tag.findall("pixmap"):
+			name = pixmap.attrib.get("name")
 			if not name:
-				raise SkinError('[Skin] pixmap needs name attribute')
-			filename = get_attr('filename')
+				raise SkinError("Pixmap needs name attribute")
+			filename = pixmap.attrib.get("filename")
 			if not filename:
-				raise SkinError('[Skin] pixmap needs filename attribute')
-			resolved_png = resolveFilename(SCOPE_CURRENT_SKIN, filename, path_prefix=path_prefix)
-			if fileExists(resolved_png):
-				switchPixmap[name] = LoadPixmap(resolved_png, cached=True)
+				raise SkinError("Pixmap needs filename attribute")
+			resolved = resolveFilename(scope, filename, path_prefix=pathSkin)
+			if pathExists(resolved):
+				switchPixmap[name] = LoadPixmap(resolved, cached=True)
 			else:
-				raise SkinError('[Skin] switchpixmap pixmap filename="%s" (%s) not found' % (filename, resolved_png))
-
-	for c in skin.findall("colors"):
-		for color in c.findall("color"):
-			get_attr = color.attrib.get
-			name = get_attr("name")
-			color = get_attr("value")
+				raise SkinError("The switchpixmap pixmap filename='%s' (%s) not found" % (filename, resolved))
+	for tag in domSkin.findall("colors"):
+		for color in tag.findall("color"):
+			name = color.attrib.get("name")
+			color = color.attrib.get("value")
 			if name and color:
-				colorNames[name] = parseColor(color)
-				if color[0] != '#':
-					for key in colorNames:
-						if key == color:
-							colorNamesHuman[name] = colorNamesHuman[key]
-							break
-				else:
-					humancolor = color[1:]
-					if len(humancolor) >= 6:
-						colorNamesHuman[name] = int(humancolor,16)
+				colors[name] = parseColor(color)
+				# print "[Skin] DEBUG: Color name='%s', color='%s'." % (name, color)
 			else:
-				print("need color and name, got %s %s" % (name, color))
-
-	for c in skin.findall("fonts"):
-		for font in c.findall("font"):
-			get_attr = font.attrib.get
-			filename = get_attr("filename", "<NONAME>")
-			name = get_attr("name", "Regular")
-			scale = get_attr("scale")
-			if scale:
-				scale = int(scale)
-			else:
-				scale = 100
-			is_replacement = get_attr("replacement") and True or False
-			render = get_attr("render")
+				raise SkinError("Tag 'color' needs a name and color, got name='%s' and color='%s'" % (name, color))
+	for tag in domSkin.findall("fonts"):
+		for font in tag.findall("font"):
+			filename = font.attrib.get("filename", "<NONAME>")
+			name = font.attrib.get("name", "Regular")
+			scale = font.attrib.get("scale")
+			scale = int(scale) if scale else 100
+			isReplacement = font.attrib.get("replacement") and True or False
+			render = font.attrib.get("render")
 			if render:
 				render = int(render)
 			else:
 				render = 0
-			resolved_font = resolveFilename(SCOPE_FONTS, filename, path_prefix=path_prefix)
-			if not fileExists(resolved_font): #when font is not available look at current skin path
-				resolved_font = resolveFilename(SCOPE_CURRENT_SKIN, filename)
-				if not fileExists(resolved_font) and fileExists(resolveFilename(SCOPE_CURRENT_LCDSKIN, filename)):
-					resolved_font = resolveFilename(SCOPE_CURRENT_LCDSKIN, filename)
-			addFont(resolved_font, name, scale, is_replacement, render)
-			#print "Font: ", resolved_font, name, scale, is_replacement
-
-		fallbackFont = resolveFilename(SCOPE_FONTS, "fallback.font", path_prefix=path_prefix)
-		if fileExists(fallbackFont):
+			filename = resolveFilename(SCOPE_FONTS, filename, path_prefix=pathSkin)
+			addFont(filename, name, scale, isReplacement, render)
+			# Log provided by C++ addFont code.
+			# print "[Skin] Add font: Font path='%s', name='%s', scale=%d, isReplacement=%s, render=%d." % (filename, name, scale, isReplacement, render)
+		fallbackFont = resolveFilename(SCOPE_FONTS, "fallback.font", path_prefix=pathSkin)
+		if pathExists(fallbackFont):
 			addFont(fallbackFont, "Fallback", 100, -1, 0)
-
-		for alias in c.findall("alias"):
-			get = alias.attrib.get
+		for alias in tag.findall("alias"):
 			try:
-				name = get("name")
-				font = get("font")
-				size = int(get("size"))
-				height = int(get("height", size)) # to be calculated some day
-				width = int(get("width", size))
-				global fonts
+				name = alias.attrib.get("name")
+				font = alias.attrib.get("font")
+				size = int(alias.attrib.get("size"))
+				height = int(alias.attrib.get("height", size))  # To be calculated some day.
+				width = int(alias.attrib.get("width", size))
 				fonts[name] = (font, size, height, width)
-			except Exception, ex:
-				print "[SKIN] bad font alias", ex
-
-	for c in skin.findall("parameters"):
-		for parameter in c.findall("parameter"):
-			get = parameter.attrib.get
+				# print "[Skin] Add font alias: name='%s', font='%s', size=%d, height=%s, width=%d." % (name, font, size, height, width)
+			except Exception as err:
+				raise SkinError("Bad font alias: '%s'" % str(err))
+	for tag in domSkin.findall("parameters"):
+		for parameter in tag.findall("parameter"):
 			try:
-				name = get("name")
-				value = get("value")
-				if name.find('Font') != -1:
-					font = value.split(";")
-					if isinstance(font, list) and len(font) == 2:
-						parameters[name] = (str(font[0]), int(font[1]))
-				else:
-					parameters[name] = map(parseParameter, value.split(","))
-			except Exception, ex:
-				print "[SKIN] bad parameter", ex
-
-	for c in skin.findall("constant-widgets"):
-		for constant_widget in c.findall("constant-widget"):
-			get = constant_widget.attrib.get
-			name = get("name")
-			if name:
-				constant_widgets[name] = constant_widget
-
-	for c in skin.findall("variables"):
-		for parameter in c.findall("variable"):
-			get = parameter.attrib.get
-			name = get("name")
-			value = get("value")
-			x, y = value.split(',')
-			if value and name:
-				variables[name] = str(x) + "," + str(y)
-
-	for c in skin.findall("subtitles"):
+				name = parameter.attrib.get("name")
+				value = parameter.attrib.get("value")
+				parameters[name] = map(parseParameter, value.split(",")) if "," in value else parseParameter(value)
+			except Exception as err:
+				raise SkinError("Bad parameter: '%s'" % str(err))
+	for tag in domSkin.findall("menus"):
+		for setup in tag.findall("menu"):
+			key = setup.attrib.get("key")
+			image = setup.attrib.get("image")
+			if key and image:
+				menus[key] = image
+				# print "[Skin] DEBUG: Menu key='%s', image='%s'." % (key, image)
+			else:
+				raise SkinError("Tag menu needs key and image, got key='%s' and image='%s'" % (key, image))
+	for tag in domSkin.findall("setups"):
+		for setup in tag.findall("setup"):
+			key = setup.attrib.get("key")
+			image = setup.attrib.get("image")
+			if key and image:
+				setups[key] = image
+				# print "[Skin] DEBUG: Setup key='%s', image='%s'." % (key, image)
+			else:
+				raise SkinError("Tag setup needs key and image, got key='%s' and image='%s'" % (key, image))
+	for tag in domSkin.findall("subtitles"):
 		from enigma import eSubtitleWidget
-		scale = ((1,1),(1,1))
-		for substyle in c.findall("sub"):
-			get_attr = substyle.attrib.get
-			font = parseFont(get_attr("font"), scale)
-			col = get_attr("foregroundColor")
+		scale = ((1, 1), (1, 1))
+		for substyle in tag.findall("sub"):
+			font = parseFont(substyle.attrib.get("font"), scale)
+			col = substyle.attrib.get("foregroundColor")
 			if col:
 				foregroundColor = parseColor(col)
 				haveColor = 1
 			else:
 				foregroundColor = gRGB(0xFFFFFF)
 				haveColor = 0
-			col = get_attr("borderColor")
+			col = substyle.attrib.get("borderColor")
 			if col:
 				borderColor = parseColor(col)
 			else:
 				borderColor = gRGB(0)
-			borderwidth = get_attr("borderWidth")
+			borderwidth = substyle.attrib.get("borderWidth")
 			if borderwidth is None:
-				# default: use a subtitle border
-				borderWidth = 3
+				borderWidth = 3  # Default: Use a subtitle border.
 			else:
 				borderWidth = int(borderwidth)
-			face = eSubtitleWidget.__dict__[get_attr("name")]
+			face = eSubtitleWidget.__dict__[substyle.attrib.get("name")]
 			eSubtitleWidget.setFontStyle(face, font, haveColor, foregroundColor, borderColor, borderWidth)
-
-	for windowstyle in skin.findall("windowstyle"):
+	for tag in domSkin.findall("windowstyle"):
 		style = eWindowStyleSkinned()
-		style_id = windowstyle.attrib.get("id")
-		if style_id:
-			style_id = int(style_id)
+		styleId = tag.attrib.get("id")
+		if styleId:
+			styleId = int(styleId)
 		else:
-			style_id = 0
-		# defaults
-		font = gFont("Regular", 20)
-		offset = eSize(20, 5)
-		for title in windowstyle.findall("title"):
-			get_attr = title.attrib.get
-			offset = parseSize(get_attr("offset"), ((1,1),(1,1)))
-			font = parseFont(get_attr("font"), ((1,1),(1,1)))
-
+			styleId = GUI_SKIN_ID
+		font = gFont("Regular", 20)  # Default
+		offset = eSize(20, 5)  # Default
+		for title in tag.findall("title"):
+			offset = parseSize(title.attrib.get("offset"), ((1, 1), (1, 1)))
+			font = parseFont(title.attrib.get("font"), ((1, 1), (1, 1)))
 		style.setTitleFont(font)
 		style.setTitleOffset(offset)
-		#print "  ", font, offset
-		for borderset in windowstyle.findall("borderset"):
+		# print "[Skin] DEBUG: WindowStyle font, offset -", font, offset
+		for borderset in tag.findall("borderset"):
 			bsName = str(borderset.attrib.get("name"))
 			for pixmap in borderset.findall("pixmap"):
-				get_attr = pixmap.attrib.get
-				bpName = get_attr("pos")
-				filename = get_attr("filename")
+				bpName = pixmap.attrib.get("pos")
+				filename = pixmap.attrib.get("filename")
 				if filename and bpName:
-					pngfile = resolveFilename(SCOPE_CURRENT_SKIN, filename, path_prefix=path_prefix)
-					png = loadPixmap(pngfile, desktop)
+					png = loadPixmap(resolveFilename(scope, filename, path_prefix=pathSkin), desktop)
 					try:
 						style.setPixmap(eWindowStyleSkinned.__dict__[bsName], eWindowStyleSkinned.__dict__[bpName], png)
-					except:
+					except Exception:
 						pass
-				#print "  borderset:", bpName, filename
-		for color in windowstyle.findall("color"):
-			get_attr = color.attrib.get
-			colorType = get_attr("name")
-			color = parseColor(get_attr("color"))
+				# print "[Skin] DEBUG: WindowStyle borderset name, filename -", bpName, filename
+		for color in tag.findall("color"):
+			colorType = color.attrib.get("name")
+			color = parseColor(color.attrib.get("color"))
 			try:
 				style.setColor(eWindowStyleSkinned.__dict__["col" + colorType], color)
-			except:
-				raise SkinError("Unknown color %s" % colorType)
-				#pass
-			#print "  color:", type, color
+			except Exception:
+				raise SkinError("Unknown color type '%s'" % colorType)
+			# print "[Skin] DEBUG: WindowStyle color type, color -", type, color
 		x = eWindowStyleManager.getInstance()
-		x.setStyle(style_id, style)
-	for margin in skin.findall("margin"):
-		style_id = margin.attrib.get("id")
-		if style_id:
-			style_id = int(style_id)
+		x.setStyle(styleId, style)
+	for tag in domSkin.findall("margin"):
+		styleId = tag.attrib.get("id")
+		if styleId:
+			styleId = int(styleId)
 		else:
-			style_id = 0
-		r = eRect(0,0,0,0)
-		v = margin.attrib.get("left")
+			styleId = GUI_SKIN_ID
+		r = eRect(0, 0, 0, 0)
+		v = tag.attrib.get("left")
 		if v:
 			r.setLeft(int(v))
-		v = margin.attrib.get("top")
+		v = tag.attrib.get("top")
 		if v:
 			r.setTop(int(v))
-		v = margin.attrib.get("right")
+		v = tag.attrib.get("right")
 		if v:
 			r.setRight(int(v))
-		v = margin.attrib.get("bottom")
+		v = tag.attrib.get("bottom")
 		if v:
 			r.setBottom(int(v))
-		# the "desktop" parameter is hardcoded to the UI screen, so we must ask
+		# The "desktop" parameter is hard-coded to the GUI screen, so we must ask
 		# for the one that this actually applies to.
-		getDesktop(style_id).setMargins(r)
-
-dom_screens = {}
-def loadSkin(name, scope = SCOPE_SKIN):
-	# Now a utility for plugins to add skin data to the screens
-	global dom_screens, display_skin_id, isVTISkin
-	filename = resolveFilename(scope, name)
-	if fileExists(filename):
-		path = os.path.dirname(filename) + "/"
-		file = open(filename, 'r')
-		for elem in xml.etree.cElementTree.parse(file).getroot():
-			if elem.tag == 'screen':
-				name = elem.attrib.get('name', None)
-				if name[:3].lower() == "vti":
-					isVTISkin = True
-				if name:
-					sid = elem.attrib.get('id', None)
-					if sid and (sid != display_skin_id):
-						# not for this display
-						elem.clear()
-						continue
-					if name in dom_screens:
-						# Clear old versions, save memory
-						dom_screens[name][0].clear()
-					dom_screens[name] = (elem, path)
-				else:
-					elem.clear()
-			else:
-				elem.clear()
-		file.close()
-
-def loadSkinData(desktop):
-	# Kinda hackish, but this is called once by mytest.py
-	global isVTISkin
-	global dom_skins
-	skins = dom_skins[:]
-	skins.reverse()
-	for (path, dom_skin) in skins:
-		loadSingleSkinData(desktop, dom_skin, path)
-		for elem in dom_skin:
-			if elem.tag == 'screen':
-				name = elem.attrib.get('name', None)
-				if name:
-					if name[:3].lower() == "vti":
-						isVTISkin = True
-					sid = elem.attrib.get('id', None)
-					if sid and (sid != display_skin_id):
-						# not for this display
-						elem.clear()
-						continue
-					if name in dom_screens:
-						# Kill old versions, save memory
-						dom_screens[name][0].clear()
-					dom_screens[name] = (elem, path)
-				else:
-					# without name, it's useless!
-					elem.clear()
-			else:
-				# non-screen element, no need for it any longer
-				elem.clear()
-	# no longer needed, we know where the screens are now.
-	del dom_skins
+		getDesktop(styleId).setMargins(r)
 
 class additionalWidget:
 	def __init__(self):
 		pass
+
 
 # Class that makes a tuple look like something else. Some plugins just assume
 # that size is a string and try to parse it. This class makes that work.
 class SizeTuple(tuple):
 	def split(self, *args):
 		return str(self[0]), str(self[1])
+
 	def strip(self, *args):
-		return '%s,%s' % self
+		return "%s,%s" % self
+
 	def __str__(self):
-		return '%s,%s' % self
+		return "%s,%s" % self
+
 
 class SkinContext:
 	def __init__(self, parent=None, pos=None, size=None, font=None):
@@ -1050,22 +851,22 @@ class SkinContext:
 				self.x, self.y = pos
 				self.w, self.h = size
 			else:
-				self.x = None #0	#none
-				self.y = None #0	#none
-				self.w = None #560	#none
-				self.h = None #550	#none
+				self.x = None
+				self.y = None
+				self.w = None
+				self.h = None
+
 	def __str__(self):
 		return "Context (%s,%s)+(%s,%s) " % (self.x, self.y, self.w, self.h)
+
 	def parse(self, pos, size, font):
-		if size in variables:
-			size = variables[size]
 		if pos == "fill":
 			pos = (self.x, self.y)
 			size = (self.w, self.h)
 			self.w = 0
 			self.h = 0
 		else:
-			w,h = size.split(',')
+			w, h = size.split(",")
 			w = parseCoordinate(w, self.w, 0, font)
 			h = parseCoordinate(h, self.h, 0, font)
 			if pos == "bottom":
@@ -1087,23 +888,21 @@ class SkinContext:
 				size = (w, self.h)
 				self.w -= w
 			else:
-				if pos in variables:
-					pos = variables[pos]
 				size = (w, h)
-				pos = pos.split(',')
+				pos = pos.split(",")
 				pos = (self.x + parseCoordinate(pos[0], self.w, size[0], font), self.y + parseCoordinate(pos[1], self.h, size[1], font))
-		return SizeTuple(pos), SizeTuple(size)
+		return (SizeTuple(pos), SizeTuple(size))
 
+
+# A context that stacks things instead of aligning them.
+#
 class SkinContextStack(SkinContext):
-	# A context that stacks things instead of aligning them
 	def parse(self, pos, size, font):
-		if size in variables:
-			size = variables[size]
 		if pos == "fill":
 			pos = (self.x, self.y)
 			size = (self.w, self.h)
 		else:
-			w,h = size.split(',')
+			w, h = size.split(",")
 			w = parseCoordinate(w, self.w, 0, font)
 			h = parseCoordinate(h, self.h, 0, font)
 			if pos == "bottom":
@@ -1119,57 +918,45 @@ class SkinContextStack(SkinContext):
 				pos = (self.x + self.w - w, self.y)
 				size = (w, self.h)
 			else:
-				if pos in variables:
-					pos = variables[pos]
 				size = (w, h)
-				pos = pos.split(',')
+				pos = pos.split(",")
 				pos = (self.x + parseCoordinate(pos[0], self.w, size[0], font), self.y + parseCoordinate(pos[1], self.h, size[1], font))
-		return SizeTuple(pos), SizeTuple(size)
+		return (SizeTuple(pos), SizeTuple(size))
 
 def readSkin(screen, skin, names, desktop):
 	if not isinstance(names, list):
 		names = [names]
-
-	# try all skins, first existing one have priority
-	global dom_screens
-	for n in names:
-		myscreen, path = dom_screens.get(n, (None,None))
-		if myscreen is not None:
-			# use this name for debug output
-			name = n
+	for n in names:  # Try all skins, first existing one has priority.
+		myScreen, path = domScreens.get(n, (None, None))
+		if myScreen is not None:
+			name = n  # Use this name for debug output.
 			break
 	else:
-		name = "<embedded-in-'%s'>" % screen.__class__.__name__
-
-	# otherwise try embedded skin
-	if myscreen is None:
-		myscreen = getattr(screen, "parsedSkin", None)
-
-	# try uncompiled embedded skin
-	if myscreen is None and getattr(screen, "skin", None):
+		name = "<embedded-in-%s>" % screen.__class__.__name__
+	if myScreen is None:  # Otherwise try embedded skin.
+		myScreen = getattr(screen, "parsedSkin", None)
+	if myScreen is None and getattr(screen, "skin", None):  # Try uncompiled embedded skin.
 		skin = screen.skin
-		print "[SKIN] Parsing embedded skin", name
+		print "[Skin] Parsing embedded skin '%s'." % name
 		if isinstance(skin, tuple):
 			for s in skin:
 				candidate = xml.etree.cElementTree.fromstring(s)
-				if candidate.tag == 'screen':
-					sid = candidate.attrib.get('id', None)
-					if (not sid) or (int(sid) == display_skin_id):
-						myscreen = candidate
+				if candidate.tag == "screen":
+					sid = candidate.attrib.get("id", None)
+					if (not sid) or (int(sid) == DISPLAY_SKIN_ID):
+						myScreen = candidate
 						break
 			else:
-				print "[SKIN] Hey, no suitable screen!"
+				print "[Skin] No suitable screen found!"
 		else:
-			myscreen = xml.etree.cElementTree.fromstring(skin)
-		if myscreen:
-			screen.parsedSkin = myscreen
-	if myscreen is None:
-		print "[SKIN] No skin to read..."
-		myscreen = screen.parsedSkin = xml.etree.cElementTree.fromstring("<screen></screen>")
-
-	screen.skinAttributes = [ ]
-	skin_path_prefix = getattr(screen, "skin_path", path)
-
+			myScreen = xml.etree.cElementTree.fromstring(skin)
+		if myScreen:
+			screen.parsedSkin = myScreen
+	if myScreen is None:
+		print "[Skin] No skin to read or screen to display."
+		myScreen = screen.parsedSkin = xml.etree.cElementTree.fromstring("<screen></screen>")
+	screen.skinAttributes = []
+	skinPath = getattr(screen, "skin_path", path)
 	context = SkinContextStack()
 	s = desktop.bounds()
 	context.x = s.left()
@@ -1177,238 +964,213 @@ def readSkin(screen, skin, names, desktop):
 	context.w = s.width()
 	context.h = s.height()
 	del s
-	collectAttributes(screen.skinAttributes, myscreen, context, skin_path_prefix, ignore=("name",))
-	context = SkinContext(context, myscreen.attrib.get('position'), myscreen.attrib.get('size'))
+	collectAttributes(screen.skinAttributes, myScreen, context, skinPath, ignore=("name",))
+	context = SkinContext(context, myScreen.attrib.get("position"), myScreen.attrib.get("size"))
+	screen.additionalWidgets = []
+	screen.renderer = []
+	usedComponents = set()
 
-	screen.additionalWidgets = [ ]
-	screen.renderer = [ ]
-	visited_components = set()
-
-	def process_constant_widget(constant_widget, context):
-		get_attr = constant_widget.attrib.get
-		wname = get_attr('name')
-		if wname:
-			try:
-				cwvalue = constant_widgets[wname]
-			except KeyError:
-				if config.crash.skin_error_crash.value:
-					print "[SKIN] ERROR - given constant-widget: '%s' not found in skin" % wname
-				else:
-					print "\033[91m[SKIN] ERROR - given constant-widget: '%s' not found in skin\033[0m" % wname
-					return
-		if cwvalue:
-			for x in cwvalue:
-				myscreen.append((x))
-		try:
-			myscreen.remove(constant_widget)
-		except ValueError:
-			pass
-
-	# now walk all widgets and stuff
-	def process_none(widget, context):
+	def processNone(widget, context):
 		pass
 
-	def process_widget(widget, context):
-		get_attr = widget.attrib.get
-		# ok, we either have 1:1-mapped widgets ('old style'), or 1:n-mapped
+	def processWidget(widget, context):
+		# Okay, we either have 1:1-mapped widgets ("old style"), or 1:n-mapped
 		# widgets (source->renderer).
-		wname = get_attr('name')
-		wsource = get_attr('source')
+		wname = widget.attrib.get("name")
+		wsource = widget.attrib.get("source")
 		if wname is None and wsource is None:
-			print "widget has no name and no source!"
+			raise SkinError("The widget has no name and no source")
 			return
 		if wname:
-#			print "Widget name=", wname
-			visited_components.add(wname)
-			# get corresponding 'gui' object
-			try:
-				attributes = screen[wname].skinAttributes = [ ]
-			except:
-				print "component with name '" + wname + "' was not found in skin of screen '" + name + "'!"
+			# print "[Skin] DEBUG: Widget name='%s'." % wname
+			usedComponents.add(wname)
+			try:  # Get corresponding "gui" object.
+				attributes = screen[wname].skinAttributes = []
+			except Exception:
+				raise SkinError("Component with name '%s' was not found in skin of screen '%s'" % (wname, name))
 			# assert screen[wname] is not Source
-			collectAttributes(attributes, widget, context, skin_path_prefix, ignore=('name',))
+			collectAttributes(attributes, widget, context, skinPath, ignore=("name",))
 		elif wsource:
-			# get corresponding source
-#			print "Widget source=", wsource
-			while True: # until we found a non-obsolete source
-				# parse our current "wsource", which might specifiy a "related screen" before the dot,
+			# print "[Skin] DEBUG: Widget source='%s'." % wsource
+			while True:  # Get corresponding source until we found a non-obsolete source.
+				# Parse our current "wsource", which might specify a "related screen" before the dot,
 				# for example to reference a parent, global or session-global screen.
 				scr = screen
-				# resolve all path components
-				path = wsource.split('.')
+				path = wsource.split(".")  # Resolve all path components.
 				while len(path) > 1:
 					scr = screen.getRelatedScreen(path[0])
 					if scr is None:
-						#print wsource
-						#print name
-						print("specified related screen '" + wsource + "' was not found in screen '" + name + "'!")
+						# print "[Skin] DEBUG: wsource='%s', name='%s'." % (wsource, name)
+						raise SkinError("Specified related screen '%s' was not found in screen '%s'" % (wsource, name))
 					path = path[1:]
-				# resolve the source.
-				source = scr.get(path[0])
+				source = scr.get(path[0])  # Resolve the source.
 				if isinstance(source, ObsoleteSource):
-					# however, if we found an "obsolete source", issue warning, and resolve the real source.
-					print "WARNING: SKIN '%s' USES OBSOLETE SOURCE '%s', USE '%s' INSTEAD!" % (name, wsource, source.new_source)
-					print "OBSOLETE SOURCE WILL BE REMOVED %s, PLEASE UPDATE!" % source.removal_date
+					# If we found an "obsolete source", issue warning, and resolve the real source.
+					print "[Skin] WARNING: SKIN '%s' USES OBSOLETE SOURCE '%s', USE '%s' INSTEAD!" % (name, wsource, source.newSource)
+					print "[Skin] OBSOLETE SOURCE WILL BE REMOVED %s, PLEASE UPDATE!" % source.removalDate
 					if source.description:
-						print source.description
+						print "[Skin] Source description: '%s'." % source.description
 					wsource = source.new_source
 				else:
-					# otherwise, use that source.
-					break
-
+					break  # Otherwise, use the source.
 			if source is None:
-				if config.crash.skin_error_crash.value:
-					raise SkinError("source '" + wsource + "' was not found in screen '" + name + "'!")
-				else:
-					print("\033[91m[Skin] Error: Source '" + wsource + "' was not found in screen '" + name + "'!")
-
-			wrender = get_attr('render')
+				raise SkinError("The source '%s' was not found in screen '%s'" % (wsource, name))
+			wrender = widget.attrib.get("render")
 			if not wrender:
-				print("you must define a renderer with render= for source '%s'" % wsource)
+				raise SkinError("For source '%s' a renderer must be defined with a 'render=' attribute" % wsource)
 			for converter in widget.findall("convert"):
-				ctype = converter.get('type')
-				assert ctype, "'convert'-tag needs a 'type'-attribute"
-				#print "Converter:", ctype
+				ctype = converter.get("type")
+				assert ctype, "[Skin] The 'convert' tag needs a 'type' attribute!"
+				# print "[Skin] DEBUG: Converter='%s'." % ctype
 				try:
 					parms = converter.text.strip()
-				except:
+				except Exception:
 					parms = ""
-				#print "Params:", parms
+				# print "[Skin] DEBUG: Params='%s'." % parms
 				try:
-					converter_class = my_import('.'.join(("Components", "Converter", ctype))).__dict__.get(ctype)
+					converterClass = my_import(".".join(("Components", "Converter", ctype))).__dict__.get(ctype)
 				except ImportError:
-					if config.crash.skin_error_crash.value:
-						raise SkinError("[Skin] Error: Converter '%s' not found" % ctype)
-					else:
-						print("\033[91m[Skin] Error: Converter '%s' not found\033[0m" % ctype)
+					raise SkinError("Converter '%s' not found" % ctype)
 				c = None
 				for i in source.downstream_elements:
-					if isinstance(i, converter_class) and i.converter_arguments == parms:
+					if isinstance(i, converterClass) and i.converter_arguments == parms:
 						c = i
 				if c is None:
-					c = converter_class(parms)
+					c = converterClass(parms)
 					c.connect(source)
 				source = c
-
 			try:
-				renderer_class = my_import('.'.join(("Components", "Renderer", wrender))).__dict__.get(wrender)
+				rendererClass = my_import(".".join(("Components", "Renderer", wrender))).__dict__.get(wrender)
 			except ImportError:
-				if config.crash.skin_error_crash.value:
-					raise SkinError("[Skin] Error: Renderer '%s' not found" % wrender)
-				else:
-					print("\033[91m[Skin] Error: Renderer '%s' not found\033[0m" % wrender)
-					return
-			renderer = renderer_class() # instantiate renderer
-			renderer.connect(source) # connect to source
-			attributes = renderer.skinAttributes = [ ]
-			collectAttributes(attributes, widget, context, skin_path_prefix, ignore=('render', 'source'))
+				raise SkinError("Renderer '%s' not found" % wrender)
+			renderer = rendererClass()  # Instantiate renderer.
+			renderer.connect(source)  # Connect to source.
+			attributes = renderer.skinAttributes = []
+			collectAttributes(attributes, widget, context, skinPath, ignore=("render", "source"))
 			screen.renderer.append(renderer)
 
-	def process_applet(widget, context):
+	def processApplet(widget, context):
 		try:
 			codeText = widget.text.strip()
-			widgetType = widget.attrib.get('type')
+			widgetType = widget.attrib.get("type")
 			code = compile(codeText, "skin applet", "exec")
-		except Exception, ex:
-			raise SkinError("applet failed to compile: " + str(ex))
+		except Exception as err:
+			raise SkinError("Applet failed to compile: '%s'" % str(err))
 		if widgetType == "onLayoutFinish":
 			screen.onLayoutFinish.append(code)
 		else:
-			print("applet type '%s' unknown!" % widgetType)
+			raise SkinError("Applet type '%s' is unknown" % widgetType)
 
-
-	def process_elabel(widget, context):
+	def processLabel(widget, context):
 		w = additionalWidget()
 		w.widget = eLabel
-		w.skinAttributes = [ ]
-		collectAttributes(w.skinAttributes, widget, context, skin_path_prefix, ignore=('name',))
+		w.skinAttributes = []
+		collectAttributes(w.skinAttributes, widget, context, skinPath, ignore=("name",))
 		screen.additionalWidgets.append(w)
 
-	def process_epixmap(widget, context):
+	def processPixmap(widget, context):
 		w = additionalWidget()
 		w.widget = ePixmap
-		w.skinAttributes = [ ]
-		collectAttributes(w.skinAttributes, widget, context, skin_path_prefix, ignore=('name',))
+		w.skinAttributes = []
+		collectAttributes(w.skinAttributes, widget, context, skinPath, ignore=("name",))
 		screen.additionalWidgets.append(w)
 
-	def process_screen(widget, context):
-		def process(w):
-			conditional = w.attrib.get('conditional')
+	def processScreen(widget, context):
+		for w in widget.getchildren():
+			conditional = w.attrib.get("conditional")
 			if conditional and not [i for i in conditional.split(",") if i in screen.keys()]:
-				return
-			objecttypes = w.attrib.get('objectTypes', '').split(",")
+				continue
+			objecttypes = w.attrib.get("objectTypes", "").split(",")
 			if len(objecttypes) > 1 and (objecttypes[0] not in screen.keys() or not [i for i in objecttypes[1:] if i == screen[objecttypes[0]].__class__.__name__]):
-				return
-			p = processors.get(w.tag, process_none)
+				continue
+			p = processors.get(w.tag, processNone)
 			try:
 				p(w, context)
-			except SkinError, e:
-				print "[SKIN] SKIN ERROR in screen '%s' widget '%s':" % (name, w.tag), e
+			except SkinError as err:
+				print "[Skin] Error in screen '%s' widget '%s' %s!" % (name, w.tag, err)
 
-		cw = widget.findall("constant-widget")
-		if cw:					#prozess non-openatv skins
-			for w in cw:
-				process(w)
-			for w in myscreen.findall("widget"):
-				process(w)
-		for w in widget.getchildren():
-			if cw and w.tag in ("constant-widget","widget"):	#for non-openatv skins
-				continue
-			process(w)
-
-	def process_panel(widget, context):
-		n = widget.attrib.get('name')
+	def processPanel(widget, context):
+		n = widget.attrib.get("name")
 		if n:
 			try:
-				s = dom_screens.get(n, None)
-				if s is None:
-					print "[SKIN] Unable to find screen '%s' referred in screen '%s'" % (n, name)
-					return
+				s = domScreens[n]
 			except KeyError:
-				print "[SKIN] Unable to find screen '%s' referred in screen '%s'" % (n, name)
+				print "[Skin] Error: Unable to find screen '%s' referred in screen '%s'!" % (n, name)
 			else:
-				process_screen(s[0], context)
-		layout = widget.attrib.get('layout')
-		if layout == 'stack':
+				processScreen(s[0], context)
+		layout = widget.attrib.get("layout")
+		if layout == "stack":
 			cc = SkinContextStack
 		else:
 			cc = SkinContext
 		try:
-			c = cc(context, widget.attrib.get('position'), widget.attrib.get('size'), widget.attrib.get('font'))
-		except Exception, ex:
-			raise SkinError("Failed to create skincontext (%s,%s,%s) in %s: %s" % (widget.attrib.get('position'), widget.attrib.get('size'), widget.attrib.get('font'), context, ex) )
-		process_screen(widget, c)
+			c = cc(context, widget.attrib.get("position"), widget.attrib.get("size"), widget.attrib.get("font"))
+		except Exception as err:
+			raise SkinError("Failed to create skin context (position='%s', size='%s', font='%s') in context '%s': %s" % (widget.attrib.get("position"), widget.attrib.get("size"), widget.attrib.get("font"), context, err))
+		processScreen(widget, c)
 
 	processors = {
-			None: process_none,
-			"constant-widget": process_constant_widget,
-			"widget": process_widget,
-			"applet": process_applet,
-			"eLabel": process_elabel,
-			"ePixmap": process_epixmap,
-			"panel": process_panel
+		None: processNone,
+		"widget": processWidget,
+		"applet": processApplet,
+		"eLabel": processLabel,
+		"ePixmap": processPixmap,
+		"panel": processPanel
 	}
 
 	try:
-		print "[SKIN] processing screen %s:" % name
-		context.x = 0 # reset offsets, all components are relative to screen
-		context.y = 0 # coordinates.
-		process_screen(myscreen, context)
-	except Exception, e:
-		print "[SKIN] SKIN ERROR in %s:" % name, e
+		msg = " from list '%s'" % ", ".join(names) if len(names) > 1 else ""
+		posX = "?" if context.x is None else str(context.x)
+		posY = "?" if context.y is None else str(context.y)
+		sizeW = "?" if context.w is None else str(context.w)
+		sizeH = "?" if context.h is None else str(context.h)
+		print "[Skin] Processing screen '%s'%s, position=(%s, %s), size=(%s x %s) for module '%s'." % (name, msg, posX, posY, sizeW, sizeH, screen.__class__.__name__)
+		context.x = 0  # Reset offsets, all components are relative to screen coordinates.
+		context.y = 0
+		processScreen(myScreen, context)
+	except Exception as err:
+		print "[Skin] Error in screen '%s' %s!" % (name, err)
 
 	from Components.GUIComponent import GUIComponent
-	nonvisited_components = [x for x in set(screen.keys()) - visited_components if isinstance(x, GUIComponent)]
-	assert not nonvisited_components, "the following components in %s don't have a skin entry: %s" % (name, ', '.join(nonvisited_components))
-	# This may look pointless, but it unbinds 'screen' from the nested scope. A better
+	unusedComponents = [x for x in set(screen.keys()) - usedComponents if isinstance(x, GUIComponent)]
+	assert not unusedComponents, "[Skin] The following components in '%s' don't have a skin entry: %s" % (name, ", ".join(unusedComponents))
+	# This may look pointless, but it unbinds "screen" from the nested scope. A better
 	# solution is to avoid the nested scope above and use the context object to pass
 	# things around.
 	screen = None
-	visited_components = None
+	usedComponents = None
 
-def parseAvailableSkinColor(color):
-	if color in colorNamesHuman:
-		return colorNamesHuman[color]
-	else:
-		print "color %s ist not available at used skin" % color
-		return None
+def getSkinFactor(refresh=False):  # This only works for screen resolution greater than HD!
+	global skinfactor
+	if refresh or not skinfactor:
+		try:
+			skinfactor = getDesktop(GUI_SKIN_ID).size().height() / 720.0
+			if skinfactor not in [1, 1.5, 3, 6]:
+				skinfactor = 1
+				print "[Skin] Unknown result for getSkinFactor '%s' -> SkinFactor set to 1!" % skinfactor
+		except Exception as err:
+			skinfactor = 1
+			print "[Skin] Error: getSkinFactor failed!  (%s)" % str(err)
+	return skinfactor
+
+# Search the domScreens dictionary to see if any of the screen names provided
+# have a skin based screen.  This will allow coders to know if the named
+# screen will be skinned by the skin code.  A return of None implies that the
+# code must provide its own skin for the screen to be displayed to the user.
+#
+def findSkinScreen(names):
+	if not isinstance(names, list):
+		names = [names]
+	for name in names:  # Try all names given, the first one found is the one that will be used by the skin engine.
+		screen, path = domScreens.get(name, (None, None))
+		if screen is not None:
+			return name
+	return None
+
+def dump(x, i=0):
+	print " " * i + str(x)
+	try:
+		for n in x.childNodes:
+			dump(n, i + 1)
+	except Exception:
+		None


### PR DESCRIPTION
- [skin.py] Refactor and optimise the code
  - Simplify, improve and optimise the skin loading code.
  - Remove the loadSkinData() method code and create a new method InitSkins() to be caaled from mytest.py  (The loadSkinData() method is now a placeholder for older versions of mytest.py and simply executes the new InitSkins() method.)
  - Provide log diagnostics for failed skin loads (XML errors).
  - Improve logging information about screens at screen load time.
  - Optimise the parseCoordinate(0 code.
  - Enhance the parseParameter() code.  Font processing is now done here and not in the skin loader code.
  - Use the new RcModel.py library code to initialise the loadPixmap() method.
  - Remove all inline image cache code and use the C++ image cache instead.
  - Simplify the logging messages.
  - Remove the defunct VTI skin processing code.
  - Fix the parameter loading code.  Now single element parameters will be returned as the correct type.  Single values will no longer be tuples.
  - Delete the whole dom_screens dictionary and code as the skin loading is more direct and simplified.
  - Add an 8K scaling factor for when 8K skins happen.
  - Create a callback so that code can be notified if the skin is changed.
  - Prepare infrastructure to allow skins to be reloaded so that in the future a GUI restart is not required.
  - Delete lots of unused code.
  - PEP8 clean up the code.

  There is probably more but these are the main points.  ;)

- [ConfigList.py] Adjust parameter for new skin code
  - The "ConfigListSeperator" parameter is a single int value.  In the previous skin code all parameters were returned as tuples.  Now single values are returned in the correct type.  The previous trick to convert the tuple to an int is no longer required.

- [setup.xml] Remove defunct config.vfd setting
  - The new skin.py code removes an old and defunct config.vfd config object.  This change make a equivalent change here.
