### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1033,7 +1033,7 @@ msgstr "%d GB"
 
 #, python-format
 msgid "%d KB"
-msgstr "%d KB"
+msgstr "%d kB"
 
 #, python-format
 msgid "%d MB"
@@ -1235,8 +1235,8 @@ msgid ""
 "Press exit to close"
 msgstr ""
 "%s\n"
-"Drücken Sie OK für Multiboot Auswahl\n"
-"Drücken Sie EXIT zum Beenden"
+"Drücken Sie OK für Multiboot-Auswahl.\n"
+"Drücken Sie EXIT zum Beenden."
 
 #, python-format
 msgid "%s %02d.%02d."
@@ -9003,7 +9003,7 @@ msgid "Image Manager"
 msgstr "Image Manager"
 
 msgid "Image Version"
-msgstr "Image Version"
+msgstr "Image-Version"
 
 #, python-format
 msgid "Image created on: %s/%s-%s-%s-backup-%s_recovery_emmc.zip"
@@ -9570,7 +9570,7 @@ msgid "KA-SAT"
 msgstr "KA-SAT"
 
 msgid "KB"
-msgstr ""
+msgstr "kB"
 
 #
 msgid "Kampfsport"
@@ -9721,7 +9721,7 @@ msgid "LCN rules:"
 msgstr ""
 
 msgid "LED Deep Standby"
-msgstr "LED Deep Standby"
+msgstr "LED Deep-Standby"
 
 msgid "LED Normal"
 msgstr "LED Normal"
@@ -23315,7 +23315,7 @@ msgid ""
 "Screens change with left/right buttons or use red, green, blue to toggle.\n"
 "Yellow for returning back to this intro"
 msgstr ""
-"Kann verwendet werden um auf defekte Pixel am TV zu testen.\n"
+"Kann verwendet werden, um auf defekte Pixel am TV zu testen.\n"
 "\n"
 "Verfügbare Farb-Test-Bildschirme:\n"
 "\n"
@@ -23328,8 +23328,9 @@ msgstr ""
 "Magenta\n"
 "Gelb\n"
 "\n"
-"Bildschirm wechseln mit Tasten LINKS/RECHTS oder mit den\nTasten ROT, GRÜN und BLAU direkt umschalten.\n"
-"Mit Taste GELB zurück zur Einführung."
+"Mit den Tasten Links/Rechts den Bildschirm wechseln.\n"
+"Mit den Tasten ROT, GRÜN oder BLAU direkt umschalten.\n"
+"Mit der Taste GELB zurück zur Einführung."
 
 #
 #~ msgid ""


### PR DESCRIPTION
Kilobytes werden abgekürzt als "kB" geschrieben, "Multiboot-Auswahl", "Deep-Standby" und "Image-Version" immer mit Bindestrich.
Tasten - außer "Links/Rechts" - werden groß geschrieben.
Und ein Komma vor "um"...
Gruß - Makumbo