### PR TITLE
Expanding the functionality of the PiP

### DIFF
--- a/data/keymap.ntr
+++ b/data/keymap.ntr
@@ -1,4 +1,3 @@
-
 <keymap>
 	<map context="ListboxActions">
 		<device name="keyboard">
@@ -180,7 +179,7 @@
 
 	<map context="InfoBarQuickMenu">
 		<key id="KEY_BLUE" mapto="quickmenu" flags="b" />
- 	</map>
+	</map>
 
 	<map context="SatlistShortcutAction">
 		<key id="KEY_YELLOW" mapto="changetype" flags="b"/>
@@ -279,7 +278,6 @@
 		<key id="KEY_RIGHT" mapto="right" flags="mr" />
 	</map>
 
-
 	<map context="MenuActions">
 		<key id="KEY_MENU" mapto="menu" flags="mr" />
 		<key id="KEY_SPACE" mapto="menu" flags="mr" />
@@ -358,16 +356,22 @@
 	</map>
 
 	<map context="InfobarTimerButtonActions">
-			<key id="KEY_PROGRAM" mapto="timerSelection" flags="b" />
+		<key id="KEY_PROGRAM" mapto="timerSelection" flags="b" />
 	</map>
 
 	<map context="InfobarVmodeButtonActions">
-			<key id="KEY_VMODE" mapto="vmodeSelection" flags="m" />
+		<key id="KEY_VMODE" mapto="vmodeSelection" flags="m" />
 	</map>
 
 	<map context="InfobarPiPActions">
 		<key id="KEY_SCREEN" mapto="activatePiP" flags="b" />
 		<key id="KEY_F6" mapto="activatePiP" flags="b" />
+		<key id="KEY_SCREEN" mapto="activatePiPlong" flags="l" />
+		<key id="KEY_F6" mapto="activatePiPlong" flags="l" />
+		<key id="KEY_LEFT" mapto="left" flags="b" />
+		<key id="KEY_RIGHT" mapto="right" flags="b" />
+		<key id="KEY_EXIT" mapto="exitpip" flags="m" />
+		<key id="KEY_ESC" mapto="exitpip" flags="m" />
 	</map>
 
 	<map context="InfobarSubserviceQuickzapActions">
@@ -492,6 +496,7 @@
 		<key id="KEY_7" mapto="seekdef:7" flags="m" />
 		<key id="KEY_9" mapto="seekdef:9" flags="m" />
 	</map>
+	
 	<map context="InfobarSeekActionsPTS">
 		<key id="KEY_PLAYPAUSE" mapto="playpauseService" flags="m" />
 		<key id="KEY_PAUSE" mapto="pauseService" flags="m" />
@@ -773,7 +778,6 @@
 		<key id="KEY_ESC" mapto="cancel" flags="m" />
 	</map>
 
-
 	<map context="DirectionActions">
 		<key id="KEY_UP" mapto="up" flags="mr" />
 		<key id="KEY_DOWN" mapto="down" flags="mr" />
@@ -825,6 +829,7 @@
 		<key id="KEY_CHANNELUP" mapto="nextBouquet" flags="m" />
 		<key id="KEY_CHANNELDOWN" mapto="prevBouquet" flags="m" />
 	</map>
+	
 	<map context="StandbyActions">
 		<key id="KEY_POWER" mapto="power" flags="m" />
 		<key id="KEY_KP1" mapto="discrete_on" flags="m" />
@@ -871,7 +876,16 @@
 		<key id="KEY_CHANNELDOWN" mapto="size-" flags="mr" />
 		<key id="KEY_INFO" mapto="mode" flags="m" />
 	</map>
-
+	
+	<map context="PiPusageModeSetupActions">
+		<key id="KEY_LEFT" mapto="left" flags="mr" />
+		<key id="KEY_RIGHT" mapto="right" flags="mr" />
+		<key id="KEY_EXIT" mapto="cancel" flags="m" />
+		<key id="KEY_ESC" mapto="cancel" flags="m" />
+		<key id="KEY_ENTER" mapto="ok" flags="m" />
+		<key id="KEY_OK" mapto="ok" flags="m" />
+	</map>
+	
 	<map context="MediaPlayerActions">
 		<device name="dreambox advanced remote control (native)">
 			<key id="KEY_RECORD" mapto="shift_record" flags="l" />
@@ -911,6 +925,7 @@
 		<key id="KEY_FILE" mapto="nextBouquet" flags="m" />
 		<key id="KEY_LIST" mapto="prevBouquet" flags="m" />
 	</map>
+	
 	<map context="CCcamInfoActions">
 		<key id="KEY_1" mapto="1" flags="m"/>
 		<key id="KEY_2" mapto="2" flags="m"/>
@@ -937,6 +952,7 @@
 		<key id="KEY_CHANNELUP" mapto="incUphop" flags="m"/>
 		<key id="KEY_CHANNELDOWN" mapto="decUphop" flags="m"/>
 	</map>
+	
 	<map context="InfoBarINFOpanel">
 		<key id="KEY_RED" mapto="infoPanel" flags="b" />
 		<key id="KEY_RED" mapto="softcamPanel" flags="l" />
@@ -1035,6 +1051,7 @@
 		<key id="KEY_PREVIOUSSONG" mapto="prevsong_long" flags="l"/>
 		<key id="KEY_NEXTSONG" mapto="nextsong_long" flags="l"/>
 		<key id="KEY_SCREEN" mapto="activatePiP" flags="b"/>
+		<key id="KEY_SCREEN" mapto="activatePiPlong" flags="l"/>
 		<key id="KEY_PROGRAM" mapto="prog" flags="b"/>
 		<key id="KEY_PROGRAM" mapto="prog_long" flags="l"/>
 		<key id="KEY_PLAYPAUSE" mapto="playpause" flags="m"/>
@@ -1108,6 +1125,7 @@
 		<key id="KEY_KEYBOARD" mapto="keyboard" flags="b"/>
 		<key id="KEY_KEYBOARD" mapto="keyboard_long" flags="l"/>
 	</map>
+	
 	<map context="SubtitlesActions">
 		<key id="KEY_SUBTITLE" mapto="subtitles" flags="m" />
 		<key id="KEY_TEXT" mapto="subtitles" flags="m" />

--- a/data/keymap.u80
+++ b/data/keymap.u80
@@ -4,6 +4,7 @@
 		<key id="KEY_UP" mapto="pageUp" flags="mr" />
 		<key id="KEY_DOWN" mapto="pageDown" flags="mr" />
 	</map>
+	
 	<map context="ListboxActions">
 		<device name="keyboard">
 			<key id="a" mapto="up" flags="mr" />
@@ -182,7 +183,7 @@
 
 	<map context="InfoBarQuickMenu">
 		<key id="KEY_BLUE" mapto="quickmenu" flags="b" />
- 	</map>
+	</map>
 
 	<map context="SatlistShortcutAction">
 		<!--key id="KEY_YELLOW" mapto="changetype" flags="b"/-->
@@ -352,20 +353,26 @@
 	</map>
 
 	<map context="InfobarTimerButtonActions">
-			<key id="KEY_PROGRAM" mapto="timerSelection" flags="m" />
+		<key id="KEY_PROGRAM" mapto="timerSelection" flags="m" />
 	</map>
 
 	<map context="InfobarVmodeButtonActions">
-			<key id="KEY_VMODE" mapto="vmodeSelection" flags="m" />
+		<key id="KEY_VMODE" mapto="vmodeSelection" flags="m" />
 	</map>
 
 	<map context="InfobarTimerButtonActions">
-			<key id="KEY_PROGRAM" mapto="timerSelection" flags="m" />
+		<key id="KEY_PROGRAM" mapto="timerSelection" flags="m" />
 	</map>
 
 	<map context="InfobarPiPActions">
 		<key id="KEY_SCREEN" mapto="activatePiP" flags="b" />
 		<key id="KEY_F6" mapto="activatePiP" flags="b" />
+		<key id="KEY_SCREEN" mapto="activatePiPlong" flags="l" />
+		<key id="KEY_F6" mapto="activatePiPlong" flags="l" />
+		<key id="KEY_LEFT" mapto="left" flags="b" />
+		<key id="KEY_RIGHT" mapto="right" flags="b" />
+		<key id="KEY_EXIT" mapto="exitpip" flags="m" />
+		<key id="KEY_ESC" mapto="exitpip" flags="m" />
 	</map>
 
 	<map context="InfobarSubserviceQuickzapActions">
@@ -531,7 +538,6 @@
 		<key id="KEY_7" mapto="seekdef:7" flags="m" />
 		<key id="KEY_9" mapto="seekdef:9" flags="m" />
 	</map>
-
 
 	<map context="MediaPlayerSeekActions">
 		<device name="dreambox advanced remote control (native)">
@@ -846,6 +852,7 @@
 		<key id="KEY_CHANNELUP" mapto="nextBouquet" flags="m" />
 		<key id="KEY_CHANNELDOWN" mapto="prevBouquet" flags="m" />
 	</map>
+	
 	<map context="StandbyActions">
 		<key id="KEY_POWER" mapto="power" flags="m" />
 		<key id="KEY_KP1" mapto="discrete_on" flags="m" />
@@ -892,7 +899,14 @@
 		<key id="KEY_CHANNELDOWN" mapto="size-" flags="mr" />
 		<key id="KEY_INFO" mapto="mode" flags="m" />
 	</map>
-
+	<map context="PiPusageModeSetupActions">
+		<key id="KEY_LEFT" mapto="left" flags="mr" />
+		<key id="KEY_RIGHT" mapto="right" flags="mr" />
+		<key id="KEY_EXIT" mapto="cancel" flags="m" />
+		<key id="KEY_ESC" mapto="cancel" flags="m" />
+		<key id="KEY_ENTER" mapto="ok" flags="m" />
+		<key id="KEY_OK" mapto="ok" flags="m" />
+	</map>
 	<map context="MediaPlayerActions">
 		<device name="dreambox advanced remote control (native)">
 			<key id="KEY_RECORD" mapto="shift_record" flags="l" />
@@ -932,6 +946,7 @@
 		<key id="KEY_FILE" mapto="nextBouquet" flags="m" />
 		<key id="KEY_LIST" mapto="prevBouquet" flags="m" />
 	</map>
+	
 	<map context="CCcamInfoActions">
 		<key id="KEY_1" mapto="1" flags="m"/>
 		<key id="KEY_2" mapto="2" flags="m"/>
@@ -958,6 +973,7 @@
 		<key id="KEY_CHANNELUP" mapto="incUphop" flags="m"/>
 		<key id="KEY_CHANNELDOWN" mapto="decUphop" flags="m"/>
 	</map>
+	
 	<map context="InfoBarINFOpanel">
 		<key id="KEY_RED" mapto="infoPanel" flags="b" />
 		<key id="KEY_RED" mapto="softcamPanel" flags="l" />
@@ -998,6 +1014,7 @@
 			<key id="KEY_NEXTSONG" mapto="next" flags="m"/>
 		</device-->
 	</map>
+	
 	<map context="ButtonSetupActions">
 		<key id="KEY_RED" mapto="red" flags="b"/>
 		<key id="KEY_RED" mapto="red_long" flags="l"/>
@@ -1054,6 +1071,7 @@
 		<key id="KEY_PREVIOUSSONG" mapto="prevsong_long" flags="l"/>
 		<key id="KEY_NEXTSONG" mapto="nextsong_long" flags="l"/>
 		<key id="KEY_SCREEN" mapto="activatePiP" flags="b"/>
+		<key id="KEY_SCREEN" mapto="activatePiPlong" flags="l"/>												  
 		<key id="KEY_PROGRAM" mapto="prog" flags="b"/>
 		<key id="KEY_PROGRAM" mapto="prog_long" flags="l"/>
 		<key id="KEY_PLAYPAUSE" mapto="playpause" flags="m"/>
@@ -1125,6 +1143,7 @@
 		<key id="KEY_VOD" mapto="vod" flags="b"/>
 		<key id="KEY_VOD" mapto="vod_long" flags="l"/>
 	</map>
+	
 	<map context="SubtitlesActions">
 		<key id="KEY_SUBTITLE" mapto="subtitles" flags="m" />
 		<key id="KEY_TEXT" mapto="subtitles" flags="m" />

--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -4,6 +4,7 @@
 		<key id="KEY_UP" mapto="pageUp" flags="mr" />
 		<key id="KEY_DOWN" mapto="pageDown" flags="mr" />
 	</map>
+	
 	<map context="ListboxActions">
 		<device name="keyboard">
 			<key id="a" mapto="up" flags="mr" />
@@ -184,7 +185,7 @@
 
 	<map context="InfoBarQuickMenu">
 		<key id="KEY_BLUE" mapto="quickmenu" flags="b" />
- 	</map>
+	</map>
 
 	<map context="SatlistShortcutAction">
 		<key id="KEY_YELLOW" mapto="changetype" flags="b"/>
@@ -359,18 +360,24 @@
 	</map>
 
 	<map context="InfobarTimerButtonActions">
-			<key id="KEY_PROGRAM" mapto="timerSelection" flags="b" />
-			<key id="KEY_CALENDAR" mapto="openAutoTimerList" flags="b" />
+		<key id="KEY_PROGRAM" mapto="timerSelection" flags="b" />
+		<key id="KEY_CALENDAR" mapto="openAutoTimerList" flags="b" />
 	</map>
 
 	<map context="InfobarVmodeButtonActions">
-			<key id="KEY_VMODE" mapto="vmodeSelection" flags="m" />
-			<key id="KEY_ANGLE" mapto="vmodeSelection" flags="m" />
+		<key id="KEY_VMODE" mapto="vmodeSelection" flags="m" />
+		<key id="KEY_ANGLE" mapto="vmodeSelection" flags="m" />
 	</map>
 
 	<map context="InfobarPiPActions">
 		<key id="KEY_SCREEN" mapto="activatePiP" flags="b" />
 		<key id="KEY_F6" mapto="activatePiP" flags="b" />
+		<key id="KEY_SCREEN" mapto="activatePiPlong" flags="l" />
+		<key id="KEY_F6" mapto="activatePiPlong" flags="l" />
+		<key id="KEY_LEFT" mapto="left" flags="b" />
+		<key id="KEY_RIGHT" mapto="right" flags="b" />
+		<key id="KEY_EXIT" mapto="exitpip" flags="m" />
+		<key id="KEY_ESC" mapto="exitpip" flags="m" />
 	</map>
 
 	<map context="InfobarSubserviceQuickzapActions">
@@ -537,7 +544,6 @@
 		<key id="KEY_7" mapto="seekdef:7" flags="m" />
 		<key id="KEY_9" mapto="seekdef:9" flags="m" />
 	</map>
-
 
 	<map context="MediaPlayerSeekActions">
 		<device name="dreambox advanced remote control (native)">
@@ -860,6 +866,7 @@
 		<key id="KEY_CHANNELUP" mapto="nextBouquet" flags="m" />
 		<key id="KEY_CHANNELDOWN" mapto="prevBouquet" flags="m" />
 	</map>
+	
 	<map context="StandbyActions">
 		<key id="KEY_POWER" mapto="power_make"   flags="m" />
 		<key id="KEY_POWER" mapto="power_break"  flags="b" />
@@ -909,7 +916,16 @@
 		<key id="KEY_CHANNELDOWN" mapto="size-" flags="mr" />
 		<key id="KEY_INFO" mapto="mode" flags="m" />
 	</map>
-
+	
+	<map context="PiPusageModeSetupActions">
+		<key id="KEY_LEFT" mapto="left" flags="mr" />
+		<key id="KEY_RIGHT" mapto="right" flags="mr" />
+		<key id="KEY_EXIT" mapto="cancel" flags="m" />
+		<key id="KEY_ESC" mapto="cancel" flags="m" />
+		<key id="KEY_ENTER" mapto="ok" flags="m" />
+		<key id="KEY_OK" mapto="ok" flags="m" />
+	</map>
+	
 	<map context="MediaPlayerActions">
 		<device name="dreambox advanced remote control (native)">
 			<key id="KEY_RECORD" mapto="shift_record" flags="l" />
@@ -949,6 +965,7 @@
 		<key id="KEY_FILE" mapto="nextBouquet" flags="m" />
 		<key id="KEY_LIST" mapto="prevBouquet" flags="m" />
 	</map>
+	
 	<map context="CCcamInfoActions">
 		<key id="KEY_1" mapto="1" flags="m"/>
 		<key id="KEY_2" mapto="2" flags="m"/>
@@ -975,6 +992,7 @@
 		<key id="KEY_CHANNELUP" mapto="incUphop" flags="m"/>
 		<key id="KEY_CHANNELDOWN" mapto="decUphop" flags="m"/>
 	</map>
+	
 	<map context="InfoBarINFOpanel">
 		<key id="KEY_RED" mapto="infoPanel" flags="b" />
 		<key id="KEY_RED" mapto="softcamPanel" flags="l" />
@@ -1016,6 +1034,7 @@
 			<key id="KEY_NEXTSONG" mapto="next" flags="m"/>
 		</device-->
 	</map>
+	
 	<map context="ButtonSetupActions">
 		<key id="KEY_RED" mapto="red" flags="b"/>
 		<key id="KEY_RED" mapto="red_long" flags="l"/>
@@ -1072,6 +1091,7 @@
 		<key id="KEY_PREVIOUSSONG" mapto="prevsong_long" flags="l"/>
 		<key id="KEY_NEXTSONG" mapto="nextsong_long" flags="l"/>
 		<key id="KEY_SCREEN" mapto="activatePiP" flags="b"/>
+		<key id="KEY_SCREEN" mapto="activatePiPlong" flags="l"/>																  
 		<key id="KEY_PROGRAM" mapto="prog" flags="b"/>
 		<key id="KEY_PROGRAM" mapto="prog_long" flags="l"/>
 		<key id="KEY_PLAYPAUSE" mapto="playpause" flags="m"/>
@@ -1145,6 +1165,7 @@
 		<key id="KEY_KEYBOARD" mapto="keyboard" flags="b"/>
 		<key id="KEY_KEYBOARD" mapto="keyboard_long" flags="l"/>
 	</map>
+	
 	<map context="SubtitlesActions">
 		<key id="KEY_SUBTITLE" mapto="subtitles" flags="m" />
 		<key id="KEY_TEXT" mapto="subtitles" flags="m" />

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -98,18 +98,21 @@
 		<item level="2" text="Show crypto info in infobar" description="Show encryption info in the infobar (when supported by the skin).">config.usage.show_cryptoinfo</item>
 		<item level="2" text="Infobar frontend data source" description="Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner.">config.usage.infobar_frontend_source</item>
 		<item level="2" text="Swap SNR in '&#37;' with SNR in 'db'" description="This option allows you to the SNR as a percentage (not all receivers support this).">config.usage.swap_snr_on_osd</item>
-		<item level="1" text="Behavior of 0 key in PiP-mode" description="Choose what you want the button '0' to do when PIP is active.">config.usage.pip_zero_button</item>
 		<item level="1" text="Sort setting screen's alphabetically" description="This option allows you to disable sorting of the option in setting screen's">config.usage.sort_settings</item>
 		<item level="0" text="Sort order for menu entries" description="This option allows you to hide and sorting of the menus" >config.usage.menu_sort_mode</item>
 		<item level="1" text="Sort plug-in browser entries" description="This option allows you to hide and sorting of the plugin browser.">config.usage.plugins_sort_mode</item>
 		<item level="1" text="Sort Extensions list alphabetically" description="This option allows you to disable sorting of the Extensions list.">config.usage.sort_extensionslist</item>
+		<item level="1" text="Color first in Extensions list" description="This option allows you to place the colored buttons (red, green, yellow, blue) to the first in the Extensions list.">config.usage.colored_first_extensionslist</item>
 		<item level="1" text="Show Restart Network in Extensions list *" description="This option allows you to disable show Restart Network in Extensions list.">config.usage.show_restart_network_extensionslist</item>
 		<item level="1" text="Show PVR status in MoviePlayer infobar" description="This option moves the PVR status from the separate window into the MoviePlayer infobar.">config.usage.movieplayer_pvrstate</item>
-		<item level="2" text="Close PiP on exit" description="When enabled the PiP can be closed by the exit button." requires="PIPAvailable">config.usage.pip_hideOnExit</item>
-		<item level="2" text="Remember last service in PiP" description="Configure if and how long the latest service in the PiP will be remembered." requires="PIPAvailable">config.usage.pip_last_service_timeout</item>
 		<item level="2" text="Show VCR scart on main menu" description="When enabled, the VCR scart option will be shown on the main menu" requires="ScartSwitch">config.usage.show_vcr_scart</item>
 		<item level="2" text="Show True/False as graphical switch" description="Enable to display all true/false, yes/no, on/off and enable/disable set up options as a graphical switch.">config.usage.boolean_graphic</item>
 		<item level="2" text="Show additional slider value" description="Enable the current value of the slider at end of the slider bar.">config.usage.show_slider_value</item>
+		<item level="2" text="PiP mode" description="Choose what you want the PIP mode how to works." requires="PIPAvailable">config.usage.pip_mode</item>
+		<item level="2" text="Ads filtering mode be default" description="After this time, the Ads filtering mode should be the default set mode." requires="PIPAvailable">config.usage.noadspip_default_mode_time</item>
+		<item level="2" text="Close PiP on exit" description="When enabled the PiP can be closed by the exit button." requires="PIPAvailable">config.usage.pip_hideOnExit</item>
+		<item level="1" text="Behavior of 0 key in PiP-mode" description="Choose what you want the button '0' to do when PIP is active." requires="PIPAvailable">config.usage.pip_zero_button</item>
+		<item level="2" text="Remember last service in PiP" description="Configure if and how long the latest service in the PiP will be remembered." requires="PIPAvailable">config.usage.pip_last_service_timeout</item>
 	</setup>
 	<setup key="channelselection" title="Channel selection settings">
 		<item level="0" text="Include CI assignment" description="Set CI assignment for detection of available services.">config.misc.use_ci_assignment</item>
@@ -494,14 +497,11 @@
 		<item level="2" text="Info button (long)" description="Set to what you want the button to do.">config.epgselection.graph_infolong</item>
 		<item level="2" text="OK button (short)" description="Set to what you want the button to do.">config.epgselection.graph_ok</item>
 		<item level="2" text="OK button (long)" description="Set to what you want the button to do.">config.epgselection.graph_oklong</item>
-
 		<item level="2" text="Red button" description="Set to what you want the button to do.">config.epgselection.graph_red</item>
 		<item level="2" text="Green button" description="Set to what you want the button to do.">config.epgselection.graph_green</item>
 		<item level="2" text="Yellow button" description="Set to what you want the button to do.">config.epgselection.graph_yellow</item>
 		<item level="2" text="Blue button" description="Set to what you want the button to do.">config.epgselection.graph_blue</item>
-		
 		<item level="2" text="Channel +/-" description="Set to what you want the button to do.">config.epgselection.graph_channelbtn</item>
-
 		<item level="2" text="Start mode" description="Here can set the EPG will alway open at the current channel, the first channel or one of both with primetime. If no primetime selected, the current time is used.">config.epgselection.graph_startmode</item>
 		<item level="2" text="Skip empty services" description="If set to 'yes' channels without EPG will not be shown.">config.epgselection.overjump</item>
 		<item level="2" text="Base time" description="Choose time interval to which the graphics will be rounded off.">config.epgselection.graph_roundto</item>
@@ -547,4 +547,4 @@
 		<item level="2" text="Show translation packages" description="If set to 'yes' it will show the 'PO' packages in browser.">config.pluginbrowser.po</item>
 		<item level="2" text="Show source packages" description="If set to 'yes' it will show the 'SRC' packages in browser.">config.pluginbrowser.src</item>
 	</setup>
-	</setupxml>
+</setupxml>

--- a/data/skin_default.xml
+++ b/data/skin_default.xml
@@ -1,4 +1,4 @@
-﻿<skin>
+<skin>
 	<include filename="Skin_ExtPlugins.xml" />
 	<fonts>
 		<font filename="nmsbd.ttf" name="Regular" scale="90" />
@@ -1173,15 +1173,12 @@ self.autoResize()
 		<panel name="BasicTemplate" />
 		<widget name="servicelist" position="10,10" size="540,400" scrollbarMode="showOnDemand" />
 	</screen>
-	<screen name="PictureInPicture" position="400,60" zPosition="-1" size="240,192" flags="wfNoBorder">
-		<widget name="video" position="0,0" size="240,135" backgroundColor="transparent" />
+	<screen name="PictureInPicture" position="400,60" size="240,192" flags="wfNoBorder" backgroundColor="transparent" zPosition="-2">
+		<widget name="video" position="0,0" size="240,192" backgroundColor="transparent" zPosition="-2" />
 	</screen>
-	<screen name="PictureInPictureZapping" position="580,60" size="120,26" flags="wfNoBorder" backgroundColor="transparent" zPosition="-1" title="PiPZap" >
-		<eLabel text="PiP-Zap" position="0,0" size="120,26" backgroundColor="transparent" transparent="1" font="Regular;22" borderColor="black" borderWidth="3" valign="center" halign="center" />
-	</screen>
-	<screen name="PiPSetup" position="center,center" size="800,200" flags="wfNoBorder" backgroundColor="transparent" zPosition="-1" title="PiPSetup" >
-		<widget name="text" position="0,0" size="800,200" backgroundColor="transparent" transparent="1" font="Regular;22" borderColor="black" borderWidth="3" valign="center" halign="center" />
-	</screen>
+	<screen name="PiPSetup" position="center,center" size="600,300" flags="wfNoBorder" backgroundColor="transparent" zPosition="2">
+		<widget name="text" position="20,20" size="580,280" font="Regular;20" foregroundColor="white" backgroundColor="black" valign="center" halign="center" />
+	</screen>																									
 	<screen name="PinInput" position="center,center" size="500,170" title="PIN code needed">
 		<panel name="PinInputTemplate" />
 	</screen>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -216,6 +216,7 @@ def InitUsageConfig():
 		("user", _("user defined")),])
 	config.usage.sort_pluginlist = ConfigYesNo(default = True)
 	config.usage.sort_extensionslist = ConfigYesNo(default = False)
+	config.usage.colored_first_extensionslist = ConfigYesNo(default = True)
 	config.usage.show_restart_network_extensionslist = ConfigYesNo(default = True)
 	config.usage.movieplayer_pvrstate = ConfigYesNo(default = False)
 
@@ -233,7 +234,11 @@ def InitUsageConfig():
 	config.usage.hdd_timer = ConfigYesNo(default = False)	
 	config.usage.output_12V = ConfigSelection(default = "do not change", choices = [
 		("do not change", _("Do not change")), ("off", _("Off")), ("on", _("On")) ])
-
+	config.usage.pip_mode = ConfigSelection(default = "standard", choices = [
+		("standard", _("Standard")), ("noadspip", _("Ads filtering mode")), ("byside", _("Side by side mode")) ])
+	config.usage.noadspip_default_mode_time = ConfigSelection(default = "180", choices = [
+		("0", _("Setting by user")), ("180", _("After 3 minutes")), ("300", _("After 5 minutes")), ("1800", _("After 30 minutes")) ])
+	config.usage.pip_lastusage = ConfigInteger(default = int(time()))
 	config.usage.pip_zero_button = ConfigSelection(default = "standard", choices = [
 		("standard", _("Standard")), ("swap", _("Swap PiP and main picture")),
 		("swapstop", _("Move PiP to main picture")), ("stop", _("Stop PiP")) ])

--- a/lib/python/Screens/ButtonSetup.py
+++ b/lib/python/Screens/ButtonSetup.py
@@ -95,7 +95,8 @@ def getButtonSetupKeys():
 		(_("Fastforward"), "fastforward", ""),
 		(_("Skip back"), "skip_back", ""),
 		(_("Skip forward"), "skip_forward", ""),
-		(_("activatePiP"), "activatePiP", ""),
+		(_("Activate Picture in Picture"), "activatePiP", ""),
+		(_("PiP usage Setup"), "activatePiPlong", ""),
 		(_("Playlist"), "playlist", ""),
 		(_("Playlist long"), "playlist_long", ""),
 		(_("Nextsong"), "nextsong", ""),
@@ -216,10 +217,9 @@ def getButtonSetupFunctions():
 	ButtonSetupFunctions.append((_("Letterbox zoom"), "Infobar/vmodeSelection", "InfoBar"))
 	ButtonSetupFunctions.append((_("Seekbar"), "Infobar/seekFwdVod", "InfoBar"))
 	if SystemInfo["PIPAvailable"]:
-		ButtonSetupFunctions.append((_("Show PIP"), "Infobar/showPiP", "InfoBar"))
-		ButtonSetupFunctions.append((_("Swap PIP"), "Infobar/swapPiP", "InfoBar"))
-		ButtonSetupFunctions.append((_("Move PIP"), "Infobar/movePiP", "InfoBar"))
-		ButtonSetupFunctions.append((_("Toggle PIPzap"), "Infobar/togglePipzap", "InfoBar"))
+		ButtonSetupFunctions.append((_("Activate Picture in Picture"), "Infobar/runmodePiPblue", "InfoBar"))
+		ButtonSetupFunctions.append((_("Swap screen"), "Infobar/runmodePiPyellow", "InfoBar"))
+		ButtonSetupFunctions.append((_("PiPSetup"), "Infobar/runmodePiPgreen", "InfoBar"))
 	ButtonSetupFunctions.append((_("Activate HbbTV (Redbutton)"), "Infobar/activateRedButton", "InfoBar"))
 	if getHaveHDMIinHD() == 'True' or getHaveHDMIinFHD() == 'True':
 		ButtonSetupFunctions.append((_("Toggle HDMI-In full screen"), "Infobar/HDMIInFull", "InfoBar"))
@@ -686,4 +686,3 @@ class InfoBarButtonSetup():
 
 	def ToggleLCDLiveTV(self):
 		config.lcd.showTv.value = not config.lcd.showTv.value
-

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -2330,7 +2330,18 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 			self.pipzaptimer.callback.remove(self.hidePipzapMessage)
 			self.pipzaptimer.stop()
 		self.session.pip.inactive()
-
+	def togglePipzapSidebySide(self):
+		assert self.session.pip
+		if self.dopipzap:
+			self.dopipzap = False
+			self.__evServiceStart()
+			lastservice = eServiceReference(self.lastservice.value)
+			if lastservice.valid() and self.getCurrentSelection() != lastservice:
+				self.setCurrentSelection(lastservice)
+		else:
+			self.dopipzap = True
+			self.__evServiceStart()
+			self.setCurrentSelection(self.session.pip.getCurrentService())
 	#called from infoBar and channelSelected
 	def zap(self, enable_pipzap=False, preview_zap=False, checkParentalControl=True, ref=None):
 		self.curRoot = self.startRoot
@@ -2343,7 +2354,8 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 				if nref and (not checkParentalControl or Components.ParentalControl.parentalControl.isServicePlayable(nref, boundFunction(self.zap, enable_pipzap=True, checkParentalControl=False))):
 					self.session.pip.playService(nref)
 					self.__evServiceStart()
-					self.showPipzapMessage()
+					if config.usage.pip_mode.value != "byside":
+						self.showPipzapMessage()
 				else:
 					self.setStartRoot(self.curRoot)
 					self.setCurrentSelection(ref)

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -1910,9 +1910,10 @@ class EPGSelection(Screen, HelpableScreen):
 				else:
 					self.zapFunc(None, False)
 		if self.session.pipshown:
-			self.Oldpipshown = False
-			self.session.pipshown = False
-			del self.session.pip
+			if not self.Oldpipshown:
+				self.Oldpipshown = False
+				self.session.pipshown = False
+				del self.session.pip
 		if self.Oldpipshown:
 			self.session.pipshown = True
 		self.closeEventViewDialog()
@@ -1933,7 +1934,7 @@ class EPGSelection(Screen, HelpableScreen):
 
 	def zapSelectedService(self, prev=False):
 		currservice = self.session.nav.getCurrentlyPlayingServiceReference() and str(self.session.nav.getCurrentlyPlayingServiceReference().toString()) or None
-		if self.session.pipshown:
+		if self.session.pipshown and config.usage.pip_mode.value == "standard":
 			self.prevch = self.session.pip.getCurrentService() and str(self.session.pip.getCurrentService().toString()) or None
 		else:
 			self.prevch = self.session.nav.getCurrentlyPlayingServiceReference() and str(self.session.nav.getCurrentlyPlayingServiceReference().toString()) or None
@@ -1973,6 +1974,8 @@ class EPGSelection(Screen, HelpableScreen):
 					self.zapFunc(ref.ref, bouquet = self.getCurrentBouquet(), preview = prev)
 					self.currch = self.session.nav.getCurrentlyPlayingServiceReference() and str(self.session.nav.getCurrentlyPlayingServiceReference().toString())
 				self['list'+str(self.activeList)].setCurrentlyPlaying(self.session.nav.getCurrentlyPlayingServiceOrGroup())
+				if self.Oldpipshown:
+					self.session.pipshown = True
 
 	def zapTo(self):
 		if self.session.nav.getCurrentlyPlayingServiceOrGroup() and '0:0:0:0:0:0:0:0:0' in self.session.nav.getCurrentlyPlayingServiceOrGroup().toString():

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -9,7 +9,7 @@ from Components.ServiceEventTracker import ServiceEventTracker
 from Components.Sources.ServiceEvent import ServiceEvent
 from Components.Sources.Boolean import Boolean
 from Components.Sources.List import List
-from Components.config import config, configfile, ConfigBoolean, ConfigClock
+from Components.config import config, configfile, ConfigBoolean, ConfigClock, ConfigYesNo, ConfigPosition, ConfigInteger
 from Components.SystemInfo import SystemInfo
 from Components.UsageConfig import preferredInstantRecordPath, defaultMoviePath, preferredTimerPath, ConfigSelection
 from Components.VolumeControl import VolumeControl
@@ -1618,7 +1618,62 @@ class InfoBarChannelSelection:
 
 	def volumeDown(self):
 		VolumeControl.instance.volDown()
-
+		
+	def zapDownToPiP(self):
+		if self.pts_blockZap_timer.isActive():
+			return
+		self["SeekActionsPTS"].setEnabled(False)
+		if self.servicelist.inBouquet():
+			prev = self.servicelist.getCurrentSelection()
+			if prev:
+				prev = prev.toString()
+				while True:
+					if config.usage.quickzap_bouquet_change.value and self.servicelist.atEnd():
+						self.servicelist.nextBouquet()
+						self.servicelist.moveTop()
+					else:
+						self.servicelist.moveDown()
+					cur = self.servicelist.getCurrentSelection()
+					if cur:
+						if self.servicelist.dopipzap:
+							isPlayable = self.session.pip.isPlayableForPipService(cur)
+						else:
+							isPlayable = isPlayableForCur(cur)
+					if cur and (cur.toString() == prev or isPlayable):
+						break
+		else:
+			self.servicelist.moveDown()
+		self.servicelist.zap(enable_pipzap = True)
+		if self.timeshiftEnabled() and self.isSeekable():
+			self["SeekActionsPTS"].setEnabled(True)
+			
+	def zapUpToPiP(self):
+		if self.pts_blockZap_timer.isActive():
+			return
+		self["SeekActionsPTS"].setEnabled(False)
+		if self.servicelist.inBouquet():
+			prev = self.servicelist.getCurrentSelection()
+			if prev:
+				prev = prev.toString()
+				while True:
+					if config.usage.quickzap_bouquet_change.value and self.servicelist.atBegin():
+						self.servicelist.prevBouquet()
+						self.servicelist.moveEnd()
+					else:
+						self.servicelist.moveUp()
+					cur = self.servicelist.getCurrentSelection()
+					if cur:
+						if self.servicelist.dopipzap:
+							isPlayable = self.session.pip.isPlayableForPipService(cur)
+						else:
+							isPlayable = isPlayableForCur(cur)
+					if cur and (cur.toString() == prev or isPlayable):
+						break
+		else:
+			self.servicelist.moveUp()
+		self.servicelist.zap(enable_pipzap = True)
+		if self.timeshiftEnabled() and self.isSeekable():
+			self["SeekActionsPTS"].setEnabled(True)
 
 class InfoBarMenu:
 	""" Handles a menu action, to open the (main) menu """
