### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -9147,7 +9147,7 @@ msgid "Install '%s' and enable this operation"
 msgstr "'%s' installieren und aktivieren"
 
 msgid "Install Failed !!"
-msgstr "Installation fehlgeschlagen !!"
+msgstr "!! Installation fehlgeschlagen !!"
 
 msgid "Install Finished."
 msgstr "Installation abgeschlossen."


### PR DESCRIPTION
@hd75hd: Im Image haben wir bei 'dicken' Fehlern zwei Ausrufezeichen VOR und HINTER den Fehlertext gesetzt.
Habe das deshalb auch hier gemacht.
Gruß - Makumbo