### PR TITLE
[Menu.py] Improve crash correction

### DIFF
--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -16,7 +16,7 @@ from Components.Pixmap import Pixmap, MovingPixmap
 from Components.Button import Button
 from Tools.LoadPixmap import LoadPixmap
 import os
-import skin
+from skin import findSkinScreen
 
 import xml.etree.cElementTree
 
@@ -354,9 +354,9 @@ class Menu(Screen, ProtectedScreen):
 		# for the skin: first try a menu_<menuID>, then Menu
 		self.skinName = [ ]
 		if menuID is not None:
-			if config.usage.menutype.value == 'horzanim' and skin.domScreens.has_key("Animmain"):
+			if config.usage.menutype.value == 'horzanim' and findSkinScreen("Animmain"):
 				self.skinName.append('Animmain')
-			elif config.usage.menutype.value == 'horzicon' and skin.domScreens.has_key("Iconmain"):
+			elif config.usage.menutype.value == 'horzicon' and findSkinScreen("Iconmain"):
 				self.skinName.append('Iconmain')
 			else:
 				self.skinName.append('menu_' + menuID)
@@ -472,14 +472,14 @@ class Menu(Screen, ProtectedScreen):
 		else:
 			t_history.thistory = t_history.thistory + str(a) + ' > '
 
-		if config.usage.menutype.value == 'horzanim' and skin.domScreens.has_key("Animmain"):
+		if config.usage.menutype.value == 'horzanim' and findSkinScreen("Animmain"):
 			self['label1'] = StaticText()
 			self['label2'] = StaticText()
 			self['label3'] = StaticText()
 			self['label4'] = StaticText()
 			self['label5'] = StaticText()
 			self.onShown.append(self.openTestA)
-		elif config.usage.menutype.value == 'horzicon' and skin.domScreens.has_key("Iconmain"):
+		elif config.usage.menutype.value == 'horzicon' and findSkinScreen("Iconmain"):
 			self['label1'] = StaticText()
 			self['label2'] = StaticText()
 			self['label3'] = StaticText()


### PR DESCRIPTION
- Don't use a skin.py internal variable if an access method is available.  In this case, don't use the "domScreens" dictionary but rather the "findSkinScreen()" method instead.  This is not likely to break if the skin.py code changes again.
- The Python coding style ".has_key()" is deprecated.
- Don't import all of skin if it isn't required.  Mistakes or errors could damage the skin code.