@@ -3272,12 +3327,14 @@ class InfoBarExtensions:
 				for y in x[1]():
 					self.updateExtension(y[0], y[1])
 
-
 	def showExtensionSelection(self):
+		config.usage.colored_first_extensionslist = ConfigYesNo(default = True)
 		self.updateExtensions()
 		extensionsList = self.extensionsList[:]
 		keys = []
 		list = []
+		new_keys = []
+		new_list = []
 		colorlist = []
 		for x in self.availableKeys:
 			if self.extensionKeys.has_key(x):
@@ -3300,11 +3357,50 @@ class InfoBarExtensions:
 		list.extend([(x[0](), x) for x in extensionsList])
 
 		keys += [""] * len(extensionsList)
-		self.session.openWithCallback(self.extensionCallback, ChoiceBox, title=_("Please choose an extension..."), list = list, keys = keys, skin_name = "ExtensionsList")
+		if config.usage.colored_first_extensionslist.value:
+			new_keys, new_list = self.changeSequenceListKey(keys, list)
+		else:
+			new_keys = keys
+			new_list = list
+		
+		self.session.openWithCallback(self.extensionCallback, ChoiceBox, title=_("Please choose an extension..."), list = new_list, keys = new_keys, skin_name = "ExtensionsList")
 
 	def extensionCallback(self, answer):
 		if answer is not None:
 			answer[1][1]()
+
+	def changeSequenceListKey(self, keys=[], list=[]):
+		temp_keys_other = []
+		temp_keys_color = []
+		new_keys = []
+		temp_list_other = []
+		temp_list_color = []
+		new_list = []
+		try:
+			len_keys = len(keys)
+			len_list = len(list)
+			i = 0
+			if len_keys > 0 and len_list > 0:
+				if len_list >= len_keys:
+					for item in keys:
+						if item in ["red", "green", "yellow", "blue"]:
+							temp_keys_color.append(item)
+							temp_list_color.append(list[i])
+						else:
+							temp_keys_other.append(item)
+							temp_list_other.append(list[i])
+						i += 1
+					if len(temp_keys_color) > 0:
+						new_keys = temp_keys_color + temp_keys_other
+						new_list = temp_list_color + temp_list_other
+					else:
+						new_keys = temp_keys_other
+						new_list = temp_list_other
+					if len_list > len_keys:
+						new_list = new_list + list[i:]
+			return new_keys, new_list
+		except Exception:
+			return keys, list
 
 	def showPluginBrowser(self):
 		from Screens.PluginBrowser import PluginBrowser
@@ -3502,49 +3598,163 @@ class InfoBarPiP:
 			self.session.pipshown
 		except:
 			self.session.pipshown = False
-
+			
 		self.lastPiPService = None
+		self.TogglePiPZapSidebySide = False
 
 		if SystemInfo["PIPAvailable"] and isinstance(self, InfoBarEPG):
 			self["PiPActions"] = HelpableActionMap(self, "InfobarPiPActions",
 				{
 					"activatePiP": (self.activePiP, self.activePiPName),
+					"activatePiPlong": (self.activePiPlong, _("PiP usage Setup")),
+					"left": (self.doSwapPiP, _("Swap PIP")),
+					"right": (self.doTogglePipzap, _("Active status change")),
+					"exitpip": (self.doExit, _("Exit")),
 				})
 			if self.allowPiP:
-				self.addExtension((self.getShowHideName, self.showPiP, lambda: True), "blue")
-				self.addExtension((self.getMoveName, self.movePiP, self.pipShown), "green")
-				self.addExtension((self.getSwapName, self.swapPiP, self.pipShown), "yellow")
-				self.addExtension((self.getTogglePipzapName, self.togglePipzap, self.pipShown), "red")
+				self.addExtension((self.getBlueName, self.runmodePiPblue, lambda: True), "blue")
+				self.addExtension((self.getGreenName, self.runmodePiPgreen, self.pipShown_green), "green")
+				self.addExtension((self.getYellowName, self.runmodePiPyellow, self.pipShown), "yellow")
+				self.addExtension((self.getRedName, self.runmodePiPred, self.pipShown_red), "red")
 			else:
-				self.addExtension((self.getShowHideName, self.showPiP, self.pipShown), "blue")
-				self.addExtension((self.getMoveName, self.movePiP, self.pipShown), "green")
+				self.addExtension((self.getBlueName, self.runmodePiPblue, self.pipShown), "blue")
+				self.addExtension((self.getGreenName, self.runmodePiPgreen, self.pipShown), "green")
 
 		self.lastPiPServiceTimeoutTimer = eTimer()
 		self.lastPiPServiceTimeoutTimer.callback.append(self.clearLastPiPService)
+		
+	def runmodePiPblue(self):
+		config.usage.pip_mode = ConfigSelection(default = "standard", choices = [
+			("standard", _("Standard")), ("noadspip", _("Ads filtering mode")), ("byside", _("Side by side mode")) ])
+		if self.session.pipshown:
+			if config.usage.pip_mode.value == "standard":
+				self.showPiP()
+			if config.usage.pip_mode.value == "noadspip":
+				self.swapPiP()
+				self.showPiP()
+			if config.usage.pip_mode.value == "byside":
+				self.showPiP()
+		else:
+			config.usage.checking_blue_button = ConfigYesNo(default = True)
+			if config.usage.checking_blue_button.value and config.workaround.blueswitch.value == "0":
+				self.checkingBlueButton()
+			self.activePiP()
+			
+	def runmodePiPgreen(self):
+		config.usage.pip_mode = ConfigSelection(default = "standard", choices = [
+			("standard", _("Standard")), ("noadspip", _("Ads filtering mode")), ("byside", _("Side by side mode")) ])
+		if self.session.pipshown:
+			if config.usage.pip_mode.value == "standard":
+				self.movePiP()
+			if config.usage.pip_mode.value == "noadspip":
+				self.showPiP()
+			if config.usage.pip_mode.value == "byside":
+				self.swapPiP()
+				self.showPiP()
+		else:
+			self.movePiP()
+			
+	def runmodePiPyellow(self):
+		self.swapPiP()
+			
+	def runmodePiPred(self):
+		if not self.session.pipshown:
+			if config.usage.historymode.value == "0":
+				self.servicelist.historyBack()
+			else:
+				self.servicelist.historyZap(-1)
+		else:
+			if config.usage.pip_mode.value == "standard":
+				self.togglePipzap()
+			if config.usage.pip_mode.value == "noadspip":
+				self.toggleSidebySidemode()
+			if config.usage.pip_mode.value == "byside":
+				self.doTogglePipzap()
 
 	def pipShown(self):
 		return self.session.pipshown
+		
+	def pipShown_red(self):
+		bv = False
+		config.usage.pip_mode = ConfigSelection(default = "standard", choices = [
+			("standard", _("Standard")), ("noadspip", _("Ads filtering mode")), ("byside", _("Side by side mode")) ])
+		if self.session.pipshown:
+			if config.usage.pip_mode.value == "standard":
+				bv = True
+			if config.usage.pip_mode.value == "noadspip":
+				bv = True
+			if config.usage.pip_mode.value == "byside":
+				bv = True
+		else:
+			bv = True
+		return bv
+		
+	def pipShown_green(self):
+		bv = True
+		config.usage.pip_mode = ConfigSelection(default = "standard", choices = [
+			("standard", _("Standard")), ("noadspip", _("Ads filtering mode")), ("byside", _("Side by side mode")) ])
+		if self.session.pipshown:
+			if config.usage.pip_mode.value != "standard":
+				#bv = False
+				bv = True
+		return bv
 
 	def pipHandles0Action(self):
 		return self.pipShown() and config.usage.pip_zero_button.value != "standard"
 
-	def getShowHideName(self):
+	def getBlueName(self):
 		if self.session.pipshown:
-			return _("Disable Picture in Picture")
+			if config.usage.pip_mode.value == "noadspip":
+				return _("Close Main screen")
+			else:
+				return _("Close Picture in Picture screen")
 		else:
 			return _("Activate Picture in Picture")
 
-	def getSwapName(self):
-		return _("Swap services")
+	def getYellowName(self):
+		return _("Swap screen")
 
-	def getMoveName(self):
-		return _("Picture in Picture Setup")
+	def getGreenName(self):
+		config.usage.pip_mode = ConfigSelection(default = "standard", choices = [
+			("standard", _("Standard")), ("noadspip", _("Ads filtering mode")), ("byside", _("Side by side mode")) ])
+		if self.session.pipshown:
+			if config.usage.pip_mode.value == "standard":
+				return _("PiP standard Setup")
+			else:
+				if config.usage.pip_mode.value == "noadspip":
+					return _("Close Picture in Picture screen")
+				else:
+					return _("Close Main screen")
+		else:
+			return _("PiP usage Setup")
 
-	def getTogglePipzapName(self):
-		slist = self.servicelist
-		if slist and slist.dopipzap:
-			return _("Zap focus to main screen")
-		return _("Zap focus to Picture in Picture")
+	def getRedName(self):
+		if self.session.pipshown:
+			if config.usage.pip_mode.value == "standard":
+				slist = self.servicelist
+				if slist and slist.dopipzap:
+					return _("Zap focus to main screen")
+				return _("Zap focus to Picture in Picture")
+			if config.usage.pip_mode.value == "noadspip":
+				return _("Change to Side by Side mode")
+			if config.usage.pip_mode.value == "byside":
+				return _("Active status change")
+		else:
+			return _("History Zap...")
+
+	def toggleSidebySidemode(self):
+		config.usage.pip_mode.setValue('byside')
+		config.usage.pip_mode.save()
+		configfile.save()
+		if config.av.pip_mode.value != "byside":
+			config.av.pip_mode.setValue('byside')
+			config.av.pip_mode.save()
+			configfile.save()
+		if config.usage.pip_zero_button.value != "swap":
+			config.usage.pip_zero_button.setValue('swap')
+			config.usage.pip_zero_button.save()
+			configfile.save()
+		self.session.pip.relocate()
 
 	def togglePipzap(self):
 		if not self.session.pipshown:
@@ -3558,6 +3768,8 @@ class InfoBarPiP:
 				self.session.pip.servicePath = currentServicePath
 
 	def showPiP(self):
+		if config.usage.pip_mode.value != "standard":
+			from Screens.InfoBar import InfoBar
 		self.lastPiPServiceTimeoutTimer.stop()
 		slist = self.servicelist
 		if self.session.pipshown:
@@ -3577,10 +3789,27 @@ class InfoBarPiP:
 						f.write(config.lcd.modeminitv.value)
 						f.close()
 				self.session.pipshown = False
+				config.usage.pip_lastusage = ConfigInteger(default = int(time()))
+				config.usage.pip_lastusage.setValue(int(time())-1)
+				config.usage.pip_lastusage.save()
+				configfile.save()													 
 			if hasattr(self, "ScreenSaverTimerStart"):
 				self.ScreenSaverTimerStart()
 		else:
-			service = self.session.nav.getCurrentService()
+			if config.usage.pip_mode.value == "standard":
+				service = self.session.nav.getCurrentService()
+			if config.usage.pip_mode.value == "noadspip":
+				newservice = self.servicelist.getCurrentSelection()
+				if InfoBar and InfoBar.instance:
+					InfoBar.zapDownToPiP(InfoBar.instance)
+				service = self.session.nav.getCurrentService()
+			if config.usage.pip_mode.value == "byside":
+				if InfoBar and InfoBar.instance:
+					InfoBar.zapDownToPiP(InfoBar.instance)
+				newservice = self.servicelist.getCurrentSelection()
+				if InfoBar and InfoBar.instance:
+					InfoBar.zapUpToPiP(InfoBar.instance)
+				service = self.session.nav.getCurrentService()
 			info = service and service.info()
 			if info:
 				xres = str(info.getInfo(iServiceInformation.sVideoWidth))
