### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3203,7 +3203,7 @@ msgid "Auto Timers"
 msgstr "AutoTimer"
 
 msgid "Auto Volume Level"
-msgstr ""
+msgstr "Automatische Lautstärkeanpassung"
 
 msgid "Auto chapter split every ? minutes (0=never)"
 msgstr "Automatischer Kapitelwechsel alle x Minuten (0=nie)"
@@ -3216,7 +3216,7 @@ msgid "Auto focus"
 msgstr "Auto Fokus"
 
 msgid "Auto focus commencing ..."
-msgstr ""
+msgstr "Auto Fokus startet..."
 
 msgid "Auto language selection"
 msgstr "Automatische Sprachauswahl"
@@ -7994,8 +7994,8 @@ msgid ""
 "\n"
 "Set this option now?"
 msgstr ""
-"Für die einfache Bedienung kann die Funktionsweise der Blauen Taste geändert werden!\n"
-"Blaue Taste: Blau-Kurz/Blau-Lang  ->  Erweiterungen/QuickMenu\n"
+"Für die einfache Bedienung kann die Funktionsweise der Taste BLAU geändert werden!\n"
+"Taste BLAU kurz/lang -> Erweiterungen/QuickMenu\n"
 "\n"
 "Soll die Änderung übernommen werden?"
 
@@ -10258,7 +10258,7 @@ msgid "Mannschaftssport"
 msgstr "Mannschaftssport"
 
 msgid "Manual"
-msgstr ""
+msgstr "Manuell"
 
 msgid "Manual Scan"
 msgstr "Manueller Suchlauf"
@@ -10341,7 +10341,7 @@ msgstr "Maxdown: "
 
 #, python-format
 msgid "Maximum minutes to jump %d !"
-msgstr "Sie können nur maximal %d Minuten springen !"
+msgstr "Sie können nur maximal %d Minuten springen!"
 
 msgid "Maximum no of days:"
 msgstr "Maximale Anzahl von Tagen:"
@@ -13036,7 +13036,7 @@ msgid "PiP mode"
 msgstr "Bild im Bild Modus"
 
 msgid "Choose what you want the PIP mode how to works."
-msgstr "Wähle aus, wie der Bild im Bild Modus funktionieren soll."
+msgstr "Wählen Sie, wie der Bild im Bild Modus funktionieren soll."
 
 msgid "Ads filtering mode"
 msgstr "Werbefiltermodus"
@@ -18327,7 +18327,7 @@ msgid "This option allows you to enable 3D Surround Sound."
 msgstr "Einstellen der 3D Surround Sound Ausgabe."
 
 msgid "This option allows you to place the colored buttons (red, green, yellow, blue) to the first in the Extensions list."
-msgstr "Mit dieser Option können Sie die farbigen Schaltflächen (rot, grün, gelb, blau) an die erste Stelle in der Liste der Erweiterungen setzen."
+msgstr "Mit dieser Option können Sie die farbigen Schaltflächen ROT, GRÜN, GELB oder BLAU an die erste Stelle in der Liste der Erweiterungen setzen."
 
 msgid "This option allows you to hide and sorting of the menus"
 msgstr "Einstellen, wie Menüeinträge sortiert oder versteckt werden sollen."


### PR DESCRIPTION
"Automatische Lautstärkeanpassung" im "Audio" Menü wie in MENU-Einstellungen-Ton-Grundeinstellungen. Tasten GROSS geschrieben.

Ganz sicher bin ich mir nicht bei folgenden Zeilen:
Ab Zeile 12304
msgid "PiP standard Setup"
msgstr "PiP-Standard Setup"
oder
msgstr "Bild im Bild Standardeinstellungen" ???

und ab Zeile 12307
msgid "PiP usage Setup"
msgstr "PiP-Verwendung Setup"
oder
msgstr "Bild im Bild Einstellungen"
oder
msgstr "Bild im Bild eigene Einstellungen" ???

Gruß - Makumbo