### PR TITLE
[skin.py] Add a few more clean ups

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -6,7 +6,7 @@ from enigma import addFont, eLabel, ePixmap, ePoint, eRect, eSize, eWindow, eWin
 from os import listdir
 from os.path import basename, dirname, isfile, join as pathjoin
 
-from Components.config import ConfigNothing, ConfigSelection, ConfigSubsection, ConfigText, config
+from Components.config import ConfigSubsection, ConfigText, config
 from Components.RcModel import rc_model
 from Components.Sources.Source import ObsoleteSource
 from Components.SystemInfo import SystemInfo
@@ -47,7 +47,7 @@ isVTISkin = False  # Temporary flag to suppress errors in OpenATV.
 
 config.skin = ConfigSubsection()
 skin = resolveFilename(SCOPE_SKIN, DEFAULT_SKIN)
-if not pathExists(skin) or not isfile(skin):
+if not isfile(skin):
 	print "[Skin] Error: Default skin '%s' is not readable or is not a file!  Using emergency skin." % skin
 	DEFAULT_SKIN = EMERGENCY_SKIN
 config.skin.primary_skin = ConfigText(default=DEFAULT_SKIN)
@@ -113,7 +113,7 @@ def InitSkins():
 	result = None
 	if isfile(resolveFilename(SCOPE_SKIN, config.skin.primary_skin.value)):
 		name = USER_SKIN_TEMPLATE % dirname(config.skin.primary_skin.value)
-		if pathExists(resolveFilename(SCOPE_CURRENT_SKIN, name)):
+		if isfile(resolveFilename(SCOPE_CURRENT_SKIN, name)):
 			result = loadSkin(name, scope=SCOPE_CURRENT_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID)
 	if result is None:
 		loadSkin(USER_SKIN, scope=SCOPE_CURRENT_SKIN, desktop=getDesktop(GUI_SKIN_ID), screenID=GUI_SKIN_ID)
@@ -357,7 +357,7 @@ def collectAttributes(skinAttributes, node, context, skinPath=None, ignore=(), f
 			if attrib in filenames:
 				# DEBUG: Why does a SCOPE_CURRENT_LCDSKIN image replace the GUI image?!?!?!
 				pngfile = resolveFilename(SCOPE_CURRENT_SKIN, value, path_prefix=skinPath)
-				if not pathExists(pngfile) and pathExists(resolveFilename(SCOPE_CURRENT_LCDSKIN, value, path_prefix=skinPath)):
+				if not isfile(pngfile) and isfile(resolveFilename(SCOPE_CURRENT_LCDSKIN, value, path_prefix=skinPath)):
 					pngfile = resolveFilename(SCOPE_CURRENT_LCDSKIN, value, path_prefix=skinPath)
 				value = pngfile
 			# Bit of a hack this, really.  When a window has a flag (e.g. wfNoBorder)
@@ -668,7 +668,7 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_CURRENT
 		filename = tag.attrib.get("filename")
 		if filename:
 			filename = resolveFilename(scope, filename, path_prefix=pathSkin)
-			if pathExists(filename):
+			if isfile(filename):
 				loadSkin(filename, scope=scope, desktop=desktop, screenID=screenID)
 			else:
 				raise SkinError("Included file '%s' not found" % filename)
@@ -681,7 +681,7 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_CURRENT
 			if not filename:
 				raise SkinError("Pixmap needs filename attribute")
 			resolved = resolveFilename(scope, filename, path_prefix=pathSkin)
-			if pathExists(resolved):
+			if isfile(resolved):
 				switchPixmap[name] = LoadPixmap(resolved, cached=True)
 			else:
 				raise SkinError("The switchpixmap pixmap filename='%s' (%s) not found" % (filename, resolved))
@@ -711,7 +711,7 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_CURRENT
 			# Log provided by C++ addFont code.
 			# print "[Skin] Add font: Font path='%s', name='%s', scale=%d, isReplacement=%s, render=%d." % (filename, name, scale, isReplacement, render)
 		fallbackFont = resolveFilename(SCOPE_FONTS, "fallback.font", path_prefix=pathSkin)
-		if pathExists(fallbackFont):
+		if isfile(fallbackFont):
 			addFont(fallbackFont, "Fallback", 100, -1, 0)
 		for alias in tag.findall("alias"):
 			try:
@@ -1096,7 +1096,7 @@ def readSkin(screen, skin, names, desktop):
 			try:
 				p(w, context)
 			except SkinError as err:
-				print "[Skin] Error in screen '%s' widget '%s' %s!" % (name, w.tag, err)
+				print "[Skin] Error in screen '%s' widget '%s' %s!" % (name, w.tag, str(err))
 
 	def processPanel(widget, context):
 		n = widget.attrib.get("name")
@@ -1138,7 +1138,7 @@ def readSkin(screen, skin, names, desktop):
 		context.y = 0
 		processScreen(myScreen, context)
 	except Exception as err:
-		print "[Skin] Error in screen '%s' %s!" % (name, err)
+		print "[Skin] Error in screen '%s' %s!" % (name, str(err))
 
 	from Components.GUIComponent import GUIComponent
 	unusedComponents = [x for x in set(screen.keys()) - usedComponents if isinstance(x, GUIComponent)]


### PR DESCRIPTION
- Use isfile() rather than pathExists().  Using isfile() as a test for existence is more optimal because, in context, it is better to know that the path exists and is a file rather than just knowing the path exists.
- Remove obsolete imports.
- Cast err as a string to ensure the print format is correct.