@@ -3588,7 +3817,8 @@ class InfoBarPiP:
 				self.session.pip = self.session.instantiateDialog(PictureInPicture)
 				self.session.pip.setAnimationMode(0)
 				self.session.pip.show()
-				newservice = self.lastPiPService or self.session.nav.getCurrentlyPlayingServiceReference() or self.servicelist.servicelist.getCurrent()
+				if config.usage.pip_mode.value == "standard":
+					newservice = self.lastPiPService or self.session.nav.getCurrentlyPlayingServiceReference() or self.servicelist.servicelist.getCurrent()
 				if self.session.pip.playService(newservice):
 					self.session.pipshown = True
 					self.session.pip.servicePath = self.servicelist.getCurrentServicePath()
@@ -3607,7 +3837,8 @@ class InfoBarPiP:
 						f.write("1")
 						f.close()
 				else:
-					newservice = self.session.nav.getCurrentlyPlayingServiceReference() or self.servicelist.servicelist.getCurrent()
+					if config.usage.pip_mode.value == "standard":
+						newservice = self.session.nav.getCurrentlyPlayingServiceReference() or self.servicelist.servicelist.getCurrent()
 					if self.session.pip.playService(newservice):
 						self.session.pipshown = True
 						self.session.pip.servicePath = self.servicelist.getCurrentServicePath()
@@ -3640,10 +3871,142 @@ class InfoBarPiP:
 		self.lastPiPService = None
 
 	def activePiP(self):
-		if self.servicelist and self.servicelist.dopipzap or not self.session.pipshown:
-			self.showPiP()
+		choicelist = [("standard", _("Standard"))]
+		if SystemInfo["VideoDestinationConfigurable"]:
+			choicelist.append(("cascade", _("Cascade PiP")))
+			choicelist.append(("split", _("Splitscreen")))
+			choicelist.append(("byside", _("Side by side")))
+		choicelist.append(("bigpig", _("Big PiP")))
+		if SystemInfo["HasExternalPIP"]:
+			choicelist.append(("external", _("External PiP")))
+		config.av.pip_mode = ConfigSelection(default="standard", choices=choicelist)
+		config.av.pip = ConfigPosition(default=[510, 28, 180, 135], args = (720, 576, 720, 576))
+		config.usage.show_infobar_on_zap = ConfigYesNo(default = True)
+		config.usage.pip_zero_button = ConfigSelection(default = "standard", choices = [
+			("standard", _("Standard")), ("swap", _("Swap PiP and main picture")),
+			("swapstop", _("Move PiP to main picture")), ("stop", _("Stop PiP")) ])
+		config.usage.pip_hideOnExit = ConfigSelection(default = "no", choices = [
+			("no", _("No")), ("popup", _("With popup")), ("without popup", _("Without popup")) ])
+		choicelist = [("-1", _("Disabled")), ("0", _("No timeout"))]
+		for i in [60, 300, 600, 900, 1800, 2700, 3600]:
+			m = i/60
+			choicelist.append(("%d" % i, ngettext("%d minute", "%d minutes", m) % m))
+		config.usage.pip_last_service_timeout = ConfigSelection(default = "-1", choices = choicelist)
+		if config.usage.pip_mode.value != "noadspip":
+			self.usageModeChecking()
+		if config.usage.pip_mode.value == "standard":
+			if config.av.pip_mode.value != "standard":
+				config.av.pip_mode.setValue('standard')
+				config.av.pip_mode.save()
+				configfile.save()
+			config.av.pip.value[0] = 456
+			config.av.pip.value[1] = 60
+			config.av.pip.value[2] = 219
+			config.av.pip.value[3] = 160
+			config.av.pip.save()
+			configfile.save()
+			self.show_infobar_on_zap(True)
+			if self.servicelist and self.servicelist.dopipzap or not self.session.pipshown:
+				self.showPiP()
+			else:
+				self.togglePipzap()
 		else:
-			self.togglePipzap()
+			if config.usage.pip_hideOnExit.value != "without popup":
+				config.usage.pip_hideOnExit.setValue('without popup')
+				config.usage.pip_hideOnExit.save()
+				configfile.save()
+			if config.usage.pip_last_service_timeout.value != "0":
+				config.usage.pip_last_service_timeout.setValue('0')
+				config.usage.pip_last_service_timeout.save()
+				configfile.save()
+			if config.usage.pip_mode.value == "noadspip":
+				if config.av.pip_mode.value != "standard":
+					config.av.pip_mode.setValue('standard')
+					config.av.pip_mode.save()
+					configfile.save()
+				config.av.pip.value[0] = 544
+				config.av.pip.value[1] = 29
+				config.av.pip.value[2] = 153
+				config.av.pip.value[3] = 112
+				config.av.pip.save()
+				configfile.save()
+				if not self.session.pipshown:
+					self.showPiP()
+				else:
+					self.swapPiP()
+					self.showPiP()
+			if config.usage.pip_mode.value == "byside":
+				if config.av.pip_mode.value != "byside":
+					config.av.pip_mode.setValue('byside')
+					config.av.pip_mode.save()
+					configfile.save()
+				if config.usage.pip_zero_button.value != "swap":
+					config.usage.pip_zero_button.setValue('swap')
+					config.usage.pip_zero_button.save()
+					configfile.save()
+				self.show_infobar_on_zap(False)
+				if not self.session.pipshown:
+					self.showPiP()
+				else:
+					self.swapPiP()
+					self.showPiP()
+				self.show_infobar_on_zap(True)
+
+	def checkingBlueButton(self):
+		list = [(_("Yes, I'm setting it up now"), True),
+				(_("Not now, but warn me next time"), False),
+				(_("No, and I will never ask for notification again"), "extend")]
+		message = _("For faster operation, the BLUE button only needs to be pressed once to use!\nBlueSwitch: Blue-Short/Blue-Long  ->  Extensions/QuickMenu\n\nSet this option now?")
+		try:
+			self.session.openWithCallback(self.checkingBlueButtonCallback, MessageBox, message, timeout=55, simple=True, list=list, default=True)
+		except:
+			pass
+
+	def checkingBlueButtonCallback(self, answer):
+		if answer == "extend":
+			config.usage.checking_blue_button.value = False
+			config.usage.checking_blue_button.save()
+			configfile.save()
+		elif answer:
+			config.workaround.blueswitch.setValue('1')
+			config.workaround.blueswitch.save()
+			config.usage.checking_blue_button.value = True
+			config.usage.checking_blue_button.save()
+			configfile.save()
+		else:
+			config.usage.checking_blue_button.value = True
+			config.usage.checking_blue_button.save()
+			configfile.save()
+
+	def usageModeChecking(self):
+		try:
+			config.usage.noadspip_default_mode_time = ConfigSelection(default = "180", choices = [
+				("0", _("Setting by user")), ("180", _("After 3 minutes")), ("300", _("After 5 minutes")), ("1800", _("After 30 minutes")) ])
+			config.usage.pip_lastusage = ConfigInteger(default = int(time()))
+			if config.usage.noadspip_default_mode_time.value == "0":
+				return
+			time_config = int(config.usage.pip_lastusage.value)
+			time_now = int(time())
+			diff_time = time_now - time_config
+			if diff_time > int(config.usage.noadspip_default_mode_time.value):
+				config.usage.pip_mode.setValue('noadspip')
+				config.usage.pip_mode.save()
+				configfile.save()
+				self.TogglePiPZapSidebySide = False
+		except:
+			return
+
+	def show_infobar_on_zap(self, mode=True):
+		if mode:
+			if not config.usage.show_infobar_on_zap.value:
+				config.usage.show_infobar_on_zap.setValue(True)
+				config.usage.show_infobar_on_zap.save()
+				configfile.save()
+		else:
+			if config.usage.show_infobar_on_zap.value:
+				config.usage.show_infobar_on_zap.setValue(False)
+				config.usage.show_infobar_on_zap.save()
+				configfile.save()
 
 	def activePiPName(self):
 		if self.servicelist and self.servicelist.dopipzap:
@@ -3672,17 +4035,88 @@ class InfoBarPiP:
 
 	def movePiP(self):
 		if self.pipShown():
-			self.session.open(PiPSetup, pip = self.session.pip)
+			config.usage.pip_mode = ConfigSelection(default = "standard", choices = [
+				("standard", _("Standard")), ("noadspip", _("Ads filtering mode")), ("byside", _("Side by side mode")) ])
+			if config.usage.pip_mode.value == "standard":
+				self.session.open(PiPSetup, pip = self.session.pip)
+			else:
+				self.activePiP()
+		else:
+			from Screens.PiPusageModeSetup import PiPusageModeSetup
+			self.session.open(PiPusageModeSetup)
+
+	def activePiPlong(self):
+		if not self.pipShown():
+			from Screens.PiPusageModeSetup import PiPusageModeSetup
+			self.session.open(PiPusageModeSetup)
+		else:
+			self.session.open(MessageBox, _("Close PIP and try again!"), MessageBox.TYPE_INFO, timeout = 12)
 
 	def pipDoHandle0Action(self):
 		use = config.usage.pip_zero_button.value
 		if "swap" == use:
-			self.swapPiP()
+			self.doSwapPiP()
 		elif "swapstop" == use:
 			self.swapPiP()
 			self.showPiP()
 		elif "stop" == use:
 			self.showPiP()
+
+	def doSwapPiP(self):
+		if hasattr(self.session, "pip"):
+			if self.TogglePiPZapSidebySide:
+				slist = self.servicelist
+				if slist and self.session.pipshown:
+					slist.togglePipzapSidebySide()
+					if slist.dopipzap:
+						currentServicePath = slist.getCurrentServicePath()
+						self.servicelist.setCurrentServicePath(self.session.pip.servicePath, doZap=False)
+						self.session.pip.servicePath = currentServicePath
+					else:
+						self.TogglePiPZapSidebySide = False
+						self.session.pip.inactive()
+						self.session.pip.inactiveToogle()
+						self.session.pip.activeSide()
+			else:
+				self.session.pip.inactive()
+				if config.usage.pip_mode.value == "byside":
+					self.session.pip.inactiveToogle()
+					self.session.pip.activeSide()
+					self.show_infobar_on_zap(False)
+					self.swapPiP()
+					self.show_infobar_on_zap(True)
+				else:
+					self.session.pip.inactiveToogle()
+					self.session.pip.inactiveSide()
+					self.swapPiP()
+		else:
+			if isinstance(self, InfoBarChannelSelection):
+				self.LeftPressed()
+			
+ 	def doTogglePipzap(self):
+		if hasattr(self.session, "pip"):
+			if config.usage.pip_mode.value == "byside":
+				if not self.TogglePiPZapSidebySide:
+					slist = self.servicelist
+					if slist and self.session.pipshown:
+						slist.togglePipzapSidebySide()
+						if slist.dopipzap:
+							self.TogglePiPZapSidebySide = True
+							self.session.pip.inactive()
+							self.session.pip.inactiveSide()
+							self.session.pip.activeToggle()
+							currentServicePath = slist.getCurrentServicePath()
+							self.servicelist.setCurrentServicePath(self.session.pip.servicePath, doZap=False)
+							self.session.pip.servicePath = currentServicePath
+				else:
+					self.doSwapPiP()
+		else:
+			if isinstance(self, InfoBarChannelSelection):
+				self.RightPressed()
+					
+	def doExit(self):
+		if isinstance(self, InfoBarShowHide):
+			self.keyHide()
 
 class InfoBarINFOpanel:
 	"""INFO-Panel - handles the infoPanel action"""
@@ -4738,11 +5172,13 @@ class InfoBarCueSheetSupport:
 	def jumpPreviousMark(self):
 		# we add 5 seconds, so if the play position is <5s after
 		# the mark, the mark before will be used
