### PR TITLE
Revert parameter corrections

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -11,7 +11,8 @@ class ConfigList(HTMLComponent, GUIComponent, object):
 	def __init__(self, list, session = None):
 		GUIComponent.__init__(self)
 		self.l = eListboxPythonConfigContent()
-		seperation = skin.parameters.get("ConfigListSeperator", 350)
+		# seperation = skin.parameters.get("ConfigListSeperator", 350)
+		seperation, = skin.parameters.get("ConfigListSeperator", (350, ))
 		self.l.setSeperation(seperation)
 		height, space = skin.parameters.get("ConfigListSlider",(17, 0))
 		self.l.setSlider(height, space)

--- a/skin.py
+++ b/skin.py
@@ -729,7 +729,8 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_CURRENT
 			try:
 				name = parameter.attrib.get("name")
 				value = parameter.attrib.get("value")
-				parameters[name] = map(parseParameter, value.split(",")) if "," in value else parseParameter(value)
+				# parameters[name] = map(parseParameter, [x.strip() for x in value.split(",")]) if "," in value else parseParameter(value)
+				parameters[name] = map(parseParameter, [x.strip() for x in value.split(",")])
 			except Exception as err:
 				raise SkinError("Bad parameter: '%s'" % str(err))
 	for tag in domSkin.findall("menus"):


### PR DESCRIPTION
- [skin.py] Revert parameter correction
  Revert the parameter parsing correction until all the places where single parameters are processed are fixed.

- [ConfigList.py] Revert parameter correction
  Revert the "separation" parameter parsing correction until all the places where single parameters are processed are also fixed.