-		self.jumpPreviousNextMark(lambda x: -x-5*90000, start=True)
+		if not hasattr(self.session, "pip"):
+			self.jumpPreviousNextMark(lambda x: -x-5*90000, start=True)
 
 	def jumpNextMark(self):
-		if not self.jumpPreviousNextMark(lambda x: x-90000):
-			self.doSeek(-1)
+		if not hasattr(self.session, "pip"):
+			if not self.jumpPreviousNextMark(lambda x: x-90000):
+				self.doSeek(-1)
 
 	def getNearestCutPoint(self, pts, cmp=abs, start=False):
 		# can be optimized

--- a/lib/python/Screens/PiPusageModeSetup.py
+++ b/lib/python/Screens/PiPusageModeSetup.py
@@ -1,0 +1,75 @@
+from Screens.Screen import Screen
+from Components.ActionMap import NumberActionMap, ActionMap
+from Components.Label import Label
+from Components.config import config, configfile, ConfigSelection, ConfigInteger
+from time import time
+
+class MyPiPmode(Screen):
+	skin = """<screen name="MyPiPmode" position="center,center" size="700,160" backgroundColor="transparent" zPosition="2">
+		<widget name="text" position="0,0" size="700,100" font="Regular;22" foregroundColor="white" backgroundColor="black" zPosition="2" halign="center" valign="center" />
+		<widget name="text_desc" position="0,100" size="700,60" font="Regular;20" foregroundColor="white" backgroundColor="black" zPosition="2" halign="center" />
+	</screen>"""
+
+class PiPusageModeSetup(Screen):
+	def __init__(self, session):
+		self.skin = MyPiPmode.skin
+		Screen.__init__(self, session)
+		
+		self.choicelist = [("standard", _("Standard")), ("noadspip", _("Ads filtering mode")), ("byside", _("Side by side mode"))]
+		config.usage.pip_mode = ConfigSelection(default = "standard", choices = self.choicelist)
+
+		self.mode = self.getMode()
+		self.orgmode = self.mode
+
+		self.helptext = _("OK - go back to the TV mode  |  EXIT - cancel  |   <  >  -  change usage mode")
+		self.modetext = _("PiP mode") + ":   %s"
+
+		self.setTitle(_("PiPSetup"))
+		self["text"] = Label(self.modetext % self.getModeName())
+		self["text_desc"] = Label(self.helptext)
+
+		self["actions"] = ActionMap(["PiPusageModeSetupActions"],
+		{
+			"ok": self.go,
+			"cancel": self.cancel,
+			"left": self.left,
+			"right": self.right
+		}, -1)
+
+	def go(self):
+		self.close()
+
+	def cancel(self):
+		self.mode = self.orgmode
+		self.setMode(self.mode)
+		self.close()
+
+	def left(self):
+		self.togglePiPMode(False)
+		self.mode = self.getMode()
+		self["text"].setText((self.modetext % self.getModeName()))
+
+	def right(self):
+		self.togglePiPMode(True)
+		self.mode = self.getMode()
+		self["text"].setText((self.modetext % self.getModeName()))
+
+	def getMode(self):
+		return config.usage.pip_mode.value
+
+	def getModeName(self):
+		return self.choicelist[config.usage.pip_mode.index][1]
+		
+	def setMode(self, mode):
+		config.usage.pip_lastusage = ConfigInteger(default = int(time()))
+		config.usage.pip_mode.value = mode
+		config.usage.pip_mode.save()
+		config.usage.pip_lastusage.setValue(int(time())+1000)
+		config.usage.pip_lastusage.save()
+		configfile.save()
+		
+	def togglePiPMode(self, mod=True):
+		if mod:
+			self.setMode(config.usage.pip_mode.choices[(config.usage.pip_mode.index + 1) % len(config.usage.pip_mode.choices)])
+		else:
+			self.setMode(config.usage.pip_mode.choices[(config.usage.pip_mode.index - 1) % len(config.usage.pip_mode.choices)])

--- a/lib/python/Screens/ScreenSaver.py
+++ b/lib/python/Screens/ScreenSaver.py
@@ -26,7 +26,11 @@ class Screensaver(Screen):
 	def layoutFinished(self):
 		picturesize = self["picture"].getSize()
 		self.maxx = self.instance.size().width() - picturesize[0]
+		if self.maxx < 1:
+			self.instance.size().width()
 		self.maxy = self.instance.size().height() - picturesize[1]
+		if self.maxy < 1:
+			self.maxy = self.instance.size().height()
 		self.doMovePicture()
 
 	def __onHide(self):
@@ -44,7 +48,11 @@ class Screensaver(Screen):
 					self.hide()
 
 	def doMovePicture(self):
-		self.posx = random.randint(1,self.maxx)
-		self.posy = random.randint(1,self.maxy)
+		try:
+			self.posx = random.randint(1,self.maxx)
+			self.posy = random.randint(1,self.maxy)
+		except Exception:
+			self.posx = 0
+			self.posy = 0
 		self["picture"].instance.move(ePoint(self.posx, self.posy))
 		self.moveLogoTimer.startLongTimer(9)

--- a/po/enigma2.pot
+++ b/po/enigma2.pot
@@ -2201,6 +2201,9 @@ msgstr ""
 msgid "Adjust the color settings so that all the color shades are distinguishable, but appear as saturated as possible. If you are happy with the result, press OK to close the video fine-tuning, or use the number keys to select other test screens."
 msgstr ""
 
+msgid "Ads filtering mode be default"
+msgstr ""
+
 msgid "Adult"
 msgstr ""
 
@@ -2244,6 +2247,18 @@ msgid "After event"
 msgstr ""
 
 msgid "After pressing OK, please wait!"
+msgstr ""
+
+msgid "After this time, the Ads filtering mode should be the default set mode."
+msgstr ""
+
+msgid "After 3 minutes"
+msgstr ""
+
+msgid "After 5 minutes"
+msgstr ""
+
+msgid "After 30 minutes"
 msgstr ""
 
 msgid "Agenten"
@@ -3770,6 +3785,15 @@ msgid "Close bouquet list."
 msgstr ""
 
 msgid "Close dialog"
+msgstr ""
+
+msgid "Close Main screen"
+msgstr ""
+
+msgid "Color first in Extensions list"
+msgstr ""
+
+msgid "Close Picture in Picture screen"
 msgstr ""
 
 msgid "Close title selection"
@@ -5946,6 +5970,9 @@ msgstr ""
 msgid "Favourites"
 msgstr ""
 
+msgid "Favourites (TV)"
+msgstr ""
+
 msgid "Feeds status:   Stable"
 msgstr ""
 
@@ -6131,6 +6158,13 @@ msgid "Food/Wine"
 msgstr ""
 
 msgid "Football"
+msgstr ""
+
+msgid ""
+"For faster operation, the BLUE button only needs to be pressed once to use!\n"
+"BlueSwitch: Blue-Short/Blue-Long  ->  Extensions/QuickMenu\n"
+"\n"
+"Set this option now?"
 msgstr ""
 
 msgid "For more information see http://www.opena.tv"
@@ -8879,6 +8913,9 @@ msgid ""
 " Please verify that you have attached a compatible WLAN device or enable your local network interface."
 msgstr ""
 
+msgid "No, and I will never ask for notification again"
+msgstr ""
+
 msgid "No, but restart from begin"
 msgstr ""
 
@@ -8986,6 +9023,9 @@ msgid "Nothing to upgrade"
 msgstr ""
 
 msgid "Nothing, just leave this menu"
+msgstr ""
+
+msgid "Not now, but warn me next time"
 msgstr ""
 
 msgctxt "now/next: 'now' event label"
@@ -9562,6 +9602,12 @@ msgid "Pillarbox"
 msgstr ""
 
 msgid "Pilot"
+msgstr ""
+
+msgid "PiP standard Setup"
+msgstr ""
+
+msgid "PiP usage Setup"
 msgstr ""
 
 msgid "Pitcairn"
@@ -13880,6 +13926,9 @@ msgid "This option allows you to choose how to display standard definition video
 msgstr ""
 
 msgid "This option allows you to enable 3D Surround Sound."
+msgstr ""
+
+msgid "This option allows you to place the colored buttons (red, green, yellow, blue) to the first in the Extensions list."
 msgstr ""
 
 msgid "This option allows you to use all HDMI Modes"
@@ -19773,6 +19822,9 @@ msgstr ""
 msgid "Set to yes for debugging the root cause of a spinner."
 msgstr ""
 
+msgid "Setting by user"
+msgstr ""
+
 msgid "Setup delay mode to zap to channels."
 msgstr ""
 
@@ -20080,6 +20132,9 @@ msgid "Subtitle language selection 4"
 msgstr ""
 
 msgid "Subtitle position"
+msgstr ""
+
+msgid "Swap screen"
 msgstr ""
 
 msgid "Swap SNR in '%' with SNR in 'db'"
@@ -20718,6 +20773,9 @@ msgid "Where do you want to backup your settings?"
 msgstr ""
 
 msgid "Yes, backup my settings!"
+msgstr ""
+
+msgid "Yes, I'm setting it up now"
 msgstr ""
 
 msgid "Yes, restore the settings now"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,10 +4,10 @@
 # Automatically generated, 2005.
 msgid ""
 msgstr ""
-"Project-Id-Version: hu_po v3.1\n"
+"Project-Id-Version: hu_po v3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-30 14:34+0100\n"
-"PO-Revision-Date: \n"
+"POT-Creation-Date: 2020-03-20 18:43+0000\n"
+"PO-Revision-Date: 2020-04-26 18:59+0200\n"
 "Last-Translator: Alec <alex1vagyok@gmail.com>\n"
 "Language-Team: Alec <alex1vagyok@gmail.com>\n"
 "Language: hu\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 2.3\n"
 
 msgid ""
 "\n"
@@ -2364,6 +2364,9 @@ msgstr ""
 "elégedett, akkor nyomja meg az OK gombot a video finombeállítások "
 "bezárásához, vagy a számgombok segítségével válasszon másik teszt ábrát."
 
+msgid "Ads filtering mode be default"
+msgstr "Reklám kiszűrési mód alapértelmezetten"
+
 msgid "Adult"
 msgstr "Felnőtt"
 
@@ -2408,6 +2411,20 @@ msgstr "Esemény után"
 
 msgid "After pressing OK, please wait!"
 msgstr "Az OK gomb lenyomása után kérem, várjon!"
+
+msgid "After this time, the Ads filtering mode should be the default set mode."
+msgstr ""
+"Ennyi idő múlva válik a Reklám kiszűrési mód alapértelmezett beállítási "
+"módra, s a Kép-a-Képben idításkor majd azzal indul."
+
+msgid "After 3 minutes"
+msgstr "3 perc múlva"
+
+msgid "After 5 minutes"
+msgstr "5 perc múlva"
+
+msgid "After 30 minutes"
+msgstr "30 perc múlva"
 
 msgid "Agenten"
 msgstr "Ügynök"
@@ -3691,7 +3708,7 @@ msgid "Cartoon"
 msgstr "Rajzfilm"
 
 msgid "Cascade PiP"
-msgstr "Kaszkád kép a képben"
+msgstr "Kaszkád Kép-a-Képben"
 
 msgid "Casting"
 msgstr "Casting"
@@ -4044,6 +4061,15 @@ msgstr "Csatornacsomag lista bezárása."
 
 msgid "Close dialog"
 msgstr "Párbeszédpanel bezárása"
+
+msgid "Close Main screen"
+msgstr "Főképernyő bezárása"
+
+msgid "Color first in Extensions list"
+msgstr "A bővítmények listájában a színes gombok elől legyenek"
+
+msgid "Close Picture in Picture screen"
+msgstr "Kép-a-Képben ablak bezárása"
 
 msgid "Close title selection"
 msgstr "Címválasztás bezárása"
@@ -6250,7 +6276,7 @@ msgid "Extensions management"
 msgstr "Bővítmények kezelése"
 
 msgid "Extensions/QuickMenu"
-msgstr "Bővítmények/QuicMenü"
+msgstr "Bővítmények/Gyors Menü"
 
 msgid "External"
 msgstr "Külső"
@@ -6385,6 +6411,9 @@ msgstr "Kedvencek hosszan"
 
 msgid "Favourites"
 msgstr "Kedvencek"
+
+msgid "Favourites (TV)"
+msgstr "Kedvenc TV csatornák"
 
 msgid "Feeds status:   Stable"
 msgstr "Folyamat státusza:   Stabil"
@@ -6576,6 +6605,18 @@ msgstr "Élelmiszer/Bor"
 
 msgid "Football"
 msgstr "Labdarúgás"
+
+msgid ""
+"For faster operation, the BLUE button only needs to be pressed once to use!\n"
+"BlueSwitch: Blue-Short/Blue-Long  ->  Extensions/QuickMenu\n"
+"\n"
+"Set this option now?"
+msgstr ""
+"A gyorsabb működés érdekében a KÉK gombot csak egyszer kell megnyomni a "
+"használathoz!\n"
+"Kék gomb: Kék röviden/Kék hosszan  ->  Bővítmények/Gyors Menü\n"
+"\n"
+"Beállítsuk ezt a lehetőséget?"
 
 msgid "For more information see http://www.opena.tv"
 msgstr "További információ: http://www.opena.tv"
@@ -8657,8 +8698,8 @@ msgid ""
 "Mode 1 suppports Kodi, PiP may not work.\n"
 "Mode 12 supports PiP, Kodi may not work."
 msgstr ""
-"Az 1-es mód támogatja a Kodi-t, PiP nem működik.\n"
-"A 12-es mód támogatja a PiP-t, a Kodi nem működik."
+"Az 1-es mód támogatja a Kodi-t, Kép-a-Képben nem működik.\n"
+"A 12-es mód támogatja a Kép-a-Képben-t, a Kodi nem működik."
 
 msgid "Mode 2"
 msgstr "Mód 2"
@@ -9208,6 +9249,12 @@ msgctxt "now/next: 'next' event label"
 msgid "Next"
 msgstr "Következő"
 
+msgid "Next bouquet"
+msgstr "Következő lista"
+
+msgid "Next page"
+msgstr "Következő oldal"
+
 msgid "Next quad PiP channel"
 msgstr "Következő quad Kép-a-Képben csatorna"
 
@@ -9454,6 +9501,9 @@ msgstr ""
 "Kérem, ellenőrizze, hogy egy kompatibilis vezeték nélküli hálózati illesztő "
 "csatlakoztatva van, és a hálózati paraméterek megfelelően be vannak állítva."
 
+msgid "No, and I will never ask for notification again"
+msgstr "Nem, és soha többé nem kérek erről értesítést"
+
 msgid "No, but restart from begin"
 msgstr "Nem, de indítsa elölröl"
 
@@ -9575,6 +9625,9 @@ msgstr "Nem kell frissíteni, naprakész a rendszer"
 
 msgid "Nothing, just leave this menu"
 msgstr "Semmi, hagyja el ezt a menüt"
+
+msgid "Not now, but warn me next time"
+msgstr "Most nem, de legközelebb figyelmeztessen arra"
 
 msgctxt "now/next: 'now' event label"
 msgid "Now"
@@ -10176,6 +10229,12 @@ msgstr "Pillarbox (fekete csíkok oldalakon)"
 msgid "Pilot"
 msgstr "Pilot"
 
+msgid "PiP standard Setup"
+msgstr "Kép-a-Képben hagyományos módjának beállítása"
+
+msgid "PiP usage Setup"
+msgstr "Kép-a-Képben működési módjának változtatása"
+
 msgid "Pitcairn"
 msgstr "Pitcairn"
 
@@ -10336,7 +10395,7 @@ msgstr ""
 "használva."
 
 msgid "Please open Picture in Picture first"
-msgstr "Kérem , először a Kép-a-Képben funkciót válassza"
+msgstr "Kérem, először a Kép-a-Képben funkciót válassza"
 
 msgid "Please press OK to continue."
 msgstr "A folytatáshoz nyomja le az OK-t."
@@ -10427,9 +10486,9 @@ msgid ""
 "Press OK to go back to the TV mode or EXIT to cancel the moving."
 msgstr ""
 "Az iránygombokkal mozgathatja a Kép-a-Képben ablakot.\n"
-"A csatornacsomag +/- gombokkal átméretezheti az ablakot.\n"
+"A csatorna váltó +/- gombokkal átméretezheti az ablakot.\n"
 "Az OK gombbal visszamehet a TV módra, vagy az EXIT gombbal befejezheti a "
-"mozgatást."
+"változtatást."
 
 msgid ""
 "Please use the UP and DOWN keys to select your language. Afterwards press "
@@ -10640,7 +10699,7 @@ msgid "Preschool"
 msgstr "Óvodai"
 
 msgid "Press '0' to toggle PiP mode"
-msgstr "Nyomja meg a '0'-t a Kép-a-Képben mód bekapcsolásához"
+msgstr "Nyomja meg a '0' gombot a Kép-a-Kép üzemmód váltásához"
 
 msgid "Press INFO on your remote control for additional information."
 msgstr "Nyomja le az INFO gombot a távírányítón a részletekért."
@@ -10721,6 +10780,12 @@ msgstr "Kijelőlt csatorna előnézete"
 
 msgid "Previous"
 msgstr "Előző"
+
+msgid "Previous bouquet"
+msgstr "Előző lista"
+
+msgid "Previous page"
+msgstr "Előző oldal"
 
 msgid "Prevsong"
 msgstr "Prevsong"
@@ -10840,7 +10905,7 @@ msgid "Protect InfoPanel"
 msgstr "Információs sáv védelme"
 
 msgid "Protect Quickmenu"
-msgstr "Quickmenu védelme"
+msgstr "Gyors Menü védelme"
 
 msgid "Protect Screens"
 msgstr "Képernyők védelme"
@@ -10934,7 +10999,7 @@ msgid "Quad PiP Screen"
 msgstr "Négy csatornás Kép-a-Képben képernyő"
 
 msgid "Quad PiP channel "
-msgstr "Quad PiP csatorna "
+msgstr "Quad Kép-a-Képben csatorna "
 
 msgid "Quad PiP is not available."
 msgstr "Négy csatornás Kép-a-Képben nem érhető el."
@@ -13199,7 +13264,7 @@ msgid "Show OE Log"
 msgstr "OE napló megjelenítése"
 
 msgid "Show PIP"
-msgstr "Kép a képben megjelenítése"
+msgstr "Kép-a-Képben megjelenítése"
 
 msgid "Show PIP in MiniTV"
 msgstr "Kép-a-Képben megjelenítése a MiniTV-ben"
@@ -13472,7 +13537,7 @@ msgid "Side by Side"
 msgstr "Egymás mellett"
 
 msgid "Side by side"
-msgstr "Kétoldalt"
+msgstr "Egymás mellett"
 
 msgid "Sierra Leone"
 msgstr "Sierra Leone"
@@ -13897,7 +13962,7 @@ msgid "Split preview mode"
 msgstr "Megosztott előnézeti mód"
 
 msgid "Splitscreen"
-msgstr "Megosztott képernyő"
+msgstr "Osztott nagy képernyős"
 
 msgid "Sport"
 msgstr "Sport"
@@ -14134,7 +14199,7 @@ msgid "Subtitle"
 msgstr "Felirat"
 
 msgid "Subtitle Quickmenu"
-msgstr "Felirat gyorsmenü"
+msgstr "Gyors Menü felirat"
 
 msgid "Subtitle long"
 msgstr "Felirat hosszan"
@@ -15072,6 +15137,13 @@ msgstr ""
 msgid "This option allows you to enable 3D Surround Sound."
 msgstr "Ez az opció lehetővé teszi a 3D Surround hang használatát."
 
+msgid ""
+"This option allows you to place the colored buttons (red, green, yellow, "
+"blue) to the first in the Extensions list."
+msgstr ""
+"Ezzel az opcióval beállíthatja, hogy a színes gombok (piros, zöld, sárga, "
+"kék) a bővítményeket megjelenítő ablakban a lista elején legyenek."
+
 msgid "This option allows you to use all HDMI Modes"
 msgstr "Ez az opció lehetővé teszi az összes HDMI mód használatát"
 
@@ -15471,7 +15543,7 @@ msgid "Toggle LCD LiveTV"
 msgstr "LCD élő TV be/ki"
 
 msgid "Toggle PIPzap"
-msgstr "Kép-a-Képben ugrás be/ki"
+msgstr "Kép-a-Képben csatornára ugrás"
 
 msgid "Toggle Picture In Graphics"
 msgstr "Toggle Picture In Graphics"
@@ -16478,7 +16550,7 @@ msgid "View list of available "
 msgstr "Az elérhetők listázása: "
 
 msgid "View list of available CommonInterface extensions"
-msgstr "Az elérhető CI-Bővítmények listázása"
+msgstr "Az elérhető CI-bővítmények listázása"
 
 msgid "View list of available EPG extensions."
 msgstr "Az elérhető EPG-bővítmények listája."
@@ -16512,7 +16584,7 @@ msgid "View list of available software extensions"
 msgstr "Az elérhető szoftveres bővítmények listázása"
 
 msgid "View list of available system extensions"
-msgstr "Az elérhető rendszer-Bővítmények listázása"
+msgstr "Az elérhető rendszer bővítmények listázása"
 
 msgid "View or edit file (if size < 1MB)"
 msgstr "Fájl megtekintése vagy szerkesztése (ha méret < 1 MB)"
@@ -17418,10 +17490,10 @@ msgid "Zap down"
 msgstr "Ugrás lefelé"
 
 msgid "Zap focus to Picture in Picture"
-msgstr "A Kép-a-Képben-ablak kezelése"
+msgstr "A Kép-a-Képben ablak kezelése"
 
 msgid "Zap focus to main screen"
-msgstr "A főképernyő kezelése"
+msgstr "A Főképernyő kezelése"
 
 msgid "Zap focused channel on full screen"
 msgstr "A teljes képernyőn a csatornára ugráskor megjelent adás fog megjelenni"
@@ -17540,7 +17612,7 @@ msgid "activate network adapter configuration"
 msgstr "hálózati adapter konfiguráció aktiválása"
 
 msgid "activatePiP"
-msgstr "aktív Kép-a-Képben"
+msgstr "Kép-a-Képben bekapcsolása"
 
 msgid "add Current"
 msgstr "aktuális hozzáadása"
@@ -18635,6 +18707,9 @@ msgstr ""
 msgid "previous channel page"
 msgstr "előző csatornaoldal"
 
+msgid "previous/next Bouquet"
+msgstr "előző/következő lista"
+
 msgid "previous/next Page"
 msgstr "előző/következő oldal"
 
@@ -19076,13 +19151,13 @@ msgid "talk show"
 msgstr "beszédműsor"
 
 msgid "team sports"
-msgstr "csapat-sport"
+msgstr "csapat sport"
 
 msgid "technology/natural science"
 msgstr "technológia/természettudomány"
 
 msgid "template file"
-msgstr "sablon-fájl"
+msgstr "sablon fájl"
 
 msgid "tennis/squash"
 msgstr "tenisz/fallabda"
@@ -19341,6 +19416,105 @@ msgstr "ugrott"
 
 msgid "zapping"
 msgstr "ugrás folyamatban"
+
+msgid "Basic settings"
+msgstr "Alapbeállítások"
+
+msgid "CIFS/Samba Setup"
+msgstr "CIFS/Samba beállítása"
+
+msgid "Convert ext3 filesystem to ext4"
+msgstr "Konvertálás ext3-ról ext4-re"
+
+msgid "CronTimers"
+msgstr "CronTimer időzítők"
+
+msgid "Decryption & Parental Control"
+msgstr "Dekódolás és szülői felügyelet"
+
+msgid "Delete EPG"
+msgstr "EPG törlése"
+
+msgid "Device Setup"
+msgstr "Hálózati eszközök beállítása"
+
+msgid "EPG"
+msgstr "Műsorújság (EPG)"
+
+msgid "Extended GUI"
+msgstr "Kiterjesztett kinézet (GUI)"
+
+msgid "HDMI CEC"
+msgstr "HDMI CEC"
+
+msgid "HDMI-IN Recording settings"
+msgstr "HDMI-IN felvételi beállítások"
+
+msgid "Input devices"
+msgstr "Beviteli eszközök"
+
+msgid "Load EPG"
+msgstr "EPG betöltése"
+
+msgid "Load/Save/Delete"
+msgstr "Betöltés/Mentés/Törlés"
+
+msgid "Mainmenu"
+msgstr "Főmenü"
+
+msgid "Manual scan"
+msgstr "Kézi keresés"
+
+msgid "OSD Position"
+msgstr "OSD pozíció"
+
+msgid "OpenVPN Setup"
+msgstr "OpenVPN beállítása"
+
+msgid "PowerTimers"
+msgstr "Kikapcsolás Időzítők"
+
+msgid "Reception"
+msgstr "Vétel beállítása"
+
+msgid "Recordings & Timeshift"
+msgstr "Felvételek és Timeshift"
+
+msgid "Recovery Mode"
+msgstr "Recovery mód"
+
+msgid "Remote Control Code"
+msgstr "Távirányító kód"
+
+msgid "Restart Gui"
+msgstr "Kezelőfelület újraindítása"
+
+msgid "STB Display"
+msgstr "STB kijelző"
+
+msgid "Save EPG"
+msgstr "EPG mentése"
+
+msgid "Shutdown"
+msgstr "Kikapcsolás"
+
+msgid "Standby / Restart"
+msgstr "Készenlét / Újraindítás"
+
+msgid "Timeshift settings"
+msgstr "Timeshift beállítása"
+
+msgid "Usage & GUI"
+msgstr "Használat és Kinézet (GUI)"
+
+msgid "VCR scart"
+msgstr "VCR scart"
+
+msgid "Video"
+msgstr "Videó"
+
+msgid "WOL Standby"
+msgstr "WOL Készenlét"
 
 msgid "0"
 msgstr "0"
@@ -19725,105 +19899,6 @@ msgstr "A(z) %s %s készüléknek nincs kapcsolata az internettel"
 msgid "Your %s %s is not connected to the internet"
 msgstr "A(z) %s %s nem kapcsolódik az internethez"
 
-msgid "Basic settings"
-msgstr "Alapbeállítások"
-
-msgid "CIFS/Samba Setup"
-msgstr "CIFS/Samba beállítása"
-
-msgid "Convert ext3 filesystem to ext4"
-msgstr "Konvertálás ext3-ról ext4-re"
-
-msgid "CronTimers"
-msgstr "CronTimer időzítők"
-
-msgid "Decryption & Parental Control"
-msgstr "Dekódolás és szülői felügyelet"
-
-msgid "Delete EPG"
-msgstr "EPG törlése"
-
-msgid "Device Setup"
-msgstr "Hálózati eszközök beállítása"
-
-msgid "EPG"
-msgstr "Műsorújság (EPG)"
-
-msgid "Extended GUI"
-msgstr "Kiterjesztett kinézet (GUI)"
-
-msgid "HDMI CEC"
-msgstr "HDMI CEC"
-
-msgid "HDMI-IN Recording settings"
-msgstr "HDMI-IN felvételi beállítások"
-
-msgid "Input devices"
-msgstr "Beviteli eszközök"
-
-msgid "Load EPG"
-msgstr "EPG betöltése"
-
-msgid "Load/Save/Delete"
-msgstr "Betöltés/Mentés/Törlés"
-
-msgid "Mainmenu"
-msgstr "Főmenü"
-
-msgid "Manual scan"
-msgstr "Kézi keresés"
-
-msgid "OSD Position"
-msgstr "OSD pozíció"
-
-msgid "OpenVPN Setup"
-msgstr "OpenVPN beállítása"
-
-msgid "PowerTimers"
-msgstr "Kikapcsolás Időzítők"
-
-msgid "Reception"
-msgstr "Vétel beállítása"
-
-msgid "Recordings & Timeshift"
-msgstr "Felvételek és Timeshift"
-
-msgid "Recovery Mode"
-msgstr "Recovery mód"
-
-msgid "Remote Control Code"
-msgstr "Távirányító kód"
-
-msgid "Restart Gui"
-msgstr "Kezelőfelület újraindítása"
-
-msgid "STB Display"
-msgstr "STB kijelző"
-
-msgid "Save EPG"
-msgstr "EPG mentése"
-
-msgid "Shutdown"
-msgstr "Kikapcsolás"
-
-msgid "Standby / Restart"
-msgstr "Készenlét / Újraindítás"
-
-msgid "Timeshift settings"
-msgstr "Timeshift beállítása"
-
-msgid "Usage & GUI"
-msgstr "Használat és Kinézet (GUI)"
-
-msgid "VCR scart"
-msgstr "VCR scart"
-
-msgid "Video"
-msgstr "Videó"
-
-msgid "WOL Standby"
-msgstr "WOL Készenlét"
-
 msgid "Auto Modes Selected."
 msgstr "Automatikus módok kiválasztva."
 
@@ -20092,6 +20167,9 @@ msgstr ""
 
 msgid "Change bouquets in quickzap"
 msgstr "Csatornacsomagok változtatása gyors ugrásban"
+
+msgid "Channel +/-"
+msgstr "Csatorna +/- gomb"
 
 msgid "Channel +/- button mode"
 msgstr "Csatorna +/- gomb módja"
@@ -21705,7 +21783,7 @@ msgid "Select Yellow Key Action long"
 msgstr "Sárga gomb művelete (hosszan)"
 
 msgid "Select how to activate the Quick EPG mode:"
-msgstr "Válassza ki, hogyan aktiválja a Quick EPG módot:"
+msgstr "Válassza ki, hogyan aktiválja a Gyors EPG módot:"
 
 msgid "Select if timeshift must continue when set to record."
 msgstr "Mi történjen akkor, mikor más esemény történik a Timeshift-t közben."
@@ -21724,6 +21802,9 @@ msgid ""
 msgstr ""
 "A teletext elhagyásakor válassza ki a képernyőfelbontás és a framebuffer "
 "helyreállításának módját."
+
+msgid "Select the time zone within the area or region."
+msgstr "Válassza ki az időzónát a területen vagy a régióban."
 
 msgid ""
 "Select what should be done when the %s %s was boot-up, normal playing or "
@@ -21775,6 +21856,9 @@ msgid "Select what you want the YELLOW-Long button to activate:"
 msgstr ""
 "Válassza ki, hogy a távirányító Sárga (hosszan) gombjával mit szeretne "
 "csinálni:"
+
+msgid "Select your time zone area or region."
+msgstr "Válassza ki az időzóna területét vagy régióját."
 
 msgid "Service Title mode"
 msgstr "Információ kijelzési módja"
@@ -21887,6 +21971,9 @@ msgstr "Adja meg, hogy a gomb megnyomásával mit szeretne csinálni."
 
 msgid "Set to yes for debugging the root cause of a spinner."
 msgstr "Állítsa 'yes'-re a foglaltság (spinner) fő okainak hibakeresésére."
+
+msgid "Setting by user"
+msgstr "Felhasználó állítsa be a működési módot"
 
 msgid "Setup delay mode to zap to channels."
 msgstr "A csatornára ugrás késleltetési módját lehet itt beállítani."
@@ -22214,6 +22301,9 @@ msgstr "Negyedleges előnyben részesített felirat"
 msgid "Subtitle position"
 msgstr "Felirat elhelyezése"
 
+msgid "Swap screen"
+msgstr "Főképernyő és a Kép-a-Képben ablak felcserélése"
+
 msgid "Swap SNR in '%' with SNR in 'db'"
 msgstr "Cserélje ki a SNR '%'-t 'db-ra'"
 
@@ -22490,6 +22580,12 @@ msgstr "Idő stílusa"
 
 msgid "Time window for detection of the wakeup by a timer [mins]"
 msgstr "Időintervalluma az ébresztés észlelésének az Időzítő által [perc]"
+
+msgid "Time zone"
+msgstr "Időzóna"
+
+msgid "Time zone area"
+msgstr "Időzóna területe"
 
 msgid "Time zone settings"
 msgstr "Időzóna beállítások"
@@ -23137,6 +23233,9 @@ msgstr "Hova szeretné elmenteni a beállításait?"
 msgid "Yes, backup my settings!"
 msgstr "Igen, mentse el a beállításaim!"
 
+msgid "Yes, I'm setting it up now"
+msgstr "Igen, most beállítom"
+
 msgid "Yes, restore the settings now"
 msgstr "Igen, állítsuk vissza most a beállításokat"
 
@@ -23352,21 +23451,3 @@ msgstr "A diák közötti idő a képnézegető diavetítésében."
 
 msgid "Time for Slideshow"
 msgstr "Idő a diavetítéshez"
-
-msgid "Next page"
-msgstr "Következő oldal"
-
-msgid "Previous page"
-msgstr "Előző oldal"
-
-msgid "Next bouquet"
-msgstr "Következő lista"
-
-msgid "Previous bouquet"
-msgstr "Előző lista"
-
-msgid "previous/next Bouquet"
-msgstr "előző/következő lista"
-
-msgid "Channel +/-"
-msgstr "Csatorna +/- gomb"


### PR DESCRIPTION
Hi,

I have expanded and modified the existing PiP solution for Enigma2.
I wanted it to be quick and easy to use.

Quick to use, either as a function or from a programmed button, or from the standard Blue button.
There is a warning window to set up a quick use of the Blue button.

The use of PiP and the PiP mode selection window can be assigned to a specific button on the remote control.
But it can be used just as quickly by the standard Blue button.

There are three modes to choose from to use PiP.
There are 3 ways:

  - standard -> Functions that are currently running
  - noadspip -> Ads could be filtered out while ads go, another channel could be watched
  - side-by-side -> If you want to watch multiple shows at once, you could use this mode the right way

The PiP mode switching window makes it easy to change the mode. No need to click multiple menu items in the main settings.

The main function of using PiP is Ad Filtering Mode. You can set how long it takes to be the default when it is in another mode. It can also be changed in the Menu.
You can also set the Color function buttons at the beginning or end of the list in the Extensions list. It can also be changed in the Menu.
This also helps with quick use.

You can also easily switch from Ad Filtering mode to Side-by-Side mode.

noadsPiP mode:
1.) I see live TV broadcast on the TV screen.
2.) When I see an advertisement (ad) on the screen, I press a button on the remote control (PiP button or a programmed button or Blue/Blue long).
3.) The active channel will be placed (moved) in the PiP window (with the ad)
4.) The following channel will be displayed on the main screen (Channel after the active channel).
5.) I see: Main screen (no ads) + PiP screen (with ads)
6.) When I see the ad end in the PiP window, I press a button on the remote control again (PiP button or a programmed button or Blue/Blue long).
7.) The contents of the PiP window will be displayed (moved) on the main screen and the PiP window will disappear.

The advertisement (ad) is viewed by sight, operation would be manual without automation!
I think this is a useful feature!

side-by-side mode:
1.) After pressing the PiP (or programmed) button, the current channel will be displayed on the left side of the screen and the channel following the current channel on the right.
2.) The live broadcast on the left would be active (sound here), the live broadcast on the right would be inactive.
3.) You can change the Active status character by pressing the LEFT button on the remote control, left and right live broadcasts can be swapped.
All operations affect only the active channel, left screen (channel change, EPG operations, ...).
4.) Press the RIGHT button to change the right screen with the Channel selection +/- buttons (Change inactive screen channel).
5.) Pressing the EXIT button will only activate the live broadcast on the main screen, the inactive live broadcast will disappear from the screen.
When you press the PiP (or programmed) button, the only inactive live broadcast will be on the main screen.

Other EPG and channel switching functions are working well, I have solved other problems.

standard mode:
- It works as usual, without change.

Multilingual usage is also resolved. I also created and added the .pot file.

I didn’t get much help to solve my development, but I managed to solve it somehow. I did it for a long time, but I feel like I’m done with it.
My development has been tested by testers on multiple set-top boxes and multiple SKINs. The tests were successful. Users found this development useful!

If you have any questions please do not hesitate to contact me!

Regards:
Alec
