### PR TITLE
Complete overhaul of English en_US (en.po) and en_GB translation files.

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -4,9 +4,9 @@ msgstr ""
 "Project-Id-Version: openATV / enigma2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-30 14:34+0100\n"
-"PO-Revision-Date: 2018-04-03 21:30+0300\n"
-"Last-Translator: TM2TURK | by thawtes <thawtes@gmail.com>\n"
-"Language-Team: TM2TURK | by thawtes <thawtes@gmail.com>\n"
+"PO-Revision-Date: 2020-07-02 11:03+0100\n"
+"Last-Translator: wedebe <wedebe@dev.null>\n"
+"Language-Team: \n"
 "Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -14,7 +14,7 @@ msgstr ""
 "X-SourceCharset: UTF-8\n"
 "X-Generated: TM2TURK by thawtes\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.3.1\n"
 
 msgid ""
 "\n"
@@ -23,7 +23,7 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"[User - bouquets (TV)]\n"
+"[User bouquets (TV)]\n"
 
 msgid ""
 "\n"
@@ -86,7 +86,7 @@ msgid ""
 "Backup your %s %s settings."
 msgstr ""
 "\n"
-"Backup your %s %s settings."
+"Back up your %s %s settings."
 
 #, python-format
 msgid ""
@@ -94,14 +94,14 @@ msgid ""
 "Backup your running %s %s image to HDD or USB."
 msgstr ""
 "\n"
-"Backup your running %s %s image to HDD or USB."
+"Back up your currently-running %s %s image to HDD or USB."
 
 msgid ""
 "\n"
 "Edit the upgrade source address."
 msgstr ""
 "\n"
-"Edit the upgrade source address."
+"Configure the upgrade source address."
 
 #, python-format
 msgid ""
@@ -109,12 +109,14 @@ msgid ""
 "Flash on the fly your %s %s."
 msgstr ""
 "\n"
-"Flash on the fly your %s %s."
+"Flash your %s %s on the fly."
 
 msgid ""
 "\n"
 "Maintain your multiboot device."
 msgstr ""
+"\n"
+"Manage your multi-boot device."
 
 #, python-format
 msgid ""
@@ -122,7 +124,7 @@ msgid ""
 "Manage extensions or plugins for your %s %s"
 msgstr ""
 "\n"
-"Manage extensions or plugins for your %s %s"
+"Manage extensions or plugins on your %s %s"
 
 #, python-format
 msgid ""
@@ -137,7 +139,7 @@ msgid ""
 "Press OK on your remote control to continue."
 msgstr ""
 "\n"
-"Press OK on your remote control to continue."
+"Press OK to continue."
 
 msgid ""
 "\n"
@@ -160,7 +162,7 @@ msgid ""
 "Restore your %s %s with a new firmware."
 msgstr ""
 "\n"
-"Restore your %s %s with a new firmware."
+"Restore your %s %s with a new image."
 
 msgid ""
 "\n"
@@ -217,13 +219,13 @@ msgid " "
 msgstr ""
 
 msgid "     no space left on back-up device"
-msgstr ""
+msgstr "     no space left on backup device"
 
 msgid "     no writing permission on back-up device"
-msgstr ""
+msgstr "     no write permission on backup device"
 
 msgid "     wrong back-up destination "
-msgstr ""
+msgstr "     invalid backup destination "
 
 #, python-format
 msgid "   (%s MHz)"
@@ -251,22 +253,22 @@ msgid "   (2.1 GHz)"
 msgstr ""
 
 msgid "  Menu key : Select quad channel"
-msgstr "  Menu key : Select quad channel"
+msgstr "  MENU button : Select quad channel"
 
 msgid "  Red key : Show/Hide channel name"
-msgstr "  Red key : Show/Hide channel name"
+msgstr "  Red button : Show/hide channel name"
 
 #, python-format
 msgid " ('%s') ends successfully."
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid " ('%s') ends with error messages."
-msgstr "Hide any zap error messages."
+msgstr " ('%s') ends with error messages."
 
 #, python-format
 msgid " ('%s') ends with error number [%d]."
-msgstr ""
+msgstr " ('%s') ends with error number [%d]."
 
 #, python-format
 msgid " (Channel %s)"
@@ -296,7 +298,7 @@ msgid " (higher than any auto)"
 msgstr " (higher than any auto)"
 
 msgid " (higher than rotor any auto)"
-msgstr " (higher than rotor any auto)"
+msgstr " (higher than rotator any auto)"
 
 msgid " (lower than any auto)"
 msgstr " (lower than any auto)"
@@ -306,13 +308,13 @@ msgid " - %d elements exist! Overwrite"
 msgstr ""
 
 msgid " - 1 element exist! Overwrite"
-msgstr ""
+msgstr " - 1 element exists! Overwrite"
 
 msgid " - file exist! Overwrite"
-msgstr ""
+msgstr " - destination file exists! Overwrite"
 
 msgid " - folder exist! Overwrite"
-msgstr ""
+msgstr " - destination folder exists! Overwrite"
 
 #, fuzzy
 msgid " <No Channel>"
@@ -330,9 +332,9 @@ msgid ""
 "\n"
 "Do you want to install the new settingslist?"
 msgstr ""
-" available !!\n"
+" available!\n"
 "\n"
-"Do you want to install the new settingslist?"
+"Would you like to install the new settings?"
 
 msgid " of "
 msgstr " of "
@@ -1001,7 +1003,7 @@ msgstr[0] "%+6d"
 msgstr[1] "%+6d"
 
 msgid "%d %B %Y"
-msgstr "%d %B %Y"
+msgstr "%a, %d %b %Y"
 
 #, fuzzy
 msgid "%d %b"
@@ -1105,15 +1107,14 @@ msgid_plural "%d seconds"
 msgstr[0] "%d second"
 msgstr[1] "%d seconds"
 
-#, fuzzy, python-format
 msgid "%d times"
-msgstr "End time"
+msgstr ""
 
 #, python-format
 msgid "%d wireless network found!"
 msgid_plural "%d wireless networks found!"
-msgstr[0] "%d wireless network found!"
-msgstr[1] "%d wireless networks found!"
+msgstr[0] "Found %d wireless network..."
+msgstr[1] "Found %d wireless networks..."
 
 msgid "%d+%b_"
 msgstr ""
@@ -1217,11 +1218,11 @@ msgstr "%s %s front panel"
 
 #, python-format
 msgid "%s %s ir keyboard"
-msgstr "%s %s ir keyboard"
+msgstr "%s %s IR keyboard"
 
 #, python-format
 msgid "%s %s ir mouse"
-msgstr "%s %s ir mouse"
+msgstr "%s %s IR mouse"
 
 #, python-format
 msgid "%s %s remote control (native)"
@@ -1257,7 +1258,7 @@ msgstr "%s - Setup"
 
 #, python-format
 msgid "%s - extraction errors."
-msgstr ""
+msgstr "%s - extraction errors."
 
 #, python-format
 msgid "%s Setup"
@@ -1308,35 +1309,35 @@ msgstr "%s/%s: %s"
 
 #, python-format
 msgid "%sMode for FHD (up to 1080p)"
-msgstr "%sMode for FHD (up to 1080p)"
+msgstr "%sFHD resolution (up to 1080p)"
 
 #, python-format
 msgid "%sMode for HD (up to 720p)"
-msgstr "%sMode for HD (up to 720p)"
+msgstr "%sHD resolution (up to 720p)"
 
 #, python-format
 msgid "%sMode for SD (up to 576p)"
-msgstr "%sMode for SD (up to 576p)"
+msgstr "%sSD resolution (up to 576p)"
 
 #, python-format
 msgid "%sMode for UHD (up to 2160p)"
-msgstr "%sMode for UHD (up to 2160p)"
+msgstr "%sUHD resolution (up to 2160p)"
 
 #, python-format
 msgid "%sRefresh rate for FHD"
-msgstr "%sRefresh rate for FHD"
+msgstr "%sFHD refresh rate"
 
 #, python-format
 msgid "%sRefresh rate for HD"
-msgstr "%sRefresh rate for HD"
+msgstr "%sHD refresh rate"
 
 #, python-format
 msgid "%sRefresh rate for SD"
-msgstr "%sRefresh rate for SD"
+msgstr "%sSD refresh rate"
 
 #, python-format
 msgid "%sRefresh rate for UHD"
-msgstr "%sRefresh rate for UHD"
+msgstr "%sUHD refresh rate"
 
 #, python-format
 msgid "%sShow 1080i as 1080p"
@@ -1344,24 +1345,24 @@ msgstr "%sShow 1080i as 1080p"
 
 #, python-format
 msgid "'%s' contains %d file(s) and %d sub-directories.\n"
-msgstr "'%s' contains %d file(s) and %d sub-directories.\n"
+msgstr "'%s' contains %d file(s) and %d subfolders.\n"
 
 #, python-format
 msgid "'%s' not installed and no known package"
 msgstr ""
 
 msgid "'Buffer in hours' or 'number of last events'. For deleting older timeshift files, the condition which occurred first has priority."
-msgstr "'Buffer in hours' or 'number of last events'. For deleting older timeshift files, the condition which occurred first has priority."
+msgstr "'Buffer in hours' or 'number of last events'. For deleting older timeshift buffer files, the condition which occurs first will take priority."
 
 msgid "'Handle standby from TV' has a higher priority as 'Handle input from TV'"
-msgstr ""
+msgstr "'Handle standby from TV' has a higher priority than 'Handle input from TV'"
 
 #, fuzzy
 msgid "'weatherplugin' is not installed!"
 msgstr "This plugin is not installed."
 
 msgid "( All readers)"
-msgstr "( All readers)"
+msgstr "( All readers )"
 
 #, python-format
 msgid "(%d jobs)"
@@ -1372,7 +1373,7 @@ msgstr ""
 
 #, python-format
 msgid "(Attention: There will be a restart after %d crashes.)"
-msgstr ""
+msgstr "(Your receiver will automatically restart after %d crashes)."
 
 #, fuzzy
 msgid "(Selectmode)"
@@ -1382,7 +1383,7 @@ msgid "(Show only reader:"
 msgstr "(Show only reader:"
 
 msgid "(e.g. TV wakeup, but not switched to correct input)"
-msgstr ""
+msgstr "(e.g. TV wake up, but not switched to correct input)"
 
 msgid "(empty)"
 msgstr "(empty)"
@@ -1391,7 +1392,7 @@ msgid "(show optional DVD audio menu)"
 msgstr "(show optional DVD audio menu)"
 
 msgid "* = Restart Required"
-msgstr "* = Restart Required"
+msgstr "* requires restart"
 
 msgid "* Only available if more than one interface is active."
 msgstr "* Only available if more than one interface is active."
@@ -1408,16 +1409,18 @@ msgstr "+24"
 msgid "-24"
 msgstr "-24"
 
-#, fuzzy
+msgid "-24/+24 Hours"
+msgstr "+/- 24 Hours"
+
 msgid "-24h/+24 Hours"
-msgstr "24+ Hours"
+msgstr "+/- 24 hours"
 
 msgid "-NO SERVICE\n"
 msgstr ""
 
 #, python-format
 msgid "-SERVICE ERROR:%d\n"
-msgstr ""
+msgstr "-SERVICE ERROR:%d\n"
 
 msgid "/s"
 msgstr "/s"
@@ -1495,9 +1498,8 @@ msgstr ""
 msgid "10 min."
 msgstr "10 min."
 
-#, fuzzy
 msgid "10 minutes"
-msgstr "30 minutes"
+msgstr ""
 
 msgid "100 MB/s"
 msgstr ""
@@ -1539,14 +1541,13 @@ msgid "1080p50: 24p/50p/60p"
 msgstr "1080p50: 24p/50p/60p"
 
 msgid "10bit"
-msgstr ""
+msgstr "10-bit"
 
 msgid "12 character"
 msgstr "12 character"
 
-#, fuzzy
 msgid "12 hours"
-msgstr "24+ Hours"
+msgstr ""
 
 msgid "12, show latin-1 characters except for greek and cyrillic, switch to 8 if needed."
 msgstr "12, show latin-1 characters except for greek and cyrillic, switch to 8 if needed."
@@ -1564,10 +1565,10 @@ msgid "12V output."
 msgstr "12V output."
 
 msgid "12bit"
-msgstr ""
+msgstr "12-bit"
 
 msgid "12bit 4:2:0/4:2:2 no PIP"
-msgstr "12bit 4:2:0/4:2:2 no PIP"
+msgstr "12-bit 4:2:0/4:2:2 no PiP"
 
 msgid "13 V"
 msgstr "13 V"
@@ -1575,9 +1576,8 @@ msgstr "13 V"
 msgid "15 min."
 msgstr "15 min."
 
-#, fuzzy
 msgid "15 minutes"
-msgstr "5 minutes"
+msgstr ""
 
 msgid "1536 Mb"
 msgstr "1536 Mb"
@@ -1592,7 +1592,7 @@ msgid "16:10 Letterbox"
 msgstr "16:10 Letterbox"
 
 msgid "16:10 PanScan"
-msgstr "16:10 PanScan"
+msgstr "16:10 Pan and Scan"
 
 msgid "16:9"
 msgstr "16:9"
@@ -1622,13 +1622,13 @@ msgid "18 V"
 msgstr "18 V"
 
 msgid "1X"
-msgstr "1X"
+msgstr "1x"
 
 msgid "1s"
 msgstr "1s"
 
 msgid "1st Infobar timeout"
-msgstr "1st Infobar timeout"
+msgstr "First infobar timeout"
 
 msgid "2"
 msgstr "2"
@@ -1636,13 +1636,11 @@ msgstr "2"
 msgid "2 GB"
 msgstr "2 GB"
 
-#, fuzzy
 msgid "2 hours"
-msgstr "24+ Hours"
+msgstr ""
 
-#, fuzzy
 msgid "2 minutes"
-msgstr "5 minutes"
+msgstr ""
 
 msgid "2.5s"
 msgstr "2.5s"
@@ -1653,25 +1651,20 @@ msgstr ""
 msgid "2048 Mb"
 msgstr "2048 Mb"
 
-#, fuzzy
 msgid "2160p 24Hz"
-msgstr "720p 24Hz"
+msgstr ""
 
-#, fuzzy
 msgid "2160p 25Hz"
-msgstr "1080p 25Hz"
+msgstr ""
 
-#, fuzzy
 msgid "2160p 30Hz"
-msgstr "1080p 30Hz"
+msgstr ""
 
-#, fuzzy
 msgid "2160p 50Hz"
-msgstr "1080p 50Hz"
+msgstr ""
 
-#, fuzzy
 msgid "2160p 60Hz"
-msgstr "1080p 60Hz"
+msgstr ""
 
 msgid "2160p50: 24p/50p/60p"
 msgstr "2160p50: 24p/50p/60p"
@@ -1682,26 +1675,23 @@ msgstr "23.976"
 msgid "24"
 msgstr "24"
 
-#, fuzzy
 msgid "24 hours"
-msgstr "24+ Hours"
+msgstr ""
 
 msgid "24+ Hours"
-msgstr "24+ Hours"
+msgstr "+24 hours"
 
 msgid "24- Hours"
-msgstr "24- Hours"
+msgstr "-24 hours"
 
 msgid "24p/24p"
 msgstr "24p/24p"
 
-#, fuzzy
 msgid "24p/25p"
-msgstr "24p/24p"
+msgstr ""
 
-#, fuzzy
 msgid "24p/30p"
-msgstr "24p/50p"
+msgstr ""
 
 msgid "24p/50p"
 msgstr "24p/50p"
@@ -1718,9 +1708,8 @@ msgstr "256"
 msgid "256 Mb"
 msgstr "256 Mb"
 
-#, fuzzy
 msgid "25p/24p"
-msgstr "24p/24p"
+msgstr ""
 
 msgid "25p/25p"
 msgstr ""
@@ -1728,31 +1717,29 @@ msgstr ""
 msgid "25p/30p"
 msgstr ""
 
-#, fuzzy
 msgid "25p/50p"
-msgstr "24p/50p"
+msgstr ""
 
-#, fuzzy
 msgid "25p/60p"
-msgstr "24p/60p"
+msgstr ""
 
 msgid "29.97"
 msgstr "29.97"
 
 msgid "2X"
-msgstr "2X"
+msgstr "2x"
 
 msgid "2nd Infobar ECM"
-msgstr "2nd Infobar ECM"
+msgstr "Second infobar ECM"
 
 msgid "2nd Infobar INFO"
-msgstr "2nd Infobar INFO"
+msgstr "Second infobar INFO"
 
 msgid "2nd Infobar timeout"
-msgstr "2nd Infobar timeout"
+msgstr "Second infobar timeout"
 
 msgid "2nd infobar"
-msgstr "2nd infobar"
+msgstr "Second infobar"
 
 msgid "2s"
 msgstr "2s"
@@ -1772,9 +1759,8 @@ msgstr "2x, 4x, 6x, 8x"
 msgid "3"
 msgstr "3"
 
-#, fuzzy
 msgid "3 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "3.5s"
 msgstr "3.5s"
@@ -1788,24 +1774,20 @@ msgstr "30 min."
 msgid "30 minutes"
 msgstr "30 minutes"
 
-#, fuzzy
 msgid "30p/24p"
-msgstr "50p/24p"
+msgstr ""
 
-#, fuzzy
 msgid "30p/25p"
-msgstr "50p/24p"
+msgstr ""
 
 msgid "30p/30p"
 msgstr ""
 
-#, fuzzy
 msgid "30p/50p"
-msgstr "50p/50p"
+msgstr ""
 
-#, fuzzy
 msgid "30p/60p"
-msgstr "50p/60p"
+msgstr ""
 
 msgid "32"
 msgstr "32"
@@ -1814,7 +1796,7 @@ msgid "32 Mb"
 msgstr "32 Mb"
 
 msgid "3D Mode"
-msgstr "3D Mode"
+msgstr "3D mode"
 
 msgid "3D Surround"
 msgstr "3D Surround"
@@ -1823,7 +1805,7 @@ msgid "3D Surround Speaker Position"
 msgstr "3D Surround Speaker Position"
 
 msgid "3X"
-msgstr "3X"
+msgstr "3x"
 
 msgid "3d mode"
 msgstr "3d mode"
@@ -1837,9 +1819,8 @@ msgstr "4"
 msgid "4 GB"
 msgstr "4 GB"
 
-#, fuzzy
 msgid "4 hours"
-msgstr "24+ Hours"
+msgstr ""
 
 msgid "420"
 msgstr "420"
@@ -1860,10 +1841,10 @@ msgid "4:3 Letterbox"
 msgstr "4:3 Letterbox"
 
 msgid "4:3 PanScan"
-msgstr "4:3 PanScan"
+msgstr "4:3 Pan and Scan"
 
 msgid "4X"
-msgstr "4X"
+msgstr "4x"
 
 msgid "4_3_letterbox"
 msgstr "4_3_letterbox"
@@ -1877,9 +1858,8 @@ msgstr "4s"
 msgid "5"
 msgstr "5"
 
-#, fuzzy
 msgid "5 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "5 min."
 msgstr "5 min."
@@ -1893,13 +1873,11 @@ msgstr ""
 msgid "50p/24p"
 msgstr "50p/24p"
 
-#, fuzzy
 msgid "50p/25p"
-msgstr "50p/24p"
+msgstr ""
 
-#, fuzzy
 msgid "50p/30p"
-msgstr "50p/50p"
+msgstr ""
 
 msgid "50p/50p"
 msgstr "50p/50p"
@@ -1916,9 +1894,8 @@ msgstr "5s"
 msgid "6"
 msgstr "6"
 
-#, fuzzy
 msgid "6 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "60 minutes"
 msgstr "60 minutes"
@@ -1926,13 +1903,11 @@ msgstr "60 minutes"
 msgid "60p/24p"
 msgstr "60p/24p"
 
-#, fuzzy
 msgid "60p/25p"
-msgstr "60p/24p"
+msgstr ""
 
-#, fuzzy
 msgid "60p/30p"
-msgstr "60p/50p"
+msgstr ""
 
 msgid "60p/50p"
 msgstr "60p/50p"
@@ -1949,9 +1924,8 @@ msgstr "64 Mb"
 msgid "7"
 msgstr "7"
 
-#, fuzzy
 msgid "7 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "720p"
 msgstr "720p"
@@ -1974,12 +1948,11 @@ msgstr "8 GB"
 msgid "8 character"
 msgstr "8 character"
 
-#, fuzzy
 msgid "8 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "8bit"
-msgstr ""
+msgstr "8-bit"
 
 msgid "9"
 msgstr "9"
@@ -1994,13 +1967,13 @@ msgid "< Default >"
 msgstr "< Default >"
 
 msgid "< Default with Picon >"
-msgstr "< Default with Picon >"
+msgstr "< Default with picon >"
 
 msgid "< User Skin >"
 msgstr "< User Skin >"
 
 msgid "<Current movielist location>"
-msgstr "<Current movielist location>"
+msgstr "<Current movie list location>"
 
 msgid "<Default movie location>"
 msgstr "<Default movie location>"
@@ -2029,12 +2002,12 @@ msgid ""
 "Extend sleep timer 30 minutes. Your %s %s\n"
 "will shut down after Recording or Powertimer event. Get in Standby now?"
 msgstr ""
-"A Recording, RecordTimer or PowerTimer is running or begins in 15 minutes.\n"
+"A recording, record timer or power timer is running or will begin soon.\n"
 "Extend sleep timer 30 minutes. Your %s %s\n"
-"will shut down after Recording or Powertimer event. Get in Standby now?"
+"will shut down after the recording or power timer event. Go to standby now?"
 
 msgid "A background update check is in progress, please wait a few minutes and try again."
-msgstr "A background update check is in progress, please wait a few minutes and try again."
+msgstr "A background update check is in progress, please try again later."
 
 #, python-format
 msgid ""
@@ -2042,33 +2015,33 @@ msgid ""
 "Do you want to keep your modifications?"
 msgstr ""
 "A configuration file (%s) has been modified since it was installed.\n"
-"Do you want to keep your modifications?"
+"Would you like to keep your modifications?"
 
 #, python-format
 msgid ""
 "A configuration file (%s) was modified since Installation.\n"
 "Do you want to keep your version?"
 msgstr ""
-"A configuration file (%s) was modified since Installation.\n"
-"Do you want to keep your version?"
+"A configuration file (%s) was modified since installation.\n"
+"Would you like to keep your version?"
 
 #, python-format
 msgid "A crashlog was %s created in '%s'"
-msgstr ""
+msgstr "A crash log has been saved %s to %s"
 
 #, python-format
 msgid ""
 "A finished powertimer wants to reboot your %s %s.\n"
 "Do that now?"
 msgstr ""
-"A finished powertimer wants to reboot your %s %s.\n"
+"A power timer wants to reboot your %s %s.\n"
 "Do that now?"
 
 msgid ""
 "A finished powertimer wants to restart the user interface.\n"
 "Do that now?"
 msgstr ""
-"A finished powertimer wants to restart the user interface.\n"
+"A power timer wants to restart your receiver's user interface.\n"
 "Do that now?"
 
 #, python-format
@@ -2076,15 +2049,15 @@ msgid ""
 "A finished powertimer wants to set your\n"
 "%s %s to standby. Do that now?"
 msgstr ""
-"A finished powertimer wants to set your\n"
-"%s %s to standby. Do that now?"
+"A power timer wants to set your %s %s to standby.\n"
+"Do that now?"
 
 #, python-format
 msgid ""
 "A finished powertimer wants to shutdown your %s %s.\n"
 "Do that now?"
 msgstr ""
-"A finished powertimer wants to shutdown your %s %s.\n"
+"A power timer wants to shut down your %s %s.\n"
 "Do that now?"
 
 #, python-format
@@ -2092,7 +2065,7 @@ msgid ""
 "A finished record timer wants to set your\n"
 "%s %s to standby. Do that now?"
 msgstr ""
-"A finished record timer wants to set your\n"
+"A finished recording timer wants to set your\n"
 "%s %s to standby. Do that now?"
 
 #, python-format
@@ -2100,51 +2073,49 @@ msgid ""
 "A finished record timer wants to shut down\n"
 "your %s %s. Shutdown now?"
 msgstr ""
-"A finished record timer wants to shut down\n"
+"A finished recording timer wants to shut down\n"
 "your %s %s. Shutdown now?"
 
 #, python-format
 msgid ""
 "A recording has been started:\n"
 "%s"
-msgstr ""
-"A recording has been started:\n"
-"%s"
+msgstr "Started recording %s"
 
 msgid ""
 "A recording is currently running.\n"
 "What do you want to do?"
 msgstr ""
-"A recording is currently running.\n"
-"What do you want to do?"
+"There's a recording in progress.\n"
+"What would you like to do?"
 
 msgid "A recording is currently running. Please stop the recording before trying to configure the positioner."
-msgstr "A recording is currently running. Please stop the recording before trying to configure the positioner."
+msgstr "A recording is currently in progress. Please stop recording before trying to configure the positioner."
 
 msgid "A recording is currently running. Please stop the recording before trying to scan."
-msgstr "A recording is currently running. Please stop the recording before trying to scan."
+msgstr "A recording is currently in progress. Please stop recording before trying to scan."
 
 msgid "A recording is currently running. Please stop the recording before trying to start the satfinder."
-msgstr "A recording is currently running. Please stop the recording before trying to start the satfinder."
+msgstr "A recording is currently in progress. Please stop recording before trying to start the sat finder."
 
 msgid "A repeating timer or just once?"
-msgstr "A repeating timer or just once?"
+msgstr "Choose how often this timer should occur."
 
 #, python-format
 msgid "A required tool (%s) was not found."
 msgstr "A required tool (%s) was not found."
 
 msgid "A search for available updates is currently in progress."
-msgstr "A search for available updates is currently in progress."
+msgstr "Searching for available updates..."
 
 msgid ""
 "A second configured interface has been found.\n"
 "\n"
 "Do you want to disable the second network interface?"
 msgstr ""
-"A second configured interface has been found.\n"
+"A second network interface has been found.\n"
 "\n"
-"Do you want to disable the second network interface?"
+"Would you like to disable that interface?"
 
 #, python-format
 msgid ""
@@ -2186,21 +2157,21 @@ msgid ""
 "Abort pseudo recordings (e.g. EPG refresh) and try again?\n"
 msgstr ""
 "A timer failed to record!\n"
-"Abort pseudo recordings (e.g. EPG refresh) and try again?\n"
+"Stop pseudo recordings (e.g. EPGrefresh) and try again?\n"
 
 msgid ""
 "A timer failed to record!\n"
 "Abort streaming and try again?\n"
 msgstr ""
 "A timer failed to record!\n"
-"Abort streaming and try again?\n"
+"Stop streaming and try again?\n"
 
 msgid ""
 "A timer failed to record!\n"
-"Disable PIP and try again?\n"
+"Disable PiP and try again?\n"
 msgstr ""
 "A timer failed to record!\n"
-"Disable PIP and try again?\n"
+"Stop Picture-in-Picture and try again?\n"
 
 msgid ""
 "A timer failed to record!\n"
@@ -2209,38 +2180,36 @@ msgstr ""
 "A timer failed to record!\n"
 "Disable TV and try again?\n"
 
-#, fuzzy
 msgid "AAC Plus downmix"
-msgstr "AAC downmix"
+msgstr "AAC+ / aacPlus / AAC-HE v1 downmix"
 
 msgid "AAC downmix"
 msgstr "AAC downmix"
 
-#, fuzzy
 msgid "AAC plus downmix"
-msgstr "AAC downmix"
+msgstr "AAC+ / aacPlus / AAC-HE v1 downmix"
 
 msgid "AAC transcoding"
 msgstr "AAC transcoding"
 
 msgid "AC3"
-msgstr "AC3"
+msgstr "Dolby Digital / Dolby AC-3"
 
 msgid "AC3 downmix"
-msgstr "AC3 downmix"
+msgstr "Downmix Dolby Digital / Dolby AC-3"
 
 msgid "AC3 plus transcoding"
-msgstr "AC3 plus transcoding"
+msgstr "Dolby Digital Plus (AC3+ / DD+ / E-AC-3 / EC-3) transcoding"
 
 msgid "AC3/Dolby offset"
-msgstr "AC3/Dolby offset"
+msgstr "Dolby Digital / Dolby AC-3 volume offset"
 
 msgid "AC3plus transcoding"
-msgstr "AC3plus transcoding"
+msgstr "Dolby Digital Plus (AC3+ / DD+ / E-AC-3 / EC-3) transcoding"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "AFL"
-msgstr "AFP"
+msgstr "AFL"
 
 msgid "AFP"
 msgstr "AFP"
@@ -2264,21 +2233,21 @@ msgstr "AV aspect is %s."
 msgid "AZPlay"
 msgstr "AZPlay"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Abenteuer"
-msgstr "center"
+msgstr "Adventure"
 
 msgid "Abort"
 msgstr "Abort"
 
 msgid "Aborted a pseudo recording.\n"
-msgstr "Aborted a pseudo recording.\n"
+msgstr "Stopped a pseudo recording.\n"
 
 msgid "Aborted a streaming service.\n"
-msgstr "Aborted a streaming service.\n"
+msgstr "Stopped a streaming service.\n"
 
 msgid "Aborting updateprogress"
-msgstr "Aborting updateprogress"
+msgstr "Canceling update progress..."
 
 msgid "About"
 msgstr "About"
@@ -2286,75 +2255,75 @@ msgstr "About"
 msgid "About..."
 msgstr "About..."
 
-#, fuzzy
 msgid "Accept the current selection"
-msgstr "Activate current configuration"
+msgstr "Accept the current selection"
 
-#, fuzzy
 msgid "Accessed:"
-msgstr "Accesspoint:"
+msgstr "Accessed:"
 
 msgid "Accesspoint:"
-msgstr "Accesspoint:"
+msgstr "Access point:"
 
-#, fuzzy
 msgid "Action"
-msgstr "Diction"
+msgstr "Action"
 
 msgid "Action on long powerbutton press"
-msgstr "Action on long powerbutton press"
+msgstr "Power button hold"
 
 msgid "Action on short powerbutton press"
-msgstr "Action on short powerbutton press"
+msgstr "Power button"
 
 msgid "Activate"
 msgstr "Activate"
 
 msgid "Activate HbbTV (Redbutton)"
-msgstr "Activate HbbTV (Redbutton)"
+msgstr "Activate HbbTV (Red button)"
 
 msgid "Activate MAC-address configuration"
-msgstr "Activate MAC-address configuration"
+msgstr "Activate MAC address configuration"
 
 msgid "Activate Picture in Picture"
-msgstr "Activate Picture in Picture"
+msgstr "Start Picture-in-Picture Mode"
 
 #, python-format
 msgid "Activate an way to send individual or specific internal HDMI-CEC commands from the command line. Type on command line 'echo help > %s' and then read the file '%s' for a short help."
 msgstr ""
+"Enable a way to send individual or specific internal HDMI-CEC commands. Type the following on the command line:\n"
+"echo help > %s\n"
+"then read the file '%s' for quick help."
 
 msgid "Activate current configuration"
 msgstr "Activate current configuration"
 
 msgid "Activate left-hand file list as multi-select source"
-msgstr ""
+msgstr "Set left side as multi-select source"
 
 msgid "Activate left-hand file list as source"
-msgstr ""
+msgstr "Set left side as source"
 
 msgid "Activate network settings"
 msgstr "Activate network settings"
 
 msgid "Activate right-hand file list as multi-select source"
-msgstr ""
+msgstr "Set right side as multi-select source"
 
 msgid "Activate right-hand file list as source"
-msgstr ""
+msgstr "Set right side as source"
 
 msgid "Activate the configured network settings."
 msgstr "Activate the configured network settings."
 
 msgid "Activate timeshift End"
-msgstr "Activate timeshift End"
+msgstr "End timeshift mode"
 
 msgid "Activate timeshift end and pause"
-msgstr "Activate timeshift end and pause"
+msgstr "End timeshift mode and pause"
 
 msgid "Activation takes place immediately. If it does feature not work, then try again with a slower send interval."
-msgstr ""
+msgstr "Activation will take place immediately. If the feature doesn't work, try again with a longer send interval."
 
 msgid "Activation takes place immediately. If this feature is not supported, the volume keys has no function!"
-msgstr ""
+msgstr "Activation will take place immediately. If the feature isn't supported, the volume buttons will have no effect."
 
 msgid "Active"
 msgstr "Active"
@@ -2374,23 +2343,20 @@ msgstr "Add AutoTimer"
 msgid "Add New Quad Channel Entry"
 msgstr "Add New Quad Channel Entry"
 
-#, fuzzy
 msgid "Add Record Timer"
 msgstr "Add a record timer"
 
 msgid "Add Timer"
-msgstr "Add Timer"
+msgstr "Add timer"
 
-#, fuzzy
 msgid "Add Zap Timer"
-msgstr "Add Timer"
+msgstr "Add a zap timer"
 
-#, fuzzy
 msgid "Add Zap+Record Timer"
-msgstr "Add a record timer"
+msgstr "Add a zap + record timer"
 
 msgid "Add a auto timer for current event"
-msgstr "Add a auto timer for current event"
+msgstr "Add an AutoTimer for the current event"
 
 msgid "Add a mark"
 msgstr "Add a mark"
@@ -2420,7 +2386,7 @@ msgid "Add current folder to bookmarks"
 msgstr ""
 
 msgid "Add directory to playlist"
-msgstr "Add directory to playlist"
+msgstr "Add folder to playlist"
 
 msgid "Add file to playlist"
 msgstr "Add file to playlist"
@@ -2429,32 +2395,32 @@ msgid "Add files to playlist"
 msgstr "Add files to playlist"
 
 msgid "Add plugin to Extensions menu*"
-msgstr ""
+msgstr "Add plugin to Extensions menu *"
 
 msgid "Add plugin to main menu*"
-msgstr ""
+msgstr "Add plugin to Main menu *"
 
 msgid "Add provider"
 msgstr "Add provider"
 
 msgid "Add recording (enter recording duration)"
-msgstr "Add recording (enter recording duration)"
+msgstr "Record for a specified duration"
 
 msgid "Add recording (enter recording endtime)"
-msgstr "Add recording (enter recording endtime)"
+msgstr "Record with a specified end time"
 
 msgid "Add recording (indefinitely)"
-msgstr "Add recording (indefinitely)"
+msgstr "Record indefinitely"
 
 msgid "Add recording (stop after current event)"
-msgstr "Add recording (stop after current event)"
+msgstr "Record the current event"
 
 #, fuzzy
 msgid "Add selected folder to bookmarks"
 msgstr "Select files/folders to backup"
 
 msgid "Add service"
-msgstr "Add service"
+msgstr "Add channel"
 
 msgid "Add timer"
 msgstr "Add timer"
@@ -2463,7 +2429,7 @@ msgid "Add title"
 msgstr "Add title"
 
 msgid "Add/Remove Timer"
-msgstr "Add/Remove Timer"
+msgstr "add/remove timer"
 
 msgid "Add/Remove timer for current event"
 msgstr "Add/Remove timer for current event"
@@ -2478,13 +2444,13 @@ msgid "Additional Info"
 msgstr "Additional Info"
 
 msgid "Additional files/folders to backup"
-msgstr "Additional files/folders to backup"
+msgstr "Additional files/folders to back up"
 
 msgid "Additional motor options allow you to enter details from your motor's spec sheet so enigma can work out how long it will take to move the dish from one satellite to another satellite."
-msgstr ""
+msgstr "Additional options allow you to enter details from your dish rotator's spec sheet so your receiver can work out how long it will take to move the dish from one satellite to another."
 
-msgid "Additional motor options allow you to enter details from your motor's spec sheet so enigma can work out how long it will take to move to another satellite."
-msgstr ""
+msgid "Additional rotator options allow you to enter details from your motor's spec sheet so your receiver can work out how long it will take to move to another satellite."
+msgstr "Additional options allow you to enter details from your dish rotator's spec sheet so your receiver can work out how long it will take to move to another satellite."
 
 msgid "Address"
 msgstr "Address"
@@ -2496,29 +2462,32 @@ msgid "Adjust 3D settings"
 msgstr "Adjust 3D settings"
 
 msgid "Adjust the color settings so that all the color shades are distinguishable, but appear as saturated as possible. If you are happy with the result, press OK to close the video fine-tuning, or use the number keys to select other test screens."
-msgstr "Adjust the color settings so that all the color shades are distinguishable, but appear as saturated as possible. If you are happy with the result, press OK to close the video fine-tuning, or use the number keys to select other test screens."
+msgstr ""
+"Adjust the color settings so that all of the color shades are distinguishable, but appear as saturated (rich) as possible.\n"
+"Press OK to close the video fine-tuning wizard when you're happy with the result; otherwise use the number buttons to show other test screens."
 
 msgid "Adjust the horizontal position of the letters used for teletext."
 msgstr "Adjust the horizontal position of the letters used for teletext."
 
 msgid "Adjust the vertical position of the letters used for teletext."
-msgstr "Adjust the vertical position of the letters used for teletext."
+msgstr "Adjust the vertical position of the letters used for teletext, measured from the bottom of the screen."
 
+#. TRANSLATORS: genre category
 msgid "Adult"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Adult Audience, Strong Violence 15+"
 msgstr ""
 
 msgid "Advanced"
-msgstr "Advanced"
+msgstr "advanced"
 
 msgid "Advanced Options"
 msgstr "Advanced Options"
 
-#, fuzzy
 msgid "Advanced Settings"
-msgstr "Advanced Options"
+msgstr "Advanced settings"
 
 msgid "Advanced options"
 msgstr "Advanced options"
@@ -2535,68 +2504,74 @@ msgstr "Advanced software plugin"
 msgid "Advanced video enhancement setup"
 msgstr "Advanced video enhancement setup"
 
+#. TRANSLATORS: genre category
 msgid "Adventure"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Afghanistan"
 msgstr "Afghanistan"
 
 msgid "After PowerLost"
-msgstr "After PowerLost"
+msgstr "After power loss"
 
 msgid "After Recording"
-msgstr "After Recording"
+msgstr "After recording"
 
 msgid "After event"
 msgstr "After event"
 
 msgid "After pressing OK, please wait!"
-msgstr "After pressing OK, please wait!"
+msgstr "Please wait after pressing OK!"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Agenten"
-msgstr "Argentina"
+msgstr "Agents"
 
+#. TRANSLATORS: regional option
 msgid "Aland Islands"
 msgstr "Aland Islands"
 
+#. TRANSLATORS: regional option
 msgid "Albania"
 msgstr "Albania"
 
 msgid "Album"
 msgstr "Album"
 
+#. TRANSLATORS: regional option
 msgid "Algeria"
 msgstr "Algeria"
 
 msgid "Alias"
 msgstr "Alias"
 
-#, fuzzy
 msgid "Alignment channel number"
-msgstr "Input channel name."
+msgstr "Align channel number"
 
-#, fuzzy
 msgid "Alignment event-progress"
-msgstr "Alignment of events"
+msgstr "Align event progress"
+
+msgid "Alignment event title"
+msgstr "Align event title"
 
 msgid "Alignment of events"
-msgstr "Alignment of events"
+msgstr "Align event title"
 
 msgid "Alignment of service names"
-msgstr "Alignment of service names"
+msgstr "Align channel name"
 
 msgid "All"
 msgstr "All"
 
 msgid "All Services"
-msgstr "All Services"
+msgstr "All Channels"
 
 msgid "All ages"
 msgstr "All ages"
 
 msgid "All resolutions"
-msgstr "All resolutions"
+msgstr "all resolutions"
 
 msgid "All satellites 1 (USALS)"
 msgstr "All satellites 1 (USALS)"
@@ -2617,78 +2592,79 @@ msgid "Allocate"
 msgstr "Allocate"
 
 msgid "Allocate a number to the physical LNB you are configuring. You will be able to select this LNB again for other satellites (e.g. motorised dishes) to save setting up the same LNB multiple times."
-msgstr ""
+msgstr "Allocate a number to the physical LNB you're configuring. You'll be able to select this LNB again for other satellites (e.g. motorized dishes) to avoid having to set up the same LNB multiple times."
 
 msgid "Allocate unused memory index"
 msgstr "Allocate unused memory index"
 
 msgid "Allow 10bit"
-msgstr ""
+msgstr "Allow 10-bit"
 
 msgid "Allow 12bit"
-msgstr ""
+msgstr "Allow 12-bit"
 
 msgid "Allow quit movieplayer with exit"
-msgstr "Allow quit movieplayer with exit"
+msgstr "Use EXIT button to quit movie player"
 
 msgid "Allow subtitle language to equal audio language"
-msgstr "Allow subtitle language to equal audio language"
+msgstr "Allow subtitle language to match audio language"
 
 msgid "Allow subtitles for hearing impaired"
-msgstr "Allow subtitles for hearing impaired"
+msgstr "Allow subtitles for the hearing impaired"
 
 msgid "Allow unstable (untested) updates"
 msgstr "Allow unstable (untested) updates"
 
-#, fuzzy
 msgid "Allow unsupported modes"
-msgstr "not supported"
+msgstr "Allow unsupported modes"
 
 msgid "Allows the %s %s to read the stored EPG data regularly."
-msgstr "Allows the %s %s to read the stored EPG data regularly."
+msgstr "Allows your %s %s to read the stored EPG data regularly."
 
 msgid "Allows the %s %s to store the EPG data regularly."
-msgstr "Allows the %s %s to store the EPG data regularly."
+msgstr "Allows your %s %s to store the EPG data regularly."
 
 msgid "Allows you to adjust the amount of time the resolution information display on screen."
-msgstr "Allows you to adjust the amount of time the resolution information display on screen."
+msgstr "Choose how long resolution information should stay on screen for."
 
 msgid "Allows you to enable the debug log. They contain very detailed information of everything the system does."
-msgstr "Allows you to enable the debug log. They contain very detailed information of everything the system does."
+msgstr ""
+"This option lets you choose whether to enable debug logging.\n"
+"These logs contain detailed information of everything the system does, and can be very useful when troubleshooting problems."
 
 #, fuzzy
 msgid "Allows you to enable the twisted log. They contain very detailed information of everything the twisted does. ('/tmp/twisted.log')"
-msgstr "Allows you to enable the debug log. They contain very detailed information of everything the system does."
+msgstr "This option lets you enable the debug log. They contain very detailed information of everything the system does."
 
 msgid "Allows you to enable/disable displaying icons on the frontpanel."
-msgstr "Allows you to enable/disable displaying icons on the frontpanel."
+msgstr "Choose whether to show symbols on the front panel display."
 
 msgid "Allows you to hide the extensions of known file types."
-msgstr "Allows you to hide the extensions of known file types."
+msgstr "This option lets you hide known file type extensions."
 
 msgid "Allows you to set the maximum size of the Debug log size (MB). When that size is reached, a new file will be created."
-msgstr "Allows you to set the maximum size of the Debug log size (MB). When that size is reached, a new file will be created."
+msgstr "This option lets you set the maximum size of the debug log in MB. When that size is reached, a new file will be created."
 
 msgid "Allows you to setup the button to do what you choose."
-msgstr "Allows you to setup the button to do what you choose."
+msgstr "Choose what you'd like the button to do."
 
 msgid "Allows you to show/hide CCcam in extensions (blue button)."
-msgstr "Allows you to show/hide CCcam in extensions (blue button)."
+msgstr "Choose whether to show CCcam on the Extensions screen (Blue button)."
 
 msgid "Allows you to show/hide Log Manager in extensions (blue button)."
-msgstr "Allows you to show/hide Log Manager in extensions (blue button)."
+msgstr "Choose whether to show Log Manager on the Extensions screen (Blue button)."
 
 msgid "Allows you to show/hide OScam in extensions (blue button)."
-msgstr "Allows you to show/hide OScam in extensions (blue button)."
+msgstr "Choose whether to show OScam on the Extensions screen (Blue button)."
 
 msgid "Almost there... "
 msgstr ""
 
 msgid "Alpha"
-msgstr "Alpha"
+msgstr "Letter"
 
 msgid "Alphanumeric"
-msgstr "Alphanumeric"
+msgstr "alphanumeric"
 
 msgid "Also on standby"
 msgstr "Also on standby"
@@ -2696,13 +2672,11 @@ msgstr "Also on standby"
 msgid "Alternative"
 msgstr "Alternative"
 
-#, fuzzy
 msgid "Alternative 1"
-msgstr "Alternative"
+msgstr "Alternative 1"
 
-#, fuzzy
 msgid "Alternative 2"
-msgstr "Alternative"
+msgstr "Alternative 2"
 
 msgid "Alternative numbering mode"
 msgstr "Alternative numbering mode"
@@ -2714,7 +2688,7 @@ msgid "Alternative services tuner priority"
 msgstr "Alternative services tuner priority"
 
 msgid "Always ask"
-msgstr "Always ask"
+msgstr "always ask"
 
 msgid "Always hide infobar"
 msgstr "Always hide infobar"
@@ -2723,11 +2697,10 @@ msgid "Always include ECM in recordings"
 msgstr "Always include ECM in recordings"
 
 msgid "Always include ECM messages in recordings. This overrides the individual timer settings globally. It allows recordings to be always decrypted afterwards (sometimes called offline decoding), if supported by your receiver. Default: off."
-msgstr "Always include ECM messages in recordings. This overrides the individual timer settings globally. It allows recordings to be always decrypted afterwards (sometimes called offline decoding), if supported by your receiver. Default: off."
+msgstr "Always include ECM data in recordings. This overrides the individual timer settings globally and (if your receiver supports it) allows recordings to always be decrypted later (sometimes called offline decoding). Default: 'off'."
 
-#, fuzzy
 msgid "Always select OK"
-msgstr "Always ask"
+msgstr "Always select 'OK'"
 
 msgid "Always show bouquets"
 msgstr "Always show bouquets"
@@ -2735,16 +2708,17 @@ msgstr "Always show bouquets"
 msgid "Always use smart1080p mode"
 msgstr "Always use smart1080p mode"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "American Football"
-msgstr "American Samoa"
+msgstr "American Football"
 
+#. TRANSLATORS: regional option
 msgid "American Samoa"
 msgstr "American Samoa"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "American Sports"
-msgstr "American Samoa"
+msgstr "American Sports"
 
 msgid ""
 "An attempt is made to capture the current TV status. If this is not possible due to incorrect or missing status messages, it may cause the receiver to respond unexpectedly.\n"
@@ -2755,23 +2729,25 @@ msgid "An empty filename is illegal."
 msgstr "An empty filename is illegal."
 
 msgid "An error occurred while downloading the packetlist. Please try again."
-msgstr "An error occurred while downloading the packetlist. Please try again."
+msgstr "Something went wrong while downloading the package list, please try again!"
 
 msgid "An unknown error occurred!"
-msgstr "An unknown error occurred!"
+msgstr "An unknown problem occurred!"
 
+#. TRANSLATORS: regional option
 msgid "Andorra"
 msgstr "Andorra"
 
+#. TRANSLATORS: regional option
 msgid "Angola"
 msgstr "Angola"
 
+#. TRANSLATORS: regional option
 msgid "Anguilla"
 msgstr "Anguilla"
 
-#, fuzzy
 msgid "Animation"
-msgstr "Animations"
+msgstr ""
 
 msgid "Animation Setup"
 msgstr "Animation Setup"
@@ -2782,63 +2758,65 @@ msgstr "Animation Speed"
 msgid "Animations"
 msgstr "Animations"
 
+#. TRANSLATORS: genre category
 msgid "Anime"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Antarctica"
 msgstr "Antarctica"
 
+#. TRANSLATORS: regional option
 msgid "Antigua and Barbuda"
 msgstr "Antigua and Barbuda"
 
 msgid "Any activity"
 msgstr "Any activity"
 
+#. TRANSLATORS: regional option
 msgid "Arabic"
 msgstr "Arabic"
 
+#. TRANSLATORS: genre category
 msgid "Architektur"
-msgstr ""
+msgstr "Architecture"
 
 msgid "Are you ready to run the script ?"
-msgstr "Are you ready to run the script ?"
+msgstr "Are you ready to run the script?"
 
 msgid "Are you sure to cancel all changes?"
-msgstr "Are you sure to cancel all changes"
+msgstr "Are you sure you want to cancel your changes?"
 
-#, fuzzy
 msgid "Are you sure to delete all cuts and marks?"
-msgstr "Are you sure to cancel all changes"
+msgstr "Are you sure you want to delete all cuts and marks?"
 
 msgid "Are you sure to purge all deleted userbouquets?"
-msgstr "Are you sure to purge all deleted userbouquets?"
+msgstr "Are you sure you want to purge all previously deleted custom bouquets?"
 
 #, python-format
 msgid "Are you sure to remove all %d.%d%s%s services?"
-msgstr "Are you sure to remove all %d.%d%s%s services?"
+msgstr "Are you sure you want to remove all %d.%d%s%s channels?"
 
 msgid "Are you sure to remove all cable services?"
-msgstr "Are you sure to remove all cable services?"
+msgstr "Are you sure you want to remove all cable channels?"
 
 msgid "Are you sure to remove all terrestrial services?"
-msgstr "Are you sure to remove all terrestrial services?"
+msgstr "Are you sure you want to remove all terrestrial channels?"
 
 msgid "Are you sure to remove this entry?"
-msgstr "Are you sure to remove this entry?"
+msgstr "Are you sure you want to remove this entry?"
 
 msgid ""
 "Are you sure you want to activate this network configuration?\n"
 "\n"
 msgstr ""
-"Are you sure you want to activate this network configuration?\n"
+"Activate this network configuration?\n"
 "\n"
 
 msgid ""
 "Are you sure you want to delete\n"
 "the following backup:\n"
-msgstr ""
-"Are you sure you want to delete\n"
-"the following backup:\n"
+msgstr "Are you sure you want to delete this backup?\n"
 
 msgid "Are you sure you want to delete all selected logs:\n"
 msgstr "Are you sure you want to delete all selected logs:\n"
@@ -2846,33 +2824,33 @@ msgstr "Are you sure you want to delete all selected logs:\n"
 #, fuzzy, python-format
 msgid "Are you sure you want to delete image slot %s ?"
 msgstr ""
-"Are you sure you want to delete this:\n"
+"Are you sure you want to delete this?\n"
 " "
 
 msgid "Are you sure you want to delete the EPG data from:\n"
-msgstr "Are you sure you want to delete the EPG data from:\n"
+msgstr "Are you sure you want to delete the EPG data at\n"
 
 msgid "Are you sure you want to delete this log:\n"
-msgstr "Are you sure you want to delete this log:\n"
+msgstr "Are you sure you want to delete this log?\n"
 
 msgid ""
 "Are you sure you want to delete this:\n"
 " "
 msgstr ""
-"Are you sure you want to delete this:\n"
+"Are you sure you want to delete\n"
 " "
 
 msgid "Are you sure you want to exit this wizard?"
-msgstr "Are you sure you want to exit this wizard?"
+msgstr "Are you sure you want to exit the wizard?"
 
 msgid "Are you sure you want to reload the EPG data from:\n"
-msgstr "Are you sure you want to reload the EPG data from:\n"
+msgstr "Are you sure you want to reload the EPG data from\n"
 
 msgid ""
 "Are you sure you want to restart your network interfaces?\n"
 "\n"
 msgstr ""
-"Are you sure you want to restart your network interfaces?\n"
+"Are you sure you want to restart your network interface?\n"
 "\n"
 
 #, python-format
@@ -2882,9 +2860,9 @@ msgid ""
 "%s\n"
 "Your receiver will restart after the backup has been restored!"
 msgstr ""
-"Are you sure you want to restore\n"
-"the following backup:\n"
+"Are you sure you want to restore this backup?\n"
 "%s\n"
+"\n"
 "Your receiver will restart after the backup has been restored!"
 
 msgid ""
@@ -2892,6 +2870,7 @@ msgid ""
 "Your receiver will restart after the backup has been restored!"
 msgstr ""
 "Are you sure you want to restore the backup?\n"
+"\n"
 "Your receiver will restart after the backup has been restored!"
 
 #, python-format
@@ -2900,58 +2879,67 @@ msgid ""
 "STB will restart after the restore"
 msgstr ""
 "Are you sure you want to restore your %s %s backup?\n"
-"STB will restart after the restore"
+"\n"
+"Your receiver will restart when complete."
 
 msgid ""
 "Are you sure you want to restore your STB backup?\n"
 "STB will restart after the restore"
 msgstr ""
-"Are you sure you want to restore your STB backup?\n"
-"STB will restart after the restore"
+"Are you sure you want to restore your latest settings backup?\n"
+"\n"
+"Your receiver will restart when complete."
 
 msgid "Are you sure you want to save the EPG Cache to:\n"
-msgstr "Are you sure you want to save the EPG Cache to:\n"
+msgstr "Are you sure you want to save the EPG data to\n"
 
 msgid "Are you sure you want to send this log:\n"
-msgstr "Are you sure you want to send this log:\n"
+msgstr "Are you sure you want to send the log\n"
 
 #, python-format
 msgid "Are you sure you want to update your %s %s ?"
-msgstr "Are you sure you want to update your %s %s ?"
+msgstr "Are you sure you want to update your %s %s?"
 
+#. TRANSLATORS: regional option
 msgid "Argentina"
 msgstr "Argentina"
 
+#. TRANSLATORS: regional option
 msgid "Armenia"
 msgstr "Armenia"
 
+#. TRANSLATORS: genre category
 msgid "Artist"
 msgstr "Artist"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "Arts & Culture"
 msgstr "Arts/Culture"
 
+#. TRANSLATORS: genre category
 msgid "Arts/Culture"
 msgstr "Arts/Culture"
 
+#. TRANSLATORS: regional option
 msgid "Aruba"
 msgstr "Aruba"
 
+#. TRANSLATORS: genre category
 msgid "Arzt"
-msgstr ""
+msgstr "Doctor"
 
 msgid "Ask user"
-msgstr "Ask user"
+msgstr "ask user"
 
 msgid "Ask user (with default as 'no')"
-msgstr "Ask user (with default as 'no')"
+msgstr "ask user (default to 'no')"
 
 msgid "Ask user (with default as 'yes')"
-msgstr "Ask user (with default as 'yes')"
+msgstr "ask user (default to 'yes')"
 
 msgid "Aspect"
-msgstr "Aspect"
+msgstr "Aspect press"
 
 msgid "Aspect Ratio"
 msgstr "Aspect Ratio"
@@ -2960,7 +2948,7 @@ msgid "Aspect list..."
 msgstr "Aspect list..."
 
 msgid "Aspect long"
-msgstr "Aspect long"
+msgstr "Aspect button hold"
 
 msgid "Aspect ratio"
 msgstr "Aspect ratio"
@@ -2983,9 +2971,9 @@ msgstr ""
 msgid "At End:"
 msgstr "At End:"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Athletics"
-msgstr "athletics"
+msgstr ""
 
 msgid "Attach a file"
 msgstr "Attach a file"
@@ -2997,7 +2985,7 @@ msgid "Audio Auto Volume Level"
 msgstr "Audio Auto Volume Level"
 
 msgid "Audio Channel"
-msgstr "Audio Channel"
+msgstr "Audio channel"
 
 msgid "Audio PID"
 msgstr "Audio PID"
@@ -3015,40 +3003,41 @@ msgid "Audio Sync"
 msgstr "Audio Sync"
 
 msgid "Audio language selection 1"
-msgstr "Audio language selection 1"
+msgstr "Audio language 1"
 
 msgid "Audio language selection 2"
-msgstr "Audio language selection 2"
+msgstr "Audio language 2"
 
 msgid "Audio language selection 3"
-msgstr "Audio language selection 3"
+msgstr "Audio language 3"
 
 msgid "Audio language selection 4"
-msgstr "Audio language selection 4"
+msgstr "Audio language 4"
 
-#, fuzzy
 msgid "Audio long"
-msgstr "Radio long"
+msgstr "Audio button hold"
 
 msgid "Audio options..."
 msgstr "Audio options..."
 
 msgid "Audio settings"
-msgstr "Audio settings"
+msgstr "Audio Settings"
 
 msgid "Audio volume step size"
-msgstr "Audio volume step size"
+msgstr "Volume step size"
 
 msgid "Audio volume step size fast mode"
-msgstr "Audio volume step size fast mode"
+msgstr "Volume jump size"
 
+#. TRANSLATORS: regional option
 msgid "Australia"
 msgstr "Australia"
 
-#, fuzzy
+#. TRANSLATORS: regional option
 msgid "Australian"
-msgstr "Australia"
+msgstr "Australian"
 
+#. TRANSLATORS: regional option
 msgid "Austria"
 msgstr "Austria"
 
@@ -3064,9 +3053,8 @@ msgstr "Auto"
 msgid "Auto Deep Standby"
 msgstr "Auto Deep Standby"
 
-#, fuzzy
 msgid "Auto Detect"
-msgstr "Auto Deep Standby"
+msgstr "Auto Detect"
 
 msgid "Auto Language"
 msgstr "Auto Language"
@@ -3079,43 +3067,43 @@ msgid "Auto Modes Selected."
 msgstr "no CAId selected"
 
 msgid "Auto Standby"
-msgstr "Auto Standby"
+msgstr "Auto standby"
 
 msgid "Auto Timer"
-msgstr "Auto Timer"
+msgstr "AutoTimer"
 
 msgid "Auto Timers"
-msgstr "Auto Timers"
+msgstr "AutoTimers"
 
 msgid "Auto Volume Level"
 msgstr "Auto Volume Level"
 
 msgid "Auto chapter split every ? minutes (0=never)"
-msgstr "Auto chapter split every ? minutes (0=never)"
+msgstr "Auto chapter split every # minutes (0: never)"
 
 msgid "Auto flesh"
-msgstr "Auto flesh"
+msgstr "Automatic flesh tone"
 
 msgid "Auto focus"
 msgstr "Auto focus"
 
 msgid "Auto focus commencing ..."
-msgstr "Auto focus commencing ..."
+msgstr "Auto focus in progress..."
 
 msgid "Auto language selection"
-msgstr "Auto language selection"
+msgstr "Auto Language Selection"
 
 msgid "Auto scart switching"
 msgstr "Auto scart switching"
 
 msgid "Auto(not available)"
-msgstr "Auto(not available)"
+msgstr "Auto (not available)"
 
 msgid "AutoMountManager"
-msgstr "AutoMountManager"
+msgstr "Auto Mount Manager"
 
 msgid "AutoUpdate"
-msgstr "AutoUpdate"
+msgstr "Auto Update"
 
 msgid "Automatic"
 msgstr "Automatic"
@@ -3124,13 +3112,13 @@ msgid "Automatic Scan"
 msgstr "Automatic Scan"
 
 msgid "Automatic Service Searching"
-msgstr "Automatic Service Searching"
+msgstr "Search for channels automatically"
 
 msgid "Automatic image backup"
 msgstr "Automatic image backup"
 
 msgid "Automatic refresh"
-msgstr "Automatic refresh"
+msgstr "Refresh automatically"
 
 msgid "Automatic resolution"
 msgstr "Automatic resolution"
@@ -3139,13 +3127,13 @@ msgid "Automatic resolution label"
 msgstr "Automatic resolution label"
 
 msgid "Automatic save"
-msgstr "Automatic save"
+msgstr "Save automatically"
 
 msgid "Automatic scan"
 msgstr "Automatic scan"
 
 msgid "Automatic scan for services"
-msgstr "Automatic scan for services"
+msgstr "Automatic scan for channels."
 
 msgid "Automatic setting backup"
 msgstr "Automatic setting backup"
@@ -3154,23 +3142,23 @@ msgid "Automatically start timeshift after"
 msgstr "Automatically start timeshift after"
 
 msgid "Automatically turn on external subtitles"
-msgstr "Automatically turn on external subtitles"
+msgstr "Automatically use external subtitles"
 
 msgid "Automatically update Client/Server View?"
-msgstr "Automatically update Client/Server View?"
+msgstr "Automatically Update Client/Server View?"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Automobil"
-msgstr "Automatic"
+msgstr "Cars"
 
 msgid "Autorecord location"
-msgstr "Autorecord location"
+msgstr "auto-record location"
 
 msgid "Autostart"
 msgstr "Autostart"
 
 msgid "Autostart:"
-msgstr "Autostart:"
+msgstr "Autostart"
 
 msgid "Available format variables"
 msgstr "Available format variables"
@@ -3188,31 +3176,32 @@ msgstr "Avoid getting stuck (at the expense of some stuttering) when the jump ti
 msgid "Axas E4HD Ultra"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Azerbaijan"
 msgstr "Azerbaijan"
 
 msgid "B"
 msgstr "B"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "B-Movie"
-msgstr "Moving"
+msgstr "B-Movie"
 
 #, python-format
 msgid "BC%d"
 msgstr "BC%d"
 
 msgid "BDMV Bludisc (HDTV titles only)"
-msgstr "BDMV Bludisc (HDTV titles only)"
+msgstr "BDMV Blu-ray disc (HDTV titles only)"
 
 msgid "BDMV Compatible Bludisc (HDTV only)"
-msgstr "BDMV Compatible Bludisc (HDTV only)"
+msgstr "BDMV Compatible Blu-ray disc (HDTV only)"
 
 msgid "BER:"
 msgstr "BER:"
 
 msgid "BLUDISC RECORDABLE"
-msgstr "BLUDISC RECORDABLE"
+msgstr "Blu-ray disc recordable"
 
 msgid "BT 2020 CL"
 msgstr "BT 2020 CL"
@@ -3247,30 +3236,30 @@ msgid "Back"
 msgstr "Back"
 
 msgid "Back USB"
-msgstr "Back USB"
+msgstr "Rear USB"
 
 msgid "Back USB 3.0"
-msgstr "Back USB 3.0"
+msgstr "Rear USB 3.0"
 
 msgid "Back, inner USB"
-msgstr "Back, inner USB"
+msgstr "Rear, inner USB"
 
 msgid "Back, lower USB"
-msgstr "Back, lower USB"
+msgstr "Rear, lower USB"
 
 msgid "Back, outer USB"
-msgstr "Back, outer USB"
+msgstr "Rear, outer USB"
 
 msgid "Back, upper USB"
-msgstr "Back, upper USB"
+msgstr "Rear, upper USB"
 
 #, python-format
 msgid "Back-up Tool for a %s\n"
-msgstr "Back-up Tool for a %s\n"
+msgstr "Backup Tool for a %s\n"
 
-#, fuzzy, python-format
+#, python-format
 msgid "Back-up Tool for an %s\n"
-msgstr "Back-up Tool for a %s\n"
+msgstr "Backup Tool for an %s\n"
 
 msgid "Back/Recall"
 msgstr "Back/Recall"
@@ -3290,13 +3279,11 @@ msgstr "Background delete option"
 msgid "Background delete speed"
 msgstr "Background delete speed"
 
-#, fuzzy
 msgid "Background:"
-msgstr "Background"
+msgstr "Background:"
 
-#, fuzzy
 msgid "Backgroundselected:"
-msgstr "Background delete speed"
+msgstr "Background selected:"
 
 msgid "Backup"
 msgstr "Backup"
@@ -3306,7 +3293,7 @@ msgid "Backup Date: %s\n"
 msgstr "Backup Date: %s\n"
 
 msgid "Backup Image"
-msgstr "Backup Image"
+msgstr "Backup image"
 
 msgid "Backup Location"
 msgstr "Backup Location"
@@ -3321,61 +3308,60 @@ msgid "Backup Mode"
 msgstr "Backup Mode"
 
 msgid "Backup Settings"
-msgstr "Backup Settings"
+msgstr "Back up settings now"
 
 msgid "Backup completed."
-msgstr "Backup completed."
+msgstr "Backup complete!"
 
 msgid "Backup done."
-msgstr "Backup done."
+msgstr "Backup complete!"
 
 msgid "Backup failed."
 msgstr "Backup failed."
 
 msgid "Backup is running..."
-msgstr "Backup is running..."
+msgstr "Backing up..."
 
 msgid ""
 "Backup plugins found\n"
 "do you want to install now?"
 msgstr ""
-"Backup plugins found\n"
-"do you want to install now?"
+"Backup plugins were found\n"
+"would you like to install them now?"
 
-#, fuzzy
 msgid "Backup settings"
-msgstr "Backup Settings"
+msgstr "Backup settings"
 
 msgid "Backup system settings"
-msgstr "Backup system settings"
+msgstr "Back up system settings"
 
-#, fuzzy, python-format
+#, python-format
 msgid "Backup to destination: %s"
-msgstr "Backup Location"
+msgstr "Backup location: %s"
 
 msgid "Backup your current image"
-msgstr "Backup your current image"
+msgstr "Back up your current image"
 
 msgid "Backup your current image to HDD or USB. This will make a 1:1 copy of your box"
-msgstr "Backup your current image to HDD or USB. This will make a 1:1 copy of your box"
+msgstr "Back up your currently running image to HDD or USB. This will make a 1:1 copy of your receiver setup"
 
 msgid "Backup your current settings"
-msgstr "Backup your current settings"
+msgstr "Back up your current settings"
 
 msgid "Backup your current settings. This includes E2-setup, channels, network and all selected files"
-msgstr "Backup your current settings. This includes E2-setup, channels, network and all selected files"
+msgstr "Back up your current settings. This includes Enigma2 setup, channels, network configuration and selected files"
 
-#, fuzzy
 msgid "Backup, flash and restore settings and no plugins"
-msgstr "Flash and restore settings and no plugins"
+msgstr "Back up, flash and restore settings without plugins"
 
-#, fuzzy
 msgid "Backup, flash and restore settings and selected plugins (ask user)"
-msgstr "Flash and restore settings and selected plugins (ask user)"
+msgstr "Back up, flash and restore settings with selected plugins (ask user)"
 
+#. TRANSLATORS: regional option
 msgid "Bahamas"
 msgstr "Bahamas"
 
+#. TRANSLATORS: regional option
 msgid "Bahrain"
 msgstr "Bahrain"
 
@@ -3385,30 +3371,35 @@ msgstr "Band"
 msgid "Bandwidth"
 msgstr "Bandwidth"
 
+#. TRANSLATORS: regional option
 msgid "Bangladesh"
 msgstr "Bangladesh"
 
+#. TRANSLATORS: regional option
 msgid "Barbados"
 msgstr "Barbados"
 
 msgid "Base time"
-msgstr "Base time"
+msgstr "Base time segment"
 
 msgid "Base transparency for OpenOpera web browser"
-msgstr "Base transparency for OpenOpera web browser"
+msgstr "Base transparency for OpenOpera web browser."
 
 msgid "Base transparency for teletext, more options available within teletext screen."
 msgstr "Base transparency for teletext, more options available within teletext screen."
 
+#. TRANSLATORS: genre category
 msgid "Baseball"
 msgstr ""
 
 msgid "Basic settings"
-msgstr "Basic settings"
+msgstr "Basic Settings"
 
+#. TRANSLATORS: genre category
 msgid "Basketball"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Basque"
 msgstr "Basque"
 
@@ -3416,13 +3407,13 @@ msgid "Begin time"
 msgstr "Begin time"
 
 msgid "Behave like stop-button"
-msgstr "Behave like stop-button"
+msgstr "Behave like stop button"
 
 msgid "Behavior of 'pause' when paused"
-msgstr "Behavior of 'pause' when paused"
+msgstr "Behavior of the Pause button when paused"
 
 msgid "Behavior of 0 key in PiP-mode"
-msgstr "Behavior of 0 key in PiP-mode"
+msgstr "Behavior of the 0 button in PiP mode"
 
 msgid "Behavior when a movie is started"
 msgstr "Behavior when a movie is started"
@@ -3433,49 +3424,60 @@ msgstr "Behavior when a movie is stopped"
 msgid "Behavior when a movie reaches the end"
 msgstr "Behavior when a movie reaches the end"
 
+#. TRANSLATORS: regional option
 msgid "Belarus"
 msgstr "Belarus"
 
-#, fuzzy
+#. TRANSLATORS: regional option
 msgid "Belgian"
-msgstr "Belgium"
+msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Belgium"
 msgstr "Belgium"
 
+#. TRANSLATORS: regional option
 msgid "Belize"
 msgstr "Belize"
 
+#. TRANSLATORS: regional option
 msgid "Benin"
 msgstr "Benin"
 
+#. TRANSLATORS: genre category
 msgid "Bericht"
-msgstr ""
+msgstr "Report"
 
 msgid "Bermuda"
 msgstr "Bermuda"
 
+#. TRANSLATORS: genre category
 msgid "Berufe"
-msgstr ""
+msgstr "Jobs"
 
 msgid "Beyonwiz U4"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Beziehung"
-msgstr ""
+msgstr "Relationship"
 
+#. TRANSLATORS: regional option
 msgid "Bhutan"
 msgstr "Bhutan"
 
 msgid "Big PiP"
 msgstr "Big PiP"
 
+#. TRANSLATORS: genre category
 msgid "Bildung"
-msgstr ""
+msgstr "Education"
 
+#. TRANSLATORS: genre category
 msgid "Biografie"
-msgstr ""
+msgstr "Biography"
 
+#. TRANSLATORS: genre category
 msgid "Biography"
 msgstr ""
 
@@ -3489,46 +3491,47 @@ msgid "Black"
 msgstr "Black"
 
 msgid "Black screen"
-msgstr "Black screen"
+msgstr "black screen"
 
 msgid "Black screen till locked"
-msgstr "Black screen till locked"
+msgstr "black screen until locked"
 
-#, fuzzy
 msgid "Blinking REC"
-msgstr "Blinking REC Symbol"
+msgstr "Blinking REC"
 
 msgid "Blinking REC Symbol"
 msgstr "Blinking REC Symbol"
 
-#, fuzzy
 msgid "Block device"
-msgstr "No service"
+msgstr "Block device"
 
 msgid "Block noise reduction"
 msgstr "Block noise reduction"
 
 msgid "Blue"
-msgstr "Blue"
+msgstr "Blue button"
 
 msgid "Blue button"
 msgstr "Blue button"
 
 msgid "Blue long"
-msgstr "Blue long"
+msgstr "Blue button hold"
 
 msgid "BlueSwitch: Blue-Short/Blue-Long"
-msgstr "BlueSwitch: Blue-Short/Blue-Long"
+msgstr "Switch Blue button press/hold actions"
 
 msgid "Bluetooth Setup"
 msgstr "Bluetooth Setup"
 
+#. TRANSLATORS: regional option
 msgid "Bolivia (Plurinational State of)"
-msgstr "Bolivia (Plurinational State of)"
+msgstr "Bolivia, Plurinational State of"
 
+#. TRANSLATORS: genre category
 msgid "Bollywood"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Bonaire, Sint Eustatius and Saba"
 msgstr "Bonaire, Sint Eustatius and Saba"
 
@@ -3536,13 +3539,13 @@ msgid "Bookmarks"
 msgstr "Bookmarks"
 
 msgid "Boost blue"
-msgstr "Boost blue"
+msgstr "Blue gain"
 
 msgid "Boost green"
-msgstr "Boost green"
+msgstr "Green gain"
 
 msgid "Boot-up action"
-msgstr "Boot-up action"
+msgstr "Startup action"
 
 msgid "Bootloader update required!"
 msgstr "Bootloader update required!"
@@ -3551,9 +3554,11 @@ msgstr "Bootloader update required!"
 msgid "Bootloader:\t\t%s\n"
 msgstr "Bootloader:\t\t%s\n"
 
+#. TRANSLATORS: regional option
 msgid "Bosnia and Herzegovina"
 msgstr "Bosnia and Herzegovina"
 
+#. TRANSLATORS: regional option
 msgid "Botswana"
 msgstr "Botswana"
 
@@ -3561,23 +3566,27 @@ msgid "Boulevard"
 msgstr ""
 
 msgid "Bouquet List"
-msgstr "Bouquet List"
+msgstr "show bouquet list"
 
 msgid "BouquetList"
-msgstr "BouquetList"
+msgstr "Bouquet List"
 
+#. TRANSLATORS: regional option
 msgid "Bouvet Island"
 msgstr "Bouvet Island"
 
 msgid "Box or driver is not support Quad PiP."
-msgstr "Box or driver is not support Quad PiP."
+msgstr "Receiver or driver does not support Quad PiP."
 
+#. TRANSLATORS: genre category
 msgid "Boxen"
-msgstr ""
+msgstr "Boxing"
 
+#. TRANSLATORS: genre category
 msgid "Boxing"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Brazil"
 msgstr "Brazil"
 
@@ -3585,17 +3594,19 @@ msgid "Brightness"
 msgstr "Brightness"
 
 msgid "Brightness (Dimmed)"
-msgstr "Brightness (Dimmed)"
+msgstr "Brightness (dimmed)"
 
 msgid "Brightness (Normal)"
-msgstr "Brightness (Normal)"
+msgstr "Brightness (normal)"
 
 msgid "Brightness (Standby)"
-msgstr "Brightness (Standby)"
+msgstr "Brightness (standby)"
 
+#. TRANSLATORS: regional option
 msgid "British Indian Ocean Territory"
 msgstr "British Indian Ocean Territory"
 
+#. TRANSLATORS: regional option
 msgid "Brunei Darussalam"
 msgstr "Brunei Darussalam"
 
@@ -3614,33 +3625,38 @@ msgstr "Build:\t%s"
 msgid "Build: %s"
 msgstr "Build: %s"
 
+#. TRANSLATORS: regional option
 msgid "Bulgaria"
 msgstr "Bulgaria"
 
+#. TRANSLATORS: regional option
 msgid "Bulgarian"
 msgstr "Bulgarian"
 
+#. TRANSLATORS: regional option
 msgid "Burkina Faso"
 msgstr "Burkina Faso"
 
 msgid "Burn Bludisc"
-msgstr "Burn Bludisc"
+msgstr "Burn Blu-ray disc"
 
 msgid "Burn DVD"
 msgstr "Burn DVD"
 
 msgid "Burn existing image to medium"
-msgstr "Burn existing image to medium"
+msgstr "Burn existing image to disc"
 
 msgid "Burn to medium"
-msgstr "Burn to medium"
+msgstr "Burn to disc"
 
+#. TRANSLATORS: regional option
 msgid "Burundi"
 msgstr "Burundi"
 
 msgid "Bus: "
 msgstr "Bus: "
 
+#. TRANSLATORS: genre category
 msgid "Business & Finance"
 msgstr ""
 
@@ -3648,10 +3664,10 @@ msgid "Button"
 msgstr "Button"
 
 msgid "Button Setup"
-msgstr "Button Setup"
+msgstr "Button Settings"
 
 msgid "ButtonSetup"
-msgstr "ButtonSetup"
+msgstr "Button Setup"
 
 msgid "By openATV Image Team"
 msgstr "By openATV Image Team"
@@ -3669,10 +3685,10 @@ msgid "C-Band"
 msgstr "C-Band"
 
 msgid "CAID"
-msgstr "CAID"
+msgstr "CAId"
 
 msgid "CAID:SrvID"
-msgstr "CAID:SrvID"
+msgstr "CAId:SrvID"
 
 msgid "CCcam Client Info"
 msgstr "CCcam Client Info"
@@ -3720,7 +3736,7 @@ msgid "CCcam Shares Info"
 msgstr "CCcam Shares Info"
 
 msgid "CCcamInfo Mainmenu"
-msgstr "CCcamInfo Mainmenu"
+msgstr "CCcam Info Main Menu"
 
 msgid "CF Drive"
 msgstr "CF Drive"
@@ -3736,17 +3752,16 @@ msgid "CHANGE BOUQUET"
 msgstr "CHANGE BOUQUET"
 
 msgid "CI (Common Interface) Setup"
-msgstr "CI (Common Interface) Setup"
+msgstr "Common Interface Setup"
 
-#, fuzzy
 msgid "CI Basic settings"
-msgstr "Basic settings"
+msgstr "CI Basic settings"
 
 msgid "CI Legacy"
 msgstr "CI Legacy"
 
 msgid "CI Operation Mode"
-msgstr "CI Operation Mode"
+msgstr "CI operation mode"
 
 msgid "CI Plus 1.2"
 msgstr "CI Plus 1.2"
@@ -3773,7 +3788,7 @@ msgid "CIHelper for SLOT CI1"
 msgstr "CIHelper for SLOT CI1"
 
 msgid "CIselectMainMenu"
-msgstr "CIselectMainMenu"
+msgstr "CI Select Main Menu"
 
 #, fuzzy
 msgid "CPU"
@@ -3802,6 +3817,7 @@ msgstr "Cable"
 msgid "Cable Scan"
 msgstr "Cable Scan"
 
+#. TRANSLATORS: regional option
 msgid "Cabo Verde"
 msgstr "Cabo Verde"
 
@@ -3829,35 +3845,34 @@ msgstr "Calibrate"
 msgid "Call-in"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Cambodia"
 msgstr "Cambodia"
 
+#. TRANSLATORS: regional option
 msgid "Cameroon"
 msgstr "Cameroon"
 
 msgid "Can be used for different fps between external subtitles and video."
 msgstr "Can be used for different fps between external subtitles and video."
 
-#, fuzzy
 msgid "Can not delete timer"
-msgstr "Cannot delete file"
+msgstr "Couldn't remove timer"
 
-#, fuzzy
 msgid "Can not download EPG"
-msgstr "Cannot delete file"
+msgstr "Couldn't download EPG"
 
 msgid "Can not download current region details"
-msgstr ""
+msgstr "Couldn't download download current region details"
 
 msgid "Can not download list of regions"
-msgstr ""
+msgstr "Couldn't download list of regions"
 
-#, fuzzy
 msgid "Can not download timers"
-msgstr "Cannot delete file"
+msgstr "Couldn't download timers"
 
 msgid "Can not post PVR log information"
-msgstr ""
+msgstr "Can't send PVR log information"
 
 #, fuzzy
 msgid "Can not post scan information"
@@ -3875,24 +3890,20 @@ msgid ""
 "%s may be in a plugin that is not installed."
 msgstr ""
 
-#, fuzzy
 msgid "Can not update timer"
-msgstr "Cannot delete file"
+msgstr "Couldn't update timer"
 
-#, fuzzy
 msgid "Can not update timer status"
-msgstr "Can not write file %s"
+msgstr "Couldn't update timer status"
 
-#, fuzzy
 msgid "Can not update timers"
-msgstr "Can not write file %s"
+msgstr "Couldn't update timers"
 
-#, fuzzy
 msgid "Can not upload timer"
-msgstr "Change next timer"
+msgstr "Couldn't upload timers"
 
 msgid "Can only find a network drive to store the backup this means after the flash the autorestore will not work. Alternatively you can mount the network drive after the flash and perform a manufacturer reset to autorestore"
-msgstr ""
+msgstr "Can only find a network drive to store the backup. This means that after flashing, autorestore will not work. Alternatively, you can mount the network drive after flashing and perform a manufacturer reset to autorestore"
 
 msgid "Can't allocate program source (e.g. tuner)"
 msgstr ""
@@ -3901,26 +3912,27 @@ msgid ""
 "Can't going to live TV!\n"
 "Switch to live TV and restart Timeshift ?"
 msgstr ""
-"Can't going to live TV!\n"
-"Switch to live TV and restart Timeshift ?"
+"Couldn't switch to live TV!\n"
+"Would you like to switch to live TV and restart timeshift?"
 
 msgid ""
 "Can't play the next Timeshift file!\n"
 "Switch to live TV and restart Timeshift ?"
 msgstr ""
 "Can't play the next Timeshift file!\n"
-"Switch to live TV and restart Timeshift ?"
+"Switch to live TV and restart timeshift?"
 
 msgid "Can't play the previous timeshift file! You can try again."
-msgstr "Can't play the previous timeshift file! You can try again."
+msgstr "Can't play the previous timeshift file! Please try again."
 
 #, python-format
 msgid "Can't read link contents: %s"
 msgstr ""
 
 msgid "Can't unmount partiton, make sure it is not being used for swap or record/timeshift paths"
-msgstr "Can't unmount partiton, make sure it is not being used for swap or record/timeshift paths"
+msgstr "Couldn't unmount partiton, make sure it's not being used for swap or record/timeshift paths"
 
+#. TRANSLATORS: regional option
 msgid "Canada"
 msgstr "Canada"
 
@@ -3930,42 +3942,38 @@ msgstr "Cancel"
 msgid "Cancel any text changes and exit"
 msgstr ""
 
-#, fuzzy
 msgid "Cancel execution?"
-msgstr "Channel selection"
+msgstr "Cancel execution?"
 
 msgid "Cancel save timeshift as movie"
 msgstr "Cancel save timeshift as movie"
 
-#, fuzzy
 msgid "Cancel the selection"
-msgstr "Channel selection"
+msgstr "Cancel the selection"
 
 msgid "Cancelled upon user request"
-msgstr ""
+msgstr "Canceled by user"
 
-#, fuzzy
 msgid "Cannot create backup directory"
-msgstr "create directory"
+msgstr "Couldn't create backup folder"
 
-#, fuzzy
 msgid "Cannot delete downloaded image"
-msgstr "Cannot delete file"
+msgstr "Couldn't delete downloaded image"
 
 msgid "Cannot delete file"
-msgstr "Cannot delete file"
+msgstr "Couldn't delete file"
 
 msgid "Cannot determine"
-msgstr "Cannot determine"
+msgstr "Can't determine"
 
 msgid "Cannot find any signal ..., aborting !"
-msgstr "Cannot find any signal ..., aborting !"
+msgstr "Couldn't find a signal, aborting!"
 
 msgid "Cannot find images - please try later"
-msgstr ""
+msgstr "Couldn't find images, please try again later."
 
 msgid "Cannot move to trash can"
-msgstr "Cannot move to trash can"
+msgstr "Couldn't move to the trash can"
 
 msgid "Capabilities: "
 msgstr "Capabilities: "
@@ -3974,7 +3982,7 @@ msgid "Capacity: "
 msgstr "Capacity: "
 
 msgid "Card infos (CCcam-Reader)"
-msgstr "Card infos (CCcam-Reader)"
+msgstr "Card info (CCcam Reader)"
 
 msgid "Cards:"
 msgstr "Cards:"
@@ -3986,8 +3994,9 @@ msgid "Cards: 0"
 msgstr "Cards: 0"
 
 msgid "Cardserial"
-msgstr "Cardserial"
+msgstr "Card serial"
 
+#. TRANSLATORS: genre category
 msgid "Cartoon"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "Casting"
 msgstr "Waiting"
 
 msgid "Caution update not yet tested !!"
-msgstr "Caution update not yet tested !!"
+msgstr "CAUTION: update hasn't been tested yet!"
 
 msgid "Cayman Islands"
 msgstr "Cayman Islands"
@@ -4014,16 +4023,16 @@ msgid "Chad"
 msgstr "Chad"
 
 msgid "Change Boxmode to control Hardware Chip Modes*"
-msgstr "Change Boxmode to control Hardware Chip Modes*"
+msgstr "Change Boxmode to control Hardware Chip Modes *"
 
 msgid "Change PIN"
 msgstr "Change PIN"
 
 msgid "Change Volume offset"
-msgstr "Change Volume offset"
+msgstr "Change Volume Offset"
 
 msgid "Change bouquets in quickzap"
-msgstr "Change bouquets in quickzap"
+msgstr "Change bouquets in quick zap mode"
 
 msgid "Change buttons for list navigation"
 msgstr ""
@@ -4035,16 +4044,16 @@ msgid "Change next timer"
 msgstr "Change next timer"
 
 msgid "Change pin code"
-msgstr "Change pin code"
+msgstr "Change PIN code"
 
 msgid "Change recording (duration)"
-msgstr "Change recording (duration)"
+msgstr "Change recording duration"
 
 msgid "Change recording (endtime)"
-msgstr "Change recording (endtime)"
+msgstr "Change recording end time"
 
 msgid "Change repeat and delay settings?"
-msgstr "Change repeat and delay settings?"
+msgstr "Change repeat and delay settings"
 
 msgid "Change skin"
 msgstr "Change skin"
@@ -4076,16 +4085,19 @@ msgid "Channel \t\t\tVolume +"
 msgstr "Channel \t\t\tVolume +"
 
 msgid "Channel +/- button mode"
-msgstr "Channel +/- button mode"
+msgstr "Channel Up/Down buttons"
+
+msgid "Channel +/-"
+msgstr "Channel Up/Down"
 
 msgid "Channel 1"
-msgstr "Channel 1"
+msgstr "channel 1"
 
 msgid "Channel 1 with Primetime"
-msgstr "Channel 1 with Primetime"
+msgstr "channel 1 at primetime"
 
 msgid "Channel Info"
-msgstr "Channel Info"
+msgstr "channel info"
 
 msgid "Channel List"
 msgstr "Channel List"
@@ -4093,20 +4105,17 @@ msgstr "Channel List"
 msgid "Channel Name"
 msgstr "Channel Name"
 
-#, fuzzy
 msgid "Channel button always changes sides"
-msgstr "Channel list on mode change"
+msgstr "Channel button always changes sides"
 
-#, fuzzy
 msgid "Channel buttons"
-msgstr "Channel down"
+msgstr "Channel buttons"
 
-#, fuzzy
 msgid "Channel buttons invert"
-msgstr "Channel +/- button mode"
+msgstr "Invert Channel Up/Down buttons"
 
 msgid "Channel down"
-msgstr "Channel down"
+msgstr "Channel Up button"
 
 msgid "Channel list context menu"
 msgstr "Channel list context menu"
@@ -4121,35 +4130,34 @@ msgid "Channel list preview"
 msgstr "Channel list preview"
 
 msgid "Channel list service mode*"
-msgstr "Channel list service mode*"
+msgstr "Channel list service mode *"
 
 msgid "Channel list show MiniTV when Skin use."
 msgstr "Channel list show MiniTV when Skin use."
 
-#, fuzzy
 msgid "Channel list show MiniTV*"
-msgstr "Channel list show MiniTV"
+msgstr "Show mini TV window in channel list *"
 
 msgid "Channel list type"
 msgstr "Channel list type"
 
 msgid "Channel not in services list"
-msgstr "Channel not in services list"
+msgstr "Channel isn't in channels list"
 
 msgid "Channel preview mode"
-msgstr "Channel preview mode"
+msgstr "Preview channels"
 
 msgid "Channel selection"
-msgstr "Channel selection"
+msgstr "Channel Selection"
 
 msgid "Channel selection configuration"
-msgstr "Channel selection configuration"
+msgstr "Channel Selection Setup"
 
 msgid "Channel selection settings"
-msgstr "Channel selection settings"
+msgstr "Channel Selection Settings"
 
 msgid "Channel up"
-msgstr "Channel up"
+msgstr "Channel Up button"
 
 msgid "Channel zap delay another button"
 msgstr "Channel zap delay another button"
@@ -4164,17 +4172,16 @@ msgid "Channel:"
 msgstr "Channel:"
 
 msgid "ChannelEPG settings"
-msgstr "ChannelEPG settings"
+msgstr "Channel EPG Settings"
 
 msgid "Channellist menu"
-msgstr "Channellist menu"
+msgstr "Channel list menu"
 
 msgid "Channelname"
-msgstr "Channelname"
+msgstr "Channel name"
 
-#, fuzzy
 msgid "Channelselection:"
-msgstr "Channel selection"
+msgstr "Channel selection:"
 
 msgid "Chap."
 msgstr "Chap."
@@ -4193,37 +4200,37 @@ msgid "Check"
 msgstr "Check"
 
 msgid "Check HDD"
-msgstr "Check HDD"
+msgstr "Check Hard Disk"
 
 msgid "Check every (hours)"
-msgstr "Check every (hours)"
+msgstr "Check every # hours"
 
 msgid "Check power and input state from TV"
 msgstr ""
 
 msgid "Check the internet connection"
-msgstr "Check the internet connection"
+msgstr "Check your receiver's internet connection"
 
 msgid "Check the internet connection again"
-msgstr "Check the internet connection again"
+msgstr "Re-check your receiver's internet connection"
 
 msgid "Check/Install online updates (you must have a working internet connection)"
-msgstr "Check/Install online updates (you must have a working internet connection)"
+msgstr "Check for and install online updates (requires a working internet connection)"
 
 msgid "Checking Feeds"
 msgstr "Checking Feeds"
 
 msgid "Checking Logs..."
-msgstr "Checking Logs..."
+msgstr "Checking logs..."
 
 msgid "Checking filesystem..."
 msgstr "Checking filesystem..."
 
 msgid "Checking for Updates..."
-msgstr "Checking for Updates..."
+msgstr "Checking for updates..."
 
 msgid "Checking the internet connection"
-msgstr "Checking the internet connection"
+msgstr "Checking internet connection..."
 
 #, python-format
 msgid ""
@@ -4233,16 +4240,17 @@ msgstr ""
 "Checking tuner %d\n"
 "DiSEqC port %s for %s"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Children"
-msgstr "Chile"
+msgstr "Childrens'"
 
+#. TRANSLATORS: genre category
 msgid "Children/Youth"
-msgstr "Children/Youth"
+msgstr "Childrens'/Youth"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Childrens"
-msgstr "Chile"
+msgstr "Childrens'"
 
 msgid "Chile"
 msgstr "Chile"
@@ -4262,17 +4270,17 @@ msgid "Chipset: BCM%s"
 msgstr "Chipset: BCM%s"
 
 msgid "Choice Box"
-msgstr "Choice Box"
+msgstr "Options..."
 
 #, python-format
 msgid "Choice where to put \"%s\""
-msgstr "Choice where to put \"%s\""
+msgstr "Choose where to put \"%s\""
 
 msgid "Choose Bouquet"
-msgstr "Choose Bouquet"
+msgstr "Please select a bouquet..."
 
 msgid "Choose Tuner"
-msgstr "Choose Tuner"
+msgstr "Select Tuner"
 
 msgid "Choose a country scheme for decoding genre information in EPG events."
 msgstr ""
@@ -4287,7 +4295,7 @@ msgid "Choose a setting where your receiver wakes up from standby."
 msgstr ""
 
 msgid "Choose a tag for easy finding a recording."
-msgstr "Choose a tag for easy finding a recording."
+msgstr "Choose one or more tags to easily find a recording."
 
 msgid "Choose between Daily, Weekly, Weekdays or user defined."
 msgstr "Choose between Daily, Weekly, Weekdays or user defined."
@@ -4298,87 +4306,90 @@ msgstr "Choose dvb wait delay for ci response."
 msgid "Choose how often to connect to IceTV server to check for updates."
 msgstr ""
 
-#, fuzzy
 msgid "Choose style of main menus"
-msgstr "Show VCR scart on main menu"
+msgstr "Choose Main menu style"
 
 msgid "Choose the CI protocol operation mode for standard ci or ciplus."
-msgstr "Choose the CI protocol operation mode for standard ci or ciplus."
+msgstr "Choose the CI protocol operation mode for standard CI or CI+."
 
 msgid "Choose the display formatting style for dates. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin."
 msgstr ""
 
 msgid "Choose the display formatting style for times. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes and 'ss' is the seconds.  ('HH' and 'hh' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin."
-msgstr ""
+msgstr "Choose the display formatting style for times. 'H' / 'HH' is the hour for a 24-hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes and 'ss' is the seconds. ('HH' and 'hh' have leading zeros for single digit values). The screen display will be based on your choice but can be influenced by the skin."
 
 msgid "Choose the front panel display formatting style for dates. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin."
-msgstr ""
+msgstr "Choose how you'd like the date to appear on the front panel display. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin."
 
 msgid "Choose the front panel display formatting style for times. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes.  ('HH' and 'hh' have leading zeros for single digit values.) The front panel display will be based on your choice but can be influenced any applicable skin."
-msgstr ""
+msgstr "Choose how you'd like the time to appear on the front panel display. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes.  ('HH' and 'hh' have leading zeros for single digit values.) The front panel display will be based on your choice but can be influenced any applicable skin."
 
 msgid "Choose the location for crash and debuglogs."
-msgstr "Choose the location for crash and debuglogs."
+msgstr "Choose where crash and debug logs should be saved."
 
 msgid "Choose the location where the EPG data will be stored when the %s %s is shut down. The location must be available at boot time."
-msgstr "Choose the location where the EPG data will be stored when the %s %s is shut down. The location must be available at boot time."
+msgstr ""
+"Choose where EPG data should be saved when your %s %s shuts down.\n"
+"The location must be available at startup."
 
 msgid "Choose the name of the file that holds the EPG data when the %s %s is shut down. This can be handy to differentiate between several boxes."
-msgstr "Choose the name of the file that holds the EPG data when the %s %s is shut down. This can be handy to differentiate between several boxes."
+msgstr ""
+"Choose the name of the file to save EPG data to when your %s %s shuts down.\n"
+"This can be useful to differentiate between several receivers."
 
 msgid "Choose time interval to which the graphics will be rounded off."
-msgstr "Choose time interval to which the graphics will be rounded off."
+msgstr "Choose the time interval to which the grid should be rounded off."
 
 msgid "Choose what you want the button '0' to do when PIP is active."
-msgstr "Choose what you want the button '0' to do when PIP is active."
+msgstr "Choose what you'd like the 0 button to do when PiP is active."
 
 msgid "Choose where to mount your devices to:"
 msgstr "Choose where to mount your devices to:"
 
 msgid "Choose whether AAC sound tracks should be transcoded."
-msgstr "Choose whether AAC sound tracks should be transcoded."
+msgstr "Choose whether AAC audio tracks should be transcoded."
 
 msgid "Choose whether AC3 Plus sound tracks should be transcoded to AC3."
-msgstr "Choose whether AC3 Plus sound tracks should be transcoded to AC3."
+msgstr "Choose whether Dolby Digital Plus / Enhanced AC-3 (commonly abbreviated as DD+, E-AC-3 or EC-3) audio tracks should be transcoded to AC3."
 
 msgid "Choose whether AC3 sound tracks should be downmixed to stereo."
-msgstr "Choose whether AC3 sound tracks should be downmixed to stereo."
+msgstr "Choose whether Dolby Digital Plus / Enhanced AC-3 (commonly abbreviated as DD+, E-AC-3 or EC-3) multi-channel audio tracks should be downmixed to 2-channel stereo."
 
 msgid "Choose whether DTS channel sound tracks should be downmixed or transcoded."
-msgstr "Choose whether DTS channel sound tracks should be downmixed or transcoded."
+msgstr "Choose whether DTS (Digital Theater Systems) channel audio tracks should be downmixed or transcoded."
 
 msgid "Choose whether DTS channel sound tracks should be downmixed to stereo."
-msgstr "Choose whether DTS channel sound tracks should be downmixed to stereo."
+msgstr "Choose whether Digital Theatre System Coherent Acoustics multi-channel audio tracks should be downmixed to 2-channel stereo."
 
 msgid "Choose whether WMA Pro channel sound tracks should be downmixed or transcoded."
-msgstr "Choose whether WMA Pro channel sound tracks should be downmixed or transcoded."
+msgstr "Choose whether WMA Pro channel audio tracks should be downmixed or transcoded."
 
 msgid "Choose whether multi channel sound tracks should be convert to PCM or SPDIF."
-msgstr "Choose whether multi channel sound tracks should be convert to PCM or SPDIF."
+msgstr "Choose whether multi-channel audio tracks should be convert to PCM or SPDIF."
 
 msgid "Choose whether multi channel sound tracks should be downmixed to stereo."
-msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr "Choose whether multi-channel audio tracks should be downmixed to two-channel stereo."
 
 msgid "Choose whether multi channel sound tracks should be output as PCM."
-msgstr "Choose whether multi channel sound tracks should be output as PCM."
+msgstr "Choose whether multi-channel audio tracks should be output as PCM."
 
 msgid "Choose whether or not to show an icon when a motorized dish is moving."
-msgstr "Choose whether or not to show an icon when a motorized dish is moving."
+msgstr "Choose whether or not to show an indicator while a motorized dish is moving."
 
 msgid "Choose which level of menu/setting's to display. 'Expert'-level shows all items."
-msgstr "Choose which level of menu/setting's to display. 'Expert'-level shows all items."
+msgstr "Choose the level of menu/settings to display. 'Expert' level will show all items."
 
 msgid "Choose which tuner to configure."
-msgstr "Choose which tuner to configure."
+msgstr "Choose a tuner to configure."
 
 msgid "Chose between record and ZAP."
-msgstr "Chose between record and ZAP."
+msgstr "Choose whether to just zap to the specified channel, record, or both."
 
 msgid "Christmas Island"
 msgstr "Christmas Island"
 
 msgid "Chronik"
-msgstr ""
+msgstr "Timeline"
 
 msgid "Circular LNB"
 msgstr "Circular LNB"
@@ -4390,13 +4401,13 @@ msgid "Circular right"
 msgstr "Circular right"
 
 msgid "Clean (Just flash and start clean)"
-msgstr ""
+msgstr "Clean (just flash and start clean)"
 
 msgid "Clean network trash cans"
-msgstr "Clean network trash cans"
+msgstr "Empty network trash cans"
 
 msgid "Cleaning Trashes"
-msgstr "Cleaning Trashes"
+msgstr "Emptying Trash Cans..."
 
 msgid "Cleanup"
 msgstr "Cleanup"
@@ -4417,14 +4428,14 @@ msgid "Clear playlist"
 msgstr "Clear playlist"
 
 msgid "Click on your remote on the button you want to change"
-msgstr "Click on your remote on the button you want to change"
+msgstr "Press the button on your remote that you'd like to change."
 
 #, python-format
 msgid "Client Info ( Oscam-Version: %s )"
-msgstr "Client Info ( Oscam-Version: %s )"
+msgstr "Client Info ( Oscam Version: %s )"
 
 msgid "ClientIP"
-msgstr "ClientIP"
+msgstr "Client IP"
 
 msgid "Clients"
 msgstr "Clients"
@@ -4432,12 +4443,11 @@ msgstr "Clients"
 msgid "Clock"
 msgstr "Clock"
 
-#, fuzzy
 msgid "Clock:"
-msgstr "Clock"
+msgstr "Clock:"
 
 msgid "Clone TV screen to LCD"
-msgstr "Clone TV screen to LCD"
+msgstr "Clone TV screen to front panel display"
 
 msgid "Close"
 msgstr "Close"
@@ -4469,9 +4479,8 @@ msgstr "Coderate HP"
 msgid "Coderate LP"
 msgstr "Coderate LP"
 
-#, fuzzy
 msgid "Collapse"
-msgstr "Elapsed"
+msgstr "Collapse"
 
 msgid "Collection name"
 msgstr "Collection name"
@@ -4494,15 +4503,16 @@ msgstr "Color space"
 msgid "Combo"
 msgstr "Combo"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Comedy"
-msgstr "comedy"
+msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Comic"
 msgstr ""
 
 msgid "Command To Run"
-msgstr "Command To Run"
+msgstr "Command to run"
 
 msgid "Command execution..."
 msgstr "Command execution..."
@@ -4528,9 +4538,8 @@ msgstr "Communication"
 msgid "Comoros"
 msgstr "Comoros"
 
-#, fuzzy
 msgid "Compensate for overscan"
-msgstr "Clear before scan"
+msgstr "Compensate for overscan"
 
 msgid "Complete"
 msgstr "Complete"
@@ -4542,18 +4551,16 @@ msgid "Complex (allows mixing audio tracks and aspects)"
 msgstr "Complex (allows mixing audio tracks and aspects)"
 
 msgid "Composition of the recording filenames"
-msgstr "Composition of the recording filenames"
+msgstr "Recording filename structure"
 
-#, fuzzy
 msgid "Computer"
-msgstr "Complete"
+msgstr ""
 
-#, fuzzy
 msgid "Config"
-msgstr "Configuring"
+msgstr "Config"
 
 msgid "Config file name (ok to change):"
-msgstr ""
+msgstr "Config file name (OK to change):"
 
 #, python-format
 msgid "Configfile %s saved."
@@ -4567,49 +4574,59 @@ msgid "Configuration mode: %s"
 msgstr "Configuration mode: %s"
 
 msgid "Configure an additional delay to improve external subtitle synchronisation."
-msgstr "Configure an additional delay to improve external subtitle synchronisation."
+msgstr "Configure an additional delay to improve external subtitle synchronization."
 
 msgid "Configure an additional delay to improve subtitle synchronisation."
-msgstr "Configure an additional delay to improve subtitle synchronisation."
+msgstr "Configure an additional delay to improve subtitle synchronization."
 
 msgid "Configure default setting for new timers. Need a restart after changing."
-msgstr "Configure default setting for new timers. Need a restart after changing."
+msgstr ""
+"Configure the default settings for new timers.\n"
+"* Requires a restart."
 
 msgid "Configure for how many minutes finished events should remain visible in the EPG. Useful when you need information about an event which has just finished, or has been delayed."
-msgstr "Configure for how many minutes finished events should remain visible in the EPG. Useful when you need information about an event which has just finished, or has been delayed."
+msgstr "Configure for how many minutes finished events should remain visible on the EPG. Useful when you need information about an event which has just finished or has been delayed."
 
 msgid "Configure for which types of recordings a warning about active recordings is shown when attempting to restart the box or the GUI."
-msgstr "Configure for which types of recordings a warning about active recordings is shown when attempting to restart the box or the GUI."
+msgstr "Configure the types of recordings for which a warning about active recordings is shown, when attempting to restart the box or the user interface."
 
 msgid "Configure how recording filenames are constructed. Standard: Date Time - Channel - Title Very very short: Title Very short: Title - Date Time Short with time: Date Time - Title Short: Date - Title Long: Date Time - Channel - Title - Info"
-msgstr "Configure how recording filenames are constructed. Standard: Date Time - Channel - Title Very very short: Title Very short: Title - Date Time Short with time: Date Time - Title Short: Date - Title Long: Date Time - Channel - Title - Info"
+msgstr ""
+"Configure how recording filenames should be formatted:\n"
+"Standard: Date Time - Channel - Title\n"
+"Very very short: Title\n"
+"Very short: Title - Date Time\n"
+"Short with time: Date Time - Title\n"
+"Short: Date - Title\n"
+"Long: Date Time - Channel - Title - Info"
 
 msgid "Configure if and how crypto icons will be shown in the channel selection list."
-msgstr "Configure if and how crypto icons will be shown in the channel selection list."
+msgstr "Configure whether, and how, crypto icons should appear in the channel selection list."
 
+# needs improvement
 msgid "Configure if and how long the latest service in the PiP will be remembered."
-msgstr "Configure if and how long the latest service in the PiP will be remembered."
+msgstr "Configure whether, and for how long, the latest channel in PiP mode should be remembered."
 
 msgid "Configure if and how service type icons will be shown."
-msgstr "Configure if and how service type icons will be shown."
+msgstr "Configure whether, and how, service type icons should appear."
 
 msgid "Configure if and how the record indicator will be shown in the channel selection list."
-msgstr "Configure if and how the record indicator will be shown in the channel selection list."
+msgstr "Configure whether, and how, the recording indicator should appear in the channel selection list."
 
 msgid "Configure if and how wide the service name column will be shown in the channel selection list."
-msgstr "Configure if and how wide the service name column will be shown in the channel selection list."
+msgstr "Configure whether, and how wide, the channel name column should appear in the channel selection list."
 
 msgid "Configure if epg.dat should be saved at all."
-msgstr "Configure if epg.dat should be saved at all."
+msgstr "Choose whether epg.dat should be saved at all."
 
 msgid "Configure if service picons will be shown in quickzap."
-msgstr "Configure if service picons will be shown in quickzap."
+msgstr "Choose whether channel picons (logos) should appear in quick zap mode."
 
 msgid "Configure if service picons will be shown in the servicelist."
-msgstr "Configure if service picons will be shown in the servicelist."
+msgstr "Choose whether channel picons (logos) should appear in the channel selection list."
 
 msgid "Configure if the subtitle should switch between normal, italic, bold and bolditalic"
-msgstr "Configure if the subtitle should switch between normal, italic, bold and bolditalic"
+msgstr "Choose whether subtitles should switch between normal, italic, bold and bold-italic."
 
 msgid "Configure interface"
 msgstr "Configure interface"
@@ -4618,7 +4635,7 @@ msgid "Configure nameservers"
 msgstr "Configure nameservers"
 
 msgid "Configure on which devices the background delete option should be used."
-msgstr "Configure on which devices the background delete option should be used."
+msgstr "Configure the devices on which the background delete option should be used."
 
 msgid "Configure remote control type"
 msgstr "Configure remote control type"
@@ -4630,70 +4647,71 @@ msgid "Configure the IP address."
 msgstr "Configure the IP address."
 
 msgid "Configure the alignment of events."
-msgstr "Configure the alignment of events."
+msgstr "Choose how event titles should be aligned."
 
 msgid "Configure the alignment of service names."
-msgstr "Configure the alignment of service names."
+msgstr "Choose how channel names should be aligned."
 
 msgid "Configure the amount of time that will be presented."
-msgstr "Configure the amount of time that will be presented."
+msgstr "Configure the amount of time that should be shown per page."
 
 msgid "Configure the aspect ratio of the screen."
-msgstr "Configure the aspect ratio of the screen."
+msgstr "Configure the output aspect ratio."
 
 msgid "Configure the behavior of the 'pause' key when movie playback is already paused."
-msgstr "Configure the behavior of the 'pause' key when movie playback is already paused."
+msgstr "Choose what you'd like the Pause button to do when movie playback is already paused."
 
 msgid "Configure the behavior when movie playback is manually stopped."
-msgstr "Configure the behavior when movie playback is manually stopped."
+msgstr "Choose what you'd like to happen when movie playback is manually stopped."
 
 msgid "Configure the behavior when movie playback is started."
-msgstr "Configure the behavior when movie playback is started."
+msgstr "Choose whether to restart, resume or prompt when movie playback is started."
 
 msgid "Configure the behavior when reaching the end of a movie, during movie playback."
-msgstr "Configure the behavior when reaching the end of a movie, during movie playback."
+msgstr "Choose what you'd like to happen when reaching the end of a movie during movie playback."
 
 msgid "Configure the border width of the subtitles. The dark border makes the subtitles easier to read on a light background."
 msgstr "Configure the border width of the subtitles. The dark border makes the subtitles easier to read on a light background."
 
 msgid "Configure the brightness level of the front panel display for dimmed operation."
-msgstr "Configure the brightness level of the front panel display for dimmed operation."
+msgstr "Configure the front panel display's brightness level when dimmed."
 
 msgid "Configure the brightness level of the front panel display for normal operation."
-msgstr "Configure the brightness level of the front panel display for normal operation."
+msgstr "Configure the front panel display's brightness level during normal use."
 
 msgid "Configure the brightness level of the front panel display for standby."
-msgstr "Configure the brightness level of the front panel display for standby."
+msgstr "Configure the front panel display's brightness level during standby."
 
 msgid "Configure the color of the external subtitles, alternative (normal in white, italic in yellow, bold in cyan, underscore in green), white or yellow."
-msgstr "Configure the color of the external subtitles, alternative (normal in white, italic in yellow, bold in cyan, underscore in green), white or yellow."
+msgstr "Choose the color to use for external subtitles - white, yellow or alternative (normal in white, italic in yellow, bold in cyan, underscore in green)."
 
 msgid "Configure the color of the teletext subtitles."
-msgstr "Configure the color of the teletext subtitles."
+msgstr "Configure the teletext subtitle text color."
 
 msgid "Configure the contrast level of the front panel display."
-msgstr "Configure the contrast level of the front panel display."
+msgstr "Configure the front panel display's contrast level."
 
+# needs improvement
 msgid "Configure the cursor behaviour in the channel selection list. When opening the channel selection list you can remain on the current service or already select up/down and you are able to revert the B+/B- buttons."
-msgstr "Configure the cursor behaviour in the channel selection list. When opening the channel selection list you can remain on the current service or already select up/down and you are able to revert the B+/B- buttons."
+msgstr "Choose what the ▲ Up, ▼ Down, ◀︎ Left and ▶︎ Right buttons should do in the channel selection list. When opening the channel selection list you can choose to stay on the current service or already select ▲ Up / ▼ Down and you are able to revert the B+/B- buttons."
 
 msgid "Configure the display resolution and the font used for teletext."
 msgstr "Configure the display resolution and the font used for teletext."
 
 msgid "Configure the duration in minutes for the screensaver."
-msgstr "Configure the duration in minutes for the screensaver."
+msgstr "Configure how long to wait for the screensaver to start."
 
 msgid "Configure the duration in minutes for the sleep timer."
 msgstr "Configure the duration in minutes for the sleep timer."
 
 msgid "Configure the end coordinate in x of the teletext display area."
-msgstr "Configure the end coordinate in x of the teletext display area."
+msgstr "Configure the end co-ordinate in x of the teletext display area."
 
 msgid "Configure the end coordinate in y of the teletext display area."
-msgstr "Configure the end coordinate in y of the teletext display area."
+msgstr "Configure the end co-ordinate in y of the teletext display area."
 
 msgid "Configure the fast mode audio volume step size (limit 1-10). Activated when volume key permanent press or press fast in a row."
-msgstr "Configure the fast mode audio volume step size (limit 1-10). Activated when volume key permanent press or press fast in a row."
+msgstr "Configure the audio volume jump size (from 1 to 10). Activated when volume +/- button is held down or pressed in quick succession."
 
 msgid "Configure the first audio language (highest priority)."
 msgstr "Configure the first audio language (highest priority)."
@@ -4702,14 +4720,13 @@ msgid "Configure the first subtitle language (highest priority)."
 msgstr "Configure the first subtitle language (highest priority)."
 
 msgid "Configure the font size of the subtitles."
-msgstr "Configure the font size of the subtitles."
+msgstr "Configure the subtitle text size."
 
-#, fuzzy
 msgid "Configure the font size relative to default size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
-msgstr "Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
+msgstr "Configure the text size relative to the default. 1 will increase the size by 1 point, whereas a negative value will decrease it."
 
 msgid "Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
-msgstr "Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
+msgstr "Configure the text size relative to skin size. 1 will increase the size by 1 point, whereas a negative value will decrease it."
 
 msgid "Configure the fourth audio language."
 msgstr "Configure the fourth audio language."
@@ -4718,19 +4735,19 @@ msgid "Configure the fourth subtitle language."
 msgstr "Configure the fourth subtitle language."
 
 msgid "Configure the function of a long press on the power button."
-msgstr "Configure the function of a long press on the power button."
+msgstr "Configure what should happen when the Power button is held down."
 
 msgid "Configure the function of a short press on the power button."
-msgstr "Configure the function of a short press on the power button."
+msgstr "Configure what should happen when the Power button is pressed."
 
 msgid "Configure the function of the <  > buttons."
-msgstr "Configure the function of the <  > buttons."
+msgstr "Configure what should happen when the ◀︎ Left and ▶︎ Right buttons are pressed."
 
 msgid "Configure the gateway."
 msgstr "Configure the gateway."
 
 msgid "Configure the general audio volume step size (limit 1-10)."
-msgstr "Configure the general audio volume step size (limit 1-10)."
+msgstr "Configure the general audio volume step size (from 1 to 10)."
 
 msgid "Configure the hard disk drive to go to standby after the specified idle time when the box is in standby."
 msgstr "Configure the hard disk drive to go to standby after the specified idle time when the box is in standby."
@@ -4743,28 +4760,28 @@ msgstr "Configure the height of the TrueType font letters used for teletext."
 
 #, fuzzy
 msgid "Configure the history of time that will be presented."
-msgstr "Configure the amount of time that will be presented."
+msgstr "Configure the amount of time passed that should be shown on opening."
 
 msgid "Configure the horizontal alignment of the subtitles."
-msgstr "Configure the horizontal alignment of the subtitles."
+msgstr "Configure how subtitles should be aligned horizontally."
 
 msgid "Configure the initial fast forward speed. When you press the fast forward button, winding will start at this speed."
-msgstr "Configure the initial fast forward speed. When you press the fast forward button, winding will start at this speed."
+msgstr "Configure the initial fast forward speed. Winding will start at this speed when you press the ▶︎▶︎ Fast forward button."
 
 msgid "Configure the initial rewind speed. When you press the rewind button, winding will start at this speed."
-msgstr "Configure the initial rewind speed. When you press the rewind button, winding will start at this speed."
+msgstr "Configure the initial rewind speed. Winding will start at this speed when you press the ◀︎◀︎ Rewind button."
 
 msgid "Configure the latitude of your location."
-msgstr "Configure the latitude of your location."
+msgstr "Configure your location's latitude (LAT)."
 
 msgid "Configure the longitude of your location."
-msgstr "Configure the longitude of your location."
+msgstr "Configure your location's longitude (LON)."
 
 msgid "Configure the minimum amount of disk space to be available for recordings. When the amount of space drops below this value, deleted items will be removed from the trash can."
-msgstr "Configure the minimum amount of disk space to be available for recordings. When the amount of space drops below this value, deleted items will be removed from the trash can."
+msgstr "Configure the minimum amount of disk space required for recordings. When the amount of space drops below this value, deleted items will be removed from the trash can."
 
 msgid "Configure the minimum width before showing the 'i' icon, '0' is equal to not showing the icon at all."
-msgstr "Configure the minimum width before showing the 'i' icon, '0' is equal to not showing the icon at all."
+msgstr "Configure the minimum width before displaying the (i) symbol. 0 will hide the icon completely."
 
 msgid "Configure the nameserver (DNS)."
 msgstr "Configure the nameserver (DNS)."
@@ -4773,31 +4790,31 @@ msgid "Configure the netmask."
 msgstr "Configure the netmask."
 
 msgid "Configure the number of days after which items are automatically removed from the trash can."
-msgstr "Configure the number of days after which items are automatically removed from the trash can."
+msgstr "Configure the number of days after which deleted items should be removed from the trash can."
 
 msgid "Configure the number of days old timers are kept before they are automatically removed from the timer list."
 msgstr "Configure the number of days old timers are kept before they are automatically removed from the timer list."
 
 msgid "Configure the number of rows shown."
-msgstr "Configure the number of rows shown."
+msgstr "Configure the number of rows to be shown."
 
 msgid "Configure the offline decoding delay in milliseconds. The configured delay is observed at each control word parity change."
 msgstr "Configure the offline decoding delay in milliseconds. The configured delay is observed at each control word parity change."
 
 msgid "Configure the possible fast forward speeds."
-msgstr "Configure the possible fast forward speeds."
+msgstr "Configure the available fast forward speeds."
 
 msgid "Configure the possible rewind speeds."
-msgstr "Configure the possible rewind speeds."
+msgstr "Configure the available rewind speeds."
 
 msgid "Configure the primary EPG language."
-msgstr "Configure the primary EPG language."
+msgstr "Configure the first EPG language."
 
 msgid "Configure the refresh rate of the screen."
 msgstr "Configure the refresh rate of the screen."
 
 msgid "Configure the screen resolution for teletext (Not all skins support full-HD teletext)."
-msgstr "Configure the screen resolution for teletext (Not all skins support full-HD teletext)."
+msgstr "Configure the screen resolution for teletext (not all skins support Full HD teletext)."
 
 msgid "Configure the second audio language."
 msgstr "Configure the second audio language."
@@ -4806,7 +4823,7 @@ msgid "Configure the second subtitle language."
 msgstr "Configure the second subtitle language."
 
 msgid "Configure the secondary EPG language."
-msgstr "Configure the secondary EPG language."
+msgstr "Configure the second EPG language."
 
 msgid "Configure the skip time interval for the '1'/'3' buttons."
 msgstr "Configure the skip time interval for the '1'/'3' buttons."
@@ -4818,7 +4835,7 @@ msgid "Configure the skip time interval for the '7'/'9' buttons."
 msgstr "Configure the skip time interval for the '7'/'9' buttons."
 
 msgid "Configure the slow motion speeds."
-msgstr "Configure the slow motion speeds."
+msgstr "Configure the available slow motion speeds."
 
 msgid "Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner."
 msgstr "Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner."
@@ -4827,10 +4844,10 @@ msgid "Configure the speed of the background deletion process. Lower speed will 
 msgstr "Configure the speed of the background deletion process. Lower speed will consume less hard disk drive performance."
 
 msgid "Configure the start coordinate in x of the teletext display area."
-msgstr "Configure the start coordinate in x of the teletext display area."
+msgstr "Configure the start co-ordinate in x of the teletext display area."
 
 msgid "Configure the start coordinate in y of the teletext display area."
-msgstr "Configure the start coordinate in y of the teletext display area."
+msgstr "Configure the start co-ordinate in y of the teletext display area."
 
 msgid "Configure the subtitle delay when timing information is not available."
 msgstr "Configure the subtitle delay when timing information is not available."
@@ -4842,91 +4859,88 @@ msgid "Configure the third subtitle language."
 msgstr "Configure the third subtitle language."
 
 msgid "Configure the transparency of the black background of graphical DVB subtitles."
-msgstr "Configure the transparency of the black background of graphical DVB subtitles."
+msgstr "Choose the background transparency level to use for DVB subtitles."
 
-#, fuzzy
 msgid "Configure the transparency of the black background of subtitles."
-msgstr "Configure the transparency of the black background of graphical DVB subtitles."
+msgstr "Choose the background transparency level to use for subtitles."
 
 msgid "Configure the tuner mode."
 msgstr "Configure the tuner mode."
 
 msgid "Configure the type of status indication icons shown in the movielist."
-msgstr "Configure the type of status indication icons shown in the movielist."
+msgstr "Configure which type of status indicator icons to show in the movie list."
 
 msgid "Configure the vertical position of the subtitles, measured from the bottom of the screen."
 msgstr "Configure the vertical position of the subtitles, measured from the bottom of the screen."
 
 msgid "Configure the width allocated to the picon."
-msgstr "Configure the width allocated to the picon."
+msgstr "Configure how wide channel picons should appear."
 
 msgid "Configure the width allocated to the service name."
-msgstr "Configure the width allocated to the service name."
+msgstr "Configure how wide channel names should appear."
 
 msgid "Configure the width of the TrueType font letters used for teletext."
-msgstr "Configure the width of the TrueType font letters used for teletext."
+msgstr "Configure how wide teletext letters should appear when using a TrueType font."
 
 msgid "Configure this tuner using simple or advanced options, or loop it through to another tuner, or copy a configuration from another tuner, or disable it."
-msgstr ""
+msgstr "Configure this tuner using simple or advanced options - loop it through to another tuner; copy a configuration from another tuner; or disable it."
 
-#, fuzzy
 msgid "Configure to show channel names, numbers, picons or all three inside EPG."
-msgstr "Configure to show the channel names, picons, or both in the EPG."
+msgstr "Choose whether to show channel numbers, names, picons, or all three on the EPG."
 
 msgid "Configure to show the channel names, picons, or both in the EPG."
-msgstr "Configure to show the channel names, picons, or both in the EPG."
+msgstr "Choose whether to show channel names, picons, or both on the EPG."
 
 msgid "Configure whether a bold TrueType font is used for teletext."
-msgstr "Configure whether a bold TrueType font is used for teletext."
+msgstr "Choose whether teletext should be displayed using a bold TrueType font."
 
 msgid "Configure whether a fixed font or a scalable TrueType font is used for teletext."
-msgstr "Configure whether a fixed font or a scalable TrueType font is used for teletext."
+msgstr "Choose whether teletext should be displayed using a fixed or scalable TrueType font."
 
 msgid "Configure whether another tuner from the preferred list is allocated for recordings instead of sharing a tuner that is already active receiving the same live TV channel."
-msgstr "Configure whether another tuner from the preferred list is allocated for recordings instead of sharing a tuner that is already active receiving the same live TV channel."
+msgstr "Choose whether another tuner from the preferred list is allocated for recordings instead of sharing a tuner that is already active receiving the same live TV channel."
 
 msgid "Configure whether another tuner from the preferred list is allocated instead of sharing a tuner that is already active recording the same channel."
-msgstr "Configure whether another tuner from the preferred list is allocated instead of sharing a tuner that is already active recording the same channel."
+msgstr "Choose whether another tuner from the preferred list is allocated instead of sharing a tuner that is already active recording the same channel."
 
-#, fuzzy
 msgid "Configure whether multi channel sound tracks should be downmixed to stereo."
-msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr "Choose whether multi-channel audio tracks should be downmixed to 2-channel stereo."
 
 msgid "Configure whether the 'recording' symbol (in the display skin and LCD skin) is visible for real recordings only or also for streaming and pseuso recordings (e.g. EPGrefresh)."
-msgstr "Configure whether the 'recording' symbol (in the display skin and LCD skin) is visible for real recordings only or also for streaming and pseuso recordings (e.g. EPGrefresh)."
+msgstr "Choose whether the 'recording' symbol (in the display skin and front panel display) should be displayed for real recordings only or for streaming and pseuso recordings too (e.g. EPGrefresh)."
 
 msgid "Configure which color format should be used on the SCART output."
-msgstr "Configure which color format should be used on the SCART output."
+msgstr "Choose which color format should be used on the SCART output."
 
 msgid "Configure which tuner for recordings will be preferred, when more than one tuner is available."
-msgstr "Configure which tuner for recordings will be preferred, when more than one tuner is available."
+msgstr "Select which tuner should be used for recordings when there's more than one available."
 
 msgid "Configure which tuner type will be preferred, when the same service is available on different types of tuners."
-msgstr "Configure which tuner type will be preferred, when the same service is available on different types of tuners."
+msgstr "Select which tuner should be used when the same channel is available on different types of tuner."
 
 msgid "Configure which tuner will be preferred for recordings, when more than one tuner is available. 'Disabled' would select a tuner based on preferred tuner in customise screen. 'Auto' would choose based on E2's default rules, ignoring preferred tuner in customise screen."
-msgstr "Configure which tuner will be preferred for recordings, when more than one tuner is available. 'Disabled' would select a tuner based on preferred tuner in customise screen. 'Auto' would choose based on E2's default rules, ignoring preferred tuner in customise screen."
+msgstr "Select which tuner should be used for recordings when more than one tuner is available. 'disabled' would select based on the preferred tuner on the customize screen. 'auto' will ignore the preferred tuner and select one based on Enigma2's default rules."
 
 msgid "Configure which tuner will be preferred, when more than one tuner is available. If set to 'auto' the system will give priority to the tuner having the lowest number of channels/satellites."
-msgstr "Configure which tuner will be preferred, when more than one tuner is available. If set to 'auto' the system will give priority to the tuner having the lowest number of channels/satellites."
+msgstr "Select which tuner should be used when there's more than one available. 'auto' will give priority to the tuner with the lowest number of channels/satellites."
 
 msgid "Configure your NTP server."
 msgstr "Configure your NTP server."
 
 msgid "Configure your Network"
-msgstr "Configure your Network"
+msgstr "Configure your network"
 
 msgid "Configure your internal LAN"
 msgstr "Configure your internal LAN"
 
 msgid "Configure your network again"
-msgstr "Configure your network again"
+msgstr "Re-configure your network"
 
 msgid "Configure your network settings, and press OK to start the scan"
-msgstr "Configure your network settings, and press OK to start the scan"
+msgstr "Configure your network settings, then press OK to start the scan"
 
 msgid "Configure your wireless LAN again"
-msgstr "Configure your wireless LAN again"
+msgstr "Re-configure your wireless LAN"
 
 msgid "Configures which video output connector will be used."
 msgstr "Configures which video output connector will be used."
@@ -4941,7 +4955,7 @@ msgid "Congo"
 msgstr "Congo"
 
 msgid "Congo (Democratic Republic of the)"
-msgstr "Congo (Democratic Republic of the)"
+msgstr "Congo, Democratic Republic of the"
 
 #, python-format
 msgid "Congratulations, you have successfully configured your %s %s for use with the IceTV Smart Recording service. Your IceTV guide will now download in the background."
@@ -4976,10 +4990,10 @@ msgid "Constellation"
 msgstr "Constellation"
 
 msgid "Consult your SCR device spec sheet for this information."
-msgstr ""
+msgstr "Refer to your SCR device's spec sheet for this information."
 
 msgid "Consult your motor's spec sheet for this information, or leave the default setting."
-msgstr ""
+msgstr "Refer to your dish rotator's spec sheet for this information or leave the default setting."
 
 #, python-format
 msgid "Contacting IceTV server and setting up your %s %s."
@@ -4992,10 +5006,10 @@ msgid "Content does not fit on DVD!"
 msgstr "Content does not fit on DVD!"
 
 msgid "Context"
-msgstr "Context"
+msgstr "Context press"
 
 msgid "Context long"
-msgstr "Context long"
+msgstr "Context button hold"
 
 msgid "Continue"
 msgstr "Continue"
@@ -5019,13 +5033,13 @@ msgid "Contrast"
 msgstr "Contrast"
 
 msgid "Control of the position how finished timer are shown in the Timer List."
-msgstr "Control of the position how finished timer are shown in the Timer List."
+msgstr "Choose where completed timers should appear in the timer list."
 
 msgid "Control the Infobar fading speed"
-msgstr "Control the Infobar fading speed"
+msgstr "Configure the length of time it should take for the infobar to fade out."
 
 msgid "Control your Softcams"
-msgstr "Control your Softcams"
+msgstr "Control your softcams"
 
 msgid "Convert ext3 filesystem to ext4"
 msgstr "Convert ext3 filesystem to ext4"
@@ -5034,7 +5048,7 @@ msgid "Convert ext3 to ext4"
 msgstr "Convert ext3 to ext4"
 
 msgid "Convert filesystem ext3 to ext4"
-msgstr "Convert filesystem ext3 to ext4"
+msgstr "Convert filesystem from ext3 to ext4"
 
 msgid "Converting ext3 to ext4..."
 msgstr "Converting ext3 to ext4..."
@@ -5042,9 +5056,9 @@ msgstr "Converting ext3 to ext4..."
 msgid "Cook Islands"
 msgstr "Cook Islands"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Cooking"
-msgstr "cooking"
+msgstr ""
 
 msgid "Cool Channel Guide"
 msgstr "Cool Channel Guide"
@@ -5071,19 +5085,17 @@ msgstr ""
 msgid "Copy 1 element"
 msgstr ""
 
-#, fuzzy
 msgid "Copy file"
-msgstr "Copying files"
+msgstr "Copy file"
 
 msgid "Copy file/directory to target directory"
-msgstr ""
+msgstr "Copy file/folder to target folder"
 
 msgid "Copy files/directories to target directory"
-msgstr ""
+msgstr "Copy files/folders to target folder"
 
-#, fuzzy
 msgid "Copy folder"
-msgstr "Copying files"
+msgstr "Copy folder"
 
 msgid "Copying files"
 msgstr "Copying files"
@@ -5116,10 +5128,10 @@ msgid "Could not find suitable media - Please remove some downloaded images or i
 msgstr ""
 
 msgid "Could not load Medium! No disc inserted?"
-msgstr "Could not load Medium! No disc inserted?"
+msgstr "Could not load disc! Please check that one has been inserted."
 
 msgid "Could not open Picture in Picture"
-msgstr "Could not open Picture in Picture"
+msgstr "Can't start picture-in-picture mode"
 
 #, python-format
 msgid "Could not open the file %s!"
@@ -5140,54 +5152,50 @@ msgstr "Could not save configfile %s!"
 msgid "Country"
 msgstr "Country"
 
-#, fuzzy
 msgid "Country for EPG event genre information"
-msgstr "Softwaremanager information"
+msgstr "EPG event genre country"
 
 msgid "Country for EPG event rating information"
-msgstr ""
+msgstr "EPG event rating country"
 
 msgid "Cpu"
-msgstr "Cpu"
+msgstr "CPU"
 
 msgid "Crash Logs"
 msgstr "Crash Logs"
 
 msgid "Crash at skin error for debug reasons ?"
-msgstr "Crash at skin error for debug reasons ?"
+msgstr "Crash on skin error for debug reasons"
 
 msgid "Create"
 msgstr "Create"
 
 msgid "Create Bludisc ISO file"
-msgstr "Create Bludisc ISO file"
+msgstr "Create Blu-ray disc ISO file"
 
 msgid "Create DVD-ISO"
-msgstr "Create DVD-ISO"
+msgstr "Create DVD ISO"
 
 msgid "Create ISO"
 msgstr "Create ISO"
 
 msgid "Create directory"
-msgstr "Create directory"
+msgstr "Create folder"
 
-#, fuzzy
 msgid "Create directory/folder"
-msgstr "Create directory"
+msgstr "Create folder"
 
 msgid "Create separate radio userbouquet"
-msgstr "Create separate radio userbouquet"
+msgstr "Create separate radio user bouquet"
 
-#, fuzzy
 msgid "Create symlink to file"
-msgstr "Create Bludisc ISO file"
+msgstr "Create symlink to file"
 
 msgid "Create user-named symbolic link"
 msgstr ""
 
-#, fuzzy
 msgid "Create:"
-msgstr "Create"
+msgstr "Create:"
 
 #, python-format
 msgid "Create: Recovery Fullbackup %s"
@@ -5197,11 +5205,11 @@ msgid "Creating AP and SC Files"
 msgstr "Creating AP and SC Files"
 
 msgid "Creating Hardlink to Timeshift file failed!"
-msgstr "Creating Hardlink to Timeshift file failed!"
+msgstr "Couldn't start timeshift mode!"
 
 #, python-format
 msgid "Creating directory %s failed."
-msgstr "Creating directory %s failed."
+msgstr "Couldn't create folder %s."
 
 msgid "Creating filesystem"
 msgstr "Creating filesystem"
@@ -5209,10 +5217,11 @@ msgstr "Creating filesystem"
 msgid "Creating partition"
 msgstr "Creating partition"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Cricket"
-msgstr "locked"
+msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Crime"
 msgstr ""
 
@@ -5226,14 +5235,15 @@ msgid "Cron Manager"
 msgstr "Cron Manager"
 
 msgid "CronManager"
-msgstr "CronManager"
+msgstr "Cron Manager"
 
 msgid "CronTimers"
-msgstr "CronTimers"
+msgstr "Cron Timers"
 
 msgid "Cuba"
 msgstr "Cuba"
 
+#. TRANSLATORS: genre category
 msgid "Cult"
 msgstr ""
 
@@ -5245,13 +5255,13 @@ msgid "Current Affairs"
 msgstr "News Current Affairs"
 
 msgid "Current CEC address"
-msgstr "Current CEC address"
+msgstr "Current HDMI-CEC address"
 
 msgid "Current Event:"
 msgstr "Current Event:"
 
 msgid "Current Status:"
-msgstr "Current Status:"
+msgstr "Current status"
 
 msgid "Current device: "
 msgstr "Current device: "
@@ -5288,19 +5298,19 @@ msgid "Custom"
 msgstr "Custom"
 
 msgid "Custom skip time for '1'/'3' buttons"
-msgstr "Custom skip time for '1'/'3' buttons"
+msgstr "Custom skip time for 1 and 3 buttons"
 
 msgid "Custom skip time for '4'/'6' buttons"
-msgstr "Custom skip time for '4'/'6' buttons"
+msgstr "Custom skip time for 4 and 6 buttons"
 
 msgid "Custom skip time for '7'/'9' buttons"
-msgstr "Custom skip time for '7'/'9' buttons"
+msgstr "Custom skip time for 7 and 9 buttons"
 
 msgid "Customise"
-msgstr "Customise"
+msgstr "Customize"
 
 msgid "Customise enigma2 personal settings"
-msgstr "Customise enigma2 personal settings"
+msgstr "Customize Enigma2 personal settings"
 
 msgid "Customize"
 msgstr "Customize"
@@ -5317,6 +5327,7 @@ msgstr "Cutlist editor"
 msgid "Cutlist editor..."
 msgstr "Cutlist editor..."
 
+#. TRANSLATORS: genre category
 msgid "Cycling"
 msgstr ""
 
@@ -5327,7 +5338,7 @@ msgid "Czech"
 msgstr "Czech"
 
 msgid "Czechia"
-msgstr "Czechia"
+msgstr "Czech Republic"
 
 msgid "DAC"
 msgstr "DAC"
@@ -5359,7 +5370,7 @@ msgid "DTS HD downmix"
 msgstr "DTS downmix"
 
 msgid "DTS downmix"
-msgstr "DTS downmix"
+msgstr "Downmix DTS"
 
 msgid "DTS/DTS-HD HR/DTS-HD MA/DTS:X"
 msgstr "DTS/DTS-HD HR/DTS-HD MA/DTS:X"
@@ -5371,14 +5382,13 @@ msgid "DVB CI Delay"
 msgstr "DVB CI Delay"
 
 msgid "DVB subtitle black transparency"
-msgstr "DVB subtitle black transparency"
+msgstr "DVB subtitle background transparency"
 
 msgid "DVB-C"
 msgstr "DVB-C"
 
-#, fuzzy
 msgid "DVB-C ANNEX B"
-msgstr "DVB-C ANNEX C"
+msgstr "DVB-C ANNEX B"
 
 msgid "DVB-C ANNEX C"
 msgstr "DVB-C ANNEX C"
@@ -5405,7 +5415,7 @@ msgid "DVD Menu"
 msgstr "DVD Menu"
 
 msgid "DVD Titlelist"
-msgstr "DVD Titlelist"
+msgstr "DVD Title List"
 
 msgid "DVD file browser"
 msgstr "DVD file browser"
@@ -5414,34 +5424,33 @@ msgid "DVD player"
 msgstr "DVD player"
 
 msgid "DVDPlayer"
-msgstr "DVDPlayer"
+msgstr "DVD Player"
 
 msgid "Daily"
 msgstr "Daily"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Dance"
-msgstr "Cancel"
+msgstr ""
 
 msgid "Danish"
 msgstr "Danish"
 
 msgid "Date"
-msgstr "Date"
+msgstr "Date (old-new)"
 
-#, fuzzy
 msgid "Date reverse"
-msgstr "alphabetic reverse"
+msgstr "Date (new-old)"
 
 msgid "Date style"
 msgstr ""
 
 msgid "Date/time input"
-msgstr "Date/time input"
+msgstr "Date/Time Entry"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Dating"
-msgstr "Waiting"
+msgstr ""
 
 msgid "Day D Mon"
 msgstr ""
@@ -5570,9 +5579,8 @@ msgstr "Deactivate"
 msgid "Debug Logs"
 msgstr "Debug Logs"
 
-#, fuzzy
 msgid "Decryption & Parental Control"
-msgstr "Parental control"
+msgstr "Decryption & Parental Control"
 
 msgid "Deep Standby"
 msgstr "Deep Standby"
@@ -5587,55 +5595,49 @@ msgid "Default  (keymap.xml)"
 msgstr "Default  (keymap.xml)"
 
 msgid "Default 'After event' *"
-msgstr "Default 'After event' *"
+msgstr "Default After event action *"
 
 msgid "Default 'Timer type' *"
-msgstr "Default 'Timer type' *"
+msgstr "Default Timer type *"
 
 msgid "Default (Instant Record)"
-msgstr "Default (Instant Record)"
+msgstr "default (record instantly)"
 
 msgid "Default (Timeshift)"
-msgstr "Default (Timeshift)"
+msgstr "Default (timeshift)"
 
 msgid "Default CPU priority (nice) for executed scripts. This can reduce the load so that scripts do not interfere with the rest of the system. (higher values = lower priority)"
-msgstr ""
+msgstr "Default CPU priority (nice) for executed scripts. This can reduce the load so that scripts won't interfere with the rest of the system (higher value = lower priority)."
 
-#, fuzzy
 msgid "Default Folder"
-msgstr "Default"
+msgstr "Default Folder"
 
 msgid "Default I/O priority (ionice) for executed scripts. This can reduce the load so that scripts do not interfere with the rest of the system. (higher values = lower priority)"
-msgstr ""
+msgstr "Default I/O priority (ionice) for executed scripts. This can reduce the load so that scripts won't interfere with the rest of the system (higher value = lower priority)."
 
-#, fuzzy
 msgid "Default Modes Selected."
-msgstr "Default movie location"
+msgstr ""
 
 msgid "Default Services Scanner"
 msgstr "Default Services Scanner"
 
-#, fuzzy
 msgid "Default directory sorting"
-msgstr "Default settings"
+msgstr "Default sort"
 
-#, fuzzy
 msgid "Default file sorting left"
-msgstr "Default recording type"
+msgstr "Default left side sort"
 
-#, fuzzy
 msgid "Default file sorting right"
-msgstr "Default recording type"
+msgstr "Default right side sort"
 
 msgid "Default files/folders to backup"
-msgstr "Default files/folders to backup"
+msgstr "Default files/folders to back up"
 
-#, fuzzy
 msgid "Default folder"
-msgstr "Select folders"
+msgstr "Default folder"
 
 msgid "Default folder if the left or right folder isn't saved, and target folder for button 5."
-msgstr ""
+msgstr "Default folder (when the left or right folder isn't remembered, or when the 5 button is pressed)."
 
 msgid "Default movie location"
 msgstr "Default movie location"
@@ -5647,43 +5649,43 @@ msgid "Default settings"
 msgstr "Default settings"
 
 msgid "Default sorting method for directories on both sides."
-msgstr ""
+msgstr "Default sorting method for folders on both sides."
 
 msgid "Default sorting method for files on the left side."
-msgstr ""
+msgstr "Default sorting method for folders on the left side."
 
 msgid "Default sorting method for files on the right side."
-msgstr ""
+msgstr "Default sorting method for folders on the right side."
 
 msgid "Defaults"
 msgstr "Defaults"
 
 msgid "Defines how fast the time jumps are repeated. Values lower than 500ms may be problematic with NAS."
-msgstr "Defines how fast the time jumps are repeated. Values lower than 500ms may be problematic with NAS."
+msgstr "Choose how quickly time jumps should be repeated. Values lower than 500ms may be problematic with a NAS."
 
 msgid "Defines the jump distance for backward jumps. The value is multiplied by the rewind speed, e.g. -4x. Values significantly lower than 2s may not work with all media files."
-msgstr "Defines the jump distance for backward jumps. The value is multiplied by the rewind speed, e.g. -4x. Values significantly lower than 2s may not work with all media files."
+msgstr "Choose the jump distance for backward jumps. The value is multiplied by the rewind speed, e.g. -4x. Values significantly lower than 2s may not work with all media files."
 
 msgid "Defines the jump distance for forward jumps. The value is multiplied by the wind speed, e.g. 4x. Values significantly lower than 4s may not work with all media files."
-msgstr "Defines the jump distance for forward jumps. The value is multiplied by the wind speed, e.g. 4x. Values significantly lower than 4s may not work with all media files."
+msgstr "Choose the jump distance for forward jumps. The value is multiplied by the wind speed, e.g. 4x. Values significantly lower than 4s may not work with all media files."
 
 msgid "Defines which fast forward speeds are using normal cueing. All other forward speeds and all rewind speeds use time jumps."
-msgstr "Defines which fast forward speeds are using normal cueing. All other forward speeds and all rewind speeds use time jumps."
+msgstr "Choose which fast forward speeds should use normal cueing. All other forward speeds and all rewind speeds will use time jumps."
 
 msgid "Delay after change voltage before switch command"
 msgstr "Delay after change voltage before switch command"
 
 msgid "Delay after continuous tone disable before diseqc"
-msgstr "Delay after continuous tone disable before diseqc"
+msgstr "Delay after continuous tone disable before DiSEqC"
 
 msgid "Delay after diseqc peripherial poweron command"
-msgstr "Delay after diseqc peripherial poweron command"
+msgstr "Delay after DiSEqC peripherial poweron command"
 
 msgid "Delay after diseqc reset command"
-msgstr "Delay after diseqc reset command"
+msgstr "Delay after DiSEqC reset command"
 
 msgid "Delay after enable voltage before motor command"
-msgstr "Delay after enable voltage before motor command"
+msgstr "Delay after enabling voltage before dish rotate command"
 
 msgid "Delay after enable voltage before switch command"
 msgstr "Delay after enable voltage before switch command"
@@ -5692,37 +5694,37 @@ msgid "Delay after final continuous tone change"
 msgstr "Delay after final continuous tone change"
 
 msgid "Delay after last diseqc command"
-msgstr "Delay after last diseqc command"
+msgstr "Delay after last DiSEqC command"
 
 msgid "Delay after last voltage change"
 msgstr "Delay after last voltage change"
 
 msgid "Delay after motor stop command"
-msgstr "Delay after motor stop command"
+msgstr "Delay after dish rotator stop command"
 
 msgid "Delay after set voltage before measure motor power"
-msgstr "Delay after set voltage before measure motor power"
+msgstr "Delay after setting voltage before measuring dish rotator power"
 
 msgid "Delay after toneburst"
 msgstr "Delay after toneburst"
 
 msgid "Delay after voltage change before motor command"
-msgstr "Delay after voltage change before motor command"
+msgstr "Delay after voltage change before dish rotator command"
 
 msgid "Delay before key repeat starts:"
-msgstr "Delay before key repeat starts:"
+msgstr "Delay before button repeat starts (in ms)"
 
 msgid "Delay before sequence repeat"
 msgstr "Delay before sequence repeat"
 
 msgid "Delay between diseqc commands"
-msgstr "Delay between diseqc commands"
+msgstr "Delay between DiSEqC commands"
 
 msgid "Delay between switch and motor command"
-msgstr "Delay between switch and motor command"
+msgstr "Delay between switch and dish rotator command"
 
 msgid "Delay for external subtitles"
-msgstr "Delay for external subtitles"
+msgstr "External subtitle delay"
 
 msgid "Delay in milliseconds after finish scrolling text on display."
 msgstr "Delay in milliseconds after finish scrolling text on display."
@@ -5758,17 +5760,16 @@ msgid "Delete EPG"
 msgstr "Delete EPG"
 
 msgid "Delete Language"
-msgstr "Delete Language"
+msgstr "Delete language"
 
 msgid "Delete Plugins"
 msgstr "Delete Plugins"
 
 msgid "Delete and uninstall Plugins. This will remove the Plugin from your box"
-msgstr "Delete and uninstall Plugins. This will remove the Plugin from your box"
+msgstr "Delete and uninstall plugins. This will remove the plugin from your receiver"
 
-#, fuzzy
 msgid "Delete current line"
-msgstr "Delete entry"
+msgstr "Delete the current line"
 
 msgid "Delete entry"
 msgstr "Delete entry"
@@ -5780,15 +5781,13 @@ msgid "Delete file"
 msgstr "Delete file"
 
 msgid "Delete file or directory (and all its contents)"
-msgstr ""
+msgstr "Delete file or folder (and all its contents)"
 
-#, fuzzy
 msgid "Delete folder"
-msgstr "Delete file"
+msgstr "Delete folder"
 
-#, fuzzy
 msgid "Delete image"
-msgstr "Delete timer"
+msgstr "Delete image"
 
 msgid "Delete playlist entry"
 msgstr "Delete playlist entry"
@@ -5805,12 +5804,11 @@ msgstr ""
 msgid "Delete the current timeshift buffer and restart timeshift"
 msgstr "Delete the current timeshift buffer and restart timeshift"
 
-#, fuzzy
 msgid "Delete the selected files or directories"
-msgstr "Select the sleep timer action."
+msgstr "Delete the selected files or folders"
 
 msgid "Delete timer"
-msgstr "Delete timer"
+msgstr "Remove timer"
 
 msgid "Deleted"
 msgstr "Deleted"
@@ -5832,16 +5830,16 @@ msgid "Denmark"
 msgstr "Denmark"
 
 msgid "Depth"
-msgstr "Depth"
+msgstr "3D depth"
 
 msgid "Descramble & record ECM' gives the option to descramble afterwards if descrambling on recording failed. 'Don't descramble, record ECM' save a scramble recording that can be descrambled on playback. 'Normal' means descramble the recording and don't record ECM."
-msgstr "Descramble & record ECM' gives the option to descramble afterwards if descrambling on recording failed. 'Don't descramble, record ECM' save a scramble recording that can be descrambled on playback. 'Normal' means descramble the recording and don't record ECM."
+msgstr "'decrypt and record ECM' will decrypt later if descrambling fails during recording. 'don't decrypt, record ECM' will save an encrypted recording which can be decrypted on playback. 'normal' will decrypt during recording without recording ECM."
 
 msgid "Descramble http streams"
-msgstr "Descramble http streams"
+msgstr "Decrypt HTTP streams"
 
 msgid "Descramble receiving http streams"
-msgstr "Descramble receiving http streams"
+msgstr "Decode receiving HTTP streams"
 
 msgid "Description"
 msgstr "Description"
@@ -5850,7 +5848,7 @@ msgid "Deselect"
 msgstr "Deselect"
 
 msgid "Details for plugin: "
-msgstr "Details for plugin: "
+msgstr "Plugin details: "
 
 msgid "Detected Devices:"
 msgstr "Detected Devices:"
@@ -5861,8 +5859,9 @@ msgstr "Detected HDD:"
 msgid "Detected NIMs:"
 msgstr "Detected NIMs:"
 
+#. TRANSLATORS: genre category
 msgid "Detektiv"
-msgstr ""
+msgstr "Detective"
 
 msgid "Device Information"
 msgstr "Device Information"
@@ -5914,7 +5913,7 @@ msgid "DiSEqC port %s: %s"
 msgstr "DiSEqC port %s: %s"
 
 msgid "DiSEqC-tester settings"
-msgstr "DiSEqC-tester settings"
+msgstr "DiSEqC tester settings"
 
 msgid "Diction"
 msgstr "Diction"
@@ -5925,33 +5924,32 @@ msgid ""
 "End Action was disabled !"
 msgstr ""
 "Difference between timer begin and end must be equal or greater than %d minutes.\n"
-"End Action was disabled !"
+"End action was disabled!"
 
 msgid "Digital contour removal"
 msgstr "Digital contour removal"
 
 msgid "Dim delay"
-msgstr "Dim delay"
+msgstr "Dim after"
 
-#, fuzzy
 msgid "Dim the LCD to the level from 'Brightness (Dimmed)' after specified time."
-msgstr "Dim the LCD after specified time."
+msgstr "Dim the front panel display after the specified time."
 
 msgid "Direct playback of linked titles without menu"
 msgstr "Direct playback of linked titles without menu"
 
 msgid "Directory"
-msgstr "Directory"
+msgstr "Directory button"
 
 #, python-format
 msgid "Directory %s does not exist."
-msgstr "Directory %s does not exist."
+msgstr "Folder %s does not exist."
 
 msgid "Directory browser"
 msgstr "Directory browser"
 
 msgid "Directory long"
-msgstr "Directory long"
+msgstr "Directory button hold"
 
 msgid "Disable"
 msgstr "Disable"
@@ -5959,18 +5957,17 @@ msgstr "Disable"
 msgid "Disable Animations"
 msgstr "Disable Animations"
 
-#, fuzzy
 msgid "Disable IceTV"
-msgstr "Disable MiniTV"
+msgstr ""
 
 msgid "Disable MiniTV"
-msgstr "Disable MiniTV"
+msgstr "Disable mini TV window"
 
 msgid "Disable Picture in Picture"
-msgstr "Disable Picture in Picture"
+msgstr "Stop Picture-in-Picture mode"
 
 msgid "Disable all VFD Symbols"
-msgstr "Disable all VFD Symbols"
+msgstr "Disable all front panel display symbols"
 
 msgid "Disable background scanning"
 msgstr "Disable background scanning"
@@ -5982,38 +5979,31 @@ msgid "Disable intro screen"
 msgstr "Disable intro screen"
 
 msgid "Disable the HDD Process on VFD"
-msgstr "Disable the HDD Process on VFD"
+msgstr "Disable hard disk status on front panel display"
 
 msgid "Disable timer"
 msgstr "Disable timer"
 
 msgid "Disabled"
-msgstr "Disabled"
+msgstr "disabled"
 
 msgid "Disabled PIP.\n"
-msgstr "Disabled PIP.\n"
+msgstr "Disabled PiP.\n"
 
 msgid "Dish"
 msgstr "Dish"
 
-#, fuzzy
 msgid "Disk full"
-msgstr "full"
+msgstr "Disk full"
 
-#, fuzzy
 msgid "Disk full?"
-msgstr "full"
-
-#, fuzzy
-msgid "Disk is not writable!"
-msgstr "Medium is not a writeable DVD!"
+msgstr "Disk full?"
 
 msgid "Disk space to reserve for recordings (in GB)"
 msgstr "Disk space to reserve for recordings (in GB)"
 
-#, fuzzy
 msgid "Disk was not found!"
-msgstr "no CI slots found"
+msgstr "Disk was not found!"
 
 msgid "Display 16:9 content as"
 msgstr "Display 16:9 content as"
@@ -6025,10 +6015,10 @@ msgid "Display >16:9 content as"
 msgstr "Display >16:9 content as"
 
 msgid "Display Settings"
-msgstr "Display Settings"
+msgstr "Front Panel Display Settings"
 
 msgid "Display Setup"
-msgstr "Display Setup"
+msgstr "Front Panel Display Display Setup"
 
 msgid "Display and user interface"
 msgstr "Display and user interface"
@@ -6037,19 +6027,19 @@ msgid "Display message before playing next movie"
 msgstr "Display message before playing next movie"
 
 msgid "Display settings"
-msgstr "Display settings"
+msgstr "Display Settings"
 
 msgid "Display the EIT now/next eventdata in infobar."
-msgstr "Display the EIT now/next eventdata in infobar."
+msgstr "Choose whether EIT now/next event data should be shown on the infobar."
 
 msgid "Djibouti"
 msgstr "Djibouti"
 
 msgid "Do center DVB subs on this service"
-msgstr "Do center DVB subs on this service"
+msgstr "Center DVB subtitles on this channel"
 
 msgid "Do not center DVB subs on this service"
-msgstr "Do not center DVB subs on this service"
+msgstr "Don't center DVB subtitles"
 
 msgid "Do not change"
 msgstr "Do not change"
@@ -6058,184 +6048,188 @@ msgid "Do not flash image"
 msgstr "Do not flash image"
 
 msgid "Do not record"
-msgstr "Do not record"
+msgstr "Exit"
 
 msgid ""
 "Do you really want to check the filesystem?\n"
 "This could take a long time!"
 msgstr ""
-"Do you really want to check the filesystem?\n"
-"This could take a long time!"
+"Are you sure you want to check the filesystem?\n"
+"This could take a while!"
 
 msgid ""
 "Do you really want to convert the filesystem?\n"
 "You cannot go back!"
 msgstr ""
-"Do you really want to convert the filesystem?\n"
-"You cannot go back!"
+"Are you sure you want to convert the filesystem?\n"
+"This can NOT be undone!"
 
 #, python-format
 msgid "Do you really want to delete %s ?"
-msgstr "Do you really want to delete %s ?"
+msgstr "Are you sure you want to delete %s?"
 
 #, python-format
 msgid "Do you really want to delete %s?"
-msgstr "Do you really want to delete %s?"
+msgstr "Are you sure you want to remove %s?"
 
 msgid "Do you really want to delete ?"
-msgstr "Do you really want to delete ?"
+msgstr "Are you sure you want to delete?"
 
 msgid "Do you really want to delete the recording?"
-msgstr "Do you really want to delete the recording?"
+msgstr "Are you sure you want to delete this recording?"
 
 msgid "Do you really want to delete this timer ?"
-msgstr "Do you really want to delete this timer ?"
+msgstr "Are you sure you want to delete this timer?"
 
 #, python-format
 msgid "Do you really want to download the plugin \"%s\"?"
-msgstr "Do you really want to download the plugin \"%s\"?"
+msgstr ""
+"Are you sure you want to download and install\n"
+"the \"%s\" plugin?"
 
 msgid "Do you really want to exit?"
-msgstr "Do you really want to exit?"
+msgstr "Are you sure you want to exit?"
 
 msgid ""
 "Do you really want to initialize the device?\n"
 "All data on the disk will be lost!"
 msgstr ""
-"Do you really want to initialize the device?\n"
-"All data on the disk will be lost!"
+"Are you sure you want to format the selected device?\n"
+"ALL DATA on it will be LOST!"
 
 msgid "Do you really want to move to trashcan ?"
-msgstr "Do you really want to move to trashcan ?"
+msgstr "Are you sure you want to move to the trash can?"
 
 #, python-format
 msgid "Do you really want to permamently remove '%s' from trash can ?"
-msgstr "Do you really want to permamently remove '%s' from trash can ?"
+msgstr "Are you sure you want to permamently remove '%s' from the trash can?"
 
 msgid "Do you really want to permanently remove from trash can ?"
-msgstr "Do you really want to permanently remove from trash can ?"
+msgstr "Are you sure you want to permanently remove this from the trash can?"
 
 #, python-format
 msgid "Do you really want to remove directory %s from the disk?"
-msgstr "Do you really want to remove directory %s from the disk?"
+msgstr "Are you sure you want to delete folder %s from the disk?"
 
 #, python-format
 msgid "Do you really want to remove the plugin \"%s\"?"
-msgstr "Do you really want to remove the plugin \"%s\"?"
+msgstr "Are you sure you want to remove the \"%s\" plugin?"
 
 #, python-format
 msgid "Do you really want to remove the timer for %s?"
-msgstr "Do you really want to remove the timer for %s?"
+msgstr "Are you sure you want to remove the timer for %s?"
 
 #, python-format
 msgid "Do you really want to remove your bookmark of %s?"
-msgstr "Do you really want to remove your bookmark of %s?"
+msgstr "Are you sure you want to remove your bookmark of %s?"
 
 #, fuzzy
 msgid "Do you want change rights?\n"
-msgstr "Do you want to install a channel list?"
+msgstr "Would you like to install a channel list?"
 
 msgid "Do you want to add any additional information ?"
-msgstr "Do you want to add any additional information ?"
+msgstr "Would you like to add any additional information?"
 
 msgid ""
 "Do you want to also install samba client ?\n"
 "This allows you to mount your windows shares on this device."
 msgstr ""
-"Do you want to also install samba client ?\n"
-"This allows you to mount your windows shares on this device."
+"Would you like to install Samba client too?\n"
+"This allows you to mount your Windows shares on this device."
 
 msgid ""
 "Do you want to attach a text file to explain the log ?\n"
 "(choose 'No' to type message using virtual keyboard.)"
 msgstr ""
-"Do you want to attach a text file to explain the log ?\n"
-"(choose 'No' to type message using virtual keyboard.)"
+"Would you like to attach a text file to explain the log?\n"
+"(select 'No' to type a message using the virtual keyboard)."
 
 msgid ""
 "Do you want to backup now?\n"
 "After pressing OK, please wait!"
 msgstr ""
-"Do you want to backup now?\n"
+"Would you like to backup now?\n"
 "After pressing OK, please wait!"
 
 msgid "Do you want to burn this collection to DVD medium?"
-msgstr "Do you want to burn this collection to DVD medium?"
+msgstr "Would you like to burn this collection to DVD?"
 
 msgid "Do you want to continue?"
-msgstr "Do you want to continue?"
+msgstr "Would you like to continue?"
 
 #, fuzzy
 msgid ""
 "Do you want to delete all other languages?\n"
 "Except English, French, German and your selection:\n"
 "\n"
-msgstr "Do you want to delete all other languages?"
+msgstr "Would you like to delete all other languages?"
 
 msgid ""
 "Do you want to delete all selected files:\n"
 "(choose 'No' to only delete the currently selected file.)"
 msgstr ""
-"Do you want to delete all selected files:\n"
-"(choose 'No' to only delete the currently selected file.)"
+"Would you like to delete all selected files:\n"
+"(select 'No' to only delete the currently selected file)."
 
 msgid "Do you want to delete the old settings in /etc/enigma2 first?"
-msgstr "Do you want to delete the old settings in /etc/enigma2 first?"
+msgstr "Would you like to delete your existing settings in /etc/enigma2 ?"
 
 msgid "Do you want to do a service scan?"
-msgstr "Do you want to do a service scan?"
+msgstr "Would you like to do a channel scan?"
 
 msgid "Do you want to do another manual service scan?"
-msgstr "Do you want to do another manual service scan?"
+msgstr "Would you like to do another manual channel scan?"
 
 #, python-format
 msgid "Do you want to download the image to %s ?"
-msgstr "Do you want to download the image to %s ?"
+msgstr "Would you like to download the image to %s?"
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Do you want to flash image\n"
 "%s"
-msgstr "Do you want to download the image to %s ?"
+msgstr ""
+"Are you sure you want to flash the image\n"
+"%s"
 
 msgid "Do you want to install a channel list?"
-msgstr "Do you want to install a channel list?"
+msgstr "Would you like to install a channel list?"
 
 msgid "Do you want to install the package:\n"
-msgstr "Do you want to install the package:\n"
+msgstr "Would you like to install the package\n"
 
 msgid "Do you want to play DVD in drive?"
-msgstr "Do you want to play DVD in drive?"
+msgstr "Would you like to play DVD in drive?"
 
 msgid "Do you want to preview this DVD before burning?"
-msgstr "Do you want to preview this DVD before burning?"
+msgstr "Would you like to preview this DVD before burning?"
 
 msgid "Do you want to produce this collection?"
-msgstr "Do you want to produce this collection?"
+msgstr "Would you like to produce this collection?"
 
 #, fuzzy, python-format
 msgid "Do you want to reboot now the image in slot %s?"
-msgstr "Do you want to reboot now with selected image?"
+msgstr "Are you sure you want to reboot now with the selected image?"
 
 #, python-format
 msgid "Do you want to reboot your %s %s"
-msgstr "Do you want to reboot your %s %s"
+msgstr "Are you sure you want to reboot your %s %s?"
 
 #, python-format
 msgid "Do you want to reboot your %s %s?"
-msgstr "Do you want to reboot your %s %s?"
+msgstr "Are you sure you want to reboot your %s %s?"
 
 msgid "Do you want to reboot your receiver?"
-msgstr "Do you want to reboot your receiver?"
+msgstr "Are you sure you want to reboot your receiver?"
 
 msgid "Do you want to remove the package:\n"
-msgstr "Do you want to remove the package:\n"
+msgstr "Are you sure you want to remove the package\n"
 
 msgid "Do you want to restart now?"
-msgstr "Do you want to restart now?"
+msgstr "Are you sure you want to restart now?"
 
 msgid "Do you want to restore your settings?"
-msgstr "Do you want to restore your settings?"
+msgstr "Are you sure you want to restore your settings?"
 
 msgid "Do you want to resume this playback?"
 msgstr "Do you want to resume this playback?"
@@ -6244,33 +6238,32 @@ msgid ""
 "Do you want to send all selected files:\n"
 "(choose 'No' to only send the currently selected file.)"
 msgstr ""
-"Do you want to send all selected files:\n"
-"(choose 'No' to only send the currently selected file.)"
+"Would you like to send all selected files:\n"
+"(choose 'No' to only send the currently selected file)."
 
 #, python-format
 msgid "Do you want to update your %s %s ?"
-msgstr "Do you want to update your %s %s ?"
+msgstr "Are you sure you want to update your %s %s?"
 
 msgid "Do you want to update your box?"
-msgstr "Do you want to update your box?"
+msgstr "Are you sure you want to update your receiver?"
 
 msgid "Do you want to upgrade the package:\n"
-msgstr "Do you want to upgrade the package:\n"
+msgstr "Would you like to upgrade the package?\n"
 
-#, fuzzy
 msgid "Do you want to view or run the script?\n"
-msgstr "Are you ready to run the script ?"
+msgstr "Would you like to view or run the script?\n"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Documentary"
-msgstr "documentary"
+msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Dokumentation"
-msgstr "Current location"
+msgstr "Documentation"
 
 msgid "Dolby Digital downmix is now"
-msgstr "Dolby Digital downmix is now"
+msgstr "Dolby Digital / Dolby AC-3 downmix is now"
 
 msgid "Dominica"
 msgstr "Dominica"
@@ -6285,7 +6278,7 @@ msgid "Don't ask again!"
 msgstr "Don't ask again!"
 
 msgid "Don't save"
-msgstr "Don't save"
+msgstr "don't save"
 
 msgid "Don't stop current event but disable coming events"
 msgstr "Don't stop current event but disable coming events"
@@ -6294,24 +6287,24 @@ msgid ""
 "Don't worry your device is still ok! There are several safety mechanisms in place!\n"
 "Your device is still as fine as it was before this procedure!"
 msgstr ""
-"Don't worry your device is still ok! There are several safety mechanisms in place!\n"
-"Your device is still as fine as it was before this procedure!"
+"Don't worry, your device is still OK! There are several safety mechanisms in place.\n"
+"Your device is still as fine as it was before this procedure."
 
 msgid "Done"
 msgstr ""
 
 #, python-format
-msgid "Done - Installed or upgraded %d packages"
-msgstr "Done - Installed or upgraded %d packages"
+msgid "Done - %d packages installed or upgraded"
+msgstr "Done! - %d packages installed or upgraded"
 
 #, python-format
 msgid "Done - Installed, upgraded or removed %d package (%s)"
 msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
-msgstr[0] "Done - Installed, upgraded or removed %d package (%s)"
-msgstr[1] "Done - Installed, upgraded or removed %d packages (%s)"
+msgstr[0] "Done! - %d package installed, upgraded or removed (%s)"
+msgstr[1] "Done! - %d packages installed, upgraded or removed packages (%s)"
 
 msgid "Down"
-msgstr "Down"
+msgstr "▼ Down"
 
 msgid "Download"
 msgstr "Download"
@@ -6321,7 +6314,7 @@ msgid "Download %s from server"
 msgstr "Download %s from server"
 
 msgid "Download .NFI-files for USB-flasher"
-msgstr "Download .NFI-files for USB-flasher"
+msgstr "Download .nfi files for USB flasher"
 
 msgid "Download Plugins"
 msgstr "Download Plugins"
@@ -6330,34 +6323,33 @@ msgid "Download Softcams"
 msgstr "Download Softcams"
 
 msgid "Download and install Plugins"
-msgstr "Download and install Plugins"
+msgstr "Download and install plugins"
 
 msgid "Download and install cam"
 msgstr "Download and install cam"
 
 msgid "Download plugins"
-msgstr "Download plugins"
+msgstr "Download Plugins"
 
 msgid "Downloadable plugins"
 msgstr "Downloadable plugins"
 
-#, fuzzy
 msgid "Downloaded Images"
-msgstr "Downloading"
+msgstr "Downloaded Images"
 
 msgid "Downloading"
 msgstr "Downloading"
 
-#, fuzzy
 msgid "Downloading Image"
-msgstr "Downloading"
+msgstr "Downloading Image..."
 
 msgid "Downloading plugin information. Please wait..."
-msgstr "Downloading plugin information. Please wait..."
+msgstr "Retrieving plugin information..."
 
 msgid "Downmix"
 msgstr "Downmix"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "Drama"
 msgstr "Movie/Drama"
@@ -6376,11 +6368,12 @@ msgstr "Drivers:\t%s"
 msgid "Drivers:\t%s"
 msgstr "Drivers:\t%s"
 
+#. TRANSLATORS: genre category
 msgid "Drogen"
-msgstr ""
+msgstr "Drugs"
 
 msgid "During this time, the transmitter and the recording destination are checked. If the recording destination (eg NAS) does not ready in time for recording, this time can be increased."
-msgstr ""
+msgstr "During this time, the transmitter and the recording destination will be checked. If the recording destination (eg. NAS) is not ready in time for recording, this time can be increased."
 
 msgid "Dutch"
 msgstr "Dutch"
@@ -6392,7 +6385,7 @@ msgid "E"
 msgstr "E"
 
 msgid "E2 Log"
-msgstr "E2 Log"
+msgstr "Enigma2 Log"
 
 msgid "E3HD/XPEEDLX/GI"
 msgstr ""
@@ -6404,26 +6397,27 @@ msgid "ECM Time"
 msgstr "ECM Time"
 
 msgid "ECM avg"
-msgstr "ECM avg"
+msgstr "ECM avg."
 
 msgid "ECM data will be included in the stream. This enables a client receiver to decode it."
-msgstr "ECM data will be included in the stream. This enables a client receiver to decode it."
+msgstr ""
+"Choose whether Entitled Control Message data should be included with streams to enable a client receiver to decrypt them.\n"
+"ECM data provides a decryption key to give a subscriber access to a particular program or service."
 
 msgid "ECM last"
 msgstr "ECM last"
 
 msgid "ECM-Time"
-msgstr "ECM-Time"
+msgstr "ECM Time"
 
 msgid "EDID decode"
 msgstr ""
 
 msgid "EJECTCD"
-msgstr ""
+msgstr "EJECTCD button"
 
-#, fuzzy
 msgid "EJECTCD long"
-msgstr "SAT long"
+msgstr "EJECTCD button hold"
 
 msgid "EPG"
 msgstr "EPG"
@@ -6432,7 +6426,7 @@ msgid "EPG Cache Check"
 msgstr "EPG Cache Check"
 
 msgid "EPG Search"
-msgstr "EPG Search"
+msgstr "Search EPG"
 
 msgid "EPG Selection"
 msgstr "EPG Selection"
@@ -6441,7 +6435,7 @@ msgid "EPG Setup"
 msgstr "EPG Setup"
 
 msgid "EPG button mode"
-msgstr "EPG button mode"
+msgstr "EPG button"
 
 msgid "EPG filename"
 msgstr "EPG filename"
@@ -6452,10 +6446,10 @@ msgid ""
 "PVR key : Input channel name\n"
 "Exit key : Finish channel edit"
 msgstr ""
-"EPG key : Switch to channel list\n"
-"Ok key : Remove selected channel\n"
-"PVR key : Input channel name\n"
-"Exit key : Finish channel edit"
+"EPG button  : Switch to channel list\n"
+"OK button   : Remove selected channel\n"
+"PVR button  : Enter channel name\n"
+"EXIT button : Finish editing channel"
 
 msgid ""
 "EPG key : Switch to quad PiP entry\n"
@@ -6463,31 +6457,31 @@ msgid ""
 "PVR key : Input channel name\n"
 "Exit key : Finish channel edit"
 msgstr ""
-"EPG key : Switch to quad PiP entry\n"
-"Ok key : Add to new entry\n"
-"PVR key : Input channel name\n"
-"Exit key : Finish channel edit"
+"EPG button  : Switch to quad PiP entry\n"
+"OK button   : Add to new entry\n"
+"PVR button  : Enter channel name\n"
+"EXIT button : Finish editing channel"
 
 msgid "EPG language selection 1"
-msgstr "EPG language selection 1"
+msgstr "EPG language 1"
 
 msgid "EPG language selection 2"
-msgstr "EPG language selection 2"
+msgstr "EPG language 2"
 
 msgid "EPG location"
-msgstr "EPG location"
+msgstr "EPG data location"
 
 msgid "EPG search"
-msgstr "EPG search"
+msgstr "search EPG"
 
 msgid "EPG selection"
 msgstr "EPG selection"
 
 msgid "EPG settings"
-msgstr "EPG settings"
+msgstr "EPG Settings"
 
 msgid "EPGSearch"
-msgstr "EPGSearch"
+msgstr "Search EPG"
 
 #, python-format
 msgid "ERROR - failed to scan (%s)!"
@@ -6499,9 +6493,8 @@ msgstr "East"
 msgid "East limit set"
 msgstr "East limit set"
 
-#, fuzzy
 msgid "Eastern"
-msgstr "East"
+msgstr "Eastern"
 
 msgid "Ecuador"
 msgstr "Ecuador"
@@ -6518,13 +6511,11 @@ msgstr "Edit Title"
 msgid "Edit chapters of current title"
 msgstr "Edit chapters of current title"
 
-#, fuzzy
 msgid "Edit current line"
-msgstr "Jump to current time"
+msgstr "Edit current line"
 
-#, fuzzy
 msgid "Edit line "
-msgstr "Edit timer"
+msgstr "Edit line "
 
 msgid "Edit mode off"
 msgstr "Edit mode off"
@@ -6535,20 +6526,19 @@ msgstr "Edit mode on"
 msgid "Edit new entry"
 msgstr "Edit new entry"
 
-#, fuzzy
 msgid "Edit position is the line end"
-msgstr "Moved to position at index"
+msgstr "Edit position the end of line"
 
 msgid "Edit settings"
 msgstr "Edit settings"
 
 #, python-format
 msgid "Edit the Nameserver configuration of your %s %s.\n"
-msgstr "Edit the Nameserver configuration of your %s %s.\n"
+msgstr "Configure your %s %s's nameserver setting.\n"
 
 #, python-format
 msgid "Edit the network configuration of your %s %s.\n"
-msgstr "Edit the network configuration of your %s %s.\n"
+msgstr "Configure your %s %s's network settings.\n"
 
 msgid "Edit timer"
 msgstr "Edit timer"
@@ -6559,33 +6549,33 @@ msgstr "Edit title"
 msgid "Edit upgrade source url."
 msgstr "Edit upgrade source url."
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Education"
-msgstr "Modulation"
+msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Education/Information"
-msgstr "Translation Information"
+msgstr "Educational/Informational"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Education/Science/Factual"
-msgstr "Education/Science/..."
+msgstr ""
 
 msgid "Egypt"
 msgstr "Egypt"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Einzelsportart"
-msgstr "winter sport"
+msgstr "Individual sports"
 
 msgid "El Salvador"
 msgstr "El Salvador"
 
 msgid "Elapsed"
-msgstr "Elapsed"
+msgstr "elapsed"
 
 msgid "Elapsed & Remaining"
-msgstr "Elapsed & Remaining"
+msgstr "elapsed & remaining"
 
 msgid "Electronic Program Guide"
 msgstr "Electronic Program Guide"
@@ -6607,14 +6597,13 @@ msgid "Enable 5V for active antenna"
 msgstr "Enable 5V for active antenna"
 
 msgid "Enable AC3/Dolby"
-msgstr "Enable AC3/Dolby"
+msgstr "Enable Dolby Digital / Dolby AC-3"
 
 msgid "Enable Autorecord"
-msgstr "Enable Autorecord"
+msgstr "Enable auto-record"
 
-#, fuzzy
 msgid "Enable BT Audio"
-msgstr "Enabled"
+msgstr "Enable Bluetooth Audio"
 
 msgid "Enable CIHelper for SLOT CI0"
 msgstr "Enable CIHelper for SLOT CI0"
@@ -6629,15 +6618,14 @@ msgstr "Enable EIT EPG"
 msgid "Enable Focus Animation"
 msgstr "Disable Animations"
 
-#, fuzzy
 msgid "Enable IceTV"
-msgstr "Enable MiniTV"
+msgstr ""
 
 msgid "Enable MHW EPG"
 msgstr "Enable MHW EPG"
 
 msgid "Enable MiniTV"
-msgstr "Enable MiniTV"
+msgstr "Enable mini TV window"
 
 msgid "Enable Netmed EPG"
 msgstr "Enable Netmed EPG"
@@ -6648,18 +6636,17 @@ msgstr "Enable Network IP address check"
 msgid "Enable Network Traffic check"
 msgstr "Enable Network Traffic check"
 
-#, fuzzy
 msgid "Enable OpenTV EPG"
-msgstr "Enable EIT EPG"
+msgstr "Enable OpenTV EPG"
 
 msgid "Enable Quad PIP"
-msgstr "Enable Quad PIP"
+msgstr "Enable quad PiP"
 
 msgid "Enable Swap at startup"
-msgstr "Enable Swap at startup"
+msgstr "Enable swap at startup"
 
 msgid "Enable Up / Down buttons for the 'all up / down' function? (at the beginning / end of the column)"
-msgstr ""
+msgstr "Chose whether the ▲ Up and ▼ Down buttons should scroll all columns together; otherwise, only the selected column will be scrolled."
 
 msgid "Enable ViaSat EPG"
 msgstr "Enable ViaSat EPG"
@@ -6684,7 +6671,7 @@ msgid "Enable auto fast scan for %s"
 msgstr "Enable auto fast scan for %s"
 
 msgid "Enable blinking rec symbol on the LCD Display"
-msgstr "Enable blinking rec symbol on the LCD Display"
+msgstr "Enable blinking REC symbol on the front panel display"
 
 msgid "Enable chapter support for video files"
 msgstr "Enable chapter support for video files"
@@ -6715,10 +6702,10 @@ msgid "Enable fallback remote receiver"
 msgstr "Enable fallback remote receiver"
 
 msgid "Enable freesat EPG"
-msgstr "Enable freesat EPG"
+msgstr "Enable Freesat EPG"
 
 msgid "Enable infobar fade-out"
-msgstr "Enable infobar fade-out"
+msgstr "Enable infobar fade out"
 
 msgid "Enable intro screen"
 msgstr "Enable intro screen"
@@ -6733,10 +6720,10 @@ msgid "Enable preview"
 msgstr "Enable preview"
 
 msgid "Enable remote enigma2 receiver to be tried to tune into services that cannot be tuned into locally (e.g. tuner is occupied or service type is unavailable on the local tuner. Specify complete URL including http:// and port number (normally ...:8001), e.g. http://second_box:8001."
-msgstr "Enable remote enigma2 receiver to be tried to tune into services that cannot be tuned into locally (e.g. tuner is occupied or service type is unavailable on the local tuner. Specify complete URL including http:// and port number (normally ...:8001), e.g. http://second_box:8001."
+msgstr "Enable remote Enigma2 receiver to be tried to tune into services which can't be tuned into locally (e.g. tuner is occupied or service type is unavailable on the local tuner. Specify complete URL including http:// and port number (usually :8001), e.g. http://second_box:8001."
 
 msgid "Enable screenshot of LCD in /tmp"
-msgstr "Enable screenshot of LCD in /tmp"
+msgstr "Enable screenshot of the front panel display to /tmp"
 
 msgid "Enable teletext caching"
 msgstr "Enable teletext caching"
@@ -6764,7 +6751,7 @@ msgid "Enabled"
 msgstr "Enabled"
 
 msgid "Enables a feature so that the receiver can decrypt streams (if the ECM data is included in the stream and a valid card is available)."
-msgstr "Enables a feature so that the receiver can decrypt streams (if the ECM data is included in the stream and a valid card is available)."
+msgstr "Enables a feature that will allow your receiver to decrypt streams (if ECM data is included in the stream and a valid card is available)."
 
 msgid "Encrypted: "
 msgstr "Encrypted: "
@@ -6782,17 +6769,17 @@ msgid "Encryption:"
 msgstr "Encryption:"
 
 msgid "End"
-msgstr "End"
+msgstr "End button"
 
-#, fuzzy
 msgid "End long"
-msgstr "Red long"
+msgstr "END button hold"
 
 msgid "End time"
 msgstr "End time"
 
+#. TRANSLATORS: genre category?
 msgid "Energie"
-msgstr ""
+msgstr "Energy"
 
 msgid "English"
 msgstr "English"
@@ -6819,7 +6806,7 @@ msgstr ""
 "© 2006 - Stephan Reichholf"
 
 msgid "Enigma2 skin selector"
-msgstr "Enigma2 skin selector"
+msgstr "Skin selector"
 
 msgid ""
 "Enjoy how IceTV can enhance your TV viewing experience by downloading the IceTV app to your smartphone or tablet. The IceTV app is available free from the iTunes App Store, the Google Play Store and the Windows Phone Store.\n"
@@ -6827,68 +6814,66 @@ msgid ""
 "Download it today!"
 msgstr ""
 
-#, fuzzy
 msgid "Enter"
-msgstr "center"
+msgstr "Enter"
 
 msgid "Enter PIN"
-msgstr "Enter PIN"
+msgstr "Enter PIN code"
 
 msgid "Enter if you are in the east or west hemisphere."
-msgstr ""
+msgstr "Select whether you're in the eastern or western hemisphere."
 
 msgid "Enter if you are north or south of the equator."
-msgstr ""
+msgstr "Select whether you're north or south of the equator."
 
 msgid "Enter main menu..."
-msgstr "Enter main menu..."
+msgstr "Enter Main menu..."
 
-#, fuzzy
 msgid "Enter multi-file selection mode"
-msgstr "Preferred tuners, multiple selection allowed"
+msgstr "Start multi-select"
 
 msgid "Enter persistent PIN code"
 msgstr "Enter persistent PIN code"
 
 msgid "Enter pin code"
-msgstr "Enter pin code"
+msgstr "Enter PIN code"
 
 msgid "Enter the frequency at which you LNB switches between low band and high band. For more information consult the spec sheet of your LNB."
-msgstr ""
+msgstr "Enter the frequency at which you LNB switches between low band and high band. Refer to your LNB's spec sheet for more information."
 
 msgid "Enter the frequency step size for the tuner to use when searching for cable multiplexes. For more information consult your cable provider's documentation."
-msgstr ""
+msgstr "Enter the frequency step size that the tuner should use when searching for cable multiplexes. Refer to your cable provider's documentation for more information."
 
 msgid "Enter the number stored in the positioner that corresponds to this satellite."
 msgstr ""
 
 msgid "Enter the service pin"
-msgstr "Enter the service pin"
+msgstr "Enter the channel PIN"
 
 msgid "Enter your current latitude. This is the number of degrees you are from the equator as a decimal."
-msgstr ""
+msgstr "Enter your current latitude. This is the number of degrees you are from the equator in decimal format."
 
 msgid "Enter your current longitude. This is the number of degrees you are from zero meridian as a decimal."
-msgstr ""
+msgstr "Enter your current longitude. This is the number of degrees you are from zero meridian in decimal format."
 
 msgid "Enter your high band local oscillator frequency. For more information consult the spec sheet of your LNB."
-msgstr ""
+msgstr "Enter your high band local oscillator frequency. Refer to your LNB's spec sheet for more information."
 
 msgid "Enter your low band local oscillator frequency. For more information consult the spec sheet of your LNB."
-msgstr ""
+msgstr "Enter your low band local oscillator frequency. Refer to your LNB's spec sheet for more information."
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Entertainment"
-msgstr "Enter main menu..."
+msgstr ""
 
 msgid "Entitlements"
 msgstr "Entitlements"
 
 msgid "Epg/Guide"
-msgstr "Epg/Guide"
+msgstr "EPG/Guide press"
 
 msgid "Epg/Guide long"
-msgstr "Epg/Guide long"
+msgstr "EPG/Guide button hold"
 
 msgid "Epos"
 msgstr ""
@@ -6905,140 +6890,143 @@ msgstr ""
 msgid "Eritrea"
 msgstr "Eritrea"
 
+#. TRANSLATORS: genre category
 msgid "Erotik"
-msgstr ""
+msgstr "Erotic"
 
 msgid "Error"
-msgstr "Error"
+msgstr "Error..."
 
 msgid "Error Download Setting"
-msgstr "Error Download Setting"
+msgstr "Couldn't Download Setting"
 
 msgid "Error code"
 msgstr "Error code"
 
-#, fuzzy
 msgid ""
 "Error creating EHD-Skin.\n"
 "Using HD-Skin!"
 msgstr ""
-"Error creating FullHD-Skin.\n"
-"Using HD-Skin!"
+"Couldn't create Full HD skin.\n"
+"Using HD skin instead!"
 
-#, fuzzy
 msgid ""
 "Error creating EHD-Skin. Icon package download not available.\n"
 "Using HD-Skin!"
 msgstr ""
-"Error creating FullHD-Skin. Icon package download not available.\n"
-"Using HD-Skin!"
+"Couldn't create Full HD skin. Icon package download not available.\n"
+"Using HD skin instead!"
 
-#, fuzzy
 msgid ""
 "Error creating EHD-Skin. Not enough flash memory free.\n"
 "Using HD-Skin!"
 msgstr ""
-"Error creating FullHD-Skin. Not enough flash memory free.\n"
-"Using HD-Skin!"
+"Couldn't create Full HD skin. Not enough flash memory available.\n"
+"Using HD skin instead!"
 
-#, fuzzy
 msgid ""
 "Error creating EHD-Skin. Some EHD-Icons are missing.\n"
 "Using HD-Skin!"
 msgstr ""
-"Error creating FullHD-Skin.\n"
-"Using HD-Skin!"
+"Couldn't create Full HD skin. Some Full HD Icons are missing.\n"
+"Using HD skin instead!"
 
 msgid "Error creating HD-Skin. Not enough flash memory free."
-msgstr "Error creating HD-Skin. Not enough flash memory free."
+msgstr "Couldn't create HD skin. Not enough flash memory available."
 
 msgid ""
 "Error creating MetrixHD-Skin.\n"
 "Please check after reboot MyMetrixLite-Plugin and apply your settings."
 msgstr ""
-"Error creating MetrixHD-Skin.\n"
-"Please check after reboot MyMetrixLite-Plugin and apply your settings."
+"Couldn't create MetrixHD skin.\n"
+"Please check the MyMetrixLite plugin after rebooting and apply your settings."
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Error creating directory %s:\n"
 "%s"
-msgstr "Creating directory %s failed."
+msgstr ""
+"Couldn't create folder %s:\n"
+"%s"
 
 msgid "Error downloading change log."
-msgstr "Error downloading change log."
+msgstr "Couldn't download changelog."
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Error during downloading image\n"
 "%s\n"
 "%s"
-msgstr "Error downloading change log."
+msgstr ""
+"Couldn't download image!\n"
+"%s\n"
+"%s"
 
 #, python-format
 msgid ""
 "Error during unzipping image\n"
 "%s"
 msgstr ""
+"Couldn't extract image!\n"
+"%s"
 
 msgid "Error executing plugin"
-msgstr "Error executing plugin"
+msgstr "Couldn't run plugin"
 
 #, python-format
 msgid ""
 "Error linking %s to %s:\n"
 "%s"
 msgstr ""
+"Couldn't link %s to %s:\n"
+"%s"
 
-#, fuzzy
 msgid "Error opening recording file"
-msgstr "real or pseudo recordings"
+msgstr "Couldn't open recording file"
 
-#, fuzzy
 msgid "Error reading bouquets.radio"
-msgstr "Error reading webpage!"
+msgstr "Couldn't read bouquets.radio"
 
-#, fuzzy
 msgid "Error reading bouquets.tv"
-msgstr "Error reading webpage!"
+msgstr "Couldn't read bouquets.tv"
 
 msgid "Error reading webpage!"
-msgstr "Error reading webpage!"
+msgstr "Couldn't open web page!"
 
 #, python-format
 msgid ""
 "Error renaming %s to %s:\n"
 "%s"
 msgstr ""
+"Couldn't rename %s to %s:\n"
+"%s"
 
 msgid "Error, unknown Result!"
-msgstr "Error, unknown Result!"
+msgstr "Error, unknown result!"
 
-#, fuzzy
 msgid "Error..."
-msgstr "Error"
+msgstr "Error..."
 
 #, python-format
 msgid ""
 "Error:\n"
 "%s"
-msgstr ""
-"Error:\n"
-"%s"
+msgstr "Something went wrong: %s"
 
 #, python-format
 msgid ""
 "Error: %s\n"
 "Retry?"
 msgstr ""
-"Error: %s\n"
-"Retry?"
+"Something went wrong: %s\n"
+"Would you like to retry?"
 
 msgid "Es folgt:"
-msgstr ""
+msgstr "It follows:"
 
+#. TRANSLATORS: genre category
 msgid "Esoterik"
-msgstr ""
+msgstr "Esoteric"
 
 msgid "Essen"
 msgstr ""
@@ -7059,24 +7047,22 @@ msgid "Even if TV has another input active?"
 msgstr ""
 
 msgid "Even if a 'wakeup' power timer starting?"
-msgstr ""
+msgstr "Even if a 'wake-up' power timer starting?"
 
 msgid "Even if a 'zap and record' recording timer starting?"
-msgstr ""
+msgstr "Even if a 'zap and record' timer is starting?"
 
-#, fuzzy
 msgid "Even if a 'zap' recording timer starting?"
-msgstr "real recordings or streaming"
+msgstr "Even if a 'zap' timer is starting?"
 
-#, fuzzy
 msgid "Event"
-msgstr "Eventview"
+msgstr "Event"
 
 msgid "Event Info"
 msgstr "Event Info"
 
 msgid "Event font size"
-msgstr "Event font size"
+msgstr "Event title text size"
 
 msgid "Event view"
 msgstr "Event view"
@@ -7085,41 +7071,40 @@ msgid "Event view menu"
 msgstr "Event view menu"
 
 msgid "Eventname only"
-msgstr "Eventname only"
+msgstr "Event name only"
 
 msgid "Eventview"
-msgstr "Eventview"
+msgstr "Event view"
 
 msgid "Eventview menu"
-msgstr "Eventview menu"
+msgstr "Event view menu"
 
-#, fuzzy
 msgid "Eventview:"
-msgstr "Eventview"
+msgstr "Event view:"
 
 msgid "Everyday"
-msgstr "Everyday"
+msgstr "Every day"
 
 msgid "Everywhere"
 msgstr "Everywhere"
 
 msgid "Exceeds Bludisc medium!"
-msgstr "Exceeds Bludisc medium!"
+msgstr "Exceeds Blu-ray disc capacity!"
 
 msgid "Exceeds dual layer medium!"
-msgstr "Exceeds dual layer medium!"
+msgstr "Exceeds dual-layer disc capacity!"
 
 msgid "Execute after current event"
-msgstr "Execute after current event"
+msgstr "Activate after current the event"
 
 msgid "Execute in "
-msgstr "Execute in "
+msgstr "Activate in "
 
 msgid "Execution condition"
 msgstr "Execution condition"
 
 msgid "Execution finished!!"
-msgstr "Execution finished!!"
+msgstr "Execution finished!"
 
 msgid "Execution progress:"
 msgstr "Execution progress:"
@@ -7137,7 +7122,7 @@ msgid "Exit EPG"
 msgstr "Exit EPG"
 
 msgid "Exit MAC-address configuration"
-msgstr "Exit MAC-address configuration"
+msgstr "Exit MAC address configuration"
 
 msgid "Exit Quad Channel Selection"
 msgstr "Exit Quad Channel Selection"
@@ -7146,7 +7131,7 @@ msgid "Exit editor"
 msgstr "Exit editor"
 
 msgid "Exit editor and write changes (if any)"
-msgstr ""
+msgstr "Exit editor and save changes (if any)"
 
 msgid "Exit input device selection."
 msgstr "Exit input device selection."
@@ -7155,7 +7140,7 @@ msgid "Exit media player?"
 msgstr "Exit media player?"
 
 msgid "Exit mediaplayer"
-msgstr "Exit mediaplayer"
+msgstr "Exit media player"
 
 msgid "Exit movie list"
 msgstr "Exit movie list"
@@ -7185,7 +7170,7 @@ msgid "Expand"
 msgstr ""
 
 msgid "Experimental mode"
-msgstr "Experimental mode"
+msgstr "experimental mode"
 
 msgid "Experimental: strict limitation to preferred tuners"
 msgstr "Experimental: strict limitation to preferred tuners"
@@ -7197,7 +7182,7 @@ msgid "Expert"
 msgstr "Expert"
 
 msgid "Expert mode"
-msgstr "Expert mode"
+msgstr "expert mode"
 
 msgid "Extend"
 msgstr "Extend"
@@ -7206,10 +7191,10 @@ msgid "Extended"
 msgstr "Extended"
 
 msgid "Extended GUI"
-msgstr "Extended GUI"
+msgstr "Extended User Interface"
 
 msgid "Extended Networksetup Plugin..."
-msgstr "Extended Networksetup Plugin..."
+msgstr "Extended Network Setup Plugin..."
 
 msgid "Extended Setup..."
 msgstr "Extended Setup..."
@@ -7227,7 +7212,7 @@ msgid "Extended network setup plugin..."
 msgstr "Extended network setup plugin..."
 
 msgid "Extended settings"
-msgstr "Extended settings"
+msgstr "Extended Settings"
 
 msgid "Extended setup..."
 msgstr "Extended setup..."
@@ -7236,10 +7221,10 @@ msgid "Extensions"
 msgstr "Extensions"
 
 msgid "Extensions management"
-msgstr "Extensions management"
+msgstr "Extension Management"
 
 msgid "Extensions/QuickMenu"
-msgstr "Extensions/QuickMenu"
+msgstr "Extensions/Quick Menu"
 
 msgid "External"
 msgstr "External"
@@ -7252,51 +7237,49 @@ msgid "External Storage %s"
 msgstr "External Storage %s"
 
 msgid "External subtitle color"
-msgstr "External subtitle color"
+msgstr "External subtitles text color"
 
 msgid "External subtitle dialog colorisation"
-msgstr "External subtitle dialog colorisation"
+msgstr "External subtitles dialog colorization"
 
 msgid "External subtitle switch fonts"
-msgstr "External subtitle switch fonts"
+msgstr "External subtitle font switching"
 
 msgid "Extra motor options"
-msgstr "Extra motor options"
+msgstr "Extra dish rotator options"
 
-#, fuzzy
 msgid "Extremsport"
-msgstr "team sports"
+msgstr "Extreme sports"
 
 msgid "Extrude from left"
 msgstr "Extrude from left"
 
 msgid "F1"
-msgstr "F1"
+msgstr "F1 press"
 
-#, fuzzy
 msgid "F1 long"
-msgstr "F2 long"
+msgstr "F1 button hold"
 
 msgid "F1/F3/F4/F4-TURBO/TRIPLEX"
 msgstr "F1/F3/F4/F4-TURBO/TRIPLEX"
 
 msgid "F2"
-msgstr "F2"
+msgstr "F2 button"
 
 msgid "F2 long"
-msgstr "F2 long"
+msgstr "F2 button hold"
 
 msgid "F3"
-msgstr "F3"
+msgstr "F3 button"
 
 msgid "F3 long"
-msgstr "F3 long"
+msgstr "F3 button hold"
 
 msgid "F4"
-msgstr "F4"
+msgstr "F4 button"
 
 msgid "F4 long"
-msgstr "F4 long"
+msgstr "F4 button hold"
 
 msgid "FCC 1953"
 msgstr ""
@@ -7311,7 +7294,7 @@ msgid "FLASH"
 msgstr "FLASH"
 
 msgid "FP Upgrade"
-msgstr "FP Upgrade"
+msgstr "Front Panel Upgrade"
 
 msgid "FSBL Update Check"
 msgstr "FSBL Update Check"
@@ -7327,10 +7310,10 @@ msgid "FTP Setup"
 msgstr "FTP Setup"
 
 msgid "Factory reset"
-msgstr "Factory reset"
+msgstr "Factory Reset"
 
 msgid "Fade the Infobar on hide"
-msgstr "Fade the Infobar on hide"
+msgstr "Fade the infobar on hide."
 
 msgid "Fahrenheit"
 msgstr "Fahrenheit"
@@ -7355,7 +7338,7 @@ msgid "False"
 msgstr "false"
 
 msgid "Familie"
-msgstr ""
+msgstr "Family"
 
 msgid "Family"
 msgstr ""
@@ -7386,13 +7369,13 @@ msgid "Fast forward speeds"
 msgstr "Fast forward speeds"
 
 msgid "Fastforward"
-msgstr "Fastforward"
+msgstr "▶︎▶︎ Fast forward"
 
 msgid "Favorites"
-msgstr "Favorites"
+msgstr "Favorites button"
 
 msgid "Favorites long"
-msgstr "Favorites long"
+msgstr "Favorites button hold"
 
 msgid "Favourites"
 msgstr "Favourites"
@@ -7404,14 +7387,13 @@ msgid "Feeds status:   Unstable"
 msgstr "Feeds status:   Unstable"
 
 msgid "Feeds status:   Updating"
-msgstr "Feeds status:   Updating"
+msgstr "Feeds status:   Updating..."
 
-#, fuzzy
 msgid "Feeds status: Unexpected"
-msgstr "Feeds status:   Unstable"
+msgstr "Feeds status: Unexpected"
 
 msgid "Fetch EPG and update timers now"
-msgstr ""
+msgstr "Update EPG data and update timers now"
 
 msgid "Fiji"
 msgstr "Fiji"
@@ -7419,24 +7401,23 @@ msgstr "Fiji"
 msgid "File"
 msgstr "File"
 
-#, fuzzy
 msgid "File Commander"
-msgstr "Command order"
+msgstr "File Commander"
 
 msgid "File Commander - Addon File-Viewer"
-msgstr ""
+msgstr "File Commander - Addon File Viewer"
 
 msgid "File Commander - Addon Mediaplayer"
-msgstr ""
+msgstr "File Commander - Addon Media Player"
 
 msgid "File Commander - Addon Movieplayer"
-msgstr ""
+msgstr "File Commander - Addon Movie Player"
 
 msgid "File Commander - all Task's are completed!"
-msgstr ""
+msgstr "File Commander - all Tasks are completed!"
 
 msgid "File Commander - generalised archive handler"
-msgstr ""
+msgstr "File Commander - generalized archive handler"
 
 msgid "File Commander - gzip Addon"
 msgstr ""
@@ -7471,10 +7452,10 @@ msgid "File checksums to calculate for button 9"
 msgstr ""
 
 msgid "File checksums/hashes"
-msgstr ""
+msgstr "Checksum/hash method"
 
 msgid "File long"
-msgstr "File long"
+msgstr "FILE button hold"
 
 #, fuzzy, python-format
 msgid "File not found: %s"
@@ -7488,25 +7469,25 @@ msgstr ""
 "Please enter username/password manually."
 
 msgid "File transfer was cancelled by user"
-msgstr ""
+msgstr "File transfer was canceled"
 
 #, python-format
 msgid "File write error: '%s'"
-msgstr ""
+msgstr "File write error: '%s'"
 
-#, fuzzy
 msgid "File/Directory Status Information"
-msgstr "Memory Information"
+msgstr "File/folder details"
 
 msgid "Files/folders to exclude from backup"
-msgstr "Files/folders to exclude from backup"
+msgstr "Exclude files/folders from backup"
 
 msgid "Filesystem Check"
-msgstr "Filesystem Check"
+msgstr "Check Filesystem"
 
 msgid "Filesystem check your Harddisk"
-msgstr "Filesystem check your Harddisk"
+msgstr "Check your hard disk's filesystem"
 
+#. TRANSLATORS: genre category
 msgid "Film-Noir"
 msgstr ""
 
@@ -7526,17 +7507,17 @@ msgid "Final position at index"
 msgstr "Final position at index"
 
 msgid "Final scroll delay"
-msgstr "Final scroll delay"
+msgstr "Delay after scrolling"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Finance"
-msgstr "France"
+msgstr ""
 
 msgid "Fine movement"
 msgstr "Fine movement"
 
 msgid "Finetune"
-msgstr "Finetune"
+msgstr "Fine tune"
 
 msgid "Finished"
 msgstr "Finished"
@@ -7545,23 +7526,25 @@ msgid "Finished configuring your network"
 msgstr "Finished configuring your network"
 
 msgid "Finished restarting your network"
-msgstr "Finished restarting your network"
+msgstr "Finished restarting your network!"
 
+#. TRANSLATORS: regional option
 msgid "Finland"
 msgstr "Finland"
 
+#. TRANSLATORS: regional option
 msgid "Finnish"
 msgstr "Finnish"
 
 msgid "First playable timeshift file!"
 msgstr "First playable timeshift file!"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Fishing"
-msgstr "Flashing"
+msgstr ""
 
 msgid "Fixed"
-msgstr "Fixed"
+msgstr "fixed"
 
 msgid "Fixed X11 font (SD)"
 msgstr "Fixed X11 font (SD)"
@@ -7569,34 +7552,32 @@ msgstr "Fixed X11 font (SD)"
 msgid "Flash"
 msgstr "Flash"
 
-#, fuzzy
 msgid "Flash Image"
-msgstr "Flashing"
+msgstr "Flash selected"
 
 msgid "Flash On the Fly"
-msgstr "Flash On the Fly"
+msgstr "Flash on the Fly"
 
 msgid "Flash Online"
 msgstr "Flash Online"
 
 msgid "Flash Online a new image"
-msgstr "Flash Online a new image"
+msgstr "Flash an online image"
 
 msgid "Flash on the fly your your Receiver software."
-msgstr "Flash on the fly your your Receiver software."
+msgstr "Flash your receiver's software on the fly"
 
 msgid "Flashing"
-msgstr "Flashing"
+msgstr "blinking icon"
 
-#, fuzzy
 msgid "Flashing Image"
-msgstr "Flashing failed"
+msgstr "Flashing Image..."
 
 msgid "Flashing failed"
 msgstr "Flashing failed"
 
 msgid "Flashing image successful"
-msgstr ""
+msgstr "Image flashed successfully"
 
 #, python-format
 msgid ""
@@ -7607,25 +7588,25 @@ msgstr ""
 msgid "Following tasks will be done after you press OK!"
 msgstr "Following tasks will be done after you press OK!"
 
-#, fuzzy
 msgid "Font size"
-msgstr "Fontsize"
+msgstr "Text size"
 
 msgid "Font:"
 msgstr "Font:"
 
 msgid "Fontsize"
-msgstr "Fontsize"
+msgstr "Text size"
 
+#. TRANSLATORS: genre category
 msgid "Food/Wine"
 msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Football"
-msgstr "football/soccer"
+msgstr "Football/Soccer"
 
 msgid "For more information see http://www.opena.tv"
-msgstr "For more information see http://www.opena.tv"
+msgstr "Go to http://www.opena.tv for more information"
 
 msgid "Force LNB Power"
 msgstr "Force LNB Power"
@@ -7636,9 +7617,8 @@ msgstr "Force LNB Tuner Power settings."
 msgid "Force LNB Tuner ToneBurst settings."
 msgstr "Force LNB Tuner ToneBurst settings."
 
-#, fuzzy
 msgid "Force Legacy Signal stats"
-msgstr "Force Legacy Signal Stats"
+msgstr "Force legacy signal stats"
 
 msgid "Force ToneBurst"
 msgstr "Force ToneBurst"
@@ -7653,10 +7633,10 @@ msgid "Format HDD"
 msgstr "Format HDD"
 
 msgid "Format your Harddisk"
-msgstr "Format your Harddisk"
+msgstr "Format your hard disk"
 
 msgid "Forward volume keys"
-msgstr "Forward volume keys"
+msgstr "Forward volume buttons"
 
 msgid "Frame rate"
 msgstr "Frame rate"
@@ -7664,17 +7644,19 @@ msgstr "Frame rate"
 msgid "Frame size in full view"
 msgstr "Frame size in full view"
 
+#. TRANSLATORS: regional option
 msgid "France"
 msgstr "France"
 
+#. TRANSLATORS: genre category
 msgid "Frauen"
-msgstr ""
+msgstr "Womens'"
 
 msgid "Free Memory:"
-msgstr "Free Memory:"
+msgstr "Free memory:"
 
 msgid "Free Swap:"
-msgstr "Free Swap:"
+msgstr "Free swap:"
 
 msgid "Free memory"
 msgstr "Free memory"
@@ -7689,17 +7671,21 @@ msgid "Free: "
 msgstr "Free: "
 
 msgid "FreeSpace"
-msgstr "FreeSpace"
+msgstr "Free Space"
 
+#. TRANSLATORS: regional option
 msgid "French"
 msgstr "French"
 
+#. TRANSLATORS: regional option
 msgid "French Guiana"
 msgstr "French Guiana"
 
+#. TRANSLATORS: regional option
 msgid "French Polynesia"
 msgstr "French Polynesia"
 
+#. TRANSLATORS: regional option
 msgid "French Southern Territories"
 msgstr "French Southern Territories"
 
@@ -7710,7 +7696,7 @@ msgid "Frequency bands"
 msgstr "Frequency bands"
 
 msgid "Frequency scan step size(khz)"
-msgstr "Frequency scan step size(khz)"
+msgstr "Frequency scan step size (khz)"
 
 msgid "Frequency steps"
 msgstr "Frequency steps"
@@ -7736,7 +7722,7 @@ msgstr "Front USB 3.0"
 
 #, python-format
 msgid "Frontprocessor version: %s"
-msgstr "Frontprocessor version: %s"
+msgstr "Front processor version: %s"
 
 msgid "Full Image Backup "
 msgstr "Full Image Backup "
@@ -7746,7 +7732,7 @@ msgstr "Full Range RGB"
 
 #, python-format
 msgid "Full back-up on %s"
-msgstr "Full back-up on %s"
+msgstr "Full backup on %s"
 
 msgid "Full transparency"
 msgstr "Full transparency"
@@ -7755,21 +7741,22 @@ msgstr "Full transparency"
 msgid "FullHD Test"
 msgstr "Small Test"
 
-#, fuzzy
 msgid "Fullbackup Images"
-msgstr "Backup Image"
+msgstr "Full backup Images"
 
 msgid "Fullscreen"
-msgstr "Fullscreen"
+msgstr "fullscreen"
 
 msgid "Fulview resulution"
-msgstr "Fulview resulution"
+msgstr "Full view resolution"
 
+#. TRANSLATORS: genre category
 msgid "Fußball"
-msgstr ""
+msgstr "Football/Soccer"
 
+#. TRANSLATORS: genre category
 msgid "Für Kinder"
-msgstr ""
+msgstr "For children"
 
 msgid "GB"
 msgstr "GB"
@@ -7785,42 +7772,57 @@ msgid ""
 "GUI needs a restart to apply a new language\n"
 "Do you want to restart the GUI now?"
 msgstr ""
-"GUI needs a restart to apply a new language\n"
-"Do you want to restart the GUI now?"
-
-msgid ""
-"GUI needs a restart to apply a new skin\n"
-"Do you want to Restart the GUI now?"
-msgstr ""
-"GUI needs a restart to apply a new skin\n"
-"Do you want to Restart the GUI now?"
+"Your receiver's user interface needs to be restarted to apply the selected language.\n"
+"\n"
+"Would you like to restart it now?"
 
 msgid ""
 "GUI needs a restart to apply a new skin\n"
 "Do you want to restart the GUI now?"
 msgstr ""
-"GUI needs a restart to apply a new skin\n"
-"Do you want to restart the GUI now?"
+"Your receiver's user interface needs to be restarted to apply the selected skin.\n"
+"\n"
+"Would you like to restart it now?"
 
+msgid ""
+"GUI needs a restart to apply a new skin\n"
+"Do you want to Restart the GUI now?"
+msgstr ""
+"Your receiver's user interface needs to be restarted to apply the selected skin.\n"
+"\n"
+"Would you like to restart it now?"
+
+msgid ""
+"GUI needs a restart to apply a new skin\n"
+"Do you want to restart the user interface now?"
+msgstr ""
+"Your receiver's user interface needs to be restarted to apply a new skin.\n"
+"\n"
+"Would you like to restart it now?"
+
+#. TRANSLATORS: genre category
 msgid "Gabon"
 msgstr "Gabon"
 
+#. TRANSLATORS: genre category
 msgid "Gambia"
 msgstr "Gambia"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Game Show"
-msgstr "Show Games show"
+msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Gangster"
 msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Gardening"
-msgstr "gardening"
-
-msgid "Garten"
 msgstr ""
+
+#. TRANSLATORS: genre category
+msgid "Garten"
+msgstr "Gardening"
 
 msgid "Gateway"
 msgstr "Gateway"
@@ -7829,41 +7831,43 @@ msgid "General"
 msgstr "General"
 
 msgid "General AC3 delay"
-msgstr "General AC3 delay"
+msgstr "General Dolby Digital / Dolby AC-3 delay"
 
-#, fuzzy
 msgid "General BT Audio delay"
-msgstr "General AC3 delay"
+msgstr "General Bluetooth audio delay"
 
 msgid "General PCM delay"
 msgstr "General PCM delay"
 
-#, fuzzy
 msgid "Generic"
-msgstr "General"
+msgstr ""
 
 msgid "Genre"
 msgstr "Genre"
 
+#. TRANSLATORS: regional option
 msgid "Georgia"
 msgstr "Georgia"
 
+#. TRANSLATORS: regional option
 msgid "German"
 msgstr "German"
 
+#. TRANSLATORS: regional option
 msgid "Germany"
 msgstr "Germany"
 
+#. TRANSLATORS: genre category
 msgid "Geschichte"
-msgstr ""
+msgstr "History"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Gesellschaft"
-msgstr "Deselect"
+msgstr "Society"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Gesundheit"
-msgstr "Fahrenheit"
+msgstr "Health"
 
 msgid "Get latest experimental image"
 msgstr "Get latest experimental image"
@@ -7872,17 +7876,19 @@ msgid "Get latest release image"
 msgstr "Get latest release image"
 
 msgid "Getting Event Info failed!"
-msgstr "Getting Event Info failed!"
+msgstr "Getting event info failed!"
 
 msgid "Getting Softcam list. Please wait..."
-msgstr "Getting Softcam list. Please wait..."
+msgstr "Getting Softcam list..."
 
 msgid "Getting plugin information. Please wait..."
-msgstr "Getting plugin information. Please wait..."
+msgstr "Getting plugin information..."
 
+#. TRANSLATORS: regional option
 msgid "Ghana"
 msgstr "Ghana"
 
+#. TRANSLATORS: regional option
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
@@ -7890,11 +7896,10 @@ msgid "Go down the list"
 msgstr "Go down the list"
 
 msgid "Go to bookmarked folder"
-msgstr ""
+msgstr "Go to bookmarked folder"
 
-#, fuzzy
 msgid "Go to end of file"
-msgstr "Jump to end of list"
+msgstr "Go to end of file"
 
 msgid "Go to first movie or last item"
 msgstr "Go to first movie or last item"
@@ -7914,9 +7919,8 @@ msgstr "Go to next event"
 msgid "Go to next page of service"
 msgstr "Go to next page of service"
 
-#, fuzzy
 msgid "Go to parent directory"
-msgstr "Parent directory"
+msgstr "Go to parent folder"
 
 msgid "Go to previous event"
 msgstr "Go to previous event"
@@ -7924,9 +7928,8 @@ msgstr "Go to previous event"
 msgid "Go to previous page of service"
 msgstr "Go to previous page of service"
 
-#, fuzzy
 msgid "Go to start of file"
-msgstr "Go to next page of service"
+msgstr ""
 
 msgid "Go up the list"
 msgstr "Go up the list"
@@ -7934,6 +7937,7 @@ msgstr "Go up the list"
 msgid "Gold"
 msgstr "Gold"
 
+#. TRANSLATORS: genre category
 msgid "Golf"
 msgstr ""
 
@@ -7947,14 +7951,13 @@ msgid "Goto :"
 msgstr "Goto :"
 
 msgid "Goto Date/Time"
-msgstr "Goto Date/Time"
+msgstr "Go to date/time"
 
 msgid "Goto Date/Timer"
-msgstr "Goto Date/Timer"
+msgstr "go to date/timer"
 
-#, fuzzy
 msgid "Goto Primetime"
-msgstr "Primetime"
+msgstr "Go to primetime"
 
 msgid "Goto X"
 msgstr "Goto X"
@@ -7963,74 +7966,78 @@ msgid "Goto index position"
 msgstr "Goto index position"
 
 msgid "Goto next bouquet"
-msgstr "Goto next bouquet"
+msgstr "Go to next bouquet"
 
 msgid "Goto next channel"
-msgstr "Goto next channel"
+msgstr "Go to next channel"
 
 msgid "Goto next day of events"
-msgstr "Goto next day of events"
+msgstr "Go to next day of events"
 
 msgid "Goto next event"
-msgstr "Goto next event"
+msgstr "Go to next event"
 
 msgid "Goto next page of events"
-msgstr "Goto next page of events"
+msgstr "Go to next page of events"
 
 msgid "Goto position"
 msgstr "Goto position"
 
 msgid "Goto previous bouquet"
-msgstr "Goto previous bouquet"
+msgstr "Go to previous bouquet"
 
 msgid "Goto previous channel"
-msgstr "Goto previous channel"
+msgstr "Go to previous channel"
 
 msgid "Goto previous day of events"
-msgstr "Goto previous day of events"
+msgstr "Go to previous day of events"
 
 msgid "Goto previous event"
-msgstr "Goto previous event"
+msgstr "Go to previous event"
 
 msgid "Goto previous page of events"
-msgstr "Goto previous page of events"
+msgstr "Go to previous page of events"
 
 msgid "Goto specific data/time"
-msgstr "Goto specific data/time"
+msgstr "Go to specific date/time"
 
 msgid "GotoX calibration"
-msgstr "GotoX calibration"
+msgstr "Goto X calibration"
 
 msgid "Graphical EPG"
 msgstr "Graphical EPG"
 
 msgid "Graphical InfobarEPG settings"
-msgstr "Graphical InfobarEPG settings"
+msgstr "Infobar Graphical EPG Settings"
 
 msgid "GraphicalEPG settings"
-msgstr "GraphicalEPG settings"
+msgstr "Graphical EPG Settings"
 
 msgid "Graphics"
-msgstr "Graphics"
+msgstr "graphical"
 
+#. TRANSLATORS: regional option
 msgid "Greece"
 msgstr "Greece"
 
+#. TRANSLATORS: regional option
 msgid "Greek"
 msgstr "Greek"
 
 msgid "Green"
-msgstr "Green"
+msgstr "Green button"
 
 msgid "Green button"
 msgstr "Green button"
 
 msgid "Green long"
-msgstr "Green long"
+msgstr "Green button hold"
 
+#. TRANSLATORS: regional option
 msgid "Greenland"
 msgstr "Greenland"
 
+#. TRANSLATORS: regional option
 msgid "Grenada"
 msgstr "Grenada"
 
@@ -8046,27 +8053,34 @@ msgstr "Grow drop"
 msgid "Grow from left"
 msgstr "Grow from left"
 
+#. TRANSLATORS: regional option
 msgid "Guadeloupe"
 msgstr "Guadeloupe"
 
+#. TRANSLATORS: regional option
 msgid "Guam"
 msgstr "Guam"
 
 msgid "Guard interval"
 msgstr "Guard interval"
 
+#. TRANSLATORS: regional option
 msgid "Guatemala"
 msgstr "Guatemala"
 
+#. TRANSLATORS: regional option
 msgid "Guernsey"
 msgstr "Guernsey"
 
+#. TRANSLATORS: regional option
 msgid "Guinea"
 msgstr "Guinea"
 
+#. TRANSLATORS: regional option
 msgid "Guinea-Bissau"
 msgstr "Guinea-Bissau"
 
+#. TRANSLATORS: regional option
 msgid "Guyana"
 msgstr "Guyana"
 
@@ -8074,7 +8088,7 @@ msgid "H7/H9/H9COMBO/H10 new Model"
 msgstr ""
 
 msgid "H: = Hourly / D: = Daily / W: = Weekly / M: = Monthly"
-msgstr "H: = Hourly / D: = Daily / W: = Weekly / M: = Monthly"
+msgstr "H: Hourly / D: Daily / W: Weekly / M: Monthly"
 
 msgid "H:mm"
 msgstr ""
@@ -8104,19 +8118,19 @@ msgid "HDMI"
 msgstr "HDMI"
 
 msgid "HDMI CEC"
-msgstr "HDMI CEC"
+msgstr "HDMI-CEC"
 
 msgid "HDMI CEC Setup"
-msgstr "HDMI CEC Setup"
+msgstr "HDMI-CEC Setup"
 
 msgid "HDMI Colordepth"
-msgstr "HDMI Colordepth"
+msgstr "HDMI color depth/bit depth"
 
 msgid "HDMI Colorimetry"
-msgstr "HDMI Colorimetry"
+msgstr "HDMI colorimetry"
 
 msgid "HDMI Colorspace"
-msgstr "HDMI Colorspace"
+msgstr "HDMI color space"
 
 msgid "HDMI HDR Type"
 msgstr ""
@@ -8125,14 +8139,13 @@ msgid "HDMI Recording"
 msgstr "HDMI Recording"
 
 msgid "HDMI-IN Recording settings"
-msgstr "HDMI-IN Recording settings"
+msgstr "HDMI-in Recording settings"
 
 msgid "HDMIin"
-msgstr "HDMIin"
+msgstr "HDMI-in"
 
-#, fuzzy
 msgid "HDR10 Support"
-msgstr "DLNA support"
+msgstr ""
 
 msgid "HELP"
 msgstr ""
@@ -8144,33 +8157,33 @@ msgid "HH:mm:ss"
 msgstr ""
 
 msgid "HI-cleanup for external subtitles"
-msgstr "HI-cleanup for external subtitles"
+msgstr "Hide HI text from external subtitles"
 
-#, fuzzy
 msgid "HLG Support"
-msgstr "DLNA support"
+msgstr "HLG Support"
 
+#. TRANSLATORS: regional option
 msgid "Haiti"
 msgstr "Haiti"
 
+#. TRANSLATORS: genre category
 msgid "Handball"
 msgstr ""
 
 msgid "Handle Python crashes"
 msgstr ""
 
-#, fuzzy
 msgid "Handle input from TV"
-msgstr "Handle wakeup from TV"
+msgstr "Handle input from TV"
 
 msgid "Handle standby from TV"
 msgstr "Handle standby from TV"
 
 msgid "Handle wakeup from TV"
-msgstr "Handle wakeup from TV"
+msgstr "Handle wake-up from TV"
 
 msgid "Hard disk setup"
-msgstr "Hard disk setup"
+msgstr "Hard Disk Setup"
 
 msgid "Hard disk standby after"
 msgstr "Hard disk standby after"
@@ -8179,52 +8192,56 @@ msgid "Hard disk standby in box standby after"
 msgstr "Hard disk standby in box standby after"
 
 msgid "Harddisk"
-msgstr "Harddisk"
+msgstr "Hard Disk"
 
 msgid "Harddisk Setup"
-msgstr "Harddisk Setup"
+msgstr "Hard Disk Setup"
 
+#. TRANSLATORS: regional option
 msgid "Heard Island and McDonald Islands"
 msgstr "Heard Island and McDonald Islands"
 
+#. TRANSLATORS: regional option
 msgid "Hebrew"
 msgstr "Hebrew"
 
 msgid "Height"
 msgstr "Height"
 
+#. TRANSLATORS: genre category
 msgid "Heimat"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Heimwerker"
-msgstr ""
+msgstr "DIY"
 
 msgid "Help"
-msgstr "Help"
+msgstr "Help button"
 
 msgid "Help long"
-msgstr "Help long"
+msgstr "Help button hold"
 
 msgid "Helps setting up your signal"
 msgstr "Helps setting up your signal"
 
 msgid "Here can set the EPG will alway open at the current channel, the first channel or one of both with primetime. If no primetime selected, the current time is used."
-msgstr "Here can set the EPG will alway open at the current channel, the first channel or one of both with primetime. If no primetime selected, the current time is used."
+msgstr "Choose whether the EPG should always open at the current channel, the first channel or either with primetime. The current time will be used if a preferred primetime hasn't been set."
 
 msgid "Here you can browse (but not modify) the files that are added to the backupfile by default (E2-setup, channels, network)."
-msgstr "Here you can browse (but not modify) the files that are added to the backupfile by default (E2-setup, channels, network)."
+msgstr "Browse files that are added to backups by default (Enigma2 setup, channels, network configuration, etc...)."
 
 msgid "Here you can select which files should be excluded from the backup."
-msgstr "Here you can select which files should be excluded from the backup."
+msgstr "This option lets you choose which files should be excluded from backups."
 
 msgid "Here you can select which files should be updated with a online update"
-msgstr "Here you can select which files should be updated with a online update"
+msgstr "This option lets you choose which files should be updated during an online update."
 
 msgid "Here you can set what is called when pressing the 'Info' key."
-msgstr ""
+msgstr "Choose what you'd like the Info button to do."
 
 msgid "Here you can specify additional files that should be added to the backup file."
-msgstr "Here you can specify additional files that should be added to the backup file."
+msgstr "This option lets you choose which files to add to backups."
 
 #, fuzzy
 msgid "Hidden / Blank"
@@ -8270,9 +8287,9 @@ msgstr "High bitrate support"
 msgid "Hispasat 30.0w"
 msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Historical"
-msgstr "History"
+msgstr ""
 
 msgid "History"
 msgstr "History"
@@ -8284,46 +8301,49 @@ msgid "History buttons mode"
 msgstr "History buttons mode"
 
 msgid "History long"
-msgstr "History long"
+msgstr "History button hold"
 
 msgid "History next"
 msgstr "History next"
 
 msgid "History zap..."
-msgstr "History zap..."
+msgstr "Zap History"
 
+#. TRANSLATORS: genre category
 msgid "Hobbys"
-msgstr ""
+msgstr "Hobbies"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Hockey"
-msgstr "locked"
+msgstr ""
 
 msgid "Hold screen"
 msgstr "Hold screen"
 
 msgid "Hold till locked"
-msgstr "Hold till locked"
+msgstr "Hold picture until locked"
 
+#. TRANSLATORS: regional option
 msgid "Holy See"
 msgstr "Holy See"
 
 msgid "Home"
-msgstr "Home"
+msgstr "Home button"
 
-#, fuzzy
 msgid "Home long"
-msgstr "Homepage long"
+msgstr "Home button hold"
 
 msgid "Homepage"
-msgstr "Homepage"
+msgstr "Homepage press"
 
 msgid "Homepage long"
-msgstr "Homepage long"
+msgstr "Homepage button hold"
 
+#. TRANSLATORS: regional option
 msgid "Honduras"
 msgstr "Honduras"
 
+#. TRANSLATORS: regional option
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
@@ -8336,20 +8356,17 @@ msgstr "Hops:"
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#, fuzzy
 msgid "Horizontal icons"
-msgstr "Horizontal"
+msgstr "horizontal icons"
 
-#, fuzzy
 msgid "Horizontal menu"
-msgstr "Horizontal"
+msgstr "horizontal menu"
 
 msgid "Horizontal turning speed"
 msgstr "Horizontal turning speed"
 
-#, fuzzy
 msgid "Horror"
-msgstr "Error"
+msgstr ""
 
 msgid "Horse Racing"
 msgstr ""
@@ -8367,10 +8384,10 @@ msgid "Hotkey"
 msgstr "Hotkey"
 
 msgid "Hotkey Setup"
-msgstr "Hotkey Setup"
+msgstr "Hotkey Settings"
 
 msgid "Hotkey Setup for"
-msgstr "Hotkey Setup for"
+msgstr "Hotkey Action"
 
 msgid "Hour"
 msgstr "Hour"
@@ -8385,14 +8402,16 @@ msgid "Hours Mins Secs"
 msgstr "Hours Mins Secs"
 
 msgid "How many minutes do you want to record?"
-msgstr "How many minutes do you want to record?"
+msgstr "Record for how many minutes?"
 
 msgid "Hue"
 msgstr "Hue"
 
+#. TRANSLATORS: regional option
 msgid "Hungarian"
 msgstr "Hungarian"
 
+#. TRANSLATORS: regional option
 msgid "Hungary"
 msgstr "Hungary"
 
@@ -8400,25 +8419,28 @@ msgid "I/O priority for script execution"
 msgstr ""
 
 msgid "IMDB search"
-msgstr "IMDB search"
+msgstr "search IMDb"
+
+msgid "IMDB search..."
+msgstr "Search IMDb..."
 
 msgid "IMDB search for current event"
-msgstr "IMDB search for current event"
+msgstr "Search IMDb for the current event"
 
 msgid "IMDb Details"
 msgstr "IMDb Details"
 
 msgid "IMDb Search"
-msgstr "IMDb Search"
+msgstr "Search IMDb"
 
 msgid "INFO"
-msgstr ""
+msgstr "Info"
 
 msgid "INFO button mode"
-msgstr "INFO button mode"
+msgstr "Info button"
 
 msgid "INFO-Panel..."
-msgstr "INFO-Panel..."
+msgstr "Info Panel..."
 
 #, fuzzy
 msgid "INS"
@@ -8496,11 +8518,12 @@ msgstr ""
 msgid "IceTV version %s"
 msgstr "Image Version"
 
+#. TRANSLATORS: regional option
 msgid "Iceland"
 msgstr "Iceland"
 
 msgid "Icons"
-msgstr "Icons"
+msgstr "icons"
 
 msgid "Idle Time: "
 msgstr "Idle Time: "
@@ -8515,104 +8538,104 @@ msgid "If editing a file, can you set the cursor start position at end or begin 
 msgstr ""
 
 msgid "If enabled the output resolution of the box will try to match the resolution of the video contents resolution"
-msgstr "If enabled the output resolution of the box will try to match the resolution of the video contents resolution"
+msgstr "If enabled, the output resolution of the box will try to match the resolution of the video contents resolution."
 
 msgid "If enabled the video will always be de-interlaced."
-msgstr "If enabled the video will always be de-interlaced."
+msgstr "If enabled, the video will always be de-interlaced."
 
 msgid "If enabled, AIT data is included in recordings."
-msgstr "If enabled, AIT data is included in recordings."
+msgstr "If enabled, AIT data will be included in recordings."
 
 msgid "If enabled, using a time window to detect a wakeup from deep standby by a timer. Default setting ist disabled and used a special signal from the receiver. But some devices set a wrong or none signal and the wakeup detection can fails."
-msgstr ""
+msgstr "If enabled, using a time window to detect a wake-up from deep standby by a timer. Default setting is disabled and uses a special signal from the receiver. But some devices set an incorrect or no signal and the wake-up detection fails."
 
 msgid "If logs are using the set maximum space used the eldest will be deleted."
 msgstr "If logs are using the set maximum space used the eldest will be deleted."
 
 msgid "If muted, hide mute icon or mute information after few seconds."
-msgstr ""
+msgstr "Choose whether to hide the mute icon or mute information after a few seconds when muted."
 
 msgid "If set to 'no', can you save older events even after zapping or interruption of the timeshift."
-msgstr "If set to 'no', can you save older events even after zapping or interruption of the timeshift."
+msgstr "When set to 'no', older events can be saved, even after zapping or interrupting timeshift mode."
 
 msgid "If set to 'no', timeshift used only one buffer file. It's recommend 'Timeshift checking for older files [in minutes]' and 'Timeshift checking for free space?' to adjust."
-msgstr "If set to 'no', timeshift used only one buffer file. It's recommend 'Timeshift checking for older files [in minutes]' and 'Timeshift checking for free space?' to adjust."
+msgstr "When set to 'no', timeshift will use only one buffer file. It's recommend to adjust 'Timeshift checking for older files [in minutes]' and 'Timeshift checking for free space?'."
 
 msgid "If set to 'yes' channels without EPG will not be shown."
-msgstr "If set to 'yes' channels without EPG will not be shown."
+msgstr "Choose whether channels without EPG data should be hidden."
 
 msgid "If set to 'yes' it will show the 'PO' packages in browser."
-msgstr "If set to 'yes' it will show the 'PO' packages in browser."
+msgstr "Choose whether 'PO' packages should be shown in the Plugin Browser."
 
 msgid "If set to 'yes' it will show the 'SRC' packages in browser."
-msgstr "If set to 'yes' it will show the 'SRC' packages in browser."
+msgstr "Choose whether 'SRC' packages should be shown in the Plugin Browser."
 
 msgid "If set to 'yes' shows a small TV-screen in the EPG."
-msgstr "If set to 'yes' shows a small TV-screen in the EPG."
+msgstr "Choose whether a mini TV window should be shown in the EPG."
 
 msgid "If set to 'yes' signal values (SNR, etc) will be calculated from API V3. This is an old API version that has now been superseded."
-msgstr ""
+msgstr "Choose whether signal values (SNR, etc.) should be calculated from API V3. This is an old API version which has been superseded."
 
 msgid "If set to 'yes' the bouquets will be shown each time you open the EPG."
-msgstr "If set to 'yes' the bouquets will be shown each time you open the EPG."
+msgstr "Choose whether the bouquet list should be shown each time you open the EPG."
 
 msgid "If set to 'yes' the channel list will be shown after switching between radio and TV modes."
-msgstr "If set to 'yes' the channel list will be shown after switching between radio and TV modes."
+msgstr "Choose whether the channel list should be shown when switching between radio and TV modes."
 
 msgid "If set to 'yes' the channel number will be displayed in the infobar."
-msgstr "If set to 'yes' the channel number will be displayed in the infobar."
+msgstr "Choose whether the channel number should be shown in the infobar."
 
 msgid "If set to 'yes' the infobar will be displayed when a new event starts."
-msgstr "If set to 'yes' the infobar will be displayed when a new event starts."
+msgstr "Choose whether the infobar should appear at the start of every event."
 
 msgid "If set to 'yes' the infobar will be displayed when changing channels."
-msgstr "If set to 'yes' the infobar will be displayed when changing channels."
+msgstr "Choose whether the infobar should appear when changing channels."
 
 msgid "If set to 'yes' you can preview channels in the EPG list."
-msgstr "If set to 'yes' you can preview channels in the EPG list."
+msgstr "Choose whether channels can be previewed from the EPG by pressing the OK button."
 
 msgid "If set to 'yes' you can preview channels in the channel list. Press 'OK' to preview the selected channel, press a 2nd 'OK' to exit and zap to that channel, pressing 'EXIT' to return to the channel you started at."
-msgstr "If set to 'yes' you can preview channels in the channel list. Press 'OK' to preview the selected channel, press a 2nd 'OK' to exit and zap to that channel, pressing 'EXIT' to return to the channel you started at."
+msgstr "Choose whether channels can be previewed from the channel list. Press OK to preview the selected channel, press OK a second time to exit the list and zap to that channel. Press EXIT to return to the channel that you started at."
 
 msgid "If set to 'yes', allows you use the seekbar to jump to a point within the event."
-msgstr "If set to 'yes', allows you use the seekbar to jump to a point within the event."
+msgstr "When set to 'yes', allows you use the seekbar to jump to a point within the event."
 
 msgid "If set to 'yes', enable autorecord for automatically background timeshift"
-msgstr "If set to 'yes', enable autorecord for automatically background timeshift"
+msgstr "Choose whether to enable auto-record for automatic background timeshift"
 
 msgid "If set to 'yes; the infobar will be displayed when Fast Forwarding or Rewinding during media playback."
-msgstr "If set to 'yes; the infobar will be displayed when Fast Forwarding or Rewinding during media playback."
+msgstr "Choose whether the infobar should appear when fast forwarding or rewinding media playback."
 
 msgid "If set to 'yes; the infobar will remain shown permanently in 'paused' state (no timeout)."
-msgstr "If set to 'yes; the infobar will remain shown permanently in 'paused' state (no timeout)."
+msgstr "Choose whether the infobar should stay on screen while paused."
 
 msgid "If the 'deep standby workaround' is enabled, it waits until the system time is synchronized. Depending on the requirement, the devices wake up will continuing after a maximum of 2 minutes."
-msgstr ""
+msgstr "If the 'deep standby workaround' is enabled, it will wait until the system time is synchronized. Depending on the requirement, the devices wake up will continuing after a maximum of 2 minutes."
 
 msgid "If the free space is less than setting value, then an attempt is made to delete the old timeshift files."
-msgstr "If the free space is less than setting value, then an attempt is made to delete the old timeshift files."
+msgstr "If the free space is less than setting value, an attempt is made to delete the old timeshift buffer files."
 
 msgid "If the text is too long to be displayed on the front panel, it will be repeated (number of times):"
-msgstr "If the text is too long to be displayed on the front panel, it will be repeated (number of times):"
+msgstr "If the text is too long to be displayed on the front panel, it will be repeated this many times:"
 
 msgid "If using multiple uncommitted switches the DiSEqC commands must be sent multiple times. Set to the number of uncommitted switches in the chain minus one."
-msgstr ""
+msgstr "If using multiple uncommitted switches, the DiSEqC commands must be sent multiple times. Set to the number of uncommitted switches in the chain minus one."
 
 msgid "If you are using a Circular polarised LNB select 'yes', otherwise select 'no'."
-msgstr ""
+msgstr "If you're using a circular polarized LNB, select 'yes', otherwise select 'no'."
 
 msgid "If you are using a DiSEqC committed switch enter the port letter required to access the LNB used for this satellite."
-msgstr ""
+msgstr "If you're using a DiSEqC committed switch, enter the port letter required to access the LNB used for this satellite."
 
 msgid "If you are using a DiSEqC uncommitted switch enter the port number required to access the LNB used for this satellite."
-msgstr ""
+msgstr "If you're using a DiSEqC uncommitted switch, enter the port number required to access the LNB used for this satellite."
 
 msgid ""
 "If you see this, something is wrong with\n"
 "your scart connection. Press OK to return."
 msgstr ""
-"If you see this, something is wrong with\n"
-"your scart connection. Press OK to return."
+"If you see can this, there's something wrong with\n"
+"your SCART connection! Press OK to return."
 
 msgid ""
 "If your TV has a brightness or contrast enhancement, disable it. If there is something called \"dynamic\", set it to standard. Adjust the backlight level to a value suiting your taste. Turn down contrast on your TV as much as possible.\n"
@@ -8620,10 +8643,10 @@ msgid ""
 "Do not care about the bright shades now. They will be set up in the next step.\n"
 "If you are happy with the result, press OK."
 msgstr ""
-"If your TV has a brightness or contrast enhancement, disable it. If there is something called \"dynamic\", set it to standard. Adjust the backlight level to a value suiting your taste. Turn down contrast on your TV as much as possible.\n"
-"Then turn the brightness setting as low as possible, but make sure that the two lowermost shades of gray stay distinguishable.\n"
-"Do not care about the bright shades now. They will be set up in the next step.\n"
-"If you are happy with the result, press OK."
+"If your TV has a brightness or contrast enhancement, disable it. If there's a \"dynamic\" setting, set it to standard. Adjust the backlight level to a value that suits your taste. Turn down the contrast on your TV as much as possible.\n"
+"Next, turn the brightness setting as low as possible, but make sure that the two lowermost shades of grey stay distinguishable.\n"
+"Don't worry about the bright shades right now. They'll be set up in the next step.\n"
+"Press OK when you're happy with the result."
 
 msgid "Ignore DVB-C namespace sub network"
 msgstr "Ignore DVB-C namespace sub network"
@@ -8635,7 +8658,7 @@ msgid "Ignore DVB-T namespace sub network"
 msgstr "Ignore DVB-T namespace sub network"
 
 msgid "Ignore unexpectedly wakeup and stay in standby"
-msgstr ""
+msgstr "Ignore unexpected wake-up and stay in standby"
 
 msgid "Image"
 msgstr "Image"
@@ -8655,9 +8678,9 @@ msgstr "Image Manager"
 msgid "Image Version"
 msgstr "Image Version"
 
-#, fuzzy, python-format
+#, python-format
 msgid "Image Version %s"
-msgstr "Image Version"
+msgstr "Image Version %s"
 
 #, python-format
 msgid "Image created on: %s/%s-%s-%s-backup-%s_mmc.zip"
@@ -8681,10 +8704,10 @@ msgid ""
 msgstr ""
 
 msgid "Image-Version"
-msgstr "Image-Version"
+msgstr "Image Version"
 
 msgid "ImageWizard"
-msgstr "ImageWizard"
+msgstr "Initialization Wizard"
 
 msgid "Immediate shutdown"
 msgstr "Immediate shutdown"
@@ -8693,13 +8716,13 @@ msgid "In addition to the check at an event start, a repetitive check can be use
 msgstr "In addition to the check at an event start, a repetitive check can be used, so that the conditions 'buffer limit in hours' or 'check free space' are detected earlier."
 
 msgid "In expert mode, configure which tuners will be preferred for recordings, when more than one tuner is available."
-msgstr "In expert mode, configure which tuners will be preferred for recordings, when more than one tuner is available."
+msgstr "In expert mode, configure which tuners will be preferred for recordings when more than one tuner is available."
 
 msgid "In expert mode, configure which tuners will be preferred, when more than one tuner is available."
-msgstr "In expert mode, configure which tuners will be preferred, when more than one tuner is available."
+msgstr "In expert mode, configure which tuners will be preferred when more than one tuner is available."
 
 msgid "In most cases this should be set to No. Only enable if you have a very specific need."
-msgstr "In most cases this should be set to No. Only enable if you have a very specific need."
+msgstr "In most cases this should be set to No. Only enable if specifically required."
 
 msgid ""
 "In order to allow you to access all the features of the IceTV smart recording service, we need to gather some basic information.\n"
@@ -8711,7 +8734,7 @@ msgid ""
 "In order to record a timer, a tuner was freed successfully:\n"
 "\n"
 msgstr ""
-"In order to record a timer, a tuner was freed successfully:\n"
+"A tuner was freed to record a timer!\n"
 "\n"
 
 msgid "In progress"
@@ -8719,7 +8742,7 @@ msgstr "In progress"
 
 #, fuzzy
 msgid "In the Standby Record on the LCD Display"
-msgstr "In the Standby blinking Clock on the LCD Display"
+msgstr "In the standby blinking clock on the front panel display"
 
 msgid "Inactive"
 msgstr "Inactive"
@@ -8734,7 +8757,7 @@ msgid "Inadyn Setup"
 msgstr "Inadyn Setup"
 
 msgid "Include AIT in http streams"
-msgstr "Include AIT in http streams"
+msgstr "Include AIT in HTTP streams"
 
 msgid "Include AIT in recordings"
 msgstr "Include AIT in recordings"
@@ -8743,13 +8766,13 @@ msgid "Include CI assignment"
 msgstr "Include CI assignment"
 
 msgid "Include ECM in http streams"
-msgstr "Include ECM in http streams"
+msgstr "Include ECM in HTTP streams"
 
 msgid "Include EIT in http streams"
-msgstr "Include EIT in http streams"
+msgstr "Include EIT in HTTP streams"
 
 msgid "Incorrect type service for PiP!"
-msgstr "Incorrect type service for PiP!"
+msgstr "Incorrect service type for PiP!"
 
 msgid "Increase time scale"
 msgstr "Increase time scale"
@@ -8766,12 +8789,15 @@ msgstr "Index"
 msgid "Index allocated:"
 msgstr "Index allocated:"
 
+#. TRANSLATORS: regional option
 msgid "India"
 msgstr "India"
 
+#. TRANSLATORS: regional option
 msgid "Indonesia"
 msgstr "Indonesia"
 
+#. TRANSLATORS: regional option
 msgid "Indonesian"
 msgstr "Indonesian"
 
@@ -8779,60 +8805,59 @@ msgid "Info"
 msgstr "Info"
 
 msgid "Info (EPG)"
-msgstr "Info (EPG)"
+msgstr "Info/EPG button"
 
 msgid "Info (EPG) Long"
-msgstr "Info (EPG) Long"
+msgstr "Info/EPG button hold"
 
 msgid "Info Panel"
 msgstr "Info Panel"
 
 msgid "Info button (long)"
-msgstr "Info button (long)"
+msgstr "Info button hold"
 
 msgid "Info button (short)"
-msgstr "Info button (short)"
+msgstr "Info button"
 
 msgid "Info icon width"
 msgstr "Info icon width"
 
 msgid "InfoBar"
-msgstr "InfoBar"
+msgstr "Infobar"
 
 msgid "InfoBar EPG mode"
-msgstr "InfoBar EPG mode"
+msgstr "Show Infobar EPG"
 
 msgid "InfoPanel"
-msgstr "InfoPanel"
+msgstr "Info Panel"
 
 msgid "Infobar EPG"
 msgstr "Infobar EPG"
 
 msgid "Infobar fade-out speed"
-msgstr "Infobar fade-out speed"
+msgstr "Infobar fade out duration"
 
 msgid "Infobar frontend data source"
 msgstr "Infobar frontend data source"
 
-#, fuzzy
 msgid "Infobar:"
-msgstr "Info bar"
+msgstr ""
 
 msgid "InfobarEPG settings"
-msgstr "InfobarEPG settings"
+msgstr "Infobar EPG Settings"
 
 msgid "Infopanel"
-msgstr "Infopanel"
+msgstr "Info panel"
 
 msgid "Information"
 msgstr "Information"
 
 msgid "Infos"
-msgstr "Infos"
+msgstr "System Info"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Infotainment"
-msgstr "CCcamInfo Mainmenu"
+msgstr ""
 
 msgid "Init"
 msgstr "Init"
@@ -8853,7 +8878,7 @@ msgid "Initial rewind speed"
 msgstr "Initial rewind speed"
 
 msgid "Initial scroll delay"
-msgstr "Initial scroll delay"
+msgstr "Delay before scrolling"
 
 msgid "Initial signal quality"
 msgstr "Initial signal quality"
@@ -8868,7 +8893,7 @@ msgid "Initialize"
 msgstr "Initialize"
 
 msgid "Initializing storage device..."
-msgstr "Initializing storage device..."
+msgstr "Formatting storage device..."
 
 msgid "Inode:"
 msgstr ""
@@ -8894,14 +8919,13 @@ msgid "Input config file name:"
 msgstr "Input channel name."
 
 msgid "Input devices"
-msgstr "Input devices"
+msgstr "Input Devices"
 
 msgid "Insert"
 msgstr ""
 
-#, fuzzy
 msgid "Insert line before current line"
-msgstr "Properties of current title"
+msgstr "Insert line before current line"
 
 msgid "Install"
 msgstr "Install"
@@ -8911,7 +8935,7 @@ msgid "Install '%s' and enable this operation"
 msgstr ""
 
 msgid "Install Failed !!"
-msgstr "Install Failed !!"
+msgstr "Install Failed!"
 
 msgid "Install Finished."
 msgstr "Install Finished."
@@ -8935,10 +8959,10 @@ msgid "Install extensions."
 msgstr "Install extensions."
 
 msgid "Install lcd picons on"
-msgstr "Install lcd picons on"
+msgstr "Install front panel display channel picons on"
 
 msgid "Install local extension"
-msgstr "Install local extension"
+msgstr "Install Local Plugin"
 
 msgid "Install or remove finished."
 msgstr "Install or remove finished."
@@ -8947,10 +8971,10 @@ msgid "Install picons on"
 msgstr "Install picons on"
 
 msgid "Install plugins"
-msgstr "Install plugins"
+msgstr "Install Plugins"
 
 msgid "Install settings, skins, software..."
-msgstr "Install settings, skins, software..."
+msgstr "Install settings, skins, channel picons, software, etc..."
 
 msgid "Installation finished."
 msgstr "Installation finished."
@@ -8962,41 +8986,35 @@ msgstr "Installed:\t%s"
 msgid "Installing"
 msgstr "Installing"
 
-#, fuzzy
 msgid "Installing Plugin ..."
-msgstr "Installing plugins..."
+msgstr "Installing plugin..."
 
 msgid "Installing Service"
 msgstr "Installing Service"
 
-#, fuzzy
 msgid "Installing Software..."
 msgstr "Installing software..."
 
-#, fuzzy
 msgid "Installing feeds from IPK ..."
-msgstr "Installing software..."
+msgstr "Installing feeds from IPK..."
 
-#, fuzzy
 msgid "Installing feeds from feed ..."
-msgstr "Installing software..."
+msgstr "Installing feeds from feed..."
 
-#, fuzzy
 msgid "Installing plugins from IPK ..."
-msgstr "Installing plugins..."
+msgstr "Installing plugins from IPK..."
 
-#, fuzzy
 msgid "Installing plugins from feed ..."
-msgstr "Installing plugins..."
+msgstr "Installing plugins from feed..."
 
 msgid "Installing software..."
 msgstr "Installing software..."
 
 msgid "Instant record"
-msgstr "Instant record"
+msgstr "Show recording options"
 
 msgid "Instant record location"
-msgstr "Instant record location"
+msgstr "Instant recording location"
 
 msgid "Instant recording location"
 msgstr "Instant recording location"
@@ -9005,14 +9023,13 @@ msgid "Instant recording..."
 msgstr "Instant recording..."
 
 msgid "Instant recordings location"
-msgstr "Instant recordings location"
+msgstr "New instant recording location"
 
 msgid "Interface"
 msgstr "Interface"
 
-#, fuzzy
 msgid "Interface:"
-msgstr "Interface: "
+msgstr "Interface:"
 
 msgid "Interface: "
 msgstr "Interface: "
@@ -9026,36 +9043,33 @@ msgstr "Intermediate"
 msgid "Internal"
 msgstr "Internal"
 
-#, fuzzy
 msgid "Internal Flash"
-msgstr "Internal flash"
+msgstr "internal Flash Memory"
 
 msgid "Internal USB"
 msgstr "Internal USB"
 
 msgid "Internal flash"
-msgstr "Internal flash"
+msgstr "internal flash memory"
 
 msgid "Internal hdd only"
-msgstr "Internal hdd only"
+msgstr "internal HDD only"
 
-#, fuzzy
 msgid "International"
-msgstr "Internal"
+msgstr ""
 
 msgid "Internet"
 msgstr "Internet"
 
 msgid "Interval between keys when repeating:"
-msgstr "Interval between keys when repeating:"
+msgstr "Interval between repeating keys (in ms)"
 
-#, fuzzy
 msgid "Invalid"
-msgstr "invalid type"
+msgstr "invalid"
 
 #, python-format
 msgid "Invalid directory selected: %s"
-msgstr "Invalid directory selected: %s"
+msgstr "Invalid folder selected: %s"
 
 msgid "Invalid location"
 msgstr "Invalid location"
@@ -9070,21 +9084,24 @@ msgid "Invert"
 msgstr "Invert"
 
 msgid "Inverts the button function."
-msgstr ""
+msgstr "Choose the direction of the Channel Up/Down buttons."
 
 msgid "Ipkg"
-msgstr "Ipkg"
+msgstr "IPKG"
 
+#. TRANSLATORS: regional option
 msgid "Iran (Islamic Republic of)"
-msgstr "Iran (Islamic Republic of)"
+msgstr "Iran, Islamic Republic of"
 
-#, fuzzy
+#. TRANSLATORS: regional option
 msgid "Iran, Islamic Republic"
-msgstr "Iran (Islamic Republic of)"
+msgstr "Iran, Islamic Republic of"
 
+#. TRANSLATORS: regional option
 msgid "Iraq"
 msgstr "Iraq"
 
+#. TRANSLATORS: regional option
 msgid "Ireland"
 msgstr "Ireland"
 
@@ -9092,14 +9109,16 @@ msgid "Is not necessary in most cases."
 msgstr ""
 
 msgid "Is this setting ok?"
-msgstr "Is this setting ok?"
+msgstr "Is this setting OK?"
 
 msgid "Is this video mode ok?"
-msgstr "Is this video mode ok?"
+msgstr "Is this video mode OK?"
 
+#. TRANSLATORS: regional option
 msgid "Isle of Man"
 msgstr "Isle of Man"
 
+#. TRANSLATORS: regional option
 msgid "Israel"
 msgstr "Israel"
 
@@ -9120,8 +9139,9 @@ msgid "It is not possible to run '%s' on <List of Storage Devices>"
 msgstr ""
 
 msgid "It's not possible to rename the filesystem root."
-msgstr ""
+msgstr "The filesystem root can't be renamed."
 
+#. TRANSLATORS: regional option
 msgid "Italian"
 msgstr "Italian"
 
@@ -9131,12 +9151,15 @@ msgstr "Italy"
 msgid "JUMP 24 HOURS"
 msgstr "JUMP 24 HOURS"
 
+#. TRANSLATORS: regional option
 msgid "Jamaica"
 msgstr "Jamaica"
 
+#. TRANSLATORS: regional option
 msgid "Japan"
 msgstr "Japan"
 
+#. TRANSLATORS: regional option
 msgid "Jersey"
 msgstr "Jersey"
 
@@ -9150,13 +9173,15 @@ msgid "Job overview"
 msgstr "Job overview"
 
 msgid "JobManager"
-msgstr "JobManager"
+msgstr "Job Manager"
 
+#. TRANSLATORS: regional option
 msgid "Jordan"
 msgstr "Jordan"
 
+#. TRANSLATORS: genre category
 msgid "Jugend"
-msgstr ""
+msgstr "Youth"
 
 msgid "Jump back 24 hours"
 msgstr "Jump back 24 hours"
@@ -9194,9 +9219,9 @@ msgstr "Just change channels"
 msgid "Just zap"
 msgstr "Just zap"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Justiz"
-msgstr "Just zap"
+msgstr "Justice"
 
 msgid "KA-SAT"
 msgstr "KA-SAT"
@@ -9205,21 +9230,26 @@ msgstr "KA-SAT"
 msgid "KB"
 msgstr "B"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Kampfsport"
-msgstr "team sports"
+msgstr "Martial arts"
 
+#. TRANSLATORS: genre category
 msgid "Katastrophe"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Kazakhstan"
 msgstr "Kazakhstan"
 
 msgid "Keep service"
-msgstr "Keep service"
+msgstr "keep service"
+
+msgid "Keep service + Reverse bouquet buttons"
+msgstr "keep service + reverse bouquet buttons"
 
 msgid "Keeps MovieList open whilst playing audio files."
-msgstr "Keeps MovieList open whilst playing audio files."
+msgstr "Keeps movie list open whilst playing audio files."
 
 msgid "Kenya"
 msgstr "Kenya"
@@ -9251,21 +9281,27 @@ msgstr "Keyboard setup"
 msgid "Keymap Selection"
 msgstr "Keymap Selection"
 
+msgid "Keymap Selection..."
+msgstr "Keymap Selection"
+
 msgid "Keymap changed, you need to restart the GUI"
-msgstr "Keymap changed, you need to restart the GUI"
+msgstr "Keymap changed, you'll need to restart the GUI"
 
-#, fuzzy
+#. TRANSLATORS: region
 msgid "Kinder"
-msgstr "Satfinder"
+msgstr "Kids"
 
+#. TRANSLATORS: regional option
 msgid "Kiribati"
 msgstr "Kiribati"
 
+#. TRANSLATORS: genre category
 msgid "Klassiker"
-msgstr ""
+msgstr "Classic"
 
+#. TRANSLATORS: genre category
 msgid "Kneipensport"
-msgstr ""
+msgstr "Pub sports"
 
 msgid "Kodi MediaCenter"
 msgstr "Kodi MediaCenter"
@@ -9280,46 +9316,56 @@ msgstr "Exit media player?"
 msgid "Kodi/extra partition free space:"
 msgstr "Kodi/extra partition free space:"
 
+#. TRANSLATORS: genre category
 msgid "Komödie"
-msgstr ""
+msgstr "Comedy"
 
+#. TRANSLATORS: regional option
 msgid "Korea (Democratic People's Republic of)"
-msgstr "Korea (Democratic People's Republic of)"
+msgstr "Korea, Democratic People's Republic of"
 
+#. TRANSLATORS: regional option
 msgid "Korea (Republic of)"
-msgstr "Korea (Republic of)"
+msgstr "Korea, Republic of"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Kraftsport"
-msgstr "water sport"
+msgstr "Weightlifting"
 
+#. TRANSLATORS: genre category
 msgid "Krieg"
-msgstr ""
+msgstr "War"
 
+#. TRANSLATORS: genre category
 msgid "Krimi"
-msgstr ""
+msgstr "Crime"
 
+#. TRANSLATORS: genre category
 msgid "Kriminalität"
-msgstr ""
+msgstr "Crime"
 
+#. TRANSLATORS: genre category
 msgid "Kultur"
-msgstr ""
+msgstr "Culture"
 
+#. TRANSLATORS: genre category
 msgid "Kunst"
-msgstr ""
+msgstr "Art"
 
+#. TRANSLATORS: genre category
 msgid "Kurzfilm"
-msgstr ""
+msgstr "Short film"
 
+#. TRANSLATORS: regional option
 msgid "Kuwait"
 msgstr "Kuwait"
 
+#. TRANSLATORS: regional option
 msgid "Kyrgyzstan"
 msgstr "Kyrgyzstan"
 
-#, fuzzy
 msgid "LAN"
-msgstr "LCN"
+msgstr "LAN"
 
 msgid "LAN adapter"
 msgstr "LAN adapter"
@@ -9327,18 +9373,17 @@ msgstr "LAN adapter"
 msgid "LAN connection"
 msgstr "LAN connection"
 
-#, fuzzy
 msgid "LAN long"
-msgstr "F1/LAN long"
+msgstr "LAN button hold"
 
 msgid "LCD Skin Setup"
-msgstr "LCD Skin Setup"
+msgstr "Front Panel Display Skin"
 
 msgid "LCD SkinSelector"
-msgstr "LCD SkinSelector"
+msgstr "Front Panel Display Skin Selector"
 
 msgid "LCD scroll speed"
-msgstr "LCD scroll speed"
+msgstr "Front panel display scroll speed"
 
 msgid "LCN plugin for DVB-T/T2 services"
 msgstr "LCN plugin for DVB-T/T2 services"
@@ -9356,13 +9401,13 @@ msgid "LED Standby"
 msgstr "LED Standby"
 
 msgid "LED brightness during deep standby."
-msgstr "LED brightness during deep standby."
+msgstr "LED brightness in deep standby."
 
 msgid "LED brightness during normal operations."
-msgstr "LED brightness during normal operations."
+msgstr "LED brightness during normal use."
 
 msgid "LED brightness during standby."
-msgstr "LED brightness during standby."
+msgstr "LED brightness in standby."
 
 msgid "LNB"
 msgstr "LNB"
@@ -9386,13 +9431,18 @@ msgid "Landestypisch"
 msgstr ""
 
 msgid "Language"
-msgstr "Language"
+msgstr "Language Settings"
 
 msgid "Language selection"
-msgstr "Language selection"
+msgstr "Language Selection"
 
+#. TRANSLATORS: regional option
 msgid "Lao People's Democratic Republic"
 msgstr "Lao People's Democratic Republic"
+
+#, python-format
+msgid "Last E2 update:\t\t%s"
+msgstr "Last Enigma2 update:\t\t%s"
 
 msgid "Last Req."
 msgstr "Last Req."
@@ -9414,9 +9464,9 @@ msgstr "Last update:\t%s"
 msgid "Last used share: "
 msgstr "Last used share: "
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Late Night"
-msgstr "Page right"
+msgstr ""
 
 msgctxt "third event: 'third' event label"
 msgid "Later"
@@ -9425,66 +9475,73 @@ msgstr ""
 msgid "Latitude"
 msgstr "Latitude"
 
+#. TRANSLATORS: regional option
 msgid "Latvia"
 msgstr "Latvia"
 
+#. TRANSLATORS: regional option
 msgid "Latvian"
 msgstr "Latvian"
 
 msgid "Leave DVD player?"
-msgstr "Leave DVD player?"
+msgstr "Quit DVD player?"
 
 msgid "Leave File Commander"
-msgstr ""
+msgstr "Quit File Commander"
 
-#, fuzzy
 msgid "Leave multi-select mode"
-msgstr "Please select medium"
+msgstr "Quit multi-select"
 
 msgid "Leave this set to 'yes' unless you fully understand why you are adjusting it."
-msgstr ""
+msgstr "Leave this set to 'yes' unless you know exactly what you're doing."
 
+#. TRANSLATORS: regional option
 msgid "Lebanon"
 msgstr "Lebanon"
 
 msgid "Left"
-msgstr "Left"
+msgstr "◀︎ Left"
 
 msgid "Left from servicename"
-msgstr "Left from servicename"
+msgstr "left of service name"
 
 msgid "Left long"
-msgstr "Left long"
+msgstr "◀︎ Left button hold"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Leichtathletik"
-msgstr "athletics"
+msgstr "Athletics"
 
+#. TRANSLATORS: genre category
 msgid "Leisure hobbies"
 msgstr "Leisure hobbies"
 
+#. TRANSLATORS: regional option
 msgid "Lesotho"
 msgstr "Lesotho"
 
 #. TRANSLATORS: (aspect ratio policy: black bars on top/bottom) in doubt, keep english term.
 msgid "Letterbox"
-msgstr "Letterbox"
+msgstr "letterbox"
 
 msgid "Letterbox zoom"
 msgstr "Letterbox zoom"
 
+#. TRANSLATORS: regional option
 msgid "Liberia"
 msgstr "Liberia"
 
+#. TRANSLATORS: regional option
 msgid "Libya"
 msgstr "Libya"
 
+#. TRANSLATORS: regional option
 msgid "Liechtenstein"
 msgstr "Liechtenstein"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Lifestyle"
-msgstr "Time scale"
+msgstr ""
 
 msgid "Light Grey"
 msgstr "Light Grey"
@@ -9499,13 +9556,13 @@ msgid "Limit east"
 msgstr "Limit east"
 
 msgid "Limit the characters that can be used in recording filenames to (7 bit) ascii. This ensures compatibility with operating systems or file systems with limited character sets."
-msgstr "Limit the characters that can be used in recording filenames to (7 bit) ascii. This ensures compatibility with operating systems or file systems with limited character sets."
+msgstr "Limit the characters that can be used in recording filenames to (7-bit) ascii. This ensures compatibility with operating systems or file systems with limited character sets."
 
 msgid "Limit west"
 msgstr "Limit west"
 
 msgid "Limits cancelled"
-msgstr "Limits cancelled"
+msgstr "Limits canceled"
 
 msgid "Limits enabled"
 msgstr "Limits enabled"
@@ -9517,7 +9574,7 @@ msgid "Limits on"
 msgstr "Limits on"
 
 msgid "Link Quality:"
-msgstr "Link Quality:"
+msgstr "Link quality:"
 
 msgid "Link quality:"
 msgstr "Link quality:"
@@ -9540,7 +9597,7 @@ msgid "List EPG functions..."
 msgstr "List EPG functions..."
 
 msgid "List available networks"
-msgstr "List available networks"
+msgstr "Show available networks"
 
 msgid "List mode"
 msgstr "List mode"
@@ -9559,10 +9616,10 @@ msgstr[0] "List version %d, found %d channel"
 msgstr[1] "List version %d, found %d channels"
 
 msgid "List/Fav"
-msgstr "List/Fav"
+msgstr "LIST/FAV button"
 
 msgid "List/Fav long"
-msgstr "List/Fav long"
+msgstr "LIST/FAV button hold"
 
 msgid "Listen to the radio..."
 msgstr "Listen to the radio..."
@@ -9570,17 +9627,19 @@ msgstr "Listen to the radio..."
 msgid "Lists reloaded!"
 msgstr "Lists reloaded!"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Literatur"
-msgstr "literature"
+msgstr "Literature"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Literaturverfilmung"
-msgstr "literature"
+msgstr "Film adaptation"
 
+#. TRANSLATORS: regional option
 msgid "Lithuania"
 msgstr "Lithuania"
 
+#. TRANSLATORS: regional option
 msgid "Lithuanian"
 msgstr "Lithuanian"
 
@@ -9590,9 +9649,8 @@ msgstr ""
 msgid "Load"
 msgstr "Load"
 
-#, fuzzy
 msgid "Load Default Settings"
-msgstr "Default settings"
+msgstr "Load default settings"
 
 msgid "Load EPG"
 msgstr "Load EPG"
@@ -9601,7 +9659,7 @@ msgid "Load playlist"
 msgstr "Load playlist"
 
 msgid "Load unlinked userbouquets"
-msgstr "Load unlinked userbouquets"
+msgstr "Load unlinked bouquets"
 
 msgid "Load/Save/Delete"
 msgstr "Load/Save/Delete"
@@ -9612,9 +9670,8 @@ msgstr "Local box"
 msgid "Local network"
 msgstr "Local network"
 
-#, fuzzy
 msgid "Locale"
-msgstr "Local"
+msgstr ""
 
 msgid "Location"
 msgstr "Location"
@@ -9634,22 +9691,20 @@ msgstr "Log"
 msgid "Log Manager"
 msgstr "Log Manager"
 
-#, fuzzy
 msgid "Log python stack trace on spinner ?"
-msgstr "Log python stack trace on spinner (may have side effects) ?"
+msgstr "Log Python stack trace on spinner (may have side effects)"
 
 msgid "Log results to harddisk"
-msgstr "Log results to harddisk"
+msgstr "Log results to hard disk"
 
 msgid "LogManager"
-msgstr "LogManager"
+msgstr "Log Manager"
 
 msgid "Login"
 msgstr ""
 
-#, fuzzy
 msgid "Login failure"
-msgstr "Mount failed"
+msgstr "Login failed"
 
 msgid "Login to IceTV server"
 msgstr ""
@@ -9658,44 +9713,43 @@ msgid "Logs location"
 msgstr "Logs location"
 
 msgid "Logs older then the set no of days will be deleted."
-msgstr "Logs older then the set no of days will be deleted."
+msgstr "Logs older than the configured number of days will be deleted."
 
 msgid "Logs settings"
-msgstr "Logs settings"
+msgstr "Logs Settings"
 
 msgid "Long << / >>"
-msgstr "Long << / >>"
+msgstr "◀︎◀︎ REW / FFWD ▶︎▶︎ hold"
 
 msgid "Long Left/Right"
-msgstr "Long Left/Right"
+msgstr "◀︎ Left / Right ▶︎ hold"
 
 msgid "Long filenames"
 msgstr "Long filenames"
 
 msgid "Long key press"
-msgstr "Long key press"
+msgstr "Button hold"
 
 msgid "Long press emulation with button"
-msgstr "Long press emulation with button"
+msgstr "Hold emulation with button"
 
 msgid "Longitude"
 msgstr "Longitude"
 
 msgid "Loop through to"
-msgstr "Loop through to"
+msgstr "loop through to"
 
 msgid "Lower Framerate save CPU Time"
-msgstr "Lower Framerate save CPU Time"
+msgstr "Lower frame rate save CPU time"
 
 msgid "Lower USB"
-msgstr "Lower USB"
+msgstr "Bottom USB"
 
-#, fuzzy
 msgid "Lower case"
-msgstr "Lower USB"
+msgstr "Lowercase"
 
 msgid "Lower limit in kilobits per seconds [kbit/s]"
-msgstr "Lower limit in kilobits per seconds [kbit/s]"
+msgstr "Lower limit in kilobits per seconds (kbit/s])"
 
 msgid "Lowest Mode"
 msgstr "Lowest Mode"
@@ -9703,21 +9757,22 @@ msgstr "Lowest Mode"
 msgid "Lowest Video output mode"
 msgstr "Lowest Video output mode"
 
+#. TRANSLATORS: regional option
 msgid "Luxembourg"
 msgstr "Luxembourg"
 
+#. TRANSLATORS: regional option
 msgid "Luxembourgish"
 msgstr "Luxembourgish"
 
-#, fuzzy
 msgid "MAC"
-msgstr "MAC:"
+msgstr "MAC"
 
 msgid "MAC-address"
-msgstr "MAC-address"
+msgstr "MAC address"
 
 msgid "MAC-address settings"
-msgstr "MAC-address settings"
+msgstr "MAC address settings"
 
 msgid "MAC:"
 msgstr "MAC:"
@@ -9728,9 +9783,8 @@ msgstr "MB"
 msgid "MIRACLEBOX_TWINPLUS"
 msgstr ""
 
-#, fuzzy
 msgid "MMA"
-msgstr "MAC:"
+msgstr "MMA"
 
 msgid "MORE"
 msgstr "MORE"
@@ -9738,19 +9792,22 @@ msgstr "MORE"
 msgid "MOUSE"
 msgstr ""
 
-#, fuzzy
 msgid "MOUSE long"
-msgstr "OK long"
+msgstr "MOUSE button hold"
 
+#. TRANSLATORS: regional option
 msgid "Macao"
 msgstr "Macao"
 
+#. TRANSLATORS: regional option
 msgid "Macedonia (the former Yugoslav Republic of)"
-msgstr "Macedonia (the former Yugoslav Republic of)"
+msgstr "Macedonia, The former Yugoslav Republic of"
 
+#. TRANSLATORS: regional option
 msgid "Madagascar"
 msgstr "Madagascar"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "Magazin"
 msgstr "news magazine"
@@ -9759,16 +9816,16 @@ msgid "Main menu"
 msgstr "Main menu"
 
 msgid "Mainmenu"
-msgstr "Mainmenu"
+msgstr "Main menu"
 
 msgid "Maintain old EPG data for"
-msgstr "Maintain old EPG data for"
+msgstr "Maintain old EPG data for # minutes"
 
 msgid "Make File Commander accessible from the Extensions menu."
-msgstr ""
+msgstr "Choose whether to show File Commander in the Extensions menu."
 
 msgid "Make File Commander accessible from the main menu."
-msgstr ""
+msgstr "Choose whether to show File Commander on the Main menu."
 
 msgid "Make this mark an 'in' point"
 msgstr "Make this mark an 'in' point"
@@ -9779,18 +9836,23 @@ msgstr "Make this mark an 'out' point"
 msgid "Make this mark just a mark"
 msgstr "Make this mark just a mark"
 
+#. TRANSLATORS: regional option
 msgid "Malawi"
 msgstr "Malawi"
 
+#. TRANSLATORS: regional option
 msgid "Malaysia"
 msgstr "Malaysia"
 
+#. TRANSLATORS: regional option
 msgid "Maldives"
 msgstr "Maldives"
 
+#. TRANSLATORS: regional option
 msgid "Mali"
 msgstr "Mali"
 
+#. TRANSLATORS: regional option
 msgid "Malta"
 msgstr "Malta"
 
@@ -9807,8 +9869,9 @@ msgstr "Manage your %s %s's software"
 msgid "Manage your online update files"
 msgstr "Manage your online update files"
 
+#. TRANSLATORS: genre category
 msgid "Mannschaftssport"
-msgstr ""
+msgstr "Team sports"
 
 msgid "Manual"
 msgstr "Manual"
@@ -9817,16 +9880,16 @@ msgid "Manual Scan"
 msgstr "Manual Scan"
 
 msgid "Manual Service Searching"
-msgstr "Manual Service Searching"
+msgstr "Search for channels manually"
 
 msgid "Manual configuration"
-msgstr "Manual configuration"
+msgstr "Configure manually"
 
 msgid "Manual scan"
-msgstr "Manual scan"
+msgstr "Manual Scan"
 
 msgid "Manual scan for services"
-msgstr "Manual scan for services"
+msgstr "Manual scan for services.,"
 
 msgid "Manual transponder"
 msgstr "Manual transponder"
@@ -9838,36 +9901,41 @@ msgid "MaraM9"
 msgstr "MaraM9"
 
 msgid "Margin after recording (minutes)"
-msgstr "Margin after recording (minutes)"
+msgstr "Add # minutes to end of recording time"
 
 msgid "Margin before recording (minutes)"
-msgstr "Margin before recording (minutes)"
+msgstr "Add # minutes to start of recording time"
 
 msgid "Mark service as dedicated 3D service"
-msgstr "Mark service as dedicated 3D service"
+msgstr "Mark as a dedicated 3D channel"
 
 msgid "Mark/Portal/Playlist"
 msgstr "Mark/Portal/Playlist"
 
-#, fuzzy
 msgid "Mark/Portal/Playlist long"
-msgstr "Mark/Portal/Playlist"
+msgstr "Mark/Portal/Playlist button hold"
 
+#. TRANSLATORS: regional option
 msgid "Marshall Islands"
 msgstr "Marshall Islands"
 
+#. TRANSLATORS: regional option
 msgid "Martinique"
 msgstr "Martinique"
 
+#. TRANSLATORS: genre category
 msgid "Mature Adult Audience 15+"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Mature Audience 15+"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Mauritania"
 msgstr "Mauritania"
 
+#. TRANSLATORS: regional option
 msgid "Mauritius"
 msgstr "Mauritius"
 
@@ -9888,17 +9956,18 @@ msgstr "Maxdown: "
 
 #, python-format
 msgid "Maximum minutes to jump %d !"
-msgstr "Maximum minutes to jump %d !"
+msgstr "Maximum minutes to jump %d!"
 
 msgid "Maximum no of days:"
-msgstr "Maximum no of days:"
+msgstr "Keep log files for # days"
 
 msgid "Maximum number of days in EPG"
-msgstr "Maximum number of days in EPG"
+msgstr "Update EPG data for next # days"
 
 msgid "Maximum space used (MB):"
-msgstr "Maximum space used (MB):"
+msgstr "Maximum space used (MB)"
 
+#. TRANSLATORS: regional option
 msgid "Mayotte"
 msgstr "Mayotte"
 
@@ -9915,10 +9984,10 @@ msgid "Media Portal"
 msgstr "Media Portal"
 
 msgid "Media long"
-msgstr "Media long"
+msgstr "Media button hold"
 
 msgid "Media playback Remaining/Elapsed as"
-msgstr "Media playback Remaining/Elapsed as"
+msgstr "Media playback remaining/elapsed as"
 
 msgid "Media player"
 msgstr "Media player"
@@ -9927,27 +9996,26 @@ msgid "Media scanner"
 msgstr "Media scanner"
 
 msgid "MediaPlayer"
-msgstr "MediaPlayer"
+msgstr "Media Player"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Medical"
-msgstr "Media"
+msgstr ""
 
-#, fuzzy
 msgid "Medien"
 msgstr "Media"
 
 msgid "Medium is not a writeable DVD!"
-msgstr "Medium is not a writeable DVD!"
+msgstr "DVD disc is not writeable!"
 
 msgid "Medium is not empty!"
-msgstr "Medium is not empty!"
+msgstr "Disc is not empty!"
 
 msgid "Medium toolbox"
-msgstr "Medium toolbox"
+msgstr "Disc toolbox"
 
 msgid "MemInfo"
-msgstr "MemInfo"
+msgstr "Memory"
 
 msgid "Memory"
 msgstr "Memory"
@@ -9959,13 +10027,13 @@ msgid "Memory index"
 msgstr "Memory index"
 
 msgid "Menu"
-msgstr "Menu"
+msgstr "MENU button"
 
 msgid "Menu config"
 msgstr "Menu config"
 
 msgid "Merging Timeshift files"
-msgstr "Merging Timeshift files"
+msgstr "Merging timeshift files"
 
 msgid "Merlin EPG Center"
 msgstr "Merlin EPG Center"
@@ -9976,22 +10044,22 @@ msgstr "Message"
 msgid "Message..."
 msgstr "Message..."
 
-#, fuzzy
 msgid "MessageBox Functions"
-msgstr "Virtual KeyBoard"
+msgstr "MessageBox Functions"
 
 msgid "Metadata changed:"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Mexico"
 msgstr "Mexico"
 
+#. TRANSLATORS: regional option
 msgid "Micronesia (Federated States of)"
-msgstr "Micronesia (Federated States of)"
+msgstr "Micronesia, Federated States of"
 
-#, fuzzy
 msgid "Mini Series"
-msgstr "All Services"
+msgstr "Miniseries"
 
 msgid "MiniDLNA"
 msgstr "MiniDLNA"
@@ -10003,10 +10071,10 @@ msgid "MiniDLNA Setup"
 msgstr "MiniDLNA Setup"
 
 msgid "MiniTV"
-msgstr "MiniTV"
+msgstr "Mini TV"
 
 msgid "MiniTV with OSD"
-msgstr "MiniTV with OSD"
+msgstr "Mini TV with OSD"
 
 #, python-format
 msgid "Minimum age %d years"
@@ -10057,7 +10125,7 @@ msgid "Mode 2"
 msgstr "Mode 2"
 
 msgid "Mode for autorestore"
-msgstr "Mode for autorestore"
+msgstr "Autorestore mode"
 
 #, fuzzy, python-format
 msgid "Model:\t\t%s %s\n"
@@ -10080,10 +10148,11 @@ msgid "Modulator"
 msgstr "Modulator"
 
 msgid "Module"
-msgstr "Module"
+msgstr "Modules"
 
+#. TRANSLATORS: regional option
 msgid "Moldova (Republic of)"
-msgstr "Moldova (Republic of)"
+msgstr "Moldova, Republic of"
 
 msgid "Mon"
 msgstr "Mon"
@@ -10091,43 +10160,48 @@ msgstr "Mon"
 msgid "Mon-Fri"
 msgstr "Mon-Fri"
 
+#. TRANSLATORS: regional option
 msgid "Monaco"
 msgstr "Monaco"
 
 msgid "Monday"
 msgstr "Monday"
 
+#. TRANSLATORS: regional option
 msgid "Mongolia"
 msgstr "Mongolia"
 
+#. TRANSLATORS: regional option
 msgid "Montenegro"
 msgstr "Montenegro"
 
 msgid "Monthly"
 msgstr "Monthly"
 
+#. TRANSLATORS: regional option
 msgid "Montserrat"
 msgstr "Montserrat"
 
+#. TRANSLATORS: regional option
 msgid "Morocco"
 msgstr "Morocco"
 
 msgid "Mosquito noise reduction"
 msgstr "Mosquito noise reduction"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Motor Sport"
-msgstr "motor sport"
+msgstr "Motorsport"
 
 msgid "Motor command retries"
-msgstr "Motor command retries"
+msgstr "Retry dish rotator command # times"
 
 msgid "Motor running timeout"
 msgstr "Motor running timeout"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Motorsport"
-msgstr "motor sport"
+msgstr ""
 
 msgid "Mount"
 msgstr "Mount"
@@ -10140,7 +10214,7 @@ msgid "Mount Manager"
 msgstr "Mount Manager"
 
 msgid "Mount Setup"
-msgstr "Mount Setup"
+msgstr "Mounts Setup"
 
 msgid "Mount failed"
 msgstr "Mount failed"
@@ -10149,13 +10223,13 @@ msgid "Mount: "
 msgstr "Mount: "
 
 msgid "MountManager"
-msgstr "MountManager"
+msgstr "Mount Manager"
 
 msgid "Mounts"
 msgstr "Mounts"
 
 msgid "Mounts Devices"
-msgstr "Mounts Devices"
+msgstr "Mount devices"
 
 msgid "Mounts Setup"
 msgstr "Mounts Setup"
@@ -10175,7 +10249,7 @@ msgid "Move Left/Right"
 msgstr "Move Left/Right"
 
 msgid "Move PIP"
-msgstr "Move PIP"
+msgstr "Move PiP"
 
 msgid "Move PiP to main picture"
 msgstr "Move PiP to main picture"
@@ -10183,9 +10257,8 @@ msgstr "Move PiP to main picture"
 msgid "Move Up/Down"
 msgstr "Move Up/Down"
 
-#, fuzzy
 msgid "Move down a line"
-msgstr "Move down a page"
+msgstr "Move down a live"
 
 msgid "Move down a page"
 msgstr "Move down a page"
@@ -10197,19 +10270,17 @@ msgstr "Go down the list"
 msgid "Move east"
 msgstr "Move east"
 
-#, fuzzy
 msgid "Move file"
-msgstr "Moving files"
+msgstr "Move file"
 
 msgid "Move file/directory to target directory"
-msgstr ""
+msgstr "Move file/folder to target folder"
 
 msgid "Move files/directories to target directory"
-msgstr ""
+msgstr "Move files/folders to target folder"
 
-#, fuzzy
 msgid "Move folder"
-msgstr "Move mode on"
+msgstr "Move folder"
 
 msgid "Move mode off"
 msgstr "Move mode off"
@@ -10270,9 +10341,9 @@ msgstr "Moved to position at index"
 msgid "Movement"
 msgstr "Movement"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Movie"
-msgstr "Moving"
+msgstr ""
 
 msgid "Movie List"
 msgstr "Movie List"
@@ -10286,17 +10357,18 @@ msgstr "Movie location"
 msgid "Movie selection"
 msgstr "Movie selection"
 
+#. TRANSLATORS: genre category
 msgid "Movie/Drama"
 msgstr "Movie/Drama"
 
 msgid "Movieplayer"
-msgstr "Movieplayer"
+msgstr "Movie Player"
 
 msgid "Moving"
 msgstr "Moving"
 
 msgid "Moving east ..."
-msgstr "Moving east ..."
+msgstr "Moving east..."
 
 msgid "Moving files"
 msgstr "Moving files"
@@ -10305,8 +10377,9 @@ msgid "Moving to position"
 msgstr "Moving to position"
 
 msgid "Moving west ..."
-msgstr "Moving west ..."
+msgstr "Moving west..."
 
+#. TRANSLATORS: regional option
 msgid "Mozambique"
 msgstr "Mozambique"
 
@@ -10316,31 +10389,28 @@ msgstr "Mtd"
 msgid "Multi EPG"
 msgstr "Multi EPG"
 
-#, fuzzy
 msgid "MultiBoot Image Manager"
-msgstr "Image Manager"
+msgstr "Multi-Boot Image Manager"
 
 msgid "MultiEPG settings"
-msgstr "MultiEPG settings"
+msgstr "Multi EPG Settings"
 
 msgid "MultiQuickButton"
-msgstr "MultiQuickButton"
+msgstr "Multi Quick Button"
 
 #, python-format
 msgid "Multiboot ERROR! - no %s in boot partition."
-msgstr ""
+msgstr "Multi-boot error! - no %s in boot partition."
 
-#, fuzzy
 msgid "Multiboot Image Selector"
-msgstr "MultiBoot Selector"
+msgstr "Multi-Boot"
 
 #, python-format
 msgid "Multiboot Image created on: %s/%s-%s-%s-backup-%s_usb.zip"
-msgstr ""
+msgstr "Multi-boot image created at: %s/%s-%s-%s-backup-%s_usb.zip"
 
-#, fuzzy
 msgid "Multiboot Manager"
-msgstr "Mount Manager"
+msgstr "Multi-Boot Manager"
 
 msgid "Multiboot manager - Cannot initialize SDcard when running image on SDcard."
 msgstr ""
@@ -10370,19 +10440,24 @@ msgstr "Multisat all select"
 msgid "Multistream"
 msgstr "Multisat"
 
+#. TRANSLATORS: genre category
 msgid "Murder"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Music"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Music/Ballet/Dance"
 msgstr "Music/Ballet/Dance"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "Musical"
 msgstr "musical/opera"
 
+#. TRANSLATORS: genre category
 msgid "Musik"
 msgstr ""
 
@@ -10397,15 +10472,17 @@ msgstr "Extension"
 msgid "My extension"
 msgstr "extensions"
 
+#. TRANSLATORS: regional option
 msgid "Myanmar"
 msgstr "Myanmar"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Mystery"
-msgstr "Yesterday"
-
-msgid "Märchen"
 msgstr ""
+
+#. TRANSLATORS: genre category
+msgid "Märchen"
+msgstr "Fairytale"
 
 msgid "N/A"
 msgstr "N/A"
@@ -10413,11 +10490,17 @@ msgstr "N/A"
 msgid "NEXT"
 msgstr "NEXT"
 
+msgid "Next bouquet"
+msgstr "next bouquet"
+
+msgid "Next page"
+msgstr "next page"
+
 msgid "NFI image flashing"
 msgstr "NFI image flashing"
 
 msgid "NFI image flashing completed. Press Yellow to Reboot!"
-msgstr "NFI image flashing completed. Press Yellow to Reboot!"
+msgstr "NFI image flashing completed. Press the Yellow button to reboot!"
 
 msgid "NFS"
 msgstr "NFS"
@@ -10440,15 +10523,15 @@ msgstr "NTP server"
 msgid "NTSC"
 msgstr "NTSC"
 
+#. TRANSLATORS: genre category
 msgid "Nachrichten"
-msgstr ""
+msgstr "News"
 
 msgid "Name"
-msgstr "Name"
+msgstr "Name (a-z)"
 
-#, fuzzy
 msgid "Name reverse"
-msgstr "Nameserver"
+msgstr "Name (z-a)"
 
 msgid "Name:"
 msgstr "Name:"
@@ -10469,38 +10552,41 @@ msgstr "Nameserver setup"
 msgid "Namespace"
 msgstr "Namespace"
 
+#. TRANSLATORS: regional option
 msgid "Namibia"
 msgstr "Namibia"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "National"
-msgstr "Location"
+msgstr ""
 
 msgid "Native"
-msgstr "Native"
+msgstr "native"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Natur"
-msgstr "Saturday"
+msgstr "Nature"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Nature"
-msgstr "literature"
+msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Nauru"
 msgstr "Nauru"
 
-#, fuzzy
 msgid "NcamInfo"
-msgstr "CCcamInfo"
+msgstr "Ncam Info"
 
+#. TRANSLATORS: regional option
 msgid "Nepal"
 msgstr "Nepal"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Netball"
-msgstr "ballet"
+msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Netherlands"
 msgstr "Netherlands"
 
@@ -10546,9 +10632,8 @@ msgstr "Network Services"
 msgid "Network Setup"
 msgstr "Network Setup"
 
-#, fuzzy
 msgid "Network Speed:"
-msgstr "Network Servers:"
+msgstr "Network Speed:"
 
 msgid "Network Test"
 msgstr "Network Test"
@@ -10578,7 +10663,7 @@ msgid "Network test"
 msgstr "Network test"
 
 msgid "Network test..."
-msgstr "Network test..."
+msgstr "Network Test"
 
 msgid "Network test: "
 msgstr "Network test: "
@@ -10590,16 +10675,16 @@ msgid "Network:"
 msgstr "Network:"
 
 msgid "NetworkWizard"
-msgstr "NetworkWizard"
+msgstr "Network Wizard"
 
 msgid "Neue Medien"
-msgstr ""
+msgstr "New media"
 
 msgid "Neutrino  (keymap.ntr)"
 msgstr "Neutrino  (keymap.ntr)"
 
 msgid "Never decrypt the content while recording. This overrides the individual timer settings globally. If enabled, recordings are stored in crypted presentation and must be decrypted afterwards (sometimes called offline decoding). Default: off."
-msgstr "Never decrypt the content while recording. This overrides the individual timer settings globally. If enabled, recordings are stored in crypted presentation and must be decrypted afterwards (sometimes called offline decoding). Default: off."
+msgstr "Never decrypt the content while recording. This will override individual timer settings globally. When enabled, recordings will be saved encrypted and must be decrypted later (sometimes called offline decoding). Default: 'off'."
 
 msgid "Never decrypt while recording"
 msgstr "Never decrypt while recording"
@@ -10607,6 +10692,7 @@ msgstr "Never decrypt while recording"
 msgid "New"
 msgstr "New"
 
+#. TRANSLATORS: regional option
 msgid "New Caledonia"
 msgstr "New Caledonia"
 
@@ -10616,9 +10702,13 @@ msgstr "New PIN"
 msgid "New Packages"
 msgstr "New Packages"
 
+msgid "New Search"
+msgstr "New search"
+
 msgid "New Setting DXAndy "
 msgstr "New Setting DXAndy "
 
+#. TRANSLATORS: regional option
 msgid "New Zealand"
 msgstr "New Zealand"
 
@@ -10626,13 +10716,11 @@ msgstr "New Zealand"
 msgid "New event info"
 msgstr "Event Info"
 
-#, fuzzy
 msgid "New folder"
-msgstr "Select folders"
+msgstr "New folder"
 
-#, fuzzy
 msgid "New password"
-msgstr "Password"
+msgstr "New password"
 
 msgid "New profile: "
 msgstr "New profile: "
@@ -10642,18 +10730,19 @@ msgid "New program info"
 msgstr "show program information..."
 
 msgid "New timers location"
-msgstr "New timers location"
+msgstr "New timer recording location"
 
-#, fuzzy
 msgid "New user"
-msgstr "Select folders"
+msgstr "New user"
 
 msgid "New version:"
 msgstr "New version:"
 
+#. TRANSLATORS: genre category
 msgid "News"
 msgstr ""
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "News/Current Affairs"
 msgstr "News Current Affairs"
@@ -10670,20 +10759,24 @@ msgid "Next quad PiP channel"
 msgstr "Next quad PiP channel"
 
 msgid "Nextsong"
-msgstr "Nextsong"
+msgstr "▶︎▶︎| Next track button"
 
 msgid "Nextsong long"
-msgstr "Nextsong long"
+msgstr "▶︎▶︎| Next track button hold"
 
+#. TRANSLATORS: regional option
 msgid "Nicaragua"
 msgstr "Nicaragua"
 
+#. TRANSLATORS: regional option
 msgid "Niger"
 msgstr "Niger"
 
+#. TRANSLATORS: regional option
 msgid "Nigeria"
 msgstr "Nigeria"
 
+#. TRANSLATORS: regional option
 msgid "Niue"
 msgstr "Niue"
 
@@ -10691,41 +10784,41 @@ msgid "No"
 msgstr "No"
 
 msgid "No (supported) DVDROM found!"
-msgstr "No (supported) DVDROM found!"
+msgstr "No (supported) DVD-ROM found!"
 
 msgid "No Connection"
 msgstr "No Connection"
 
 msgid "No Devices Found !!"
-msgstr "No Devices Found !!"
+msgstr "No Devices Found!"
 
 msgid "No HDD found or HDD not initialized!"
-msgstr "No HDD found or HDD not initialized!"
+msgstr "No HDD found or HDD not formatted!"
 
 msgid ""
 "No Settings loaded !!\n"
 "\n"
 "Please install first a settinglist"
 msgstr ""
-"No Settings loaded !!\n"
+"No Settings loaded!\n"
 "\n"
-"Please install first a settinglist"
+"Please install settings first"
 
 #, fuzzy
 msgid "No TS recorder available"
 msgstr "No free index available"
 
 msgid "No Timeshift found to save as recording!"
-msgstr "No Timeshift found to save as recording!"
+msgstr "No timeshift buffer found to save!"
 
 msgid "No active channel found."
 msgstr "No active channel found."
 
 msgid "No age block"
-msgstr "No age block"
+msgstr "no age block"
 
 msgid "No backup needed"
-msgstr "No backup needed"
+msgstr "No thanks"
 
 msgid "No cable tuner found!"
 msgstr "No cable tuner found!"
@@ -10751,7 +10844,7 @@ msgstr ""
 "(Timeout reading PAT)"
 
 msgid "No delay"
-msgstr "No delay"
+msgstr "no delay"
 
 #, fuzzy
 msgid "No demux available"
@@ -10764,20 +10857,19 @@ msgid "No details for this image file"
 msgstr "No details for this image file"
 
 msgid "No displayable files on this medium found!"
-msgstr "No displayable files on this medium found!"
+msgstr "There were no displayable files found on this device!"
 
 msgid "No entry in lcn db. Please do a service scan."
-msgstr "No entry in lcn db. Please do a service scan."
+msgstr "No entry in LCN db. Please do a service scan."
 
-#, fuzzy
 msgid "No error"
-msgstr "unknown error"
+msgstr "No error"
 
 msgid "No event info found, recording indefinitely."
-msgstr "No event info found, recording indefinitely."
+msgstr "No event info found, recording indefinitely..."
 
 msgid "No fast winding possible yet.. but you can use the number buttons to skip forward/backward!"
-msgstr "No fast winding possible yet.. but you can use the number buttons to skip forward/backward!"
+msgstr "Fast winding is not possible yet, but you can use the number buttons to skip forward/backward!"
 
 #, fuzzy
 msgid "No files found."
@@ -10806,19 +10898,19 @@ msgid "No networks found"
 msgstr "No networks found"
 
 msgid "No of items switch (increase or reduced)"
-msgstr "No of items switch (increase or reduced)"
+msgstr "No. of items switch (increase or reduced)"
 
 msgid "No packages were upgraded yet. So you can check your network and try again."
-msgstr "No packages were upgraded yet. So you can check your network and try again."
+msgstr "No packages hav been upgraded yet. Please check your network connection and try again."
 
 msgid "No positioner capable frontend found."
-msgstr "No positioner capable frontend found."
+msgstr "No positioner-capable frontend found."
 
 msgid "No priority"
 msgstr "No priority"
 
 msgid "No satellite, terrestrial or cable tuner is configured. Please check your tuner setup."
-msgstr "No satellite, terrestrial or cable tuner is configured. Please check your tuner setup."
+msgstr "No satellite, terrestrial or cable tuner has been configured. Please check your tuner config."
 
 msgid "No service"
 msgstr "No service"
@@ -10833,7 +10925,7 @@ msgid "No suitable sat tuner found!"
 msgstr "No suitable sat tuner found!"
 
 msgid "No tags are set on these movies."
-msgstr "No tags are set on these movies."
+msgstr "These movies have no tags set."
 
 msgid "No timeout"
 msgstr "No timeout"
@@ -10845,7 +10937,7 @@ msgid "No transparency"
 msgstr "No transparency"
 
 msgid "No tuner is available for recording a timer!\n"
-msgstr "No tuner is available for recording a timer!\n"
+msgstr "There is no tuner available to record a timer!\n"
 
 msgid ""
 "No tuner is available for recording a timer!\n"
@@ -10853,26 +10945,26 @@ msgid ""
 "The following methods of freeing a tuner were tried without success:\n"
 "\n"
 msgstr ""
-"No tuner is available for recording a timer!\n"
+"There's no tuner available to record a timer!\n"
 "\n"
-"The following methods of freeing a tuner were tried without success:\n"
+"Tried the following without success:\n"
 "\n"
 
 msgid "No tuner is configured for use with a diseqc positioner!"
-msgstr "No tuner is configured for use with a diseqc positioner!"
+msgstr "There is no tuner configured for use with a DiSEqC positioner!"
 
 msgid ""
 "No tuner is enabled!\n"
 "Please setup your tuner settings before you start a service scan."
 msgstr ""
-"No tuner is enabled!\n"
-"Please setup your tuner settings before you start a service scan."
+"There are no tuners enabled!\n"
+"Please set up your tuner before starting a service scan."
 
 msgid "No update required!"
 msgstr "No update required!"
 
 msgid "No updates available. Please try again later."
-msgstr "No updates available. Please try again later."
+msgstr "No updates available, please try again later."
 
 msgid "No valid region details were found"
 msgstr ""
@@ -10882,58 +10974,55 @@ msgid "No viewer installed for this file type: %s"
 msgstr ""
 
 msgid "No wireless networks found! Searching..."
-msgstr "No wireless networks found! Searching..."
+msgstr "Searching... no wireless networks found!"
 
 msgid ""
 "No working local network adapter found.\n"
 "Please verify that you have attached a network cable and your network is configured correctly."
 msgstr ""
-"No working local network adapter found.\n"
+"Couldn't find a working local network adapter.\n"
 "Please verify that you have attached a network cable and your network is configured correctly."
 
 msgid ""
 "No working wireless network adapter found.\n"
 "Please verify that you have attached a compatible WLAN device and your network is configured correctly."
 msgstr ""
-"No working wireless network adapter found.\n"
-"Please verify that you have attached a compatible WLAN device and your network is configured correctly."
+"Couldn't find a working wireless network adapter.\n"
+"Please verify that you have attached a compatible wireless network device and your network is configured correctly."
 
 msgid ""
 "No working wireless network interface found.\n"
 " Please verify that you have attached a compatible WLAN device or enable your local network interface."
 msgstr ""
-"No working wireless network interface found.\n"
-" Please verify that you have attached a compatible WLAN device or enable your local network interface."
+"Couldn't find a working wireless network interface.\n"
+" Please verify that you have attached a compatible wireless network device or enable your local network interface."
 
 msgid "No, but restart from begin"
 msgstr "No, but restart from begin"
 
-#, fuzzy
 msgid "No, do not backup a image"
-msgstr "Do not flash image"
+msgstr "No, do not back up image"
 
-#, fuzzy
 msgid "No, do not flash an image"
-msgstr "Do not flash image"
+msgstr "No, do not flash an image"
 
 msgid "No, do nothing."
-msgstr "No, do nothing."
+msgstr "No, do nothing"
 
 msgid "No, just start my %s %s"
 msgstr "No, just start my %s %s"
 
 msgid "No, never"
-msgstr "No, never"
+msgstr "no, never"
 
 msgid "No, scan later manually"
-msgstr "No, scan later manually"
+msgstr "No, not now"
 
-#, fuzzy
 msgid "No, show always the plugin browser"
-msgstr "Show the plugin browser.."
+msgstr "no, always show the Plugin Browser"
 
 msgid "No, show always the timer list"
-msgstr ""
+msgstr "no, always show the timer list"
 
 msgid "NodeID"
 msgstr "NodeID"
@@ -10942,12 +11031,13 @@ msgid "NodeID: "
 msgstr "NodeID: "
 
 msgid "None"
-msgstr "None"
+msgstr "none"
 
 #, python-format
 msgid "None of the hash programs for the hashes %s are available"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Norfolk Island"
 msgstr "Norfolk Island"
 
@@ -10957,24 +11047,27 @@ msgstr "Normal mode"
 msgid "North"
 msgstr "North"
 
+#. TRANSLATORS: regional option
 msgid "Northern Mariana Islands"
 msgstr "Northern Mariana Islands"
 
+#. TRANSLATORS: regional option
 msgid "Norway"
 msgstr "Norway"
 
+#. TRANSLATORS: regional option
 msgid "Norwegian"
 msgstr "Norwegian"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Not Classified"
-msgstr "Not associated"
+msgstr "Not classified"
 
 msgid "Not Defined"
 msgstr "Not Defined"
 
 msgid "Not Flashing"
-msgstr "Not Flashing"
+msgstr "icon"
 
 msgid "Not Shown"
 msgstr "Not Shown"
@@ -10987,7 +11080,7 @@ msgstr "Not associated"
 
 #, python-format
 msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
+msgstr "Not enough disk space. Please free up some space and try again (%d MB required, %d MB available)."
 
 #, python-format
 msgid ""
@@ -10997,27 +11090,26 @@ msgid ""
 "Free Space: %sMB\n"
 "Path: %s"
 msgstr ""
-"Not enough free Diskspace!\n"
+"Not enough free disk space!\n"
 "\n"
-"Filesize: %sMB\n"
-"Free Space: %sMB\n"
+"File size: %sMB\n"
+"Free space: %sMB\n"
 "Path: %s"
 
 msgid "Not mounted"
 msgstr "Not mounted"
 
-#, fuzzy
 msgid "Not running"
-msgstr "running..."
+msgstr "Not running"
 
 msgid "Not tested:"
 msgstr "Not tested:"
 
 msgid "Not-Associated"
-msgstr "Not-Associated"
+msgstr "Not Associated"
 
 msgid "Note: slot list does not show current image or empty slots."
-msgstr ""
+msgstr "* Note that the slot list does't show the currently running image or empty slots."
 
 msgid "Nothing"
 msgstr "Nothing"
@@ -11027,13 +11119,13 @@ msgid ""
 "Please setup your tuner settings before you start a service scan."
 msgstr ""
 "Nothing to scan!\n"
-"Please setup your tuner settings before you start a service scan."
+"Please configure your tuner before you start a channel scan."
 
 msgid "Nothing to upgrade"
 msgstr "Nothing to upgrade"
 
 msgid "Nothing, just leave this menu"
-msgstr "Nothing, just leave this menu"
+msgstr "Nothing, just quit this menu"
 
 #, fuzzy
 msgctxt "now/next: 'now' event label"
@@ -11053,16 +11145,16 @@ msgid "Number"
 msgstr "Number"
 
 msgid "Number of digits in channel number"
-msgstr "Number of digits in channel number"
+msgstr "Channel number digits"
 
 msgid "Number of lines in script messages"
 msgstr ""
 
 msgid "Number of rows"
-msgstr "Number of rows"
+msgstr "Number of rows to show"
 
 msgid "Number of rows to display"
-msgstr "Number of rows to display"
+msgstr "Number of rows to show"
 
 msgid "Number or SMS style data entry"
 msgstr ""
@@ -11090,16 +11182,16 @@ msgid "OK"
 msgstr "OK"
 
 msgid "OK button (long)"
-msgstr "OK button (long)"
+msgstr "OK button hold"
 
 msgid "OK button (short)"
-msgstr "OK button (short)"
+msgstr "OK button"
 
 msgid "OK button mode"
-msgstr "OK button mode"
+msgstr "OK button"
 
 msgid "OK long"
-msgstr "OK long"
+msgstr "OK button hold"
 
 msgid "OK, guide me through the upgrade process"
 msgstr "OK, guide me through the upgrade process"
@@ -11111,7 +11203,7 @@ msgid "OSD"
 msgstr "OSD"
 
 msgid "OSD 3D Setup"
-msgstr "OSD 3D Setup"
+msgstr "OSD 3D Settings"
 
 msgid "OSD Adjustment"
 msgstr "OSD Adjustment"
@@ -11123,7 +11215,7 @@ msgid "OSD Settings"
 msgstr "OSD Settings"
 
 msgid "OSD Setup"
-msgstr "OSD Setup"
+msgstr "On Screen Display Setup"
 
 msgid "OSD name request"
 msgstr "OSD name request"
@@ -11132,36 +11224,39 @@ msgid "OSD position setup"
 msgstr "OSD position setup"
 
 msgid "OSD settings"
-msgstr "OSD settings"
+msgstr "OSD Settings"
 
 msgid "OScam Info"
 msgstr "OScam Info"
 
 msgid "OScamInfo"
-msgstr "OScamInfo"
+msgstr "OScam Info"
 
 #, fuzzy
 msgid "OVR"
 msgstr "PVR"
 
 msgid "Off"
-msgstr "Off"
+msgstr "off"
 
 msgid "Offline decode delay (ms)"
-msgstr "Offline decode delay (ms)"
+msgstr "Offline decode delay in ms"
 
 msgid "Ok"
-msgstr "Ok"
+msgstr "OK"
 
 msgid "Older files in the timeshift directory are removed on every event change."
-msgstr "Older files in the timeshift directory are removed on every event change."
+msgstr "Older files in the timeshift folder are removed on every event change."
 
+#. TRANSLATORS: regional option
 msgid "Olympia"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Olympics"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Oman"
 msgstr "Oman"
 
@@ -11179,7 +11274,7 @@ msgid "On end of movie (as menu)"
 msgstr "On end of movie (as menu)"
 
 msgid "On reaching the end of a file during playback, you can choose the box's behavior."
-msgstr "On reaching the end of a file during playback, you can choose the box's behavior."
+msgstr "Choose what the receiver should do on reaching the end of a file during playback."
 
 msgid "On valid ONIDs, ignore frequency sub network part"
 msgstr "On valid ONIDs, ignore frequency sub network part"
@@ -11197,25 +11292,25 @@ msgid "Online software update"
 msgstr "Online software update"
 
 msgid "OnlineVersionCheck"
-msgstr "OnlineVersionCheck"
+msgstr "Online Version Check"
 
 msgid "Only extensions."
 msgstr "Only extensions."
 
 msgid "Only free scan"
-msgstr "Only free scan"
+msgstr "Free to air channels only"
 
 msgid "Only move the dish quickly after this hour."
-msgstr ""
+msgstr "Slow down dish movement before this hour."
 
 msgid "Only move the dish quickly before this hour."
-msgstr ""
+msgstr "Slow down dish movement after this hour."
 
 msgid "Only on startup"
 msgstr "Only on startup"
 
 msgid "Only select 'yes' if you are using a multiswich that requires a DiSEqC Port-A command signal. For all other setups select 'no'."
-msgstr ""
+msgstr "Select 'yes' ONLY if you're using a multiswitch that requires a DiSEqC Port A command signal. For all other setups, select 'no'."
 
 msgid "Open"
 msgstr "Open"
@@ -11224,10 +11319,10 @@ msgid "Open AutoTimer"
 msgstr "Open AutoTimer"
 
 msgid "Open AutoTimerlist..."
-msgstr "Open AutoTimerlist..."
+msgstr "Open AutoTimer list..."
 
 msgid "Open EPGSearch..."
-msgstr "Open EPGSearch..."
+msgstr "Open EPG Search..."
 
 msgid "Open IMDB..."
 msgstr "Open IMDB..."
@@ -11236,34 +11331,34 @@ msgid "Open MediaPortal..."
 msgstr "Open MediaPortal..."
 
 msgid "Open Timerlist..."
-msgstr "Open Timerlist..."
+msgstr "Open Timer list..."
 
 msgid "Open bouquetlist..."
-msgstr "Open bouquetlist..."
+msgstr "Open bouquet list..."
 
 msgid "Open favourites list"
-msgstr "Open favourites list"
+msgstr "Open favorites list"
 
 msgid "Open long"
-msgstr "Open long"
+msgstr "OPEN button hold"
 
 msgid "Open satellites list"
 msgstr "Open satellites list"
 
 msgid "Open service list"
-msgstr "Open service list"
+msgstr "Open channel list"
 
 msgid "Open service list and select next channel"
-msgstr "Open service list and select next channel"
+msgstr "Open channel list and select next channel"
 
 msgid "Open service list and select next channel for PiP"
-msgstr "Open service list and select next channel for PiP"
+msgstr "Open channel list and select next channel for PiP"
 
 msgid "Open service list and select previous channel"
 msgstr "Open service list and select previous channel"
 
 msgid "Open service list and select previous channel for PiP"
-msgstr "Open service list and select previous channel for PiP"
+msgstr "Open channel list and select previous channel for PiP"
 
 msgid "Open settings/actions menu"
 msgstr ""
@@ -11289,25 +11384,23 @@ msgstr "OpenVpn Log"
 msgid "OpenVpn Setup"
 msgstr "OpenVpn Setup"
 
-#, fuzzy
 msgid "Operating LED status in deep standby mode"
-msgstr "Power LED state during deep-standby/standby."
+msgstr "Power LED state during deep standby."
 
-#, fuzzy
 msgid "Operating LED status in standby mode"
-msgstr "Power LED state during deep-standby/standby."
+msgstr "Power LED state during standby."
 
 msgid "Operating LED status while running"
-msgstr ""
+msgstr "Power LED state during normal operation."
 
 msgid "Option"
 msgstr "Option"
 
 msgid "Option long"
-msgstr "Option long"
+msgstr "Option button hold"
 
 msgid "Option to disable picons on the Infobar"
-msgstr "Option to disable picons on the Infobar"
+msgstr "Option to disable picons on the infobar."
 
 msgid "Option to enable the Hardware Standby Timer"
 msgstr "Option to enable the Hardware Standby Timer"
@@ -11319,7 +11412,7 @@ msgid "Ordinary"
 msgstr ""
 
 msgid "Original"
-msgstr "Original"
+msgstr "original"
 
 msgid "Oscam Info - Configuration"
 msgstr "Oscam Info - Configuration"
@@ -11329,65 +11422,65 @@ msgstr "Oscam Info - Main Menu"
 
 #, python-format
 msgid "Oscam Log ( Oscam-Version: %s )"
-msgstr "Oscam Log ( Oscam-Version: %s )"
+msgstr "Oscam Log ( Oscam Version: %s )"
 
 msgid "OscamInfo Mainmenu"
-msgstr "OscamInfo Mainmenu"
+msgstr "Oscam Info Main Menu"
 
 msgid "Other"
 msgstr "Other"
 
+#. TRANSLATORS: genre category
 msgid "Outdoor"
 msgstr ""
 
 msgid "Overall progress:"
 msgstr "Overall progress:"
 
-#, fuzzy
 msgid "Overscan Test"
-msgstr "scan state"
+msgstr "Overscan Test"
 
 msgid "Overwrite Bootlogo Files ?"
-msgstr "Overwrite Bootlogo Files ?"
+msgstr "Overwrite Boot Logo files"
 
 msgid "Overwrite Driver Files ?"
-msgstr "Overwrite Driver Files ?"
+msgstr "Overwrite Driver files"
 
 msgid "Overwrite Emu Files ?"
-msgstr "Overwrite Emu Files ?"
+msgstr "Overwrite Emu files"
 
 msgid "Overwrite Picon Files ?"
-msgstr "Overwrite Picon Files ?"
+msgstr "Overwrite Picon files"
 
 msgid "Overwrite Setting Files ?"
-msgstr "Overwrite Setting Files ?"
+msgstr "Overwrite Settings files"
 
 msgid "Overwrite Spinner Files ?"
-msgstr "Overwrite Spinner Files ?"
+msgstr "Overwrite Spinner files"
 
 msgid "Overwrite bootlogo files during software upgrade?"
-msgstr "Overwrite bootlogo files during software upgrade?"
+msgstr "Choose whether to overwrite boot logo files during a software upgrade."
 
 msgid "Overwrite configuration files during software upgrade?"
-msgstr "Overwrite configuration files during software upgrade?"
+msgstr "Choose whether to overwrite configuration files during a software upgrade."
 
 msgid "Overwrite configuration files?"
-msgstr "Overwrite configuration files?"
+msgstr "Overwrite Configuration files"
 
 msgid "Overwrite driver files during software upgrade?"
-msgstr "Overwrite driver files during software upgrade?"
+msgstr "Choose whether to overwrite driver files during a software upgrade."
 
 msgid "Overwrite picon files during software upgrade?"
-msgstr "Overwrite picon files during software upgrade?"
+msgstr "Choose whether to overwrite picon files during a software upgrade."
 
 msgid "Overwrite setting files (channellist) during software upgrade?"
-msgstr "Overwrite setting files (channellist) during software upgrade?"
+msgstr "Choose whether to overwrite settings files (eg. channel list) during a software upgrade."
 
 msgid "Overwrite softcam files during software upgrade?"
-msgstr "Overwrite softcam files during software upgrade?"
+msgstr "Overwrite Softcam files during software upgrade"
 
 msgid "Overwrite spinner files during software upgrade?"
-msgstr "Overwrite spinner files during software upgrade?"
+msgstr "Choose whether to overwrite spinner files during a software upgrade."
 
 msgid "Owner:"
 msgstr ""
@@ -11398,13 +11491,11 @@ msgstr "PAGE UP/DOWN"
 msgid "PAL"
 msgstr "PAL"
 
-#, fuzzy
 msgid "PC"
-msgstr "PCM"
+msgstr "PC button"
 
-#, fuzzy
 msgid "PC long"
-msgstr "PIP long"
+msgstr "PC button hold"
 
 msgid "PCM"
 msgstr "PCM"
@@ -11415,9 +11506,8 @@ msgstr "PCM Multichannel"
 msgid "PCR PID"
 msgstr "PCR PID"
 
-#, fuzzy
 msgid "PDC"
-msgstr "PCM"
+msgstr "PDC"
 
 msgid "PID"
 msgstr "PID"
@@ -11429,13 +11519,13 @@ msgid "PIN code needed"
 msgstr "PIN code needed"
 
 msgid "PIP"
-msgstr "PIP"
+msgstr "PiP"
 
 msgid "PIP long"
-msgstr "PIP long"
+msgstr "PiP button hold"
 
 msgid "PIP with OSD"
-msgstr "PIP with OSD"
+msgstr "PiP with OSD"
 
 msgid "PLP ID"
 msgstr "PLP ID"
@@ -11456,10 +11546,10 @@ msgid "PRIMETIME"
 msgstr "PRIMETIME"
 
 msgid "PVR"
-msgstr "PVR"
+msgstr "PVR button"
 
 msgid "PVR long"
-msgstr "PVR long"
+msgstr "PVR button hold"
 
 msgid "Package list"
 msgstr "Package list"
@@ -11471,17 +11561,16 @@ msgid "Packages"
 msgstr "Packages"
 
 msgid "Packet management"
-msgstr "Packet management"
+msgstr "Package management"
 
 msgid "Packet manager"
-msgstr "Packet manager"
+msgstr "Package manager"
 
 msgid "Page down"
 msgstr "Page down"
 
-#, fuzzy
 msgid "Page down list"
-msgstr "Page down"
+msgstr "Page down list"
 
 msgid "Page right"
 msgstr "Page right"
@@ -11489,36 +11578,39 @@ msgstr "Page right"
 msgid "Page up"
 msgstr "Page up"
 
-#, fuzzy
 msgid "Page up list"
-msgstr "Package list"
+msgstr "Page up list"
 
 msgid "PageDown"
-msgstr "PageDown"
+msgstr "Page Down button"
 
 msgid "PageDown long"
-msgstr "PageDown long"
+msgstr "Page Down button hold"
 
 msgid "PageUp"
-msgstr "PageUp"
+msgstr "Page Up button"
 
 msgid "PageUp long"
-msgstr "PageUp long"
+msgstr "Page Up button hold"
 
+#. TRANSLATORS: regional option
 msgid "Pakistan"
 msgstr "Pakistan"
 
+#. TRANSLATORS: regional option
 msgid "Palau"
 msgstr "Palau"
 
+#. TRANSLATORS: regional option
 msgid "Palestine, State of"
 msgstr "Palestine, State of"
 
-#. TRANSLATORS: (aspect ratio policy: cropped content on left/right) in doubt, keep english term
+#. TRANSLATORS: (aspect ratio policy: cropped content on left/right) if in doubt, keep english term
 #. TRANSLATORS: (aspect ratio policy: Fit width, cut/crop top and bottom (Maintain aspect ratio))
 msgid "Pan&scan"
-msgstr "Pan&scan"
+msgstr "pan and scan"
 
+#. TRANSLATORS: regional option
 msgid "Panama"
 msgstr "Panama"
 
@@ -11528,40 +11620,42 @@ msgstr "Panic channel"
 msgid "Panic to"
 msgstr "Panic to"
 
+#. TRANSLATORS: regional option
 msgid "Papua New Guinea"
 msgstr "Papua New Guinea"
 
-#, fuzzy
 msgid "Parabel"
-msgstr "Label"
+msgstr "Parabola"
 
+#. TRANSLATORS: regional option
 msgid "Paraguay"
 msgstr "Paraguay"
 
-#, fuzzy
 msgid "Parent Directory"
-msgstr "Parent directory"
+msgstr "Parent Folder"
 
 msgid "Parent directory"
-msgstr "Parent directory"
+msgstr "Parent folder"
 
 msgid "Parental Guidance Recommended"
 msgstr ""
 
 msgid "Parental control"
-msgstr "Parental control"
+msgstr "Parental Control"
 
 msgid "Parental control services editor"
 msgstr "Parental control services editor"
 
 msgid "Parental control setup"
-msgstr "Parental control setup"
+msgstr "Parental Control Setup"
 
+#. TRANSLATORS: genre category
 msgid "Parliament"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Parodie"
-msgstr ""
+msgstr "Parody"
 
 msgid "Partitions"
 msgstr "Partitions"
@@ -11575,19 +11669,17 @@ msgstr "Password"
 msgid "Password (httpwd)"
 msgstr "Password (httpwd)"
 
-#, fuzzy
 msgid "Password Setup"
-msgstr "Password"
+msgstr "Password Setup"
 
-#, fuzzy
 msgid "Password changed"
-msgstr "Password (httpwd)"
+msgstr "Password changed"
 
 msgid "Password:"
 msgstr "Password:"
 
 msgid "Path to save not exist: '/tmp/'"
-msgstr ""
+msgstr "Save location (/tmp) doesn't exist"
 
 msgid "Pause"
 msgstr "Pause"
@@ -11601,50 +11693,47 @@ msgstr "Pause playback"
 msgid "Pause/Continue playback"
 msgstr "Pause/Continue playback"
 
-#, fuzzy
 msgid "Pausing"
-msgstr "using:"
+msgstr "Pausing"
 
 msgid "Peak load (max queued requests per workerthread)"
-msgstr "Peak load (max queued requests per workerthread)"
+msgstr "Peak load (max. queued requests per worker thread)"
 
 msgid "Percentage"
-msgstr "Percentage"
+msgstr "percentage"
 
 msgid "Percentage left"
-msgstr "Percentage left"
+msgstr "% on left"
 
 msgid "Percentage right"
-msgstr "Percentage right"
+msgstr "% on right"
 
-#, fuzzy
 msgid "Percentage/Progress bar left"
-msgstr "Progress bar left"
+msgstr "%/progress bar on left"
 
-#, fuzzy
 msgid "Percentage/Progress bar right"
-msgstr "Progress bar right"
+msgstr "%/progress bar on right"
 
 msgid "Perform a full image backup"
 msgstr "Perform a full image backup"
 
 msgid "Perform a image backup before updating."
-msgstr "Perform a image backup before updating."
+msgstr "Back up image before updating."
 
 msgid "Perform a setting backup before updating."
-msgstr "Perform a setting backup before updating."
+msgstr "Back up settings before updating."
 
 msgid "Perform a settings backup,"
-msgstr "Perform a settings backup,"
+msgstr "Back up settings,"
 
 msgid "Perform a settings backup, making a backup before updating is strongly advised."
-msgstr "Perform a settings backup, making a backup before updating is strongly advised."
+msgstr "Back up settings - making a backup before updating is highly recommedned!"
 
 msgid "Perform an online update check in the background"
-msgstr "Perform an online update check in the background"
+msgstr "Do an online update check in the background"
 
 msgid "Permanently delete all recordings in the trash can?"
-msgstr "Permanently delete all recordings in the trash can?"
+msgstr "Are you sure you want to permanently delete all recordings in the trash can?"
 
 msgid "Permanently remove all deleted items"
 msgstr "Permanently remove all deleted items"
@@ -11653,15 +11742,18 @@ msgstr "Permanently remove all deleted items"
 msgid "Permissions:"
 msgstr "Version: "
 
+#. TRANSLATORS: regional option
 msgid "Persian"
 msgstr "Persian"
 
 msgid "Personalize your Skin"
 msgstr "Personalize your Skin"
 
+#. TRANSLATORS: regional option
 msgid "Peru"
 msgstr "Peru"
 
+#. TRANSLATORS: regional option
 msgid "Philippines"
 msgstr "Philippines"
 
@@ -11669,53 +11761,56 @@ msgid "PiP"
 msgstr "PiP"
 
 msgid "PiP-Zap"
-msgstr "PiP-Zap"
+msgstr "PiP Zap"
 
 msgid "PiPSetup"
-msgstr "PiPSetup"
+msgstr "PiP Setup"
+
+msgid "PiP settings"
+msgstr "PiP Settings"
 
 msgid "PiPZap"
-msgstr "PiPZap"
+msgstr "PiP Zap"
 
 msgid "Picon"
-msgstr "Picon"
+msgstr "channel picon"
 
 msgid "Picon and Service Name"
-msgstr "Picon and Service Name"
+msgstr "channel picon and name"
 
 msgid "Picon and service name"
-msgstr "Picon and service name"
+msgstr "channel picon and name"
 
 msgid "Picon width"
-msgstr "Picon width"
+msgstr "Channel picon width"
 
-#, fuzzy
 msgid "Picture in EPG"
-msgstr "Picture in graphics"
+msgstr "Picture in EPG"
 
 msgid "Picture in Picture Setup"
-msgstr "Picture in Picture Setup"
+msgstr "Picture-in-Picture Setup"
 
 msgid "Picture in graphics"
-msgstr "Picture in graphics"
+msgstr "Show mini TV window"
 
 msgid "Picture player"
 msgstr "Picture player"
 
 msgid "PicturePlayer"
-msgstr "PicturePlayer"
+msgstr "Picture Viewer"
 
-#, fuzzy
 msgid "Pictures"
-msgstr "PicturePlayer"
+msgstr "Pictures"
 
 #. TRANSLATORS: (aspect ratio policy: black bars on left/right) in doubt, keep english term.
 msgid "Pillarbox"
-msgstr "Pillarbox"
+msgstr "pillarbox"
 
+#. TRANSLATORS: genre category
 msgid "Pilot"
 msgstr "Pilot"
 
+#. TRANSLATORS: regional option
 msgid "Pitcairn"
 msgstr "Pitcairn"
 
@@ -11733,17 +11828,16 @@ msgid "Play audio in background"
 msgstr "Play audio in background"
 
 msgid "Play audio-CD..."
-msgstr "Play audio-CD..."
+msgstr "Play audio CD..."
 
 msgid "Play back media files"
-msgstr "Play back media files"
+msgstr "Play media files"
 
 msgid "Play entry"
 msgstr "Play entry"
 
-#, fuzzy
 msgid "Play folder"
-msgstr "Play entry"
+msgstr "Play folder"
 
 msgid "Play from next mark or playlist entry"
 msgstr "Play from next mark or playlist entry"
@@ -11773,17 +11867,17 @@ msgstr "Play recorded movies..."
 msgid "Play title"
 msgstr "Delay time"
 
-msgid "Play/view/edit/install/extract/run file or enter directory"
+msgid "Play/view/edit/install/extract/run file or enter folder"
 msgstr ""
 
 msgid "Playlist"
 msgstr "Playlist"
 
 msgid "Playlist long"
-msgstr "Playlist long"
+msgstr "Playlist button hold"
 
 msgid "Playpause"
-msgstr "Playpause"
+msgstr "▶︎|| Play/Pause"
 
 msgid "Please add titles to the compilation."
 msgstr "Please add titles to the compilation."
@@ -11792,46 +11886,47 @@ msgid "Please be patient, a backup will now be made,\n"
 msgstr "Please be patient, a backup will now be made,\n"
 
 msgid "Please change recording endtime"
-msgstr "Please change recording endtime"
+msgstr "Set Recording End Time"
 
-#, fuzzy
 msgid "Please check the manual of the receiver"
-msgstr "Please enter name of the new directory"
+msgstr "Please refer to your receiver's documentation"
 
 msgid "Please check your network settings!"
 msgstr "Please check your network settings!"
 
 msgid "Please choose CCcam-Reader"
-msgstr "Please choose CCcam-Reader"
+msgstr "Please choose a CCcam reader"
 
 msgid "Please choose an extension..."
 msgstr "Please choose an extension..."
 
 msgid "Please choose he package..."
-msgstr "Please choose he package..."
+msgstr "Please choose a package..."
 
 msgid "Please choose reader"
-msgstr "Please choose reader"
+msgstr "Please choose a reader"
 
 msgid ""
 "Please configure or verify your Nameservers by filling out the required values.\n"
 "When you are ready press OK to continue."
 msgstr ""
-"Please configure or verify your Nameservers by filling out the required values.\n"
-"When you are ready press OK to continue."
+"Please configure or verify your nameservers by entering the required details.\n"
+"\n"
+"Press OK when you're ready to continue..."
 
 msgid ""
 "Please configure your internet connection by filling out the required values.\n"
 "When you are ready press OK to continue."
 msgstr ""
-"Please configure your internet connection by filling out the required values.\n"
-"When you are ready press OK to continue."
+"Please configure your internet connection by entering the required details.\n"
+"\n"
+"Press OK when you're ready to continue..."
 
 msgid "Please connect your %s %s to the internet"
 msgstr "Please connect your %s %s to the internet"
 
 msgid "Please do not change any values unless you know what you are doing!"
-msgstr "Please do not change any values unless you know what you are doing!"
+msgstr "Please do NOT change any values unless you know exactly what you're doing!"
 
 msgid "Please enter a name for the new bouquet"
 msgstr "Please enter a name for the new bouquet"
@@ -11846,33 +11941,29 @@ msgid "Please enter filename (empty = use current date)"
 msgstr "Please enter filename (empty = use current date)"
 
 msgid "Please enter name of the new directory"
-msgstr "Please enter name of the new directory"
+msgstr "Please enter a name for the new folder"
 
-#, fuzzy
 msgid "Please enter name of the new symlink"
-msgstr "Please enter name of the new directory"
+msgstr "Please enter a name for the new symlink"
 
 msgid "Please enter new description:"
-msgstr "Please enter new description:"
+msgstr "Please enter a new description:"
 
 msgid "Please enter new name:"
-msgstr "Please enter new name:"
+msgstr "Please enter a new name:"
 
-#, fuzzy
 msgid "Please enter password"
-msgstr "Please enter new name:"
+msgstr "Please enter password"
 
 msgid "Please enter search string for your location"
 msgstr "Please enter search string for your location"
 
 msgid "Please enter the correct pin code"
-msgstr "Please enter the correct pin code"
+msgstr "Please enter the correct PIN code"
 
-#, fuzzy
 msgid "Please enter the new directory name"
-msgstr "Please enter name of the new directory"
+msgstr "Please enter a name for the new folder"
 
-#, fuzzy
 msgid "Please enter the new file name"
 msgstr "Please enter a new filename"
 
@@ -11889,10 +11980,10 @@ msgid "Please follow the instructions on the TV"
 msgstr "Please follow the instructions on the TV"
 
 msgid "Please note that the previously selected media could not be accessed and therefore the default directory is being used instead."
-msgstr "Please note that the previously selected media could not be accessed and therefore the default directory is being used instead."
+msgstr "Please note that the previously selected media could not be accessed so the default folder is being used instead."
 
 msgid "Please open Picture in Picture first"
-msgstr "Please open Picture in Picture first"
+msgstr "Please start picture-in-picture mode first"
 
 msgid "Please press OK to continue."
 msgstr "Please press OK to continue."
@@ -11900,9 +11991,8 @@ msgstr "Please press OK to continue."
 msgid "Please press OK to start Kodi..."
 msgstr "Please press OK to start Kodi..."
 
-#, fuzzy
 msgid "Please select a backup destination"
-msgstr "Please select an aspect ratio..."
+msgstr "Please select a backup destination"
 
 msgid "Please select a default EPG type..."
 msgstr "Please select a default EPG type..."
@@ -11917,7 +12007,7 @@ msgid "Please select a resolution..."
 msgstr "Please select a resolution..."
 
 msgid "Please select a sub service..."
-msgstr "Please select a sub service..."
+msgstr "Please select a subservice..."
 
 msgid "Please select a subservice to record..."
 msgstr "Please select a subservice to record..."
@@ -11926,22 +12016,22 @@ msgid "Please select a subservice..."
 msgstr "Please select a subservice..."
 
 msgid "Please select an NFI file and press green key to flash!"
-msgstr "Please select an NFI file and press green key to flash!"
+msgstr "Please select an NFI file and press the Green button to flash."
 
 msgid "Please select an aspect ratio..."
 msgstr "Please select an aspect ratio..."
 
 msgid "Please select device to use as swapfile location"
-msgstr "Please select device to use as swapfile location"
+msgstr "Please select a device to use for swap file"
 
 msgid "Please select medium to be scanned"
-msgstr "Please select medium to be scanned"
+msgstr "Please select the device to be scanned:"
 
 msgid "Please select medium to use as backup location"
-msgstr "Please select medium to use as backup location"
+msgstr "Please select a device to save backups to:"
 
 msgid "Please select tag to filter..."
-msgstr "Please select tag to filter..."
+msgstr "Please select a tag to filter by..."
 
 #, fuzzy
 msgid "Please select the IceTV service that you wish to use."
@@ -11955,9 +12045,9 @@ msgid ""
 "\n"
 "Please press OK to continue."
 msgstr ""
-"Please select the network interface that you want to use for your internet connection.\n"
+"Please select the network interface that you'd like to use for your internet connection.\n"
 "\n"
-"Please press OK to continue."
+"Press OK to continue."
 
 msgid "Please select the region that most closely matches your physical location. The region is required to enable us to provide the correct guide information for the channels you can receive."
 msgstr ""
@@ -11967,16 +12057,16 @@ msgid ""
 "\n"
 "Please press OK to continue."
 msgstr ""
-"Please select the wireless network that you want to connect to.\n"
+"Please select the wireless network that you'd like to connect to.\n"
 "\n"
-"Please press OK to continue."
+"Press OK to continue."
 
 msgid ""
 "Please select what to do after flashing the image:\n"
 "(In addition, if it exists, a local script will be executed as well at /media/hdd/images/config/myrestore.sh)"
 msgstr ""
 "Please select what to do after flashing the image:\n"
-"(In addition, if it exists, a local script will be executed as well at /media/hdd/images/config/myrestore.sh)"
+"(Additionally, a script will be executed if one exists at /media/hdd/images/config/myrestore.sh)"
 
 msgid "Please set up tuner A"
 msgstr "Please set up tuner A"
@@ -11986,7 +12076,8 @@ msgid ""
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner A\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
 msgid "Please set up tuner B"
 msgstr "Please set up tuner B"
@@ -11996,7 +12087,8 @@ msgid ""
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner B\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
 msgid "Please set up tuner C"
 msgstr "Please set up tuner C"
@@ -12006,7 +12098,8 @@ msgid ""
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner C\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
 msgid "Please set up tuner D"
 msgstr "Please set up tuner D"
@@ -12016,148 +12109,149 @@ msgid ""
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner D\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
 msgid ""
 "Please set up tuner E\n"
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner E\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
 msgid ""
 "Please set up tuner F\n"
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner F\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
 msgid ""
 "Please set up tuner G\n"
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner G\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
 msgid ""
 "Please set up tuner H\n"
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner H\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
 msgid ""
 "Please set up tuner I\n"
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner I\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
 msgid ""
 "Please set up tuner J\n"
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 "Please set up tuner J\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
-#, fuzzy
 msgid ""
 "Please set up tuner Q\n"
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
-"Please set up tuner A\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"Please set up tuner Q\n"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
-#, fuzzy
 msgid ""
 "Please set up tuner R\n"
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
-"Please set up tuner A\n"
-"For Hybrid Tuner Models switch Tuner Type with left and right keys"
+"Please set up tuner R\n"
+"\n"
+"For hybrid tuners, select the tuner type by using the ◀︎ Left and ▶︎ Right buttons."
 
-#, fuzzy
 msgid "Please set your time zone"
-msgstr "Setup your timezone."
+msgstr "Please select your time zone"
 
 msgid ""
 "Please setup your user interface by adjusting the values till the edges of the red box are touching the edges of your TV.\n"
 "When you are ready press OK to continue."
 msgstr ""
-"Please setup your user interface by adjusting the values till the edges of the red box are touching the edges of your TV.\n"
-"When you are ready press OK to continue."
+"Set up your user interface by adjusting the values until the edges of the red box touch the edges of your TV screen.\n"
+"Press OK when you're ready to continue..."
 
 msgid ""
 "Please setup your user interface by adjusting the values till the edges of the red box are touching the edges of your TV.\n"
 "When you are ready press green to continue."
 msgstr ""
-"Please setup your user interface by adjusting the values till the edges of the red box are touching the edges of your TV.\n"
-"When you are ready press green to continue."
+"Please set up your user interface by adjusting the values until the edges of the red box touch the edges of your TV screen.\n"
+"Press the Green button when you're ready to continue..."
 
 msgid ""
 "Please use direction keys to move the PiP window.\n"
 "Press Bouquet +/- to resize the window.\n"
 "Press OK to go back to the TV mode or EXIT to cancel the moving."
 msgstr ""
-"Please use direction keys to move the PiP window.\n"
-"Press Bouquet +/- to resize the window.\n"
-"Press OK to go back to the TV mode or EXIT to cancel the moving."
+"Use the direction keys to move the PiP window.\n"
+"Press the BOUQUET +/- buttons to resize the window.\n"
+"Press OK to return to TV mode or EXIT to cancel moving."
 
 msgid "Please use the UP and DOWN keys to select your language. Afterwards press the OK button."
-msgstr "Please use the UP and DOWN keys to select your language. Afterwards press the OK button."
+msgstr "Please use the ▲ Up and ▼ Down buttons to select your language, then press OK to continue..."
 
-#, fuzzy
 msgid "Please wait"
-msgstr "Please wait."
+msgstr "Please wait"
 
 msgid "Please wait for activation of your network configuration..."
-msgstr "Please wait for activation of your network configuration..."
+msgstr "Activating your network configuration, please wait..."
 
 msgid "Please wait while gathering data..."
-msgstr "Please wait while gathering data..."
+msgstr "Gathering data, please wait..."
 
 msgid "Please wait while scanning is in progress..."
-msgstr "Please wait while scanning is in progress..."
+msgstr "Scanning, please wait..."
 
-#, fuzzy
 msgid "Please wait while the list downloads..."
-msgstr "Please wait while gathering data..."
+msgstr "Downloading list, please wait..."
 
 msgid "Please wait while we check your installed plugins..."
-msgstr "Please wait while we check your installed plugins..."
+msgstr "Checking your installed plugins..."
 
 msgid "Please wait while we configure your network..."
-msgstr "Please wait while we configure your network..."
+msgstr "Configuring your network..."
 
 msgid "Please wait while we prepare your network interfaces..."
-msgstr "Please wait while we prepare your network interfaces..."
+msgstr "Preparing your network interface..."
 
 msgid "Please wait while we test your network..."
-msgstr "Please wait while we test your network..."
+msgstr "Testing your network..."
 
 msgid "Please wait while your network is restarting..."
-msgstr "Please wait while your network is restarting..."
+msgstr "Restarting your network interface, please wait..."
 
 msgid "Please wait while your skin setting is restoring..."
-msgstr "Please wait while your skin setting is restoring..."
+msgstr "Restoring your skin settings..."
 
 msgid "Please wait whilst feeds state is checked."
-msgstr "Please wait whilst feeds state is checked."
+msgstr "Checking feeds state, please wait..."
 
-#, fuzzy
 msgid "Please wait, Loading image."
-msgstr "Please wait... Loading list..."
+msgstr "Loading image..."
 
-#, fuzzy
 msgid "Please wait, restarting cardserver."
-msgstr "Please wait (updating packages)"
+msgstr "Restarting cardserver..."
 
 msgid "Please wait, restarting softcam and cardserver."
-msgstr ""
+msgstr "Restarting softcam and cardserver..."
 
-#, fuzzy
 msgid "Please wait, restarting softcam."
-msgstr "Please wait while gathering data..."
+msgstr "Restarting softcam, please wait..."
 
 msgid "Please wait."
 msgstr "Please wait."
@@ -12166,11 +12260,10 @@ msgid "Please wait..."
 msgstr "Please wait..."
 
 msgid "Please wait... Loading list..."
-msgstr "Please wait... Loading list..."
+msgstr "Loading list, please wait..."
 
-#, fuzzy
 msgid "Please wait...almost ready! "
-msgstr "Please wait..."
+msgstr "Please wait, almost ready..."
 
 msgid "Plugin Browser"
 msgstr "Plugin Browser"
@@ -12191,14 +12284,16 @@ msgid "Plugin manager help"
 msgstr "Plugin manager help"
 
 msgid "Pluginbrowser Settings"
-msgstr "Pluginbrowser Settings"
+msgstr "Plugin Browser Settings"
 
 msgid "Plugins"
 msgstr "Plugins"
 
+#. TRANSLATORS: genre category
 msgid "Poker"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Poland"
 msgstr "Poland"
 
@@ -12208,12 +12303,13 @@ msgstr "Polarisation"
 msgid "Polarization"
 msgstr "Polarization"
 
+#. TRANSLATORS: regional option
 msgid "Polish"
 msgstr "Polish"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Politik"
-msgstr "Polish"
+msgstr "Politics"
 
 msgid "Popup"
 msgstr "Popup"
@@ -12236,13 +12332,14 @@ msgstr "Port D"
 msgid "Port:"
 msgstr "Port:"
 
-#, fuzzy
 msgid "Porträt"
-msgstr "Port"
+msgstr "Portrait"
 
+#. TRANSLATORS: regional option
 msgid "Portugal"
 msgstr "Portugal"
 
+#. TRANSLATORS: regional option
 msgid "Portuguese"
 msgstr "Portuguese"
 
@@ -12250,10 +12347,10 @@ msgid "Position Setup"
 msgstr "Position Setup"
 
 msgid "Position of finished Timers in Timerlist"
-msgstr "Position of finished Timers in Timerlist"
+msgstr "Position of completed timers in timer list"
 
 msgid "Position of recording icons"
-msgstr "Position of recording icons"
+msgstr "Align recording icons"
 
 msgid "Position stored at index"
 msgstr "Position stored at index"
@@ -12271,86 +12368,82 @@ msgid "Positioner Setup Log"
 msgstr "Positioner Setup Log"
 
 msgid "Positioner setup"
-msgstr "Positioner setup"
+msgstr "Positioner Setup"
 
 msgid "Power"
 msgstr "Power"
 
-#, fuzzy
 msgid "Power LED State in Deep-Standby"
-msgstr "Power LED State in Deep-Standby/Standby"
+msgstr "Power LED state during deep standby."
 
-#, fuzzy
 msgid "Power LED State in Standby"
-msgstr "Power LED State in Deep-Standby/Standby"
+msgstr "Power LED state during standby."
 
 msgid "Power LED can be turned on or off here."
 msgstr ""
 
-#, fuzzy
 msgid "Power LED state during deep-standby."
-msgstr "Power LED state during deep-standby/standby."
+msgstr "Power LED state during deep standby."
 
-#, fuzzy
 msgid "Power LED state during standby."
-msgstr "Power LED state during deep-standby/standby."
+msgstr "Power LED state during standby."
 
 msgid "Power On Display"
-msgstr "Power On Display"
+msgstr "Enable front panel display"
 
 msgid "Power long"
-msgstr "Power long"
+msgstr "Power button hold"
 
 msgid "Power management. Consult your receiver's manual for more information."
-msgstr ""
+msgstr "Power management. Refer to your receiver's documentation for more information."
 
 msgid "Power threshold in mA"
 msgstr "Power threshold in mA"
 
 msgid "Power threshold. Consult your receiver's manual for more information."
-msgstr ""
+msgstr "Power threshold. Refer to your receiver's documentation for more information."
 
 msgid "PowerManager entry"
-msgstr "PowerManager entry"
+msgstr "Power Manager Entry"
 
 msgid "PowerManager log"
-msgstr "PowerManager log"
+msgstr "Power Manager Log"
 
 msgid "PowerTimer"
-msgstr "PowerTimer"
+msgstr "Power Timer"
 
 msgid "PowerTimer DeepStandby"
-msgstr "PowerTimer DeepStandby"
+msgstr "Power timer deep standby"
 
 msgid "PowerTimer List"
-msgstr "PowerTimer List"
+msgstr "Power Timer List"
 
 msgid "PowerTimer Overview"
-msgstr "PowerTimer Overview"
+msgstr "Power Timer Overview"
 
 msgid "PowerTimer Standby"
-msgstr "PowerTimer Standby"
+msgstr "Power timer standby"
 
 msgid "PowerTimers"
-msgstr "PowerTimers"
+msgstr "Power Timers"
 
 msgid "Predefined"
-msgstr "Predefined"
+msgstr "Pre-defined"
 
 msgid "Predefined transponder"
-msgstr "Predefined transponder"
+msgstr "Pre-defined transponder"
 
 msgid "Prefer AC3 track"
-msgstr "Prefer AC3 track"
+msgstr "Prefer Dolby Digital / Dolby AC-3 track"
 
 msgid "Prefer AC3+ track"
-msgstr "Prefer AC3+ track"
+msgstr "Prefer Dolby Digital Plus (AC3+ / DD+ / E-AC-3 / EC-3) track"
 
 msgid "Prefer audio track stored by service"
 msgstr "Prefer audio track stored by service"
 
 msgid "Prefer graphical DVB subtitles"
-msgstr "Prefer graphical DVB subtitles"
+msgstr "Prefer DVB subtitles"
 
 msgid "Prefer subtitles for hearing impaired"
 msgstr "Prefer subtitles for hearing impaired"
@@ -12365,58 +12458,57 @@ msgid "Preferred tuner for recordings"
 msgstr "Preferred tuner for recordings"
 
 msgid "Preferred tuners for recordings, multiple selection allowed"
-msgstr "Preferred tuners for recordings, multiple selection allowed"
+msgstr "Preferred tuners for recordings (multiple selections allowed)"
 
 msgid "Preferred tuners, multiple selection allowed"
-msgstr "Preferred tuners, multiple selection allowed"
+msgstr "Preferred tuners (multiple selections allowed)"
 
-#, fuzzy
 msgid "Preparation time for recording (seconds)"
-msgstr "Margin before recording (minutes)"
+msgstr "Recording preparation time (in seconds)"
 
 msgid "Prepare another USB stick for image flashing"
 msgstr "Prepare another USB stick for image flashing"
 
 msgid "Preparing... Please wait"
-msgstr "Preparing... Please wait"
+msgstr "Preparing, please wait..."
 
+#. TRANSLATORS: genre category
 msgid "Preschool"
 msgstr ""
 
 msgid "Press '0' to toggle PiP mode"
-msgstr "Press '0' to toggle PiP mode"
+msgstr "Press the 0 button to toggle PiP mode"
 
 msgid "Press INFO on your remote control for additional information."
-msgstr "Press INFO on your remote control for additional information."
+msgstr "Press Info for more information."
 
 msgid "Press Init to format SDcard."
 msgstr ""
 
 msgid "Press MENU on your remote control for additional options."
-msgstr "Press MENU on your remote control for additional options."
+msgstr "Press MENU for additional options."
 
-#, fuzzy
 msgid "Press MENU to install additional language(s)."
-msgstr "Press MENU on your remote control for additional options."
+msgstr "Press MENU to install more languages."
 
 msgid "Press OK on your remote control to continue."
-msgstr "Press OK on your remote control to continue."
+msgstr "Press OK to continue."
 
 msgid "Press OK to activate the selected skin."
 msgstr "Press OK to activate the selected skin."
 
 msgid "Press OK to activate the settings."
-msgstr "Press OK to activate the settings."
+msgstr "Press OK to activate these settings."
 
 msgid "Press OK to edit the settings."
-msgstr "Press OK to edit the settings."
+msgstr "Press OK to change the settings."
 
 #, python-format
 msgid "Press OK to get further details for %s"
 msgstr "Press OK to get further details for %s"
 
 msgid "Press OK to scan"
-msgstr "Press OK to scan"
+msgstr "Press OK to start scanning."
 
 #, fuzzy
 msgid "Press OK to select a group of satellites to configure in one block."
@@ -12429,16 +12521,16 @@ msgid "Press OK to select a service."
 msgstr "Press OK to select a service."
 
 msgid "Press OK to select satellites"
-msgstr "Press OK to select satellites"
+msgstr "Press OK to select satellites."
 
 msgid "Press OK to select/deselect a CAId."
 msgstr "Press OK to select/deselect a CAId."
 
 msgid "Press OK to set the MAC-address."
-msgstr "Press OK to set the MAC-address."
+msgstr "Press OK to set the MAC address."
 
 msgid "Press OK to start the scan"
-msgstr "Press OK to start the scan"
+msgstr "Press OK to start scanning"
 
 msgid "Press OK to toggle the selection"
 msgstr "Press OK to toggle the selection"
@@ -12447,13 +12539,13 @@ msgid "Press OK to toggle the selection."
 msgstr "Press OK to toggle the selection."
 
 msgid "Press this button to emulate a long press on a button pressed afterwards (this also overrides any other actions assigned to emulation button)."
-msgstr "Press this button to emulate a long press on a button pressed afterwards (this also overrides any other actions assigned to emulation button)."
+msgstr "Press this button to emulate a button hold/long press afterwards (this will override any other actions assigned to the emulation button)."
 
 msgid "Press yellow to set this interface as the default interface."
-msgstr "Press yellow to set this interface as the default interface."
+msgstr "Press the Yellow button to set this as the default interface."
 
 msgid "Pressing the panic button will zap you to this channelnumber in your first bouquet."
-msgstr "Pressing the panic button will zap you to this channelnumber in your first bouquet."
+msgstr "Pressing the panic button will zap you to this channel number from your first bouquet."
 
 msgid "Prev quad PiP channel"
 msgstr "Prev quad PiP channel"
@@ -12470,17 +12562,23 @@ msgstr "Preview selected channel"
 msgid "Previous"
 msgstr "Previous"
 
+msgid "Previous bouquet"
+msgstr "previous bouquet"
+
+msgid "Previous page"
+msgstr "previous page"
+
 msgid "Prevsong"
-msgstr "Prevsong"
+msgstr "|◀︎◀︎ Previous track"
 
 msgid "Prevsong long"
-msgstr "Prevsong long"
+msgstr "|◀︎◀︎ Previous track button hold"
 
 msgid "Primary DNS"
 msgstr "Primary DNS"
 
 msgid "Primetime"
-msgstr "Primetime"
+msgstr "primetime"
 
 msgid "Primetime hour"
 msgstr "Primetime hour"
@@ -12492,7 +12590,7 @@ msgid "Priority"
 msgstr "Priority"
 
 msgid "Probable causes could be"
-msgstr ""
+msgstr "Possible causes include"
 
 msgid "Process"
 msgstr "Process"
@@ -12535,7 +12633,7 @@ msgid ""
 msgstr ""
 
 msgid "Program long"
-msgstr "Program long"
+msgstr "Program button hold"
 
 msgid "Programmlisten History"
 msgstr "Programmlisten History"
@@ -12553,33 +12651,28 @@ msgid "Programmlisten-Updater from DXAndy"
 msgstr "Programmlisten-Updater from DXAndy"
 
 msgid "Progress"
-msgstr "Progress"
+msgstr "progress"
 
 msgid "Progress bar left"
-msgstr "Progress bar left"
+msgstr "left side progress bar"
 
 msgid "Progress bar right"
-msgstr "Progress bar right"
+msgstr "right side progress bar"
 
-#, fuzzy
 msgid "Progress bar/Percentage left"
-msgstr "Progress bar left"
+msgstr "left side progress bar and %"
 
-#, fuzzy
 msgid "Progress bar/Percentage right"
-msgstr "Progress bar right"
+msgstr "right side progress bar and %"
 
-#, fuzzy
 msgid "Progress bar/Remaining minutes left"
-msgstr "Progress bar left"
+msgstr "left side progress bar and time remaining"
 
-#, fuzzy
 msgid "Progress bar/Remaining minutes right"
-msgstr "Progress bar right"
+msgstr "right side progress bar and time remaining"
 
-#, fuzzy
 msgid "Progress info font size"
-msgstr "Service info font size"
+msgstr "Progress info text size"
 
 msgid "Progress:"
 msgstr "Progress:"
@@ -12588,16 +12681,16 @@ msgid "Prominent"
 msgstr ""
 
 msgid "Properties of current title"
-msgstr "Properties of current title"
+msgstr "Current title properties"
 
 msgid "Protect InfoPanel"
-msgstr "Protect InfoPanel"
+msgstr "Protect info panel"
 
 msgid "Protect Quickmenu"
-msgstr "Protect Quickmenu"
+msgstr "Protect quick menu"
 
 msgid "Protect Screens"
-msgstr "Protect Screens"
+msgstr "Protect screens"
 
 msgid "Protect configuration"
 msgstr "Protect configuration"
@@ -12606,13 +12699,13 @@ msgid "Protect context menus"
 msgstr "Protect context menus"
 
 msgid "Protect main menu"
-msgstr "Protect main menu"
+msgstr "Protect Main menu"
 
 msgid "Protect movie list"
 msgstr "Protect movie list"
 
 msgid "Protect on epg age"
-msgstr "Protect on epg age"
+msgstr "Protect on EPG age"
 
 msgid "Protect plugin browser"
 msgstr "Protect plugin browser"
@@ -12636,7 +12729,7 @@ msgid "Prov"
 msgstr "Prov"
 
 msgid "Prov long"
-msgstr "Prov long"
+msgstr "Prov button hold"
 
 msgid "Provider"
 msgstr "Provider"
@@ -12656,17 +12749,20 @@ msgstr "Providers:"
 msgid "Providers: "
 msgstr "Providers: "
 
+#. TRANSLATORS: genre category
 msgid "Psychologie"
-msgstr ""
+msgstr "Psychology"
 
+#. TRANSLATORS: regional option
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
+#. TRANSLATORS: genre category
 msgid "Puppentrick"
-msgstr ""
+msgstr "Puppetry"
 
 msgid "Put TV in standby"
-msgstr "Put TV in standby"
+msgstr "Put TV into standby"
 
 msgid "Put your AV Receiver in standby"
 msgstr "Put your AV Receiver in standby"
@@ -12678,6 +12774,7 @@ msgstr "Python frontend for /tmp/mmi.socket"
 msgid "Python:\t\t%s"
 msgstr "Python:\t%s"
 
+#. TRANSLATORS: regional option
 msgid "Qatar"
 msgstr "Qatar"
 
@@ -12687,21 +12784,20 @@ msgstr "Quad PiP Channel Selection"
 msgid "Quad PiP Screen"
 msgstr "Quad PiP Screen"
 
-#, fuzzy
 msgid "Quad PiP channel "
-msgstr "Next quad PiP channel"
+msgstr "Quad PiP channel "
 
 msgid "Quad PiP is not available."
 msgstr "Quad PiP is not available."
 
 msgid "Question"
-msgstr "Question"
+msgstr "Question..."
 
 msgid "Quick"
 msgstr "Quick"
 
 msgid "Quick Actions"
-msgstr "Quick Actions"
+msgstr "quick actions"
 
 msgid "Quick Launch Menu"
 msgstr "Quick Launch Menu"
@@ -12713,14 +12809,15 @@ msgid "Quick zap"
 msgstr "Quick zap"
 
 msgid "QuickEPG mode"
-msgstr "QuickEPG mode"
+msgstr "Quick EPG mode"
 
 msgid "QuickMenu"
-msgstr "QuickMenu"
+msgstr "Quick Menu"
 
 msgid "QuickMenu/Extensions"
-msgstr "QuickMenu/Extensions"
+msgstr "Quick Menu/Extensions"
 
+#. TRANSLATORS: genre category
 msgid "Quiz"
 msgstr ""
 
@@ -12728,18 +12825,16 @@ msgid "RAM"
 msgstr "RAM"
 
 msgid "REC"
-msgstr "REC"
+msgstr "● REC"
 
 msgid "REC Symbol"
 msgstr "REC Symbol"
 
-#, fuzzy
 msgid "REC Symbol in Standby"
-msgstr "only in Standby"
+msgstr "Show REC symbol in standby"
 
-#, fuzzy
 msgid "REC Symbol in use"
-msgstr "REC Symbol"
+msgstr "Show REC symbol during normal use"
 
 msgid "RF output"
 msgstr "RF output"
@@ -12748,20 +12843,20 @@ msgid "RGB"
 msgstr "RGB"
 
 msgid "Radio"
-msgstr "Radio"
+msgstr "Radio button"
 
 msgid "Radio Channel Selection"
 msgstr "Radio Channel Selection"
 
 msgid "Radio long"
-msgstr "Radio long"
+msgstr "Radio button hold"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Radsport"
-msgstr "team sports"
+msgstr "Cycling"
 
 msgid "Ram"
-msgstr "Ram"
+msgstr "RAM"
 
 msgid "Random"
 msgstr "Random"
@@ -12791,67 +12886,71 @@ msgstr "Reader Statistics"
 
 #, python-format
 msgid "Ready to install \"%s\" ?"
-msgstr "Ready to install \"%s\" ?"
+msgstr "Ready to install \"%s\"?"
 
 #, python-format
 msgid "Ready to install %s ?"
-msgstr "Ready to install %s ?"
+msgstr "Ready to install %s?"
 
 #, python-format
 msgid "Ready to remove \"%s\" ?"
-msgstr "Ready to remove \"%s\" ?"
+msgstr "Ready to remove \"%s\"?"
 
 #, python-format
 msgid "Ready to remove %s ?"
-msgstr "Ready to remove %s ?"
+msgstr "Ready to remove %s?"
 
+#. TRANSLATORS: genre category
 msgid "Real Life"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Reality"
 msgstr ""
 
 msgid "Really WOL now?"
-msgstr "Really WOL now?"
+msgstr "Are you sure you want to WoL now?"
 
 msgid "Really close without saving settings?"
-msgstr "Really close without saving settings?"
+msgstr "Are you sure you want to close without saving your changes?"
 
 msgid "Really delete done timers?"
-msgstr "Really delete done timers?"
+msgstr "Are you sure you want to remove completed timers?"
 
-#, fuzzy
+msgid "Really delete completed timers?"
+msgstr "Are you sure you want to remove completed timers?"
+
 msgid "Really delete this entry?"
-msgstr "Really delete done timers?"
+msgstr "Are you sure you want to delete this entry?"
 
 msgid "Really exit the subservices quickzap?"
-msgstr "Really exit the subservices quickzap?"
+msgstr "Are you sure you want to exit the subservices quick zap?"
 
 msgid "Really reboot into Recovery Mode?"
-msgstr "Really reboot into Recovery Mode?"
+msgstr "Are you sure you want to reboot into recovery mode?"
 
 msgid "Really reboot now?"
-msgstr "Really reboot now?"
+msgstr "Are you sure you want to reboot now?"
 
 #, python-format
 msgid "Really reflash your %s %s and reboot now?"
-msgstr "Really reflash your %s %s and reboot now?"
+msgstr "Are you sure you want to reflash your %s %s and reboot now?"
 
 msgid "Really restart now?"
-msgstr "Really restart now?"
+msgstr "Are you sure you want to restart now?"
 
 msgid "Really shutdown now?"
-msgstr "Really shutdown now?"
+msgstr "Are you sure you want to shutdown now?"
 
 msgid "Really upgrade the front panel and reboot now?"
-msgstr "Really upgrade the front panel and reboot now?"
+msgstr "Are you sure you want to upgrade the front panel and reboot now?"
 
 msgid "Really upgrade the frontprocessor and reboot now?"
-msgstr "Really upgrade the frontprocessor and reboot now?"
+msgstr "Are you sure you want to upgrade the front processor and reboot?"
 
 #, python-format
 msgid "Really upgrade your %s %s and reboot now?"
-msgstr "Really upgrade your %s %s and reboot now?"
+msgstr "Are you sure you want to upgrade your %s %s and reboot now?"
 
 msgid "Reboot"
 msgstr "Reboot"
@@ -12863,10 +12962,10 @@ msgid "Rebuild LCN bouquet now?"
 msgstr "Rebuild LCN bouquet now?"
 
 msgid "Rec"
-msgstr "Rec"
+msgstr "● REC"
 
 msgid "Rec long"
-msgstr "Rec long"
+msgstr "● REC button hold"
 
 #, fuzzy
 msgid "Reception"
@@ -12885,7 +12984,7 @@ msgid "Record"
 msgstr "Record"
 
 msgid "Record - same as record button"
-msgstr "Record - same as record button"
+msgstr "record (same as record button)"
 
 msgid "Record next"
 msgstr "Record next"
@@ -12894,14 +12993,14 @@ msgid "Record now"
 msgstr "Record now"
 
 msgid "Record started! Stopping timeshift now ..."
-msgstr "Record started! Stopping timeshift now ..."
+msgstr "Started recording! Stopping timeshift..."
 
 #, python-format
 msgid "Record time limited due to conflicting timer %s"
 msgstr "Record time limited due to conflicting timer %s"
 
 msgid "Record write error (no space on disk?)"
-msgstr ""
+msgstr "Record write error (no space on disk?)"
 
 msgid "Recordable media toolbox"
 msgstr "Recordable media toolbox"
@@ -12912,70 +13011,64 @@ msgstr "Recording"
 msgid "Recording Setup"
 msgstr "Recording Setup"
 
-#, fuzzy
 msgid "Recording aborted"
-msgstr "Recordings abort PIP"
+msgstr "Recording canceled"
 
-#, fuzzy
 msgid "Recording failed"
-msgstr "Recording type"
+msgstr "Recording failed"
 
-#, fuzzy
 msgid "Recording finished"
-msgstr "Recording settings"
+msgstr "Recording finished"
 
 msgid "Recording in progress"
 msgstr "Recording in progress"
 
-#, fuzzy
 msgid "Recording running"
-msgstr "Recording settings"
+msgstr "Recording"
 
 msgid "Recording settings"
-msgstr "Recording settings"
+msgstr "Recording Settings"
 
-#, fuzzy
 msgid "Recording started"
-msgstr "Recording type"
+msgstr "Recording started"
 
-#, fuzzy
 msgid "Recording stopped"
-msgstr "Recording type"
+msgstr "Recording stopped"
 
-#, fuzzy
 msgid "Recording tuning failed"
-msgstr "Recording settings"
+msgstr "Recording tuning failed"
 
 msgid "Recording type"
 msgstr "Recording type"
 
 msgid "Recording(s) are in progress or coming up in few seconds!"
-msgstr "Recording(s) are in progress or coming up in few seconds!"
+msgstr "There's a recording in progress or coming up!"
 
 msgid ""
 "Recording(s) are in progress or coming up in few seconds!\n"
 "Entering standby, after recording the box will shutdown."
 msgstr ""
-"Recording(s) are in progress or coming up in few seconds!\n"
-"Entering standby, after recording the box will shutdown."
+"There's a recording in progress or starting soon!\n"
+"\n"
+"Entering standby now - your receiver will shut down when recording is complete."
 
 msgid "Recordings"
 msgstr "Recordings"
 
 msgid "Recordings & Timeshift"
-msgstr "Recordings & Timeshift"
+msgstr "Recording & Timeshift"
 
 msgid "Recordings abort PIP"
-msgstr "Recordings abort PIP"
+msgstr "Stop PiP mode to record"
 
 msgid "Recordings abort pseudo recordings"
-msgstr "Recordings abort pseudo recordings"
+msgstr "Stop pseudo recordings to record"
 
 msgid "Recordings abort streaming"
-msgstr "Recordings abort streaming"
+msgstr "Stop streaming to record"
 
 msgid "Recordings always have priority"
-msgstr "Recordings always have priority"
+msgstr "Prioritize recordings"
 
 #, fuzzy
 msgid "Records"
@@ -12985,7 +13078,7 @@ msgid "Recovery Mode"
 msgstr "Recovery Mode"
 
 msgid "Red"
-msgstr "Red"
+msgstr "Red button"
 
 msgid "Red button"
 msgstr "Red button"
@@ -12994,10 +13087,10 @@ msgid "Red button..."
 msgstr "Red button..."
 
 msgid "Red colored"
-msgstr "Red colored"
+msgstr "red color text"
 
 msgid "Red long"
-msgstr "Red long"
+msgstr "Red button hold"
 
 msgid "Reduce the size of the service picons for more line spacing between them."
 msgstr "Reduce the size of the service picons for more line spacing between them."
@@ -13006,7 +13099,7 @@ msgid "Reduce time scale"
 msgstr "Reduce time scale"
 
 msgid "Reenter PIN"
-msgstr "Reenter PIN"
+msgstr "Re-enter PIN"
 
 #, python-format
 msgid ""
@@ -13014,12 +13107,12 @@ msgid ""
 "Please wait until your %s %s reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Reflash in progress\n"
-"Please wait until your %s %s reboots\n"
-"This may take a few minutes"
+"Reflash in progress.\n"
+"Please wait until your %s %s reboots!\n"
+"This could take a while..."
 
 msgid "Refresh every (in hours)"
-msgstr "Refresh every (in hours)"
+msgstr "Refresh every # hours"
 
 msgid "Refresh rate"
 msgstr "Refresh rate"
@@ -13028,9 +13121,8 @@ msgid "Refresh rate for 'Lowest Mode'"
 msgstr "Refresh rate for 'Lowest Mode'"
 
 msgid "Refresh rate selection."
-msgstr "Refresh rate selection."
+msgstr "Refresh rate for selection."
 
-#, fuzzy
 msgid "Refresh screen"
 msgstr "Refresh rate"
 
@@ -13040,22 +13132,23 @@ msgstr "Regard deep standby as standby"
 msgid "Region"
 msgstr "Region"
 
-#, fuzzy
 msgid "Regional"
-msgstr "Region"
+msgstr ""
 
 #, fuzzy
 msgid "Regular file"
 msgstr "template file"
 
+#. TRANSLATORS: genre category
 msgid "Reisen"
-msgstr ""
+msgstr "Travel"
 
+#. TRANSLATORS: genre category
 msgid "Reiten"
-msgstr ""
+msgstr "Horse riding"
 
 msgid "Relative"
-msgstr "Relative"
+msgstr "relative"
 
 msgid "Release Notes"
 msgstr "Release Notes"
@@ -13063,45 +13156,42 @@ msgstr "Release Notes"
 msgid "Relevant PIDs Routing"
 msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Religion"
-msgstr "religion"
+msgstr ""
 
 msgid "Reload"
 msgstr "Reload"
 
 msgid "Reload Services"
-msgstr "Reload Services"
+msgstr "Reload channels"
 
 msgid "Reload blacklists"
 msgstr "Reload blacklists"
 
 msgid "Reloading EPG Cache..."
-msgstr "Reloading EPG Cache..."
+msgstr "Reloading EPG cache..."
 
 msgid "Reloading bouquets and services..."
 msgstr "Reloading bouquets and services..."
 
 msgid "Remaining"
-msgstr "Remaining"
+msgstr "remaining"
 
 msgid "Remaining & Elapsed"
-msgstr "Remaining & Elapsed"
+msgstr "remaining & elapsed"
 
-#, fuzzy
 msgid "Remaining minutes left"
-msgstr "Remaining & Elapsed"
+msgstr "time remaining"
 
 msgid "Remaining minutes right"
-msgstr ""
+msgstr "Time remaining on right"
 
-#, fuzzy
 msgid "Remaining minutes/Progress bar left"
-msgstr "Progress bar left"
+msgstr "left side remaining time/progress bar"
 
-#, fuzzy
 msgid "Remaining minutes/Progress bar right"
-msgstr "Progress bar right"
+msgstr "left side remaining time/progress bar"
 
 msgid "Remember last service in PiP"
 msgstr "Remember last service in PiP"
@@ -13116,14 +13206,14 @@ msgid "Remote box"
 msgstr "Remote box"
 
 msgid "Remote control model shown"
-msgstr "Remote control model shown"
+msgstr "Remote control model to show"
 
 msgid "Remote control type"
 msgstr "Remote control type"
 
 #, python-format
 msgid "Removal of this slot will not show in %s Gui.  Are you sure you want to delete image slot %s ?"
-msgstr ""
+msgstr "Removal of this slot will not show in %s GUI. Are you sure you want to delete image slot %s?"
 
 msgid "Remove"
 msgstr "Remove"
@@ -13154,7 +13244,7 @@ msgid "Remove bookmark"
 msgstr "Remove bookmark"
 
 msgid "Remove completed timers after (days)"
-msgstr "Remove completed timers after (days)"
+msgstr "Remove completed timers after X days"
 
 #, fuzzy
 msgid "Remove confirmation"
@@ -13170,19 +13260,19 @@ msgid "Remove finished."
 msgstr "Remove finished."
 
 msgid "Remove hide VBI line for this service"
-msgstr "Remove hide VBI line for this service"
+msgstr "Don't hide VBI line for this channel"
 
 msgid "Remove items from trash can after (days)"
-msgstr "Remove items from trash can after (days)"
+msgstr "Remove items from trash can after # days"
 
 msgid "Remove plugins"
-msgstr "Remove plugins"
+msgstr "Remove Plugins"
 
 msgid "Remove selected folder from bookmarks"
 msgstr ""
 
 msgid "Remove texts for the hearing impaired from external subtitles (instrumental music or environmental sounds, e.g., when a doorbell rings or a gun shot is heard)."
-msgstr "Remove texts for the hearing impaired from external subtitles (instrumental music or environmental sounds, e.g., when a doorbell rings or a gun shot is heard)."
+msgstr "Remove text for the hearing impaired from external subtitles (instrumental music or environmental sounds, e.g., when a doorbell rings or a gun shot is heard)."
 
 msgid "Remove timer"
 msgstr "Remove timer"
@@ -13198,7 +13288,7 @@ msgstr "Removing Service"
 
 #, python-format
 msgid "Removing directory %s failed. (Maybe not empty.)"
-msgstr "Removing directory %s failed. (Maybe not empty.)"
+msgstr "Couldn't delete folder %s (it might not be empty)."
 
 msgid "Removing partition table"
 msgstr "Removing partition table"
@@ -13209,9 +13299,8 @@ msgstr "Rename"
 msgid "Rename failed!"
 msgstr "Rename failed!"
 
-#, fuzzy
 msgid "Rename file/directory"
-msgstr "create directory"
+msgstr "Rename file/folder"
 
 msgid "Rename name and description for new events"
 msgstr "Rename name and description for new events"
@@ -13223,46 +13312,46 @@ msgstr "Rename to:"
 msgid "Renamed %s!"
 msgstr "Renamed %s!"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Renovation"
-msgstr "Resolution"
+msgstr "House & DIY"
 
 msgid "Repeat"
 msgstr "Repeat"
 
 msgid "Repeat Display Message"
-msgstr "Repeat Display Message"
+msgstr "Repeat display message"
 
 msgid "Repeat the sent standby and wakeup commands"
-msgstr ""
+msgstr "Repeat the sent standby and wake-up commands"
 
 msgid "Repeat the standby commands?"
 msgstr ""
 
 msgid "Repeat type"
-msgstr "Repeat type"
+msgstr "Frequency"
 
 msgid "Repeating event currently recording... What do you want to do?"
-msgstr "Repeating event currently recording... What do you want to do?"
+msgstr "Currently recording a repeating event, what would you like to do?"
 
 msgid "Repeats"
 msgstr "Repeats"
 
 msgid "Replace `- ` in dialogs with colored text per speaker (like teletext subtitles for the hearing impaired)"
-msgstr "Replace `- ` in dialogs with colored text per speaker (like teletext subtitles for the hearing impaired)"
+msgstr "Replace '- ' in dialog with colored text per speaker (like teletext subtitles for the hearing impaired)."
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Reportage"
-msgstr "Percentage"
+msgstr "Report"
 
 msgid "Require authentication for http streams"
-msgstr "Require authentication for http streams"
+msgstr "Require authentication for HTTP streams"
 
 msgid "Required medium type:"
 msgstr "Required medium type:"
 
 msgid "Rereading partition table"
-msgstr "Rereading partition table"
+msgstr "Re-reading partition table"
 
 msgid "Reserved"
 msgstr "Reserved"
@@ -13298,7 +13387,7 @@ msgid "Resolution"
 msgstr "Resolution"
 
 msgid "Restart"
-msgstr "Restart"
+msgstr "Full Restart"
 
 #, python-format
 msgid "Restart %s %s."
@@ -13311,13 +13400,13 @@ msgid "Restart GUI"
 msgstr "Restart GUI"
 
 msgid "Restart GUI after x crashes"
-msgstr ""
+msgstr "Restart user interface after # crashes"
 
 msgid "Restart GUI now?"
-msgstr "Restart GUI now?"
+msgstr "Restart user interface now?"
 
 msgid "Restart Gui"
-msgstr "Restart Gui"
+msgstr "Fast Restart (User Interface)"
 
 msgid "Restart Network"
 msgstr "Restart Network"
@@ -13325,32 +13414,30 @@ msgstr "Restart Network"
 msgid "Restart Network Adapter"
 msgstr "Restart Network Adapter"
 
-#, fuzzy
 msgid "Restart both"
-msgstr "Restart test"
+msgstr "Restart both"
 
 #, fuzzy
 msgid "Restart cardserver"
 msgstr "get the cards' server"
 
 msgid "Restart enigma"
-msgstr "Restart enigma"
+msgstr "Restart Enigma2"
 
 msgid "Restart necessary, restart GUI now?"
-msgstr "Restart necessary, restart GUI now?"
+msgstr "Restart required, restart user interface now?"
 
 msgid "Restart network"
-msgstr "Restart network"
+msgstr "Restart network interface"
 
 msgid "Restart network and remount connections"
-msgstr "Restart network and remount connections"
+msgstr "Restart network and re-mount connections"
 
 msgid "Restart network to with current setup"
-msgstr "Restart network to with current setup"
+msgstr "Restart network with current config"
 
-#, fuzzy
 msgid "Restart softcam"
-msgstr "Restart test"
+msgstr "Restart softcam"
 
 msgid "Restart test"
 msgstr "Restart test"
@@ -13368,13 +13455,13 @@ msgid "Restore Plugins"
 msgstr "Restore Plugins"
 
 msgid "Restore Settings"
-msgstr "Restore Settings"
+msgstr "Restore settings now"
 
 msgid "Restore backups"
-msgstr "Restore backups"
+msgstr "Manage Backups"
 
 msgid "Restore is running..."
-msgstr "Restore is running..."
+msgstr "Restoring..."
 
 msgid "Restore settings from a backup"
 msgstr "Restore settings from a backup"
@@ -13383,19 +13470,20 @@ msgid "Restore system settings"
 msgstr "Restore system settings"
 
 msgid "Restore your settings back from a backup. After restore the box will restart to activated the new settings"
-msgstr "Restore your settings back from a backup. After restore the box will restart to activated the new settings"
+msgstr "Restore your settings back from a backup. After restoring, your receiver will restart to activate the new settings"
 
 msgid "Restoring..."
 msgstr "Restoring..."
 
 msgid "Restrict the active time range"
-msgstr "Restrict the active time range"
+msgstr "Restrict active time range"
 
+#. TRANSLATORS: genre category
 msgid "Restricted 18+"
 msgstr ""
 
 msgid "Resume from last position"
-msgstr "Resume from last position"
+msgstr "resume from last position"
 
 #, python-format
 msgid "Resume position at %s"
@@ -13404,42 +13492,40 @@ msgstr "Resume position at %s"
 msgid "Resuming playback"
 msgstr "Resuming playback"
 
-#, fuzzy
 msgid "Retrieving image list - Please wait..."
-msgstr "Getting Softcam list. Please wait..."
+msgstr "Downloading latest image list, please wait..."
 
-#, fuzzy
 msgid "Retrieving image slots - Please wait..."
-msgstr "Getting Softcam list. Please wait..."
+msgstr "Retrieving image slots, please wait..."
 
 msgid "Return to movie list"
-msgstr "Return to movie list"
+msgstr "return to movie list"
 
 msgid "Return to previous service"
-msgstr "Return to previous service"
+msgstr "return to previous service"
 
+#. TRANSLATORS: regional option
 msgid "Reunion"
 msgstr "Reunion"
 
 msgid "Reverse bouquet buttons"
-msgstr "Reverse bouquet buttons"
+msgstr "reverse bouquet buttons"
 
-#, fuzzy
 msgid "Reverse left file sorting"
-msgstr "Reverse list"
+msgstr "Reverse left file sorting"
 
 msgid "Reverse list"
 msgstr "Reverse list"
 
-#, fuzzy
 msgid "Reverse right file sorting"
-msgstr "Never decrypt while recording"
+msgstr "Reverse right file sorting"
 
+#. TRANSLATORS: genre category
 msgid "Revue"
 msgstr ""
 
 msgid "Rewind"
-msgstr "Rewind"
+msgstr "◀︎◀︎ Rewind"
 
 msgid "Rewind speeds"
 msgstr "Rewind speeds"
@@ -13448,53 +13534,57 @@ msgid "Rewrap subtitles"
 msgstr "Rewrap subtitles"
 
 msgid "Right"
-msgstr "Right"
+msgstr "▶︎ Right"
 
 msgid "Right from servicename"
-msgstr "Right from servicename"
+msgstr "right of service name"
 
 msgid "Right long"
-msgstr "Right long"
+msgstr "▶︎ Right button hold"
 
 msgid "Roll-off"
 msgstr "Roll-off"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Romance"
-msgstr "romance"
+msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Romania"
 msgstr "Romania"
 
+#. TRANSLATORS: regional option
 msgid "Romanian"
 msgstr "Romanian"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Romantik"
-msgstr "Romania"
+msgstr "Romantic"
 
 msgid "Root"
 msgstr "Root"
 
 msgid "Root directory"
-msgstr "Root directory"
+msgstr "Root folder"
 
 msgid "Rotor step position:"
-msgstr "Rotor step position:"
+msgstr "Rotator step position:"
 
 msgid "Rotor turning speed"
-msgstr "Rotor turning speed"
+msgstr "Rotator turning speed"
 
-#, fuzzy
 msgid "Routing request"
-msgstr "Source request"
+msgstr "Routing request"
 
+#. TRANSLATORS: genre category
 msgid "Rowing"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Rugby"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Rugby League"
 msgstr ""
 
@@ -13509,7 +13599,7 @@ msgid "Run Confirmation"
 msgstr "Run Confirmation"
 
 msgid "Run how often ?"
-msgstr "Run how often ?"
+msgstr "Run frequency"
 
 msgid "Run script"
 msgstr ""
@@ -13528,14 +13618,17 @@ msgid "Running"
 msgstr "Running"
 
 msgid "Running Myrestore script, Please wait ..."
-msgstr "Running Myrestore script, Please wait ..."
+msgstr "Running Myrestore script, please wait..."
 
+#. TRANSLATORS: regional option
 msgid "Russian"
 msgstr "Russian"
 
+#. TRANSLATORS: regional option
 msgid "Russian Federation"
 msgstr "Russian Federation"
 
+#. TRANSLATORS: regional option
 msgid "Rwanda"
 msgstr "Rwanda"
 
@@ -13552,7 +13645,7 @@ msgid "SAT"
 msgstr "SAT"
 
 msgid "SAT long"
-msgstr "SAT long"
+msgstr "SAT button hold"
 
 msgid "SATA"
 msgstr "SATA"
@@ -13567,7 +13660,7 @@ msgid "SD"
 msgstr "SD"
 
 msgid "SDcard is not initialised for multiboot - Exit and use MultiBoot Image Manager to initialise"
-msgstr ""
+msgstr "SDcard is not initialized for multi-boot - Exit and use Multi-Boot Image Manager to initialize"
 
 msgid "SDcard switch ERROR! - H9 root files not transferred to SD card"
 msgstr ""
@@ -13593,39 +13686,44 @@ msgstr "SPDIF"
 msgid "SSID:"
 msgstr "SSID:"
 
-#, fuzzy
 msgid "STARTUP_"
-msgstr "STARTUP"
+msgstr "STARTUP_"
 
-#, fuzzy
 msgid "STB Display"
-msgstr "Display"
+msgstr "Front Panel Display Settings"
 
+#. TRANSLATORS: genre category
 msgid "Saga"
 msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Sailing"
-msgstr "Scaling mode"
+msgstr "Sailing"
 
 msgid "Saint Barthelemy"
 msgstr "Saint Barthelemy"
 
+#. TRANSLATORS: regional option
 msgid "Saint Helena, Ascension and Tristan da Cunha"
 msgstr "Saint Helena, Ascension and Tristan da Cunha"
 
+#. TRANSLATORS: regional option
 msgid "Saint Kitts and Nevis"
 msgstr "Saint Kitts and Nevis"
 
+#. TRANSLATORS: regional option
 msgid "Saint Lucia"
 msgstr "Saint Lucia"
 
+#. TRANSLATORS: regional option
 msgid "Saint Martin (French part)"
-msgstr "Saint Martin (French part)"
+msgstr "Saint Martin, French part"
 
+#. TRANSLATORS: regional option
 msgid "Saint Pierre and Miquelon"
 msgstr "Saint Pierre and Miquelon"
 
+#. TRANSLATORS: regional option
 msgid "Saint Vincent and the Grenadines"
 msgstr "Saint Vincent and the Grenadines"
 
@@ -13648,20 +13746,23 @@ msgstr "* current animation"
 msgid "Same resolution as skin"
 msgstr "Same resolution as skin"
 
+#. TRANSLATORS: regional option
 msgid "Samoa"
 msgstr "Samoa"
 
+#. TRANSLATORS: regional option
 msgid "San Marino"
 msgstr "San Marino"
 
+#. TRANSLATORS: regional option
 msgid "Sao Tome and Principe"
-msgstr "Sao Tome and Principe"
+msgstr "São Tomé and Príncipe"
 
 msgid "Sat"
 msgstr "Sat"
 
 msgid "Sat Finder"
-msgstr "Sat Finder"
+msgstr "Signal Finder"
 
 msgid "Satellite"
 msgstr "Satellite"
@@ -13685,8 +13786,9 @@ msgid "Satellites"
 msgstr "Satellites"
 
 msgid "Satfinder"
-msgstr "Satfinder"
+msgstr "Sat finder"
 
+#. TRANSLATORS: genre category
 msgid "Satire"
 msgstr ""
 
@@ -13699,15 +13801,15 @@ msgstr "Saturation"
 msgid "Saturday"
 msgstr "Saturday"
 
+#. TRANSLATORS: regional option
 msgid "Saudi Arabia"
 msgstr "Saudi Arabia"
 
 msgid "Save"
 msgstr "Save"
 
-#, fuzzy
 msgid "Save / Enter text and exit"
-msgstr "save last directory on exit"
+msgstr "Save / Enter text and exit"
 
 msgid "Save EPG"
 msgstr "Save EPG"
@@ -13716,55 +13818,54 @@ msgid "Save EPG data"
 msgstr "Save EPG data"
 
 msgid "Save and record"
-msgstr "Save and record"
+msgstr "save and record"
 
 msgid "Save and stop"
-msgstr "Save and stop"
+msgstr "save and stop"
 
 msgid "Save every (in hours)"
-msgstr "Save every (in hours)"
+msgstr "Save every # hours"
 
-#, fuzzy
 msgid "Save left folder on exit"
-msgstr "save last directory on exit"
+msgstr "Remember left folder on exit"
 
 msgid "Save playlist"
 msgstr "Save playlist"
 
-#, fuzzy
 msgid "Save right folder on exit"
-msgstr "save last directory on exit"
+msgstr "Remember right folder on exit"
 
-#, fuzzy
 msgid "Save settings and EPG data"
-msgstr "Save EPG data"
+msgstr "Save settings and EPG data"
 
 #, python-format
 msgid ""
 "Save the commands and the output to a file?\n"
 "('%s')"
 msgstr ""
+"Save the commands and output to a file?\n"
+"('%s')"
 
 msgid "Save the left folder list location on exit."
-msgstr ""
+msgstr "Remember the left folder list location on exit"
 
 msgid "Save the right folder list location on exit."
-msgstr ""
+msgstr "Remember the right folder location list on exit"
 
 msgid "Save timeshift as movie and continue recording"
-msgstr "Save timeshift as movie and continue recording"
+msgstr "Continue recording and save timeshift buffer"
 
 msgid "Save timeshift as movie and stop recording"
-msgstr "Save timeshift as movie and stop recording"
+msgstr "Stop recording and save timeshift buffer"
 
 msgid "Saving EPG Cache..."
-msgstr "Saving EPG Cache..."
+msgstr "Saving EPG data..."
 
 msgid "Saving Timeshift files"
-msgstr "Saving Timeshift files"
+msgstr "Saving timeshift buffer..."
 
 msgid "Saving timeshift as movie now. This might take a while!"
-msgstr "Saving timeshift as movie now. This might take a while!"
+msgstr "Saving timeshift buffer, this might take a while..."
 
 msgid "Scaler sharpness"
 msgstr "Scaler sharpness"
@@ -13797,10 +13898,10 @@ msgid "Scan files..."
 msgstr "Scan files..."
 
 msgid "Scan for local extensions and install them"
-msgstr "Scan for local extensions and install them"
+msgstr "Scan for and install local plugins"
 
 msgid "Scan wireless networks"
-msgstr "Scan wireless networks"
+msgstr "Scan for wireless networks"
 
 msgid "Scan your network for wireless access points and connect to them using your selected wireless device.\n"
 msgstr "Scan your network for wireless access points and connect to them using your selected wireless device.\n"
@@ -13813,17 +13914,17 @@ msgstr "Scanning %s..."
 #, python-format
 msgid "Scanning - %d%% completed"
 msgid_plural "Scanning - %d%% completed"
-msgstr[0] "Scanning - %d%% completed"
-msgstr[1] "Scanning - %d%% completed"
+msgstr[0] "Scanning - %d%%..."
+msgstr[1] "Scanning - %d%%..."
 
 #, python-format
 msgid "Scanning completed, %d channel found"
 msgid_plural "Scanning completed, %d channels found"
-msgstr[0] "Scanning completed, %d channel found"
-msgstr[1] "Scanning completed, %d channels found"
+msgstr[0] "Scanning complete - %d channel found"
+msgstr[1] "Scanning complete - %d channels found"
 
 msgid "Scanning failed!"
-msgstr "Scanning failed!"
+msgstr "Scan failed!"
 
 msgid "Scanning..."
 msgstr "Scanning..."
@@ -13831,37 +13932,40 @@ msgstr "Scanning..."
 msgid "Scans default lamedbs sorted by satellite with a connected dish positioner"
 msgstr "Scans default lamedbs sorted by satellite with a connected dish positioner"
 
+#. TRANSLATORS: genre category
 msgid "Sci-Fi"
-msgstr ""
+msgstr "Sci-fi"
 
+#. TRANSLATORS: genre category
 msgid "Science"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Science & Tech"
-msgstr ""
+msgstr "Science & Technology"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Science-Fiction"
-msgstr "Skinselector"
+msgstr "Science fiction"
 
 msgid "Screenshot of LCD in /tmp"
-msgstr "Screenshot of LCD in /tmp"
+msgstr "Screenshot of front panel display to /tmp"
 
 #, python-format
 msgid "Script '%s' must have read permission to be able to run it"
 msgstr ""
 
 msgid "ScriptRunner"
-msgstr "ScriptRunner"
+msgstr "Script Runner"
 
 msgid "Scrolling Speed"
-msgstr "Scrolling Speed"
+msgstr "Scroll speed"
 
 msgid "Scrolling delay (software renderer)"
-msgstr "Scrolling delay (software renderer)"
+msgstr "Software renderer scroll delay"
 
 msgid "Scrolling speed (software renderer)"
-msgstr "Scrolling speed (software renderer)"
+msgstr "Software renderer scroll speed"
 
 msgid "Search"
 msgstr "Search"
@@ -13870,10 +13974,10 @@ msgid "Search IMDb for information about current event."
 msgstr "Search IMDb for information about current event."
 
 msgid "Search Sats"
-msgstr "Search Sats"
+msgstr "Search for satellite signals"
 
 msgid "Search Sats, check signal and lock"
-msgstr "Search Sats, check signal and lock"
+msgstr "Search satellites, check signal and lock."
 
 msgid "Search east"
 msgstr "Search east"
@@ -13885,10 +13989,10 @@ msgid "Search for similar events"
 msgstr "Search for similar events"
 
 msgid "Search the epg for current event."
-msgstr "Search the epg for current event."
+msgstr "Search EPG for the current event."
 
 msgid "Search weather location ID"
-msgstr "Search weather location ID"
+msgstr "Look up weather location ID"
 
 msgid "Search west"
 msgstr "Search west"
@@ -13897,35 +14001,37 @@ msgid "Search/WEB"
 msgstr "Search/WEB"
 
 msgid "Search/WEB long"
-msgstr "Search/WEB long"
+msgstr "Search/WEB button hold"
 
 msgid "Searching"
 msgstr "Searching"
 
 msgid "Searching east ..."
-msgstr "Searching east ..."
+msgstr "Searching east..."
 
 msgid "Searching for available updates. Please wait..."
-msgstr "Searching for available updates. Please wait..."
+msgstr "Searching for available updates, please wait..."
 
 msgid "Searching for new installed or removed packages. Please wait..."
-msgstr "Searching for new installed or removed packages. Please wait..."
+msgstr "Searching for newly-installed or removed packages..."
 
 msgid "Searching west ..."
-msgstr "Searching west ..."
+msgstr "Searching west..."
+
+msgid "Searching your network. Please wait..."
+msgstr "Searching your network, please wait..."
 
 msgid "Second cable of motorized LNB"
 msgstr "Second cable of motorized LNB"
 
 msgid "SecondInfoBar"
-msgstr "SecondInfoBar"
+msgstr "Second infobar"
 
 msgid "Secondary DNS"
 msgstr "Secondary DNS"
 
-#, fuzzy
 msgid "Secondinfobar:"
-msgstr "SecondInfoBar"
+msgstr "Second infobar:"
 
 msgid "Seek"
 msgstr "Seek"
@@ -13991,29 +14097,28 @@ msgid "Select 'yes' to only send the DiSEqC command when changing from one satel
 msgstr ""
 
 msgid "Select (source list) or enter directory (target list)"
-msgstr ""
+msgstr "Select (source list) or enter folder (target list)"
 
 msgid "Select CAId"
 msgstr "Select CAId"
 
-#, fuzzy
 msgid "Select Card Server"
-msgstr "Select a movie"
+msgstr "Select Card Server"
 
 msgid "Select Enigma2 Skin"
-msgstr "Select Enigma2 Skin"
+msgstr "Select User Interface Skin"
 
-msgid "Select Fast DiSEqC if your aerial system supports this. If you are unsure select 'no'."
+msgid "Select Fast DiSEqC if your aerial system supports this. Select 'no' if you're unsure."
 msgstr ""
 
 msgid "Select HDD"
 msgstr "Select HDD"
 
 msgid "Select LCD Skin"
-msgstr "Select LCD Skin"
+msgstr "Select Front Panel Display Skin"
 
 msgid "Select Lan/Wlan"
-msgstr "Select Lan/Wlan"
+msgstr "Select LAN/Wireless network"
 
 msgid "Select Location"
 msgstr "Select Location"
@@ -14022,23 +14127,22 @@ msgid "Select Quad Channels"
 msgstr "Select Quad Channels"
 
 msgid "Select Red-key action"
-msgstr "Select Red-key action"
+msgstr "Red button"
 
 msgid "Select Red-key action long"
-msgstr "Select Red-key action long"
+msgstr "Red button hold"
 
-#, fuzzy
 msgid "Select Softcam"
-msgstr "select Slot"
+msgstr "Select Softcam"
 
 msgid "Select Software Update"
 msgstr "Select Software Update"
 
 msgid "Select Yellow Key Action"
-msgstr "Select Yellow Key Action"
+msgstr "Yellow button"
 
 msgid "Select Yellow Key Action long"
-msgstr "Select Yellow Key Action long"
+msgstr "Yellow button hold"
 
 msgid "Select Your Skin"
 msgstr "Select Your Skin"
@@ -14052,9 +14156,8 @@ msgstr "Select a movie"
 msgid "Select a network adapter"
 msgstr "Select a network adapter"
 
-#, fuzzy
 msgid "Select a path"
-msgstr "Select a tuner"
+msgstr "Select a path"
 
 msgid "Select a script to run:"
 msgstr "Select a script to run:"
@@ -14076,13 +14179,13 @@ msgid "Select additional backup files"
 msgstr "Select additional backup files"
 
 msgid "Select additional files to backup"
-msgstr "Select additional files to backup"
+msgstr "Select additional files to back up"
 
 msgid "Select an image to be downloaded"
 msgstr "Select an image to be downloaded"
 
 msgid "Select audio track"
-msgstr "Select audio track"
+msgstr "Select Audio Track"
 
 msgid "Select backup location"
 msgstr "Select backup location"
@@ -14091,7 +14194,7 @@ msgid "Select channel audio"
 msgstr "Select channel audio"
 
 msgid "Select channel to record from"
-msgstr "Select channel to record from"
+msgstr "Select channel to record"
 
 msgid "Select copy destination for:"
 msgstr "Select copy destination for:"
@@ -14112,7 +14215,7 @@ msgid "Select files to exclude from backup"
 msgstr "Select files to exclude from backup"
 
 msgid "Select files/folders to backup"
-msgstr "Select files/folders to backup"
+msgstr "Select files/folders to back up"
 
 msgid "Select folders"
 msgstr "Select folders"
@@ -14124,13 +14227,13 @@ msgid "Select how the satellite dish is set up. i.e. fixed dish, single LNB, DiS
 msgstr ""
 
 msgid "Select how to activate the Quick EPG mode:"
-msgstr "Select how to activate the Quick EPG mode:"
+msgstr "Choose how to activate quick EPG mode."
 
 msgid "Select how your box will upgrade."
-msgstr "Select how your box will upgrade."
+msgstr "Select how your box should upgrade."
 
 msgid "Select if timeshift must continue when set to record."
-msgstr "Select if timeshift must continue when set to record."
+msgstr "Select whether timeshift should continue when set to record."
 
 msgid "Select if you want the Subservice mode to be activated."
 msgstr "Select if you want the Subservice mode to be activated."
@@ -14154,7 +14257,7 @@ msgid "Select of the number"
 msgstr "Select of the number"
 
 msgid "Select provider to add..."
-msgstr "Select provider to add..."
+msgstr "Select a provider to add..."
 
 msgid "Select refresh rate"
 msgstr "Select refresh rate"
@@ -14163,10 +14266,10 @@ msgid "Select satellites"
 msgstr "Select satellites"
 
 msgid "Select seekbar to be activated by arrow L/R (long) or << >> (long)."
-msgstr "Select seekbar to be activated by arrow L/R (long) or << >> (long)."
+msgstr "Choose whether to activate the seekbar by holding down the ◀︎ / ▶︎ or ◀︎◀︎ / ▶︎▶︎ buttons."
 
 msgid "Select service to add..."
-msgstr "Select service to add..."
+msgstr "Select a service to add..."
 
 msgid "Select sort method:"
 msgstr "Select sort method:"
@@ -14175,7 +14278,7 @@ msgid "Select target folder"
 msgstr "Select target folder"
 
 msgid "Select the Swap File Size:"
-msgstr "Select the Swap File Size:"
+msgstr "Enter Swap File Size:"
 
 msgid "Select the Unicable channel to be assigned to this tuner. This is a unique value. Be certain that no other device connected to this same Unicable system is allocated to the same Unicable channel."
 msgstr ""
@@ -14199,7 +14302,10 @@ msgid "Select the character or action under the virtual keyboard cursor"
 msgstr ""
 
 msgid "Select the desired function and click on \"OK\" to assign it. Use \"CH+/-\" to toggle between the lists. Select an assigned function and click on \"OK\" to de-assign it. Use \"Next/Previous\" to change the order of the assigned functions."
-msgstr "Select the desired function and click on \"OK\" to assign it. Use \"CH+/-\" to toggle between the lists. Select an assigned function and click on \"OK\" to de-assign it. Use \"Next/Previous\" to change the order of the assigned functions."
+msgstr ""
+"Select the desired function, then press OK to assign it. Use CH +/- to toggle between the lists.\n"
+"Select an assigned function, then press OK to unassign it.\n"
+"Use the Next and Previous buttons to change the order of the assigned functions."
 
 msgid "Select the manufacturer of your SCR device. If the manufacturer is not listed, set 'SCR' to 'user defined' and enter the device parameters manually according to its spec sheet."
 msgstr ""
@@ -14217,34 +14323,34 @@ msgid "Select the protocol used by your SCR device. Choices are 'SCR Unicable' (
 msgstr ""
 
 msgid "Select the satellite which is connected to Port-A of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'."
-msgstr ""
+msgstr "Select the satellite which is connected to Port A of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'."
 
 msgid "Select the satellite which is connected to Port-B of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'."
-msgstr ""
+msgstr "Select the satellite which is connected to Port B of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'."
 
 msgid "Select the satellite which is connected to Port-C of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'."
-msgstr ""
+msgstr "Select the satellite which is connected to Port C of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'."
 
 msgid "Select the satellite which is connected to Port-D of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'."
-msgstr ""
+msgstr "Select the satellite which is connected to Port D of your switch. If you are unsure select 'automatic' and the receiver will attempt to determine this for you. If nothing is connected to this port, select 'nothing connected'."
 
 msgid "Select the satellite you want to configure. Once that satellite is configured you can select and configure other satellites that will be accessed using this same tuner."
-msgstr ""
+msgstr "Select the satellite you want to configure. Once that satellite is configured, you can select and configure other satellites that will be accessed using this same tuner."
 
 msgid "Select the satellite your dish receives from. If you are unsure select 'automatic' and the receiver will attempt to determine this for you."
-msgstr ""
+msgstr "Select the satellite your dish is pointed at. If you are unsure select 'automatic' and the receiver will attempt to determine this for you."
 
 msgid "Select the sleep timer action."
 msgstr "Select the sleep timer action."
 
 msgid "Select the tuner that controls the motorised dish."
-msgstr ""
+msgstr "Select which tuner should be used to control the motorized dish."
 
 msgid "Select the tuner that this loopthrough depends on."
 msgstr ""
 
 msgid "Select the tuner to which the signal cable of the SCR device is connected."
-msgstr ""
+msgstr "Select the tuner your SCR device is connected to"
 
 msgid "Select the type of LNB/device being used (normally 'Universal'). If your LNB type is not available select 'user defined'."
 msgstr ""
@@ -14274,40 +14380,40 @@ msgid "Select video mode"
 msgstr "Select video mode"
 
 msgid "Select what should be done when the %s %s was boot-up, normal playing or goto standby."
-msgstr "Select what should be done when the %s %s was boot-up, normal playing or goto standby."
+msgstr "Select whether your %s %s should start up normally or just go straight to standby."
 
 msgid "Select what should be done when the %s %s was shutdown incorrectly, or after the Power was lost."
-msgstr "Select what should be done when the %s %s was shutdown incorrectly, or after the Power was lost."
+msgstr "Select what should happen when your %s %s hasn't been shut down properly (e.g after losing power)."
 
 msgid "Select what you want the Channel +/- button to activate:"
-msgstr "Select what you want the Channel +/- button to activate:"
+msgstr "Choose what you'd like the Channel +/- buttons to do."
 
 msgid "Select what you want the EPG button to activate:"
-msgstr "Select what you want the EPG button to activate:"
+msgstr "Choose what you'd like the EPG button to do."
 
 msgid "Select what you want the INFO button to activate:"
-msgstr "Select what you want the INFO button to activate:"
+msgstr "Choose what you'd like the Info button to do."
 
 msgid "Select what you want the OK button to activate:"
-msgstr "Select what you want the OK button to activate:"
+msgstr "Choose what you'd like the OK button to do."
 
 msgid "Select what you want the RED button to activate:"
-msgstr "Select what you want the RED button to activate:"
+msgstr "Choose what you'd like the Red button to do."
 
 msgid "Select what you want the RED-Long button to activate:"
-msgstr "Select what you want the RED-Long button to activate:"
+msgstr "Choose what you'd like the Red button to do when held down."
 
 msgid "Select what you want the TV button to activate:"
-msgstr "Select what you want the TV button to activate:"
+msgstr "Choose what you'd like the TV button to do."
 
 msgid "Select what you want the Up/Down button to activate:"
-msgstr "Select what you want the Up/Down button to activate:"
+msgstr "Choose what you'd like the Up/Down button to do."
 
 msgid "Select what you want the YELLOW button to activate:"
-msgstr "Select what you want the YELLOW button to activate:"
+msgstr "Choose what you'd like the Yellow button to do."
 
 msgid "Select what you want the YELLOW-Long button to activate:"
-msgstr "Select what you want the YELLOW-Long button to activate:"
+msgstr "Choose what you'd like the Yellow button to do when held down."
 
 msgid "Select wireless network"
 msgstr "Select wireless network"
@@ -14317,19 +14423,19 @@ msgid "Select your ATSC provider."
 msgstr "ATSC provider"
 
 msgid "Select your Language for Audio/Subtitles"
-msgstr "Select your Language for Audio/Subtitles"
+msgstr "Select your language for audio/subtitles"
 
 msgid "Select your country. If not available select 'all'."
-msgstr ""
+msgstr "Select your country. If it's not listed, select 'all'"
 
 msgid "Select your provider and region. If not present in this list you will need to select one of the other 'service scan types'."
-msgstr ""
+msgstr "Select your provider and region. If they're not listed, you'll need to select a different 'service scan type'."
 
 msgid "Select your provider, and press OK to start the scan"
-msgstr "Select your provider, and press OK to start the scan"
+msgstr "Select your provider, then press OK to start the scan"
 
 msgid "Select your region. If not available change 'Country' to 'all' and select one of the default alternatives."
-msgstr ""
+msgstr "Select your region. If it's not listed, change 'Country' to 'all' and select one of the default alternatives."
 
 #, fuzzy, python-format
 msgid "Selected Image:\t\t%s"
@@ -14344,12 +14450,12 @@ msgid ""
 "\n"
 "Do you want to install this settinglist?"
 msgstr ""
-"Selected settingslist:\n"
+"Selected settings:\n"
 "\n"
 "Setting: %s\n"
 "Date: %s\n"
 "\n"
-"Do you want to install this settinglist?"
+"Would you like to install these settings?"
 
 #, python-format
 msgid ""
@@ -14359,7 +14465,7 @@ msgid ""
 msgstr ""
 "Selected settingslist: %s\n"
 "\n"
-"Do you want to delete this settinglist?"
+"Would you like to delete these settings?"
 
 #, python-format
 msgid ""
@@ -14369,7 +14475,7 @@ msgid ""
 msgstr ""
 "Selected settingslist: %s\n"
 "\n"
-"Do you want to restore this settinglist?"
+"Would you like to restore these settings?"
 
 msgid "Selecting satellites 1 (USALS)"
 msgstr "Selecting satellites 1 (USALS)"
@@ -14377,9 +14483,8 @@ msgstr "Selecting satellites 1 (USALS)"
 msgid "Selecting satellites 2 (USALS)"
 msgstr "Selecting satellites 2 (USALS)"
 
-#, fuzzy
 msgid "Selecting this option allows you to configure a group of satellites in one block."
-msgstr "This option allows you to disable sorting of the Extensions list."
+msgstr "Selecting this option lets you to configure a group of satellites in one block."
 
 msgid "Send"
 msgstr "Send"
@@ -14393,6 +14498,7 @@ msgstr "Send DiSEqC"
 msgid "Send DiSEqC only on satellite change"
 msgstr "Send DiSEqC only on satellite change"
 
+#. TRANSLATORS: regional option
 msgid "Senegal"
 msgstr "Senegal"
 
@@ -14402,24 +14508,27 @@ msgstr "Seperate titles with a main menu"
 msgid "Sequence repeat"
 msgstr "Sequence repeat"
 
+#. TRANSLATORS: regional option
 msgid "Serbia"
 msgstr "Serbia"
 
+#. TRANSLATORS: regional option
 msgid "Serbian"
 msgstr "Serbian"
 
 msgid "Serial No"
 msgstr "Serial No"
 
+#. TRANSLATORS: genre category
 msgid "Serie"
-msgstr ""
+msgstr "Series"
 
 msgid "Serv.Name"
 msgstr "Serv.Name"
 
 #, python-format
 msgid "Server Info ( Oscam-Version: %s )"
-msgstr "Server Info ( Oscam-Version: %s )"
+msgstr "Server Info ( Oscam Version: %s )"
 
 msgid "Server down"
 msgstr "Server down"
@@ -14440,36 +14549,34 @@ msgid "Service Information"
 msgstr "Service Information"
 
 msgid "Service Name"
-msgstr "Service Name"
+msgstr "channel name"
 
-#, fuzzy
 msgid "Service Number and Service Name"
-msgstr "Picon and Service Name"
+msgstr "channel number and name"
 
-#, fuzzy
 msgid "Service Number, Picon and Service Name"
-msgstr "Picon and Service Name"
+msgstr "channel number, name and picon"
 
 msgid "Service Title mode"
-msgstr "Service Title mode"
+msgstr "Channel title style"
 
 msgid "Service cant been added to the favourites."
-msgstr "Service cant been added to the favourites."
+msgstr "Channel can't be added to favorites."
 
 msgid "Service font size"
-msgstr "Service font size"
+msgstr "Channel name text size"
 
 msgid "Service has been added to the favourites."
-msgstr "Service has been added to the favourites."
+msgstr "Channel has been added to favorites."
 
 msgid "Service has been added to the selected bouquet."
-msgstr "Service has been added to the selected bouquet."
+msgstr "Channel has been added to the selected bouquet."
 
 msgid "Service info"
-msgstr "Service info"
+msgstr "Chanbnel info"
 
 msgid "Service info font size"
-msgstr "Service info font size"
+msgstr "Channel info text size"
 
 msgid ""
 "Service invalid!\n"
@@ -14479,10 +14586,10 @@ msgstr ""
 "(Timeout reading PMT)"
 
 msgid "Service name"
-msgstr "Service name"
+msgstr "Channel name"
 
 msgid "Service name font size"
-msgstr "Service name font size"
+msgstr "Channel name text size"
 
 msgid ""
 "Service not found!\n"
@@ -14492,66 +14599,62 @@ msgstr ""
 "(SID not found in PAT)"
 
 msgid "Service number font size"
-msgstr "Service number font size"
+msgstr "Channel number text size"
 
-#, fuzzy
 msgid "Service off-air"
-msgstr "Service Name"
+msgstr "Channel off air"
 
-#, fuzzy
 msgid "Service picons aspect ratio"
-msgstr "Service picons downsize"
+msgstr "Channel picon aspect ratio"
 
 msgid "Service picons downsize"
-msgstr "Service picons downsize"
+msgstr "Channel picon downsize"
 
 msgid "Service reference"
 msgstr "Service reference"
 
 msgid "Service scan"
-msgstr "Service scan"
+msgstr "Channel Scan"
 
 msgid ""
 "Service unavailable!\n"
 "Check tuner configuration!"
 msgstr ""
-"Service unavailable!\n"
+"Channel unavailable!\n"
 "Check tuner configuration!"
 
 msgid "Service width"
-msgstr "Service width"
+msgstr "Channel name width"
 
 msgid "ServiceName"
-msgstr "ServiceName"
+msgstr "Channel name"
 
 msgid "ServicePicon"
-msgstr "ServicePicon"
+msgstr "Channel picon"
 
 msgid "Serviceinfo"
-msgstr "Serviceinfo"
+msgstr "Channel Info"
 
 msgid "Services"
-msgstr "Services"
+msgstr "Channels"
 
 msgid "Services may be grouped in bouquets. When enabled, you can use more than one bouquet."
-msgstr "Services may be grouped in bouquets. When enabled, you can use more than one bouquet."
+msgstr "Channels can be grouped into bouquets. When enabled, more than one bouquet can be used."
 
-#, fuzzy
 msgid "Set Basetime"
-msgstr "Base time"
+msgstr "Set base time"
 
 msgid "Set CI assignment for detection of available services."
 msgstr "Set CI assignment for detection of available services."
 
 msgid "Set Framerate for MiniTV"
-msgstr "Set Framerate for MiniTV"
+msgstr "Set mini TV frame rate (FPS)"
 
 msgid "Set System"
 msgstr "Set System"
 
-#, fuzzy
 msgid "Set action for 'Info' key"
-msgstr "Select action for timer %s:"
+msgstr "Info button"
 
 msgid "Set archive mode (644)"
 msgstr ""
@@ -14560,7 +14663,7 @@ msgid "Set default"
 msgstr "Set default"
 
 msgid "Set end time"
-msgstr "Set end time"
+msgstr "End time"
 
 msgid "Set executable mode (755)"
 msgstr ""
@@ -14572,51 +14675,50 @@ msgid "Set for 'stout' and 'sterr' the number of lines in script info or script 
 msgstr ""
 
 msgid "Set fps for external subtitles"
-msgstr "Set fps for external subtitles"
+msgstr "External subtitle FPS"
 
 msgid "Set interface as the default Interface"
-msgstr "Set interface as the default Interface"
+msgstr "Set this interface as the default"
 
 msgid "Set limits"
 msgstr "Set limits"
 
 msgid "Set pin code persistent"
-msgstr "Set pin code persistent"
+msgstr "Set persistent PIN code"
 
 msgid "Set sequence repeats if your aerial system requires this. Normally if the aerial system has been configured correctly sequence repeats will not be necessary. If yours does, recheck you have command order set correctly."
 msgstr ""
 
 msgid "Set startup service"
-msgstr "Set startup service"
+msgstr "Select when to set this as the startup channel"
 
 #, python-format
 msgid "Set the MAC-address of your %s %s.\n"
-msgstr "Set the MAC-address of your %s %s.\n"
+msgstr "Set the MAC address of your %s %s.\n"
 
-#, fuzzy
 msgid "Set the aspect ratio of the service picons."
-msgstr "The aspect ratio of the recording."
+msgstr "Set channel picon aspect ratio."
 
 msgid "Set the channel for this timer."
 msgstr "Set the channel for this timer."
 
 msgid "Set the date the timer must start."
-msgstr "Set the date the timer must start."
+msgstr "Set the timer start date."
 
 msgid "Set the default location for your autorecord-files. Press 'OK' to add new locations, select left/right to select an existing location."
-msgstr "Set the default location for your autorecord-files. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr "Set the default location for auto-record files. Press OK to add a new location, or use the ◀︎ Left and ▶︎ Right buttons to select an existing location."
 
 msgid "Set the default location for your instant recordings. Press 'OK' to add new locations, select left/right to select an existing location."
-msgstr "Set the default location for your instant recordings. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr "Set the default location for instant recordings. Press OK to add a new location, or use the ◀︎ Left and ▶︎ Right buttons to select an existing location."
 
 msgid "Set the default location for your recordings. Press 'OK' to add new locations, select left/right to select an existing location."
-msgstr "Set the default location for your recordings. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr "Set the default location for recordings. Press OK to add a new location, or use the ◀︎ Left and ▶︎ Right buttons to select an existing location."
 
 msgid "Set the default location for your timers. Press 'OK' to add new locations, select left/right to select an existing location."
-msgstr "Set the default location for your timers. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr "Set the default location for timer recordings. Press OK to add a new location, or use the ◀︎ Left and ▶︎ Right buttons to select an existing location."
 
 msgid "Set the default location for your timeshift-files. Press 'OK' to add new locations, select left/right to select an existing location."
-msgstr "Set the default location for your timeshift-files. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr "Set the default location for timeshift buffer files. Press OK to add a new location, or use the ◀︎ Left and ▶︎ Right buttons to select an existing location."
 
 msgid "Set the default sorting method."
 msgstr "Set the default sorting method."
@@ -14625,46 +14727,46 @@ msgid "Set the delay time between repeated loops, this is used by software rende
 msgstr "Set the delay time between repeated loops, this is used by software renderer in some skins."
 
 msgid "Set the description of the recording."
-msgstr "Set the description of the recording."
+msgstr "Enter a description for this recording."
 
 msgid "Set the jump-size of the seekbar."
-msgstr "Set the jump-size of the seekbar."
+msgstr "Set the seekbar jump size."
 
 msgid "Set the name the recording will get."
-msgstr "Set the name the recording will get."
+msgstr "Enter a name for this recording."
 
 msgid "Set the position of the recording icons"
-msgstr "Set the position of the recording icons"
+msgstr "Choose where recording icons should appear"
 
 msgid "Set the screen type you get on pressing 'OK' when the info bar shows to 2nd infobar Lite or event info."
-msgstr "Set the screen type you get on pressing 'OK' when the info bar shows to 2nd infobar Lite or event info."
+msgstr "Set which screen should be shown after pressing OK on the infobar - second infobar lite or Event Info."
 
 msgid "Set the scrolling speed of text on the front display, this is used by software renderer in some skins."
-msgstr "Set the scrolling speed of text on the front display, this is used by software renderer in some skins."
+msgstr "Set the front panel display text scroll speed used by software renderer in some skins."
 
 msgid "Set the scrolling speed of text on the front display."
-msgstr "Set the scrolling speed of text on the front display."
+msgstr "Set the front panel display text scroll speed."
 
 msgid "Set the time before checking video source for resolution information."
-msgstr "Set the time before checking video source for resolution information."
+msgstr "Set the delay before checking video source for resolution information."
 
 msgid "Set the time the timer must start."
-msgstr "Set the time the timer must start."
+msgstr "Set the timer begin time."
 
 msgid "Set the time the timer must stop."
-msgstr "Set the time the timer must stop."
+msgstr "Set the timer end time."
 
 msgid "Set the time to hide the infobar."
-msgstr "Set the time to hide the infobar."
+msgstr "Set the time after which the infobar should be hidden."
 
 msgid "Set the time to hide the second infobar. The bar also disappears on pressing 'OK'."
-msgstr "Set the time to hide the second infobar. The bar also disappears on pressing 'OK'."
+msgstr "Set the time after which the second infobar should be hidden. The infobar can also closed by pressing OK again."
 
-msgid "Set the time to wait for execute the default action in shutdown, standby or restart messages. (e.g. used in Timer, PowerTimer, Sleeptimer, ...)"
-msgstr ""
+msgid "Set the time to wait for execute the default action in shutdown, standby or restart messages. (e.g. used in Timer, Power Timer, Sleep timer, ...)"
+msgstr "Set the time to wait before performing the default action in shutdown, standby or restart message prompts (as used in timers, power timers, sleep timers, etc...)"
 
 msgid "Set the type of the progress indication in the channel selection screen."
-msgstr "Set the type of the progress indication in the channel selection screen."
+msgstr "Set the type of progress indicator to show on the channel list."
 
 msgid "Set time window to 1 hour"
 msgstr "Set time window to 1 hour"
@@ -14685,13 +14787,13 @@ msgid "Set time window to 6 hours"
 msgstr "Set time window to 6 hours"
 
 msgid "Set to the desired primetime (hour)."
-msgstr "Set to the desired primetime (hour)."
+msgstr "Set to your preferred primetime hour."
 
 msgid "Set to the desired primetime (minutes."
-msgstr "Set to the desired primetime (minutes."
+msgstr "Set to your preferred primetime minute."
 
 msgid "Set to what you want the button to do."
-msgstr "Set to what you want the button to do."
+msgstr "Choose what you'd like this button to do."
 
 #, fuzzy
 msgid "Set to yes for debugging the root cause of a spinner."
@@ -14701,7 +14803,7 @@ msgid "Set voltage and 22KHz"
 msgstr "Set voltage and 22KHz"
 
 msgid "Sets the root folder of movie list, to remove the '..' from benign shown in that folder."
-msgstr "Sets the root folder of movie list, to remove the '..' from benign shown in that folder."
+msgstr "Sets the root folder of the movie list, to remove the '..' from beginning shown in that folder."
 
 msgid "Setting Restored "
 msgstr "Setting Restored "
@@ -14709,8 +14811,9 @@ msgstr "Setting Restored "
 msgid "Settings"
 msgstr "Settings"
 
+#. TRANSLATORS: used on Channel Selection List menu and Usage & GUI menu
 msgid "Settings..."
-msgstr "Settings..."
+msgstr "Settings"
 
 msgid "Setup"
 msgstr "Setup"
@@ -14720,91 +14823,91 @@ msgid "Setup - %s"
 msgstr "Setup - %s"
 
 msgid "Setup AFP"
-msgstr "Setup AFP"
+msgstr "Set Up AFP"
 
 msgid "Setup Audio Sync"
-msgstr "Setup Audio Sync"
+msgstr "Set Up Audio Sync"
 
 msgid "Setup Audio Sync settings"
-msgstr "Setup Audio Sync settings"
+msgstr "Set Up Audio Sync"
 
 msgid "Setup Audiomode"
-msgstr "Setup Audiomode"
+msgstr "Set Up Audio"
 
 msgid "Setup Enigma2"
-msgstr "Setup Enigma2"
+msgstr "Set up Enigma2"
 
 msgid "Setup FTP"
-msgstr "Setup FTP"
+msgstr "Set Up FTP"
 
 msgid "Setup Harddisk"
-msgstr "Setup Harddisk"
+msgstr "Set Up Hard Disk"
 
 msgid "Setup Inadyn"
-msgstr "Setup Inadyn"
+msgstr "Set Up Inadyn"
 
 msgid "Setup InputDevice"
-msgstr "Setup InputDevice"
+msgstr "Set Up Input Device"
 
 msgid "Setup Language"
-msgstr "Setup Language"
+msgstr "Set Up Language"
 
 msgid "Setup MiniDLNA"
-msgstr "Setup MiniDLNA"
+msgstr "Set Up MiniDLNA"
 
 msgid "Setup Mounts"
-msgstr "Setup Mounts"
+msgstr "Set up mounts"
 
 msgid "Setup NFS"
-msgstr "Setup NFS"
+msgstr "Set Up NFS"
 
 msgid "Setup Network Services"
-msgstr "Setup Network Services"
+msgstr "Set up network services"
 
 msgid "Setup Network Services (Samba, Ftp, NFS, ...)"
-msgstr "Setup Network Services (Samba, Ftp, NFS, ...)"
+msgstr "Set up network services (Samba, FTP, NFS, etc...)"
 
 msgid "Setup OpenVPN"
-msgstr "Setup OpenVPN"
+msgstr "Set Up OpenVPN"
 
 msgid "Setup Plugin filter"
-msgstr "Setup Plugin filter"
+msgstr "Set Up Plugin Filter"
 
 msgid "Setup Plugin filter. Here you can select which Plugins are showed in the PluginBrowser"
-msgstr "Setup Plugin filter. Here you can select which Plugins are showed in the PluginBrowser"
+msgstr "Set up plugin filter. Here you can select which Plugins are shown in the Plugin Browser"
 
 msgid "Setup Plugins"
-msgstr "Setup Plugins"
+msgstr "Set Up Plugins"
 
 msgid "Setup SABnzbd"
-msgstr "Setup SABnzbd"
+msgstr "Set Up SABnzbd"
 
 msgid "Setup Samba"
-msgstr "Setup Samba"
+msgstr "Set Up Samba"
 
 msgid "Setup Telnet"
-msgstr "Setup Telnet"
+msgstr "Set Up Telnet"
 
 msgid "Setup Tuner"
-msgstr "Setup Tuner"
+msgstr "Set Up Tuner"
 
 msgid "Setup Video/Audio"
-msgstr "Setup Video/Audio"
+msgstr "Set Up Audio & Video"
 
 msgid "Setup Videomode"
-msgstr "Setup Videomode"
+msgstr "Set Up Video"
 
 msgid "Setup delay mode to zap to channels."
-msgstr "Setup delay mode to zap to channels."
+msgstr "Set up delay mode to zap to channels."
 
 msgid "Setup each tuner for your satellite system"
-msgstr "Setup each tuner for your satellite system"
+msgstr "Set up your satellite system's tuners."
 
 msgid "Setup how to control the channel changing."
-msgstr "Setup how to control the channel changing."
+msgstr "Set up how to control the channel changing."
 
 msgid "Setup interface"
-msgstr "Setup interface"
+msgstr "Set up interface"
 
 msgid "Setup menu"
 msgstr "Setup menu"
@@ -14813,101 +14916,102 @@ msgid "Setup mode"
 msgstr "Setup mode"
 
 msgid "Setup network time synchronization interval."
-msgstr "Setup network time synchronization interval."
+msgstr "Set up network time synchronization interval."
 
 msgid "Setup network. Here you can setup DHCP, IP, DNS"
-msgstr "Setup network. Here you can setup DHCP, IP, DNS"
+msgstr "Set up network. Here you can setup DHCP, IP, DNS"
 
 msgid "Setup rotor"
-msgstr "Setup rotor"
+msgstr "Set up rotator"
 
 msgid "Setup the interval to check for online updates. (in hours)"
-msgstr "Setup the interval to check for online updates. (in hours)"
+msgstr "Set up the interval to check for online updates. (in hours)"
 
 msgid "Setup tuner(s)"
-msgstr "Setup tuner(s)"
+msgstr "Set up tuner(s)"
 
 msgid "Setup uShare"
-msgstr "Setup uShare"
+msgstr "Set up uShare"
 
 msgid "Setup your Audio Mode"
-msgstr "Setup your Audio Mode"
+msgstr "Set up your audio mode"
 
 msgid "Setup your Channel selection configuration"
-msgstr "Setup your Channel selection configuration"
+msgstr "Set up channel selection options"
 
 msgid "Setup your Device mounts (USB, HDD, others...)"
-msgstr "Setup your Device mounts (USB, HDD, others...)"
+msgstr "Set up your device mounts (USB, HDD, etc...)"
 
 msgid "Setup your EPG config"
-msgstr "Setup your EPG config"
+msgstr "Set up your EPG config"
 
 msgid "Setup your Harddisk"
-msgstr "Setup your Harddisk"
+msgstr "Set up your hard disk"
 
 msgid "Setup your LCD"
-msgstr "Setup your LCD"
+msgstr "Set up your front panel display (LCD/VFD)"
 
 msgid "Setup your OSD"
-msgstr "Setup your OSD"
+msgstr "Set up your OSD"
 
 msgid "Setup your Skin"
-msgstr "Setup your Skin"
+msgstr "Set up your skin"
 
 msgid "Setup your System"
-msgstr "Setup your System"
+msgstr "Set up your system"
 
 msgid "Setup your Tuner and search for channels"
-msgstr "Setup your Tuner and search for channels"
+msgstr "Set up your tuner and search for channels"
 
 msgid "Setup your Video Mode, Video Output and other Video Settings"
-msgstr "Setup your Video Mode, Video Output and other Video Settings"
+msgstr "Set up your video mode, video output and other video settings"
 
 msgid "Setup your display"
-msgstr "Setup your display"
+msgstr "Set up your display"
 
 msgid "Setup your local network"
-msgstr "Setup your local network"
+msgstr "Set Up Local Network"
 
 msgid "Setup your local network. For Wlan you need to boot with a USB-Wlan stick"
-msgstr "Setup your local network. For Wlan you need to boot with a USB-Wlan stick"
+msgstr "Set up your local network. For wireless network, you need to connect a wireless network adapter"
 
 msgid "Setup your mounts for network"
-msgstr "Setup your mounts for network"
+msgstr "Set up your device and network mounts"
 
 msgid "Setup your network interface. If no Wlan stick is used, you only can select Lan"
-msgstr "Setup your network interface. If no Wlan stick is used, you only can select Lan"
+msgstr "Set up your network interface. If you haven't connected a wireless network adapter, you'll only be able to select LAN"
 
 msgid "Setup your network mounts"
-msgstr "Setup your network mounts"
+msgstr "Set up your network mounts"
 
 msgid "Setup your positioner"
-msgstr "Setup your positioner"
+msgstr "Set up your positioner"
 
 msgid "Setup your positioner for your satellite system"
-msgstr "Setup your positioner for your satellite system"
+msgstr "Set up your satellite system's positioner."
 
 msgid "Setup your recording config"
-msgstr "Setup your recording config"
+msgstr "Set up your recording preferences"
 
 msgid "Setup your remote buttons"
-msgstr "Setup your remote buttons"
+msgstr "Set up your remote control buttons"
 
 msgid "Setup your satellite equipment"
-msgstr "Setup your satellite equipment"
+msgstr "Set up your satellite equipment"
 
 msgid "Setup your timezone."
-msgstr "Setup your timezone."
+msgstr "Set up your time zone"
 
+#. TRANSLATORS: regional option
 msgid "Seychelles"
 msgstr "Seychelles"
 
 #, python-format
 msgid "Shall the USB stick wizard proceed and program the image file %s into flash memory?"
-msgstr "Shall the USB stick wizard proceed and program the image file %s into flash memory?"
+msgstr "Proceed with the USB stick wizard write the image %s to flash memory?"
 
 msgid "Share Folder's"
-msgstr "Share Folder's"
+msgstr "Share Folders"
 
 msgid "Share View"
 msgstr "Share View"
@@ -14924,13 +15028,13 @@ msgstr "Shellscript"
 msgid "Shift"
 msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Shopping"
-msgstr "zapping"
+msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Short Film"
-msgstr "Short filenames"
+msgstr ""
 
 msgid "Short filenames"
 msgstr "Short filenames"
@@ -14963,35 +15067,32 @@ msgstr "Show 1080p 25fps as"
 msgid "Show 1080p 30fps as"
 msgstr "Show 1080p 30fps as"
 
-#, fuzzy
 msgid "Show 2160p 24fps as"
-msgstr "Show 720p 24fps as"
+msgstr ""
 
-#, fuzzy
 msgid "Show 2160p 25fps as"
-msgstr "Show 1080p 25fps as"
+msgstr ""
 
-#, fuzzy
 msgid "Show 2160p 30fps as"
-msgstr "Show 1080p 30fps as"
+msgstr ""
 
 msgid "Show 24p up to 720p / higher than 720p as"
 msgstr "Show 24p up to 720p / higher than 720p as"
 
 msgid "Show 24p up to resolution 720p or higher than 720p as a different Framerate."
-msgstr "Show 24p up to resolution 720p or higher than 720p as a different Framerate."
+msgstr "Show 24p up to resolution 720p or higher than 720p as a different frame rate."
 
 msgid "Show 25p up to 720p / higher than 720p as"
 msgstr "Show 25p up to 720p / higher than 720p as"
 
 msgid "Show 25p up to resolution 720p or higher than 720p as a different Framerate."
-msgstr "Show 25p up to resolution 720p or higher than 720p as a different Framerate."
+msgstr "Show 25p up to resolution 720p or higher than 720p as a different frame rate."
 
 msgid "Show 30p up to 720p / higher than 720p as"
 msgstr "Show 30p up to 720p / higher than 720p as"
 
 msgid "Show 30p up to resolution 720p or higher than 720p as a different Framerate."
-msgstr "Show 30p up to resolution 720p or higher than 720p as a different Framerate."
+msgstr "Show 30p up to resolution 720p or higher than 720p as a different frame rate."
 
 msgid "Show 480/576p 24fps as"
 msgstr "Show 480/576p 24fps as"
@@ -15000,7 +15101,7 @@ msgid "Show 720p 24fps as"
 msgstr "Show 720p 24fps as"
 
 msgid "Show Audioselection"
-msgstr "Show Audioselection"
+msgstr "Show audio selection"
 
 msgid "Show AutoTimer List"
 msgstr "Show AutoTimer List"
@@ -15009,7 +15110,7 @@ msgid "Show Box Portal..."
 msgstr "Show Box Portal..."
 
 msgid "Show CCcam in extensions ?"
-msgstr "Show CCcam in extensions ?"
+msgstr "Show CCcam on Extensions screen?"
 
 msgid "Show CI messages"
 msgstr "Show CI messages"
@@ -15030,25 +15131,25 @@ msgid "Show CoolSingleGuide"
 msgstr "Show CoolSingleGuide"
 
 msgid "Show CoolTVGuide"
-msgstr "Show CoolTVGuide"
+msgstr "Show Cool TV Guide"
 
 msgid "Show Display Icons"
-msgstr "Show Display Icons"
+msgstr "Show symbols on front panel display"
 
 msgid "Show E2 Log"
-msgstr "Show E2 Log"
+msgstr "Show Enigma2 Log"
 
 msgid "Show EIT now/next in infobar"
-msgstr "Show EIT now/next in infobar"
+msgstr "Show now/next on infobar"
 
 msgid "Show EPG"
 msgstr "Show EPG"
 
 msgid "Show EPG for current channel..."
-msgstr "Show EPG for current channel..."
+msgstr "Show EPG for the current channel..."
 
 msgid "Show Eventview"
-msgstr "Show Eventview"
+msgstr "Show Event View"
 
 msgid "Show Format Setup..."
 msgstr "Show Format Setup..."
@@ -15057,52 +15158,50 @@ msgid "Show Graphical EPG"
 msgstr "Show Graphical EPG"
 
 msgid "Show HDD progress"
-msgstr "Show HDD progress"
+msgstr "Show hard disk status"
 
 msgid "Show HDMI Output Resolution"
-msgstr "Show HDMI Output Resolution"
+msgstr "Show HDMI output resolution"
 
 msgid "Show HDMI-Output Res"
-msgstr "Show HDMI-Output Res"
+msgstr "Show HDMI output resolution"
 
-#, fuzzy
 msgid "Show HDMIRecord setup..."
-msgstr "Show HDMIRecord setup.."
+msgstr "Show HDMIRecord setup..."
 
 msgid "Show Infobar"
-msgstr "Show Infobar"
+msgstr "Show infobar"
 
 #, fuzzy
 msgid "Show Information..."
 msgstr "show program information..."
 
 msgid "Show Live in MiniTV"
-msgstr "Show Live in MiniTV"
+msgstr "Show live in mini TV window"
 
 msgid "Show Log"
 msgstr "Show Log"
 
 msgid "Show Log Manager in extensions list ?"
-msgstr "Show Log Manager in extensions list ?"
+msgstr "Show log manager on Extensions screen"
 
-#, fuzzy
 msgid "Show Main Menu as"
-msgstr "Show Movies"
+msgstr "Show Main menu as"
 
 msgid "Show Media playback Remaining/Elapsed as"
-msgstr "Show Media playback Remaining/Elapsed as"
+msgstr "Show media playback remaining/elapsed time as"
 
 msgid "Show Merlin EPG Center"
 msgstr "Show Merlin EPG Center"
 
 msgid "Show MiniTV in the Front Display"
-msgstr "Show MiniTV in the Front Display"
+msgstr "Show mini TV on the front panel display"
 
 msgid "Show Movies"
 msgstr "Show Movies"
 
 msgid "Show Movies List"
-msgstr "Show Movies List"
+msgstr "show movies list"
 
 msgid "Show Multi EPG"
 msgstr "Show Multi EPG"
@@ -15111,19 +15210,19 @@ msgid "Show OE Log"
 msgstr "Show OE Log"
 
 msgid "Show OScam in extensions ?"
-msgstr "Show OScam in extensions ?"
+msgstr "Show OScam on Extensions screen?"
 
 msgid "Show PIP"
-msgstr "Show PIP"
+msgstr "Show PiP"
 
 msgid "Show PIP in MiniTV"
-msgstr "Show PIP in MiniTV"
+msgstr "Show PiP in mini TV"
 
 msgid "Show PIP in the Front Display"
-msgstr "Show PIP in the Front Display"
+msgstr "Show PiP in the Front Display"
 
 msgid "Show PVR status in MoviePlayer infobar"
-msgstr "Show PVR status in MoviePlayer infobar"
+msgstr "Show PVR status in movie player infobar"
 
 msgid "Show RFmod setup..."
 msgstr "Show RFmod setup..."
@@ -15135,45 +15234,43 @@ msgid "Show Record Movies"
 msgstr "Show Record Movies"
 
 msgid "Show Restart Network in Extensions list *"
-msgstr "Show Restart Network in Extensions list *"
+msgstr "Show Restart Network on Extensions screen *"
 
 msgid "Show SD as"
 msgstr "Show SD as"
 
 msgid "Show Script completed message"
-msgstr ""
+msgstr "Show script completed message"
 
 msgid "Show Single EPG"
 msgstr "Show Single EPG"
 
 msgid "Show Task's completed message"
-msgstr ""
+msgstr "Show tasks completed message"
 
 msgid "Show Time Remaining/Elapsed"
-msgstr "Show Time Remaining/Elapsed"
+msgstr "Show remaining/elapsed time as"
 
 msgid "Show Timer List"
 msgstr "Show Timer List"
 
 msgid "Show Transponder Remaining/Elapsed as"
-msgstr "Show Transponder Remaining/Elapsed as"
+msgstr "Show transponder remaining/elapsed time as"
 
 msgid "Show True/False as graphical switch"
 msgstr ""
 
 msgid "Show VCR scart on main menu"
-msgstr "Show VCR scart on main menu"
+msgstr "Show VCR scart on Main menu"
 
-#, fuzzy
 msgid "Show Vertical EPG"
-msgstr "Show Graphical EPG"
+msgstr "Show Vertical EPG"
 
 msgid "Show WLAN status"
-msgstr "Show WLAN status"
+msgstr "Show wireless network status"
 
-#, fuzzy
 msgid "Show additional slider value"
-msgstr "%s additional screens"
+msgstr "Show additional slider value"
 
 msgid "Show advanced settings"
 msgstr "Show advanced settings"
@@ -15182,35 +15279,35 @@ msgid "Show animation while busy"
 msgstr "Show animation while busy"
 
 msgid "Show as Picture (press any key to close)"
-msgstr ""
+msgstr "Show as Picture (press any button to close)"
 
 #, python-format
 msgid "Show as Picture and save as file ('%s')"
 msgstr ""
 
 msgid "Show background in Radio Mode"
-msgstr "Show background in Radio Mode"
+msgstr "Show background in radio mode"
 
 msgid "Show background when tuned to a radio channel."
 msgstr "Show background when tuned to a radio channel."
 
 msgid "Show bouquet on launch"
-msgstr "Show bouquet on launch"
+msgstr "Show bouquet list on opening"
 
 msgid "Show bouquet selection menu"
 msgstr "Show bouquet selection menu"
 
 msgid "Show channel number in infobar"
-msgstr "Show channel number in infobar"
+msgstr "Show channel number on infobar"
 
 msgid "Show channel numbers in channel selection"
-msgstr "Show channel numbers in channel selection"
+msgstr "Show channel numbers"
 
 msgid "Show channel selection"
 msgstr "Show channel selection"
 
 msgid "Show chapter positions for supported video files. (gstreamer version must be greather than 1)"
-msgstr "Show chapter positions for supported video files. (gstreamer version must be greather than 1)"
+msgstr "Show chapter positions for supported video files (requires GStreamer version > 1)."
 
 msgid "Show columns"
 msgstr "Show columns"
@@ -15228,13 +15325,13 @@ msgid "Show contents of zip file"
 msgstr ""
 
 msgid "Show crash info on screen and write crash log for x times"
-msgstr ""
+msgstr "Show crash info on screen and write crash log # times"
 
 msgid "Show crypto icons"
 msgstr "Show crypto icons"
 
 msgid "Show crypto info in infobar"
-msgstr "Show crypto info in infobar"
+msgstr "Show crypto info on infobar"
 
 msgid "Show default backup files"
 msgstr "Show default backup files"
@@ -15244,30 +15341,28 @@ msgstr "Show detailed event info"
 
 #, fuzzy
 msgid "Show detailed event info (setup in menu)"
-msgstr "Show detailed event info"
+msgstr "Show detailed event info (set up in menu)"
 
-#, fuzzy
 msgid "Show directories first"
-msgstr "Show Movies List"
+msgstr "Show folders first"
 
 msgid "Show directories on first or last in list.(must restart File Commander)"
-msgstr ""
+msgstr "Show folders on first or last in list. (must restart File Commander)"
 
 msgid "Show encryption info in the infobar (when supported by the skin)."
 msgstr "Show encryption info in the infobar (when supported by the skin)."
 
 msgid "Show epg"
-msgstr "Show epg"
+msgstr "Show EPG"
 
 msgid "Show event details"
 msgstr "Show event details"
 
-#, fuzzy
 msgid "Show event genre information"
-msgstr "Softwaremanager information"
+msgstr "Show event genre information"
 
 msgid "Show event-progress in channel selection"
-msgstr "Show event-progress in channel selection"
+msgstr "Show event progress"
 
 msgid "Show eventinfo plugins"
 msgstr "Show eventinfo plugins"
@@ -15296,16 +15391,14 @@ msgstr "Show help"
 msgid "Show icon for new/unseen items"
 msgstr "Show icon for new/unseen items"
 
-#, fuzzy
 msgid "Show image information"
-msgstr "Softwaremanager information"
+msgstr "Show image information"
 
-#, fuzzy
 msgid "Show in Standby"
-msgstr "only in Standby"
+msgstr "Show in Standby"
 
 msgid "Show in extensions list ?"
-msgstr "Show in extensions list ?"
+msgstr "Show on Extensions screen"
 
 msgid "Show info"
 msgstr "Show info"
@@ -15329,25 +15422,22 @@ msgid "Show infobar permanently while paused"
 msgstr "Show infobar permanently while paused"
 
 msgid "Show infobar picons"
-msgstr "Show infobar picons"
+msgstr "Show infobar channel picons"
 
 msgid "Show job tasks in extensions"
-msgstr "Show job tasks in extensions"
+msgstr "Show job tasks on Extensions screen"
 
 msgid "Show live tv when movie stopped"
-msgstr "Show live tv when movie stopped"
+msgstr "Show live TV when movie stopped"
 
-#, fuzzy
 msgid "Show log"
-msgstr "Show Log"
+msgstr "Show log"
 
-#, fuzzy
 msgid "Show marked events"
-msgstr "Show detailed event info"
+msgstr "Highlight current events"
 
-#, fuzzy
 msgid "Show marked events in all rows."
-msgstr "Show detailed event info"
+msgstr "Choose whether to highlight the current event on every channel"
 
 msgid "Show menu"
 msgstr "Show menu"
@@ -15356,16 +15446,16 @@ msgid "Show menu numbers"
 msgstr "Show menu numbers"
 
 msgid "Show message if File Commander is not running and all Task's are completed."
-msgstr ""
+msgstr "Show message if File Commander is not running and all tasks are completed."
 
 msgid "Show message if a background script ends successfully. Has 'stout', then this is displayed as additional info."
 msgstr ""
 
 msgid "Show message when recording starts"
-msgstr "Show message when recording starts"
+msgstr "Show message when a recording starts"
 
 msgid "Show movie lengths in movielist"
-msgstr "Show movie lengths in movielist"
+msgstr "Show movie durations in movie list"
 
 msgid "Show movies"
 msgstr "Show movies"
@@ -15374,7 +15464,7 @@ msgid "Show multi channel EPG"
 msgstr "Show multi channel EPG"
 
 msgid "Show network mounts ..."
-msgstr "Show network mounts ..."
+msgstr "Show network mounts..."
 
 msgid "Show next picture"
 msgstr ""
@@ -15385,18 +15475,17 @@ msgstr "Show on Display"
 msgid "Show or hide the extended description, (skin dependent)."
 msgstr "Show or hide the extended description, (skin dependent)."
 
-#, fuzzy
 msgid "Show parting lines"
-msgstr "Show info line"
+msgstr "Show dividing lines"
 
 msgid "Show parting lines between events."
-msgstr ""
+msgstr "Choose whether events should be shown with parting lines between them."
 
 msgid "Show picon background colour"
-msgstr "Show picon background colour"
+msgstr "Channel picon background color"
 
 msgid "Show positioner movement"
-msgstr "Show positioner movement"
+msgstr "Positioner movement indicator"
 
 msgid "Show preview of current mode (*)."
 msgstr "Show preview of current mode (*)."
@@ -15406,7 +15495,7 @@ msgid "Show previous picture"
 msgstr "Switch to previous channel"
 
 msgid "Show quickmenu..."
-msgstr "Show quickmenu..."
+msgstr "Show quick menu..."
 
 msgid "Show record indicator"
 msgstr "Show record indicator"
@@ -15418,10 +15507,10 @@ msgid "Show satellites list"
 msgstr "Show satellites list"
 
 msgid "Show screensaver"
-msgstr "Show screensaver"
+msgstr "Screensaver delay"
 
 msgid "Show service list"
-msgstr "Show service list"
+msgstr "Show channel list"
 
 msgid "Show service name and event description among each other instead of side by side. After a change, an adjustment of the number of lines is required."
 msgstr ""
@@ -15430,7 +15519,7 @@ msgid "Show service type icons"
 msgstr "Show service type icons"
 
 msgid "Show servicelist or movies"
-msgstr "Show servicelist or movies"
+msgstr "Show channel list or movies"
 
 msgid "Show setup..."
 msgstr "Show setup..."
@@ -15439,58 +15528,55 @@ msgid "Show shutdown menu"
 msgstr "Show shutdown menu"
 
 msgid "Show single epg for current channel"
-msgstr "Show single epg for current channel"
+msgstr "Show Single EPG for the current channel"
 
-#, fuzzy
 msgid "Show single epg for current channel (setup in menu)"
-msgstr "Show single epg for current channel"
+msgstr "Show Single EPG for the current channel (set up in menu)"
 
 msgid "Show single service EPG"
-msgstr "Show single service EPG"
+msgstr "Show Single EPG for the current channel"
 
 msgid "Show source packages"
 msgstr "Show source packages"
 
 msgid "Show spinning logo when system is busy."
-msgstr "Show spinning logo when system is busy."
+msgstr "Show a spinning image when the system is busy."
 
 msgid "Show status icons in movielist"
-msgstr "Show status icons in movielist"
+msgstr "Show status icons in movie list"
 
 msgid "Show status messages when switch to live TV"
-msgstr "Show status messages when switch to live TV"
+msgstr "Show notification when switching to live TV"
 
 msgid "Show subservice selection"
 msgstr "Show subservice selection"
 
 msgid "Show subtitle quick menu"
-msgstr "Show subtitle quick menu"
+msgstr "Show the subtitle quick menu"
 
 msgid "Show subtitle selection"
 msgstr "Show subtitle selection"
 
-#, fuzzy
 msgid "Show task list"
-msgstr "Show service list"
+msgstr "Show the task list"
 
 msgid "Show the DreamPlex player..."
 msgstr "Show the DreamPlex player..."
 
 msgid "Show the Power Timer..."
-msgstr "Show the Power Timer..."
+msgstr "Show the power timer..."
 
 msgid "Show the Sleep Timer..."
-msgstr "Show the Sleep Timer..."
+msgstr "Show the sleep timer..."
 
-#, fuzzy
 msgid "Show the information on current event."
-msgstr "Show the information on current event."
+msgstr "Show information about the current event."
 
 msgid "Show the list of AutoTimers."
-msgstr "Show the list of AutoTimers."
+msgstr "Show the AutoTimer list."
 
 msgid "Show the list of timers."
-msgstr "Show the list of timers."
+msgstr "Show the timer list."
 
 msgid "Show the media center..."
 msgstr "Show the media center..."
@@ -15499,25 +15585,25 @@ msgid "Show the media player..."
 msgstr "Show the media player..."
 
 msgid "Show the plugin browser.."
-msgstr "Show the plugin browser.."
+msgstr "Show the plugin browser..."
 
 msgid "Show the plugins..."
-msgstr "Show the plugins..."
+msgstr "Show the plugins list..."
 
 msgid "Show the radio player..."
 msgstr "Show the radio player..."
 
 msgid "Show the tv player..."
-msgstr "Show the tv player..."
+msgstr "Show the TV player..."
 
 msgid "Show time elapsed as positive"
-msgstr "Show time elapsed as positive"
+msgstr "Show elapsed time as +"
 
 msgid "Show time in 24 hour clock format."
-msgstr "Show time in 24 hour clock format."
+msgstr "Choose whether to show the timeline in 24-hour format."
 
 msgid "Show time remaining/elapsed"
-msgstr "Show time remaining/elapsed"
+msgstr "Show remaining/elapsed time"
 
 msgid "Show translation packages"
 msgstr "Show translation packages"
@@ -15530,21 +15616,19 @@ msgid "Show two lines per entry"
 msgstr "Show Merlin EPG Center"
 
 msgid "Show unknown Videoresolution as next higher or as highest screen resolution."
-msgstr "Show unknown Videoresolution as next higher or as highest screen resolution."
+msgstr "Show unknown video resolution as next higher or highest screen resolution."
 
-#, fuzzy
 msgid "Show unknown extension as text"
-msgstr "Show in extensions list ?"
+msgstr "Open files with unknown extension as text"
 
 msgid "Show unknown file extensions with 'Addon File-Viewer'."
-msgstr ""
+msgstr "Open files with unknown extensions using 'Addon File Viewer'."
 
 msgid "Show unknown video format as"
 msgstr "Show unknown video format as"
 
-#, fuzzy
 msgid "Show vertical Program Guide"
-msgstr "Electronic Program Guide"
+msgstr "Show Vertical EPG"
 
 msgid "Show warning before restart"
 msgstr "Show warning before restart"
@@ -15552,9 +15636,8 @@ msgstr "Show warning before restart"
 msgid "Show warning when timeshift is stopped"
 msgstr "Show warning when timeshift is stopped"
 
-#, fuzzy
 msgid "Show/Games show"
-msgstr "Show Games show"
+msgstr "Show/Gameshow"
 
 msgid "Show/Hide focus bar"
 msgstr "Show/Hide focus bar"
@@ -15563,28 +15646,28 @@ msgid "Shows Plugins Browser. Here you can setup installed Plugin"
 msgstr "Shows Plugins Browser. Here you can setup installed Plugin"
 
 msgid "Shows available plugins. Here you can download and install them"
-msgstr "Shows available plugins. Here you can download and install them"
+msgstr "Show, download and install available plugins"
 
 msgid "Shows available softcams. Here you can download and install them"
 msgstr "Shows available softcams. Here you can download and install them"
 
 msgid "Shows live tv or informations on LCD."
-msgstr "Shows live tv or informations on LCD."
+msgstr "Shows live TV or information on the front panel display."
 
 msgid "Shows the icons when new/unseen, else will not show an icon."
 msgstr "Shows the icons when new/unseen, else will not show an icon."
 
 msgid "Shows the state of your wireless LAN connection.\n"
-msgstr "Shows the state of your wireless LAN connection.\n"
+msgstr "Shows the state and details of your wireless network connection.\n"
 
 msgid "Shows the watched status of the movie."
-msgstr "Shows the watched status of the movie."
+msgstr "Shows the watched progress of the movie."
 
 msgid "Shuffle playlist"
 msgstr "Shuffle playlist"
 
 msgid "Shutdown"
-msgstr "Shutdown"
+msgstr "Shut down"
 
 msgid "Side by Side"
 msgstr "Side by Side"
@@ -15602,7 +15685,7 @@ msgid "Signal OK, proceeding"
 msgstr "Signal OK, proceeding"
 
 msgid "Signal Strength:"
-msgstr "Signal Strength:"
+msgstr "Signal strength:"
 
 msgid "Signal quality"
 msgstr "Signal quality"
@@ -15614,13 +15697,13 @@ msgid "Signal: "
 msgstr "Signal: "
 
 msgid "Similar"
-msgstr "Similar"
+msgstr "Find similar"
 
 msgid "Similar broadcasts:"
 msgstr "Similar broadcasts:"
 
 msgid "Simple"
-msgstr "Simple"
+msgstr "simple"
 
 msgid "Simple fade"
 msgstr "Simple fade"
@@ -15635,18 +15718,19 @@ msgstr "List of storage devices"
 msgid "Simple zoom"
 msgstr "Simple zoom"
 
-#, fuzzy
 msgid "SimpleUmount"
-msgstr "Simple"
+msgstr "Simple Umount"
 
+#. TRANSLATORS: regional option
 msgid "Simplified Chinese"
 msgstr "Simplified Chinese"
 
+#. TRANSLATORS: regional option
 msgid "Singapore"
 msgstr "Singapore"
 
 msgid "Single"
-msgstr "Single"
+msgstr "single"
 
 msgid "Single EPG"
 msgstr "Single EPG"
@@ -15655,14 +15739,16 @@ msgid "Single satellite"
 msgstr "Single satellite"
 
 msgid "Single step (GOP)"
-msgstr "Single step (GOP)"
+msgstr "single step (GOP)"
 
 msgid "SingleEPG settings"
-msgstr "SingleEPG settings"
+msgstr "Single EPG Settings"
 
+#. TRANSLATORS: regional option
 msgid "Sint Maarten (Dutch part)"
-msgstr "Sint Maarten (Dutch part)"
+msgstr "Sint Maarten, Dutch part"
 
+#. TRANSLATORS: genre category
 msgid "Sitcom"
 msgstr ""
 
@@ -15672,17 +15758,14 @@ msgstr "Site latitude"
 msgid "Site longitude"
 msgstr "Site longitude"
 
-#, fuzzy
 msgid "Size"
-msgstr "Size: "
+msgstr "Size increasing"
 
-#, fuzzy
 msgid "Size reverse"
-msgstr "Servers"
+msgstr "Size decreasing"
 
-#, fuzzy
 msgid "Size:"
-msgstr "Size: "
+msgstr "Size:"
 
 msgid "Size: "
 msgstr "Size: "
@@ -15694,29 +15777,28 @@ msgid "Skin Selector"
 msgstr "Skin Selector"
 
 msgid "Skin Setting"
-msgstr "Skin Setting"
+msgstr "skin setting"
 
 msgid "Skin Setup"
-msgstr "Skin Setup"
+msgstr "Skin Settings"
 
 msgid "Skin setup"
-msgstr "Skin setup"
+msgstr "Skin Setup"
 
 msgid "SkinSelector"
-msgstr "SkinSelector"
+msgstr "Skin Selector"
 
 msgid "Skins"
 msgstr "Skins"
 
-#, fuzzy
 msgid "Skinselector"
-msgstr "SkinSelector"
+msgstr "Skin Selector"
 
 msgid "Skip back"
 msgstr "Skip back"
 
 msgid "Skip empty services"
-msgstr "Skip empty services"
+msgstr "Hide empty channels"
 
 msgid "Skip forward"
 msgstr "Skip forward"
@@ -15724,12 +15806,12 @@ msgstr "Skip forward"
 msgid "Skip internet connection check (disables automatic package installation)"
 msgstr "Skip internet connection check (disables automatic package installation)"
 
-#, fuzzy
 msgid "Skip selection"
-msgstr "Skinselector"
+msgstr "Skip selection"
 
+#. TRANSLATORS: genre category
 msgid "Slapstick"
-msgstr ""
+msgstr "Slapstick comedy"
 
 msgid "Sleep"
 msgstr "Sleep"
@@ -15741,10 +15823,10 @@ msgid "Sleep delay"
 msgstr "Sleep delay"
 
 msgid "Sleep long"
-msgstr "Sleep long"
+msgstr "Sleep button hold"
 
 msgid "SleepTimer"
-msgstr "SleepTimer"
+msgstr "Sleep Timer"
 
 msgid "Slide drop"
 msgstr "Slide drop"
@@ -15762,7 +15844,7 @@ msgid "Slide right to left"
 msgstr "Slide right to left"
 
 msgid "Slide show interval (sec.)"
-msgstr "Slide show interval (sec.)"
+msgstr "Slide show interval in seconds"
 
 msgid "Slide top to bottom"
 msgstr "Slide top to bottom"
@@ -15771,15 +15853,19 @@ msgstr "Slide top to bottom"
 msgid "Slot %d"
 msgstr "Slot %d"
 
+#. TRANSLATORS: regional option
 msgid "Slovak"
 msgstr "Slovak"
 
+#. TRANSLATORS: regional option
 msgid "Slovakia"
 msgstr "Slovakia"
 
+#. TRANSLATORS: regional option
 msgid "Slovenia"
 msgstr "Slovenia"
 
+#. TRANSLATORS: regional option
 msgid "Slovenian"
 msgstr "Slovenian"
 
@@ -15790,7 +15876,7 @@ msgid "Slow motion speeds"
 msgstr "Slow motion speeds"
 
 msgid "Small progress"
-msgstr "Small progress"
+msgstr "small progress"
 
 msgid "Smartcard PIN"
 msgstr "Smartcard PIN"
@@ -15804,24 +15890,28 @@ msgstr ""
 msgid "Smpte 240M"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Soap"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Soap Opera"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Soccer"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Social/Political/Economics"
-msgstr "Social/Political/Economics"
+msgstr "Social Affairs/Politics/Economics"
 
+#. TRANSLATORS: genre category
 msgid "Society & Culture"
 msgstr ""
 
-#, fuzzy
 msgid "Socket"
-msgstr "locked"
+msgstr "Socket"
 
 msgid "Softcam"
 msgstr "Softcam"
@@ -15832,21 +15922,18 @@ msgstr "Softcam Setup"
 msgid "Softcam settings"
 msgstr "Softcam settings"
 
-#, fuzzy
 msgid "Softcam setup"
-msgstr "Softcam Setup"
+msgstr "Softcam setup"
 
 msgid "Softcam-Panel"
-msgstr "Softcam-Panel"
+msgstr "Softcam Panel"
 
 msgid "Softcam-Panel..."
-msgstr "Softcam-Panel..."
+msgstr "Softcam Panel..."
 
-#, fuzzy
 msgid "Softcam-Setup"
 msgstr "Softcam Setup"
 
-#, fuzzy
 msgid "SoftcamSetup"
 msgstr "Softcam Setup"
 
@@ -15866,10 +15953,10 @@ msgid "Software Update"
 msgstr "Software Update"
 
 msgid "Software management"
-msgstr "Software management"
+msgstr "Software Management"
 
 msgid "Software manager setup"
-msgstr "Software manager setup"
+msgstr "Software Manager Setup"
 
 msgid "Software restore"
 msgstr "Software restore"
@@ -15878,17 +15965,19 @@ msgid "Software update"
 msgstr "Software update"
 
 msgid "Softwaremanager information"
-msgstr "Softwaremanager information"
+msgstr "Software manager information"
 
 msgid "Softwaremanager..."
-msgstr "Softwaremanager..."
+msgstr "Software manager..."
 
 msgid "Softwareupdate"
-msgstr "Softwareupdate"
+msgstr "Software update"
 
+#. TRANSLATORS: regional option
 msgid "Solomon Islands"
 msgstr "Solomon Islands"
 
+#. TRANSLATORS: regional option
 msgid "Somalia"
 msgstr "Somalia"
 
@@ -15896,71 +15985,73 @@ msgid ""
 "Some TV devices can't swich to correct input if a another hdmi port active. This setting set the TV to standby before.\n"
 "(If the TV does not turn back on, may require a slower transmission interval or the repetition of wake-up commands.)"
 msgstr ""
+"Some television sets can't swich to the correct input if a another HDMI input is active. This setting puts the TV into standby beforehand.\n"
+"(If the TV doesn't turn back on, it could require a longer transmission interval or a repeat of wake-up commands)."
 
 msgid "Some plugins are not available:\n"
 msgstr "Some plugins are not available:\n"
 
 msgid "Sorry CIHelper Config is Missing"
-msgstr "Sorry CIHelper Config is Missing"
+msgstr "Sorry, CIHelper Config is Missing"
 
 msgid "Sorry Inadyn Config is Missing"
-msgstr "Sorry Inadyn Config is Missing"
+msgstr "Sorry, Inadyn Config is Missing"
 
 msgid "Sorry MediaScanner is not installed!"
-msgstr "Sorry MediaScanner is not installed!"
+msgstr "Sorry, MediaScanner is not installed!"
 
 msgid "Sorry MiniDLNA Config is Missing"
-msgstr "Sorry MiniDLNA Config is Missing"
+msgstr "Sorry, MiniDLNA Config is Missing"
 
 msgid "Sorry feeds are down for maintenance"
-msgstr "Sorry feeds are down for maintenance"
+msgstr "Sorry, feeds are currently unavailable"
 
 msgid "Sorry feeds are down for maintenance, please try again later."
-msgstr "Sorry feeds are down for maintenance, please try again later."
+msgstr "Sorry, feeds are currently unavailable, please try again later."
 
 msgid "Sorry feeds are down for maintenance, please try again later. If this issue persists please check www.opena.tv"
-msgstr "Sorry feeds are down for maintenance, please try again later. If this issue persists please check www.opena.tv"
+msgstr "Sorry, feeds are currently unavailable, please try again later. If this issue persists, please check www.opena.tv"
 
 msgid "Sorry no backups found!"
-msgstr "Sorry no backups found!"
+msgstr "Sorry, no backups were found!"
 
 msgid "Sorry only possible to record 2 channels at once"
-msgstr "Sorry only possible to record 2 channels at once"
+msgstr "Only 2 channels can be recorded at the same time"
 
 msgid "Sorry uShare Config is Missing"
-msgstr "Sorry uShare Config is Missing"
+msgstr "uShare config seems to be missing"
 
 msgid ""
 "Sorry your Backup destination does not exist\n"
 "\n"
 "Please choose an other one."
 msgstr ""
-"Sorry your Backup destination does not exist\n"
+"Your backup destination does not exist\n"
 "\n"
-"Please choose an other one."
+"Please choose an alternative location."
 
 #, python-format
 msgid "Sorry, %s has not been installed!"
-msgstr "Sorry, %s has not been installed!"
+msgstr "Sorry, %s hasn't been installed!"
 
 msgid "Sorry, no backups found!"
-msgstr "Sorry, no backups found!"
+msgstr "Sorry, no backups were found!"
 
 msgid "Sorry, no details available!"
-msgstr "Sorry, no details available!"
+msgstr "Sorry, no details are available!"
 
 msgid "Sorry, no physical devices that supports SWAP attached. Can't create Swapfile on network or fat32 filesystems"
-msgstr "Sorry, no physical devices that supports SWAP attached. Can't create Swapfile on network or fat32 filesystems"
+msgstr "Sorry, no physical devices that support swap are attached. Can't create swap file on network or FAT32 filesystems"
 
 msgid "Sorry, there was a problem:"
-msgstr "Sorry, there was a problem:"
+msgstr "Sorry, something went wrong:"
 
 msgid ""
 "Sorry, your backup destination is not writeable.\n"
 "Please select a different one."
 msgstr ""
-"Sorry, your backup destination is not writeable.\n"
-"Please select a different one."
+"Sorry, your backup destination isn'tt writeable.\n"
+"Please select a different location."
 
 msgid "Sort"
 msgstr "Sort"
@@ -15990,10 +16081,10 @@ msgid "Sort order for menu entries"
 msgstr "Sort order for menu entries"
 
 msgid "Sort plug-in browser entries"
-msgstr "Sort plug-in browser entries"
+msgstr "Sort plugin browser entries"
 
 msgid "Sort setting screen's alphabetically"
-msgstr "Sort setting screen's alphabetically"
+msgstr "Sort setting screens alphabetically"
 
 msgid "Sorting left files by name, date or size"
 msgstr ""
@@ -16013,21 +16104,26 @@ msgstr "Source request"
 msgid "South"
 msgstr "South"
 
+#. TRANSLATORS: regional option
 msgid "South Africa"
 msgstr "South Africa"
 
+#. TRANSLATORS: regional option
 msgid "South Georgia and the South Sandwich Islands"
 msgstr "South Georgia and the South Sandwich Islands"
 
+#. TRANSLATORS: regional option
 msgid "South Sudan"
 msgstr "South Sudan"
 
 msgid "Space used:"
 msgstr "Space used:"
 
+#. TRANSLATORS: regional option
 msgid "Spain"
 msgstr "Spain"
 
+#. TRANSLATORS: regional option
 msgid "Spanish"
 msgstr "Spanish"
 
@@ -16046,33 +16142,38 @@ msgstr "Serial No"
 msgid "Special Features"
 msgstr "Special Features"
 
+#. TRANSLATORS: genre category
 msgid "Spiele"
-msgstr ""
+msgstr "Games"
 
+#. TRANSLATORS: genre category
 msgid "Spielfilm"
-msgstr ""
+msgstr "Motion pictures"
 
 msgid "Split preview mode"
 msgstr "Split preview mode"
 
 msgid "Splitscreen"
-msgstr "Splitscreen"
+msgstr "Split screen"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Sport"
-msgstr "Sports"
+msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Sports"
 msgstr "Sports"
 
+#. TRANSLATORS: genre category
 msgid "Sprache"
-msgstr ""
+msgstr "Language"
 
+#. TRANSLATORS: regional option
 msgid "Sri Lanka"
 msgstr "Sri Lanka"
 
 msgid "Standard"
-msgstr "Standard"
+msgstr "standard"
 
 msgid "Standard (always)"
 msgstr "Standard (always)"
@@ -16080,9 +16181,8 @@ msgstr "Standard (always)"
 msgid "Standard list"
 msgstr "Standard list"
 
-#, fuzzy
 msgid "Standard menu"
-msgstr "Standard"
+msgstr "standard menu"
 
 msgid "Standby"
 msgstr "Standby"
@@ -16094,7 +16194,7 @@ msgid "Standby / restart"
 msgstr "Standby / restart"
 
 msgid "Standby without TV shutdown"
-msgstr "Standby without TV shutdown"
+msgstr "Standby without shutting down TV"
 
 msgid "Start"
 msgstr "Start"
@@ -16115,7 +16215,7 @@ msgid "Start offline decode"
 msgstr "Start offline decode"
 
 msgid "Start recording?"
-msgstr "Start recording?"
+msgstr "Select a recording option:"
 
 msgid "Start teletext"
 msgstr "Start teletext"
@@ -16137,10 +16237,10 @@ msgid "Start/stop/select cam"
 msgstr "Start/stop/select cam"
 
 msgid "Start/stop/select your cam, You need to install first a softcam"
-msgstr "Start/stop/select your cam, You need to install first a softcam"
+msgstr "Start/stop/select your cam, you'll need to install a softcam first"
 
 msgid "StartWizard"
-msgstr "StartWizard"
+msgstr "Start Wizard"
 
 msgid "Starting Softcam"
 msgstr "Starting Softcam"
@@ -16180,19 +16280,19 @@ msgid "Stepped west"
 msgstr "Stepped west"
 
 msgid "Stop"
-msgstr "Stop"
+msgstr "■ Stop"
 
 msgid "Stop PiP"
 msgstr "Stop PiP"
 
 msgid "Stop Streams"
-msgstr "Stop Streams"
+msgstr "Stop streams"
 
 msgid "Stop current event and disable coming events"
 msgstr "Stop current event and disable coming events"
 
 msgid "Stop current event but not coming events"
-msgstr "Stop current event but not coming events"
+msgstr "Stop current event but not upcoming events"
 
 msgid "Stop entry"
 msgstr "Stop entry"
@@ -16201,10 +16301,10 @@ msgid "Stop playing this movie?"
 msgstr "Stop playing this movie?"
 
 msgid "Stop previous broadcasted service on return to movielist."
-msgstr "Stop previous broadcasted service on return to movielist."
+msgstr "Stop previous broadcasted service on return to movie list."
 
 msgid "Stop recording"
-msgstr "Stop recording"
+msgstr "Stop recording..."
 
 msgid "Stop recording and delete"
 msgstr "Stop recording and delete"
@@ -16231,16 +16331,16 @@ msgid "Stop timeshift"
 msgstr "Stop timeshift"
 
 msgid "Stop timeshift and save timeshift buffer as movie"
-msgstr "Stop timeshift and save timeshift buffer as movie"
+msgstr "Stop timeshift and save buffer"
 
 msgid "Stop timeshift and save timeshift buffer as movie and start recording of current event"
-msgstr "Stop timeshift and save timeshift buffer as movie and start recording of current event"
+msgstr "Stop timeshift and save buffer; Start recording current event"
 
 msgid "Stop timeshift while recording?"
-msgstr "Stop timeshift while recording?"
+msgstr "Stop timeshift while recording"
 
 msgid "Stop's timeshift being used if a recording is in progress. (advisable for usb sticks)"
-msgstr "Stop's timeshift being used if a recording is in progress. (advisable for usb sticks)"
+msgstr "Stops timeshift being used if a recording is in progress (advisable for USB sticks)."
 
 msgid "Stopped"
 msgstr "Stopped"
@@ -16249,7 +16349,7 @@ msgid "Stopping Softcam"
 msgstr "Stopping Softcam"
 
 msgid "Storage devices"
-msgstr "Storage devices"
+msgstr "Storage Devices"
 
 msgid "Store at index"
 msgstr "Store at index"
@@ -16267,31 +16367,29 @@ msgid "Stream request"
 msgstr "Stream request"
 
 msgid "Stream-tv"
-msgstr "Stream-tv"
+msgstr "Stream TV"
 
 msgid "Streaming"
 msgstr "Streaming"
 
 msgid "Streaming clients info"
-msgstr "Streaming clients info"
+msgstr "Streaming Clients"
 
-#, fuzzy
 msgid "Streaming recording ended"
-msgstr "Change recording (endtime)"
+msgstr "Streaming recording ended"
 
 #. TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (force aspect))
-#, fuzzy
 msgid "Stretch full"
-msgstr "Stretch linear"
+msgstr "stretch full"
 
 #. TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (All parts lose aspect))
 msgid "Stretch linear"
-msgstr "Stretch linear"
+msgstr "stretch linear"
 
 #. TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching the top/bottom (Center of picture maintains aspect, top/bottom lose aspect heaver than on linear stretch))
 #. TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching the left/right (Center 50% of picture maintain aspect, left/right 25% lose aspect heaver than on linear stretch))
 msgid "Stretch nonlinear"
-msgstr "Stretch nonlinear"
+msgstr "stretch nonlinear"
 
 msgid "Strict DLNA"
 msgstr "Strict DLNA"
@@ -16302,8 +16400,9 @@ msgstr "Stripes"
 msgid "Strongest position"
 msgstr "Strongest position"
 
+#. TRANSLATORS: genre category
 msgid "Stumm"
-msgstr ""
+msgstr "Silent"
 
 msgid "Style:"
 msgstr "Style:"
@@ -16312,25 +16411,23 @@ msgstr "Style:"
 msgid "Subservice list..."
 msgstr "Subservices"
 
-#, fuzzy
 msgid "Subservice mode (green Button)"
-msgstr "Subservice mode"
+msgstr "Subservice mode (Green button)"
 
 msgid "Subservices"
 msgstr "Subservices"
 
 msgid "Subtitle"
-msgstr "Subtitle"
+msgstr "Subtitle button"
 
 msgid "Subtitle Quickmenu"
-msgstr "Subtitle Quickmenu"
+msgstr "Subtitle Quick Menu"
 
 msgid "Subtitle alignment"
-msgstr "Subtitle alignment"
+msgstr "Horizontal alignment"
 
-#, fuzzy
 msgid "Subtitle black transparency"
-msgstr "DVB subtitle black transparency"
+msgstr "Subtitle background transparency"
 
 msgid "Subtitle border width"
 msgstr "Subtitle border width"
@@ -16342,34 +16439,34 @@ msgid "Subtitle delay when timing lacks"
 msgstr "Subtitle delay when timing lacks"
 
 msgid "Subtitle font size"
-msgstr "Subtitle font size"
+msgstr "Subtitle text size"
 
 msgid "Subtitle language selection 1"
-msgstr "Subtitle language selection 1"
+msgstr "Subtitle language 1"
 
 msgid "Subtitle language selection 2"
-msgstr "Subtitle language selection 2"
+msgstr "Subtitle language 2"
 
 msgid "Subtitle language selection 3"
-msgstr "Subtitle language selection 3"
+msgstr "Subtitle language 3"
 
 msgid "Subtitle language selection 4"
-msgstr "Subtitle language selection 4"
+msgstr "Subtitle language 4"
 
 msgid "Subtitle long"
-msgstr "Subtitle long"
+msgstr "Subtitle button hold"
 
 msgid "Subtitle position"
-msgstr "Subtitle position"
+msgstr "Vertical position"
 
 msgid "Subtitle selection"
-msgstr "Subtitle selection"
+msgstr "Select Subtitles"
 
 msgid "Subtitle selection..."
 msgstr "Subtitle selection..."
 
 msgid "Subtitle settings"
-msgstr "Subtitle settings"
+msgstr "Subtitle Settings"
 
 msgid "Subtitles"
 msgstr "Subtitles"
@@ -16380,6 +16477,7 @@ msgstr "Subtitles Settings"
 msgid "Succeeded:"
 msgstr "Succeeded:"
 
+#. TRANSLATORS: regional option
 msgid "Sudan"
 msgstr "Sudan"
 
@@ -16392,9 +16490,11 @@ msgstr "Sunday"
 msgid "Support at"
 msgstr "Support at"
 
+#. TRANSLATORS: regional option
 msgid "Suriname"
 msgstr "Suriname"
 
+#. TRANSLATORS: regional option
 msgid "Svalbard and Jan Mayen"
 msgstr "Svalbard and Jan Mayen"
 
@@ -16405,34 +16505,34 @@ msgid "Swap File Manager"
 msgstr "Swap File Manager"
 
 msgid "Swap File not found. You have to create the file before to activate."
-msgstr "Swap File not found. You have to create the file before to activate."
+msgstr "Swap file not found. You'll need to create the file before activating."
 
 msgid "Swap Manager"
 msgstr "Swap Manager"
 
 msgid "Swap PIP"
-msgstr "Swap PIP"
+msgstr "Swap PiP"
 
 msgid "Swap PiP and main picture"
 msgstr "Swap PiP and main picture"
 
 msgid "Swap Place:"
-msgstr "Swap Place:"
+msgstr "Swap location:"
 
 msgid "Swap SNR in '%' with SNR in 'db'"
-msgstr "Swap SNR in '%' with SNR in 'db'"
+msgstr "Show SNR as % instead of dB"
 
 msgid "Swap Size:"
-msgstr "Swap Size:"
+msgstr "Swap size:"
 
 msgid "Swap buttons right/left with channel plus/minus or the channel button changed always the side."
-msgstr ""
+msgstr "Swap ◀︎ Left and ▶︎ Right buttons with Channel +/- or the channel button changed always the side."
 
 msgid "Swap services"
 msgstr "Swap services"
 
 msgid "SwapManager"
-msgstr "SwapManager"
+msgstr "Swap Manager"
 
 msgid "SwaptoNand"
 msgstr ""
@@ -16441,32 +16541,36 @@ msgstr ""
 msgid "SwaptoSD"
 msgstr "Swap"
 
+#. TRANSLATORS: regional option
 msgid "Swaziland"
 msgstr "Swaziland"
 
+#. TRANSLATORS: regional option
 msgid "Sweden"
 msgstr "Sweden"
 
+#. TRANSLATORS: regional option
 msgid "Swedish"
 msgstr "Swedish"
 
+#. TRANSLATORS: genre category
 msgid "Swimming"
 msgstr ""
 
 msgid "Switch Blue-Short (QuickMenu) with Blue-Long (Extensions)"
-msgstr "Switch Blue-Short (QuickMenu) with Blue-Long (Extensions)"
+msgstr "Switch the Blue button press action (Quick Menu) with hold action (Extensions)."
 
 msgid "Switch Mode to enable HDR Modes or PIP Functions"
-msgstr "Switch Mode to enable HDR Modes or PIP Functions"
+msgstr "Switch Mode to enable HDR Modes or PiP Functions"
 
 msgid "Switch TV to correct input"
 msgstr "Switch TV to correct input"
 
 msgid "Switch between Audio-, Subtitlepage"
-msgstr "Switch between Audio-, Subtitlepage"
+msgstr "Switch between Audio and Subtitle settings"
 
 msgid "Switch between filelist/playlist"
-msgstr "Switch between filelist/playlist"
+msgstr "Switch between file list/playlist"
 
 msgid "Switch between normal mode and list mode"
 msgstr "Switch between normal mode and list mode"
@@ -16494,13 +16598,13 @@ msgid "Switch to TV mode"
 msgstr "Switch to TV mode"
 
 msgid "Switch to filelist"
-msgstr "Switch to filelist"
+msgstr "Switch to file list"
 
 msgid "Switch to next channel in history"
 msgstr "Switch to next channel in history"
 
 msgid "Switch to next sub service"
-msgstr "Switch to next sub service"
+msgstr "Switch to next subservice"
 
 msgid "Switch to playlist"
 msgstr "Switch to playlist"
@@ -16512,7 +16616,7 @@ msgid "Switch to previous channel in history"
 msgstr "Switch to previous channel in history"
 
 msgid "Switch to previous sub service"
-msgstr "Switch to previous sub service"
+msgstr "Switch to previous subservice"
 
 msgid "Switch to radio mode"
 msgstr "Switch to radio mode"
@@ -16521,8 +16625,9 @@ msgid "Switchable tuner types:"
 msgstr "Switchable tuner types:"
 
 msgid "Switching to live TV - timeshift is still active!"
-msgstr "Switching to live TV - timeshift is still active!"
+msgstr "Switching to live TV... timeshift is still active!"
 
+#. TRANSLATORS: regional option
 msgid "Switzerland"
 msgstr "Switzerland"
 
@@ -16536,17 +16641,18 @@ msgid "Symlink to "
 msgstr ""
 
 msgid "Sync NTP every (minutes)"
-msgstr "Sync NTP every (minutes)"
+msgstr "Sync NTP every # minutes"
 
 msgid "Sync failure moving back to origin !"
-msgstr "Sync failure moving back to origin !"
+msgstr "Sync failure moving back to origin!"
 
 msgid "Sync time using"
 msgstr "Sync time using"
 
 msgid "Synchronize systemtime using transponder or internet."
-msgstr "Synchronize systemtime using transponder or internet."
+msgstr "Choose either transponder information or an internet time server to synchronize your receiver's time."
 
+#. TRANSLATORS: regional option
 msgid "Syrian Arab Republic"
 msgstr "Syrian Arab Republic"
 
@@ -16573,10 +16679,10 @@ msgid "System: "
 msgstr "System: "
 
 msgid "SystemInfo"
-msgstr "SystemInfo"
+msgstr "System Info"
 
 msgid "Systeminfo"
-msgstr "Systeminfo"
+msgstr "System info"
 
 #, fuzzy
 msgid "T2MI PID"
@@ -16606,10 +16712,10 @@ msgid "TSID"
 msgstr "TSID"
 
 msgid "TV"
-msgstr "TV"
+msgstr "TV button"
 
 msgid "TV button mode"
-msgstr "TV button mode"
+msgstr "TV button"
 
 msgid "TV physical address report"
 msgstr "TV physical address report"
@@ -16623,34 +16729,39 @@ msgstr "Table of content for collection"
 msgid "Tags"
 msgstr "Tags"
 
+#. TRANSLATORS: regional option
 msgid "Taiwan"
 msgstr "Taiwan"
 
+#. TRANSLATORS: regional option
 msgid "Tajikistan"
 msgstr "Tajikistan"
 
+#. TRANSLATORS: genre category
 msgid "Talk"
 msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Talk Show"
-msgstr "talk show"
+msgstr "Talk show"
 
+#. TRANSLATORS: genre category
 msgid "Tanz"
-msgstr ""
+msgstr "Dance"
 
+#. TRANSLATORS: regional option
 msgid "Tanzania, United Republic of"
 msgstr "Tanzania, United Republic of"
 
-#, fuzzy
 msgid "Task list"
-msgstr "Package list"
+msgstr "Task list"
 
+#. TRANSLATORS: genre category
 msgid "Technik"
-msgstr ""
+msgstr "Technology"
 
 msgid "Teletext"
-msgstr "Teletext"
+msgstr "Text button"
 
 msgid "Teletext CleanAlgo (resolution reset algorithm)"
 msgstr "Teletext CleanAlgo (resolution reset algorithm)"
@@ -16668,7 +16779,7 @@ msgid "Teletext StartY (lower border)"
 msgstr "Teletext StartY (lower border)"
 
 msgid "Teletext TTFBold (0=normal, 1=bold)"
-msgstr "Teletext TTFBold (0=normal, 1=bold)"
+msgstr "Teletext TTFBold (0: normal, 1: bold)"
 
 msgid "Teletext TTFHeightFactor16 (TrueType letter height)"
 msgstr "Teletext TTFHeightFactor16 (TrueType letter height)"
@@ -16686,7 +16797,7 @@ msgid "Teletext TTFWidthFactor16 (TrueType letter width)"
 msgstr "Teletext TTFWidthFactor16 (TrueType letter width)"
 
 msgid "Teletext UseTTF (0=fixed font, 1=TrueType)"
-msgstr "Teletext UseTTF (0=fixed font, 1=TrueType)"
+msgstr "Teletext UseTTF (0: fixed font, 1: TrueType)"
 
 msgid "Teletext base visibility"
 msgstr "Teletext base visibility"
@@ -16709,9 +16820,9 @@ msgstr "Telnet Port"
 msgid "Telnet Setup"
 msgstr "Telnet Setup"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Tennis"
-msgstr "Finnish"
+msgstr ""
 
 msgid "Terrestrial"
 msgstr "Terrestrial"
@@ -16733,20 +16844,22 @@ msgid "Test type"
 msgstr "Test type"
 
 msgid "Testscreens"
-msgstr "Testscreens"
+msgstr "Test Screens"
 
 msgid "Testscreens that are helpfull to fine-tune your display"
-msgstr "Testscreens that are helpfull to fine-tune your display"
+msgstr "Test screens to help you fine-tune your display"
 
 msgid "Text"
-msgstr "Text"
+msgstr "text only"
 
 msgid "Text color"
 msgstr "Text color"
 
+#. TRANSLATORS: regional option
 msgid "Thai"
 msgstr "Thai"
 
+#. TRANSLATORS: regional option
 msgid "Thailand"
 msgstr "Thailand"
 
@@ -16754,35 +16867,31 @@ msgid ""
 "Thank you for using the wizard.\n"
 "Please press OK to continue."
 msgstr ""
-"Thank you for using the wizard.\n"
-"Please press OK to continue."
+"Thanks for using the wizard!\n"
+"Press OK to continue..."
 
 msgid ""
 "Thank you for using the wizard. Your %s %s is now ready to use.\n"
 "Please press OK to start using your %s %s."
 msgstr ""
-"Thank you for using the wizard. Your %s %s is now ready to use.\n"
-"Please press OK to start using your %s %s."
+"Thanks for using the wizard! Your %s %s is now ready to use!\n"
+"Press OK to start using your %s %s..."
 
 msgid "The %s %s reads the stored EPG data every (hours)."
-msgstr "The %s %s reads the stored EPG data every (hours)."
+msgstr "Your %s %s reads the stored EPG data every # hours."
 
 msgid "The %s %s stores the EPG data every (hours)."
-msgstr "The %s %s stores the EPG data every (hours)."
+msgstr "Your %s %s stores the EPG data every # hours."
 
 msgid ""
 "The AutoTimer plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The AutoTimer plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the AutoTimer plugin!"
 
 msgid ""
 "The Cool TV Guide plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The Cool TV Guide plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the Cool TV Guide plugin!"
 
 msgid "The DVD standard doesn't support H.264 (HDTV) video streams."
 msgstr "The DVD standard doesn't support H.264 (HDTV) video streams."
@@ -16790,30 +16899,24 @@ msgstr "The DVD standard doesn't support H.264 (HDTV) video streams."
 msgid ""
 "The DreamPlex plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The DreamPlex plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the DreamPlex plugin!"
 
 msgid ""
 "The EPGSearch plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The EPGSearch plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the EPGSearch plugin!"
 
 msgid ""
 "The Filesystem on your Timeshift-Device does not support hardlinks.\n"
 "Make sure it is formatted in EXT2, EXT3 or EXT4!"
 msgstr ""
-"The Filesystem on your Timeshift-Device does not support hardlinks.\n"
-"Make sure it is formatted in EXT2, EXT3 or EXT4!"
+"Your chosen timeshift device doesn't support hardlinks.\n"
+"Please use an ext2, ext3 or ext4 formatted device."
 
 msgid ""
 "The IMDb plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The IMDb plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the IMDb plugin!"
 
 #, python-format
 msgid ""
@@ -16831,30 +16934,22 @@ msgstr ""
 msgid ""
 "The MediaCenter plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The MediaCenter plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the MediaCenter plugin!"
 
 msgid ""
 "The MediaPlayer plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The MediaPlayer plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the Media Player plugin!"
 
 msgid ""
 "The MediaPortal plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The MediaPortal plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the MediaPortal plugin!"
 
 msgid ""
 "The Merlin EPG Center plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The Merlin EPG Center plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the Merlin EPG Center plugin!"
 
 msgid "The PIN code has been changed successfully."
 msgstr "The PIN code has been changed successfully."
@@ -16863,18 +16958,16 @@ msgid "The PIN code has been saved successfully."
 msgstr "The PIN code has been saved successfully."
 
 msgid "The PIN codes you entered are different."
-msgstr "The PIN codes you entered are different."
+msgstr "The PIN codes you entered don't match."
 
 #, fuzzy
 msgid ""
 "The SimpleUmount plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The MediaCenter plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the MediaCenter plugin!"
 
 msgid "The TV was switched to the recording service!\n"
-msgstr "The TV was switched to the recording service!\n"
+msgstr "The channel was changed to record an event!\n"
 
 msgid ""
 "The USB stick was prepared to be bootable.\n"
@@ -16886,9 +16979,7 @@ msgstr ""
 msgid ""
 "The VideoMode plugin is not installed!\n"
 "Please install it."
-msgstr ""
-"The VideoMode plugin is not installed!\n"
-"Please install it."
+msgstr "Please install the VideoMode plugin!"
 
 msgid "The aspect ratio of the recording."
 msgstr "The aspect ratio of the recording."
@@ -16901,10 +16992,10 @@ msgid ""
 "What do you want to do ?"
 msgstr ""
 "The available disk space for timeshift is less than specified in the settings.\n"
-"What do you want to do ?"
+"What would you like to do?"
 
 msgid "The backup failed. Please choose a different backup location."
-msgstr "The backup failed. Please choose a different backup location."
+msgstr "Backup failed, please choose a different backup location."
 
 msgid "The bitrate of the video encoder. Larger value improves quality and increases file size."
 msgstr "The bitrate of the video encoder. Larger value improves quality and increases file size."
@@ -16913,8 +17004,8 @@ msgid ""
 "The buffer time for timeshift exceeds the specified limit in the settings.\n"
 "What do you want to do ?"
 msgstr ""
-"The buffer time for timeshift exceeds the specified limit in the settings.\n"
-"What do you want to do ?"
+"The timeshift buffer time exceeds the specified limit in the settings.\n"
+"What would you like to do?"
 
 msgid "The current update may be unstable"
 msgstr "The current update may be unstable"
@@ -16923,30 +17014,30 @@ msgid ""
 "The default backup selection cannot be changed.\n"
 "Please use the 'additional' and 'excluded' backup selection."
 msgstr ""
-"The default backup selection cannot be changed.\n"
-"Please use the 'additional' and 'excluded' backup selection."
+"The default backup selections can't be changed.\n"
+"Please use the 'additional' and 'excluded' backup options."
 
 msgid "The default settings are 5 minutes earlier to wakeup from deep standby. It possibly may be necessary to change this. (e.g.: the actual wake-up time is inaccurate or to late, waiting to a network-drive, etc.)"
-msgstr "The default settings are 5 minutes earlier to wakeup from deep standby. It possibly may be necessary to change this. (e.g.: the actual wake-up time is inaccurate or to late, waiting to a network-drive, etc.)"
+msgstr "The default settings are 5 minutes earlier to wake up from deep standby. It may be necessary to change this, for example if the actual wake-up time is inaccurate or too late, waiting for a network drive, etc."
 
 msgid "The default settings are wakeup time - 5 minutes and timer begin time + 5 minutes. This setting changed the time window before the wakeup time. So can be detected a wakeup by a timer even at very early starting receivers."
-msgstr "The default settings are wakeup time - 5 minutes and timer begin time + 5 minutes. This setting changed the time window before the wakeup time. So can be detected a wakeup by a timer even at very early starting receivers."
+msgstr "The default settings are wake-up time of -5 minutes and timer begin time +5 minutes. This setting changes the time window before the wake-up time. So can be detected a wake-up by a timer even at very early starting receivers."
 
 #, python-format
 msgid ""
 "The directory %s is not a EXT2, EXT3, EXT4, NFS or CIFS partition.\n"
 "Make sure you select a valid partition type."
 msgstr ""
-"The directory %s is not a EXT2, EXT3, EXT4, NFS or CIFS partition.\n"
-"Make sure you select a valid partition type."
+"%s is not on an ext2, ext3, ext4, NFS or CIFS partition.\n"
+"Please select a location with a valid partition type."
 
 #, python-format
 msgid ""
 "The directory %s is not writable.\n"
 "Make sure you select a writable directory instead."
 msgstr ""
-"The directory %s is not writable.\n"
-"Make sure you select a writable directory instead."
+"Can't write to %s\n"
+"Please select a writable location."
 
 #, python-format
 msgid ""
@@ -16960,7 +17051,7 @@ msgstr ""
 "\n"
 "%s\n"
 "\n"
-"Do you want to write the USB flasher to this stick?"
+"Would you like to write the USB flasher to it?"
 
 msgid "The following files were found..."
 msgstr "The following files were found..."
@@ -16972,22 +17063,24 @@ msgid ""
 "The function has interrupted.\n"
 "Don't press in the next time any key until the picture from mvi-file is displayed!"
 msgstr ""
+"The function has interrupted.\n"
+"Please don't press any button until the picture from mvi file is displayed!"
 
 msgid "The hash of a directory can't be calculated."
-msgstr ""
+msgstr "The hash of a folder can't be calculated."
 
 msgid "The height of the picture. The input will be scaled to match this value."
 msgstr "The height of the picture. The input will be scaled to match this value."
 
 #, python-format
 msgid "The installation of the default settings is finished. You can now continue configuring your %s %s by pressing the OK button on the remote control."
-msgstr "The installation of the default settings is finished. You can now continue configuring your %s %s by pressing the OK button on the remote control."
+msgstr "Default settings have been installed. You can now continue configuring your %s %s by pressing the OK button on your remote control."
 
 msgid "The loopthrough setting is wrong."
-msgstr "The loopthrough setting is wrong."
+msgstr "The loopthrough setting isn't valid."
 
 msgid "The md5sum validation failed, the file may be corrupted!"
-msgstr "The md5sum validation failed, the file may be corrupted!"
+msgstr "The md5sum validation failed, the file may be corrupt!"
 
 msgid ""
 "The network wizard extension is not installed!\n"
@@ -16997,14 +17090,14 @@ msgstr ""
 "Please install it."
 
 msgid "The password can not be blank."
-msgstr ""
+msgstr "The password can't be blank."
 
 #, python-format
 msgid "The path %s already exists."
 msgstr "The path %s already exists."
 
 msgid "The pin code you entered is wrong."
-msgstr "The pin code you entered is wrong."
+msgstr "You've entered an incorrect PIN code."
 
 #, python-format
 msgid "The results have been written to %s."
@@ -17014,7 +17107,7 @@ msgid "The saved PIN was cleared."
 msgstr "The saved PIN was cleared."
 
 msgid "The servicelist is reloaded."
-msgstr "The servicelist is reloaded."
+msgstr "The channel list has been reloaded."
 
 msgid "The setting 'without query' is the same as 'standard' without additional confirmation query. All other dependencies (e.g. recordings, time range) stay persist."
 msgstr "The setting 'without query' is the same as 'standard' without additional confirmation query. All other dependencies (e.g. recordings, time range) stay persist."
@@ -17042,25 +17135,25 @@ msgid "The timer file (pm_timers.xml) is corrupt and could not be loaded."
 msgstr "The timer file (pm_timers.xml) is corrupt and could not be loaded."
 
 msgid "The timer file (timers.xml) is corrupt and could not be loaded."
-msgstr "The timer file (timers.xml) is corrupt and could not be loaded."
+msgstr "The timer file (timers.xml) is corrupt and couldn't be loaded."
 
 msgid ""
 "The unicable connection setting is wrong.\n"
 " Maybe recursive connection of tuners."
 msgstr ""
-"The unicable connection setting is wrong.\n"
+"The unicable connection setting isn't valid.\n"
 " Maybe recursive connection of tuners."
 
 #, python-format
 msgid "The user interface of your %s %s is restarting"
-msgstr "The user interface of your %s %s is restarting"
+msgstr "Your %s %s's user interface is restarting..."
 
 #, python-format
 msgid ""
 "The user interface of your %s %s is restarting\n"
 "due to an error in mytest.py"
 msgstr ""
-"The user interface of your %s %s is restarting\n"
+"Your %s %s's user interface needs to restart\n"
 "due to an error in mytest.py"
 
 msgid "The width of the picture. The input will be scaled to match this value."
@@ -17071,7 +17164,7 @@ msgid ""
 "Please install it and choose what you want to do next."
 msgstr ""
 "The wireless LAN plugin is not installed!\n"
-"Please install it and choose what you want to do next."
+"Please install it and choose what you'd like to do next."
 
 msgid ""
 "The wireless LAN plugin is not installed!\n"
@@ -17081,18 +17174,20 @@ msgstr ""
 "Please install it."
 
 msgid "The wizard can backup your current settings. Do you want to do a backup now?"
-msgstr "The wizard can backup your current settings. Do you want to do a backup now?"
+msgstr ""
+"The wizard can back up your current settings.\n"
+"Would you like to do that now?"
 
 #, python-format
 msgid "The wizard found a configuration backup. Do you want to restore your old settings from %s?"
-msgstr "The wizard found a configuration backup. Do you want to restore your old settings from %s?"
+msgstr "The wizard found a configuration backup. Would you like to restore your settings from %s?"
 
 msgid "The wizard is finished now."
-msgstr "The wizard is finished now."
+msgstr "The wizard is now finished."
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Theater"
-msgstr "Create"
+msgstr ""
 
 msgid "There are at least "
 msgstr "There are at least "
@@ -17118,351 +17213,349 @@ msgid ""
 "\n"
 "Do you want to flash-online ?"
 msgstr ""
-"There are to many update packages !!\n"
+"There are too many packages to update!\n"
 "\n"
 "There is a risk that your %s %s will not\n"
-"boot after online-update, or will show disfunction in running Image.\n"
+"boot properly or will experience issues after an online update.\n"
 "\n"
-"You need to flash new !!\n"
+"A fresh image flash will increase stability\n"
 "\n"
-"Do you want to flash-online ?"
+"Would you like to flash online?"
 
 msgid "There is no signal to lock on !"
-msgstr "There is no signal to lock on !"
+msgstr "There is no signal to lock onto!"
 
 msgid ""
 "There might not be enough space on the selected partition..\n"
 "Do you really want to continue?"
 msgstr ""
-"There might not be enough space on the selected partition..\n"
-"Do you really want to continue?"
+"There might not be enough space on the selected partition...\n"
+"Are you sure you want to continue?"
 
-#, fuzzy
 msgid "There was an error downloading current region details"
-msgstr "There was an error downloading the updatelist. Please try again."
+msgstr "Something went wrong while trying to download details for the current region, please try again."
 
-#, fuzzy
 msgid "There was an error downloading the region list"
-msgstr "There was an error downloading the updatelist. Please try again."
+msgstr "Something went wrong while trying to download a list of regions, please try again."
 
 msgid "There was an error downloading the updatelist. Please try again."
-msgstr "There was an error downloading the updatelist. Please try again."
+msgstr "Something went wrong while trying to download a list of updates, please try again."
 
-#, fuzzy
 msgid "There was an error while trying to login."
-msgstr "There was an error downloading the updatelist. Please try again."
+msgstr "Something went wrong while trying to log in."
 
 #, python-format
 msgid "This %s %s cannot decode %s streams!"
-msgstr "This %s %s cannot decode %s streams!"
+msgstr "Your %s %s can't decode %s streams!"
 
 msgid "This DVD RW medium is already formatted - reformatting will erase all content on the disc."
-msgstr "This DVD RW medium is already formatted - reformatting will erase all content on the disc."
+msgstr "This DVD RW disc is already formatted - reformatting will ERASE ALL CONTENT on it."
 
 msgid "This Device is already mounted as HDD."
-msgstr "This Device is already mounted as HDD."
+msgstr "This device is already mounted as HDD."
 
-#, fuzzy
 msgid "This Option allows you to switch Audio to BT Speakers."
-msgstr "This option allows you to Power Off the display."
+msgstr "This option lets you to switch audio to Bluetooth speakers."
 
 msgid "This allows you change the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size"
-msgstr "This allows you change the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size"
+msgstr "This option lets you change the text size relative to skin size. 1 will increase by 1 point size, and -1 will decrease it."
 
 msgid "This allows you change the number of rows shown."
-msgstr "This allows you change the number of rows shown."
+msgstr "This option lets you choose how many rows should be shown."
 
 msgid "This allows you to set the number of digits to 5, if you have more than 9999 channels."
-msgstr "This allows you to set the number of digits to 5, if you have more than 9999 channels."
+msgstr "This option lets you set the number of digits to use for channel numbers, useful if you have many channels."
 
 msgid "This allows you to show drivers modules in downloads"
-msgstr "This allows you to show drivers modules in downloads"
+msgstr "Choose whether to show driver modules in downloads."
 
 msgid "This allows you to show extensions modules in downloads"
-msgstr "This allows you to show extensions modules in downloads"
+msgstr "Choose whether to show extension modules in downloads."
 
 msgid "This allows you to show kernel modules in downloads"
-msgstr "This allows you to show kernel modules in downloads"
+msgstr "Choose whether to show kernel modules in downloads."
 
 msgid "This allows you to show languages in downloads"
-msgstr "This allows you to show languages in downloads"
+msgstr "Choose whether to show languages in downloads."
 
 msgid "This allows you to show lcd skins in downloads"
-msgstr "This allows you to show lcd skins in downloads"
+msgstr "Choose whether to show front panel display (LCD/VFD) skins in downloads."
 
 msgid "This allows you to show m2k modules in downloads"
-msgstr "This allows you to show m2k modules in downloads"
+msgstr "Choose whether to show m2k modules in downloads."
 
 msgid "This allows you to show picons modules in downloads"
-msgstr "This allows you to show picons modules in downloads"
+msgstr "Choose whether to show channel picons (logos) in downloads."
 
 msgid "This allows you to show pli modules in downloads"
-msgstr "This allows you to show pli modules in downloads"
+msgstr "Choose whether to show pli modules in downloads."
 
 msgid "This allows you to show security modules in downloads"
-msgstr "This allows you to show security modules in downloads"
+msgstr "Choose whether to show security modules in downloads."
 
 msgid "This allows you to show settings modules in downloads"
-msgstr "This allows you to show settings modules in downloads"
+msgstr "Choose whether to show settings modules in downloads."
 
 msgid "This allows you to show skin modules in downloads"
-msgstr "This allows you to show skin modules in downloads"
+msgstr "Choose whether to show skins in downloads."
 
 msgid "This allows you to show softcams modules in downloads"
-msgstr "This allows you to show softcams modules in downloads"
+msgstr "Choose whether to show softcam modules in downloads."
 
 msgid "This allows you to show systemplugins modules in downloads"
-msgstr "This allows you to show systemplugins modules in downloads"
+msgstr "Choose whether to show system plugins in downloads."
 
 msgid "This allows you to show vix modules in downloads"
-msgstr "This allows you to show vix modules in downloads"
+msgstr "Choose whether to show vix modules in downloads."
 
 msgid "This allows you to show weblinks modules in downloads"
-msgstr "This allows you to show weblinks modules in downloads"
+msgstr "Choose whether to show weblink modules in downloads."
 
 #, fuzzy, python-format
 msgid "This field allows you to search an additional symbol rate up to %s."
-msgstr "This option allows you to hide and sorting of the menus"
+msgstr "This option lets you hide and sorting of the menus"
 
 msgid "This is a workaround for some devices there wakeup again after switching in standby. The wak up command's from other devices will ignored for few seconds."
-msgstr ""
+msgstr "This is a workaround for some devices that wake up again after switching to standby. The wake-up commands from other devices will ignored momentarily."
 
 msgid "This is the order in which DiSEqC commands are sent to the aerial system. The order must correspond exactly with the order the physical devices are arranged along the signal cable (starting from the receiver end)."
 msgstr ""
 
-#, fuzzy
 msgid "This line is not editable!"
-msgstr "This plugin is not installed."
+msgstr "This line can't be edited!"
 
 msgid "This option allows to reduce the block-noise in the picture. Obviously this is at the cost of the picture's sharpness."
-msgstr "This option allows to reduce the block-noise in the picture. Obviously this is at the cost of the picture's sharpness."
+msgstr "This option lets you choose the level of block noise reduction in the picture. This happens at the expense of the picture's sharpness."
 
 msgid "This option allows to set the level of dynamic contrast of the picture."
-msgstr "This option allows to set the level of dynamic contrast of the picture."
+msgstr ""
+"This option lets you set the dynamic contrast level in the picture.\n"
+"This makes dark areas darker and bright areas brighter, but at the expense of picture detail."
 
 msgid "This option allows you can config the Colordepth for UHD"
-msgstr "This option allows you can config the Colordepth for UHD"
+msgstr "This option lets you set the color depth (also known as as bit depth) for UHD"
 
 msgid "This option allows you can config the Colorimetry for HDR"
-msgstr "This option allows you can config the Colorimetry for HDR"
+msgstr "This option lets you set the colorimetry for HDR.This relates to how color is perceived."
 
 msgid "This option allows you can config the Colorspace from Auto to RGB"
-msgstr "This option allows you can config the Colorspace from Auto to RGB"
+msgstr ""
+"Choose between Auto and RGB color spaces.\n"
+"This determines how color signals are sent to your TV."
 
-#, fuzzy
 msgid "This option allows you can enable or disable the 10 Bit Color Mode"
-msgstr "This option allows you can config the Colordepth for UHD"
+msgstr "Choose whether to enable or disable 10-bit color mode"
 
-#, fuzzy
 msgid "This option allows you can enable or disable the 12 Bit Color Mode"
-msgstr "This option allows you can config the Colordepth for UHD"
+msgstr "Choose whether to enable or disable 12-bit color mode"
 
-#, fuzzy
 msgid "This option allows you can force the HDR Modes for UHD"
-msgstr "This option allows you can config the Colordepth for UHD"
+msgstr ""
+"This option allows you to force HDR mode for UHD\n"
+"High Dynamic Range; HDR pictures on supported television sets will have brighter highlights, more impact and a wider range of color detail."
 
-#, fuzzy
 msgid "This option allows you can force the HDR10 Modes for UHD"
-msgstr "This option allows you can config the Colordepth for UHD"
+msgstr ""
+"This option allows you to force HDR10 mode for UHD\n"
+"High Dynamic Range for streaming; HDR10 is similar to Dolby Vision.HDR pictures on supported television sets will have brighter highlights, more impact and a wider range of color detail."
 
-#, fuzzy
 msgid "This option allows you can force the HLG Modes for UHD"
-msgstr "This option allows you can config the Colordepth for UHD"
+msgstr ""
+"This option allows you to force HLG mode for UHDHybrid Log Gamma; HLG is a type of High Dynamic Range (HDR) for broadcast cable, satellite and live TV.\n"
+"HDR pictures on supported television sets have brighter highlights, more impact and a wider range of color detail."
 
 msgid "This option allows you choose how to display elapsed time  as + or -"
-msgstr "This option allows you choose how to display elapsed time  as + or -"
+msgstr "Choose whether to display elapsed time as + or -"
 
 msgid "This option allows you choose how to display remaining time, or elapsed time, or both."
-msgstr "This option allows you choose how to display remaining time, or elapsed time, or both."
+msgstr "Choose whether to display remaining time, elapsed time, or both."
 
-#, fuzzy
 msgid "This option allows you choose how to display the Time or nothing in Standby"
-msgstr "This option allows you choose how to display elapsed time  as + or -"
+msgstr "Choose whether to show the time or nothing when the receiver is in standby"
 
 msgid "This option allows you choose how to display the remaining/elapsed time for Media playback."
-msgstr "This option allows you choose how to display the remaining/elapsed time for Media playback."
+msgstr "Choose how to display remaining/elapsed time during media playback."
 
 msgid "This option allows you choose how to display the remaining/elapsed time for live tv."
-msgstr "This option allows you choose how to display the remaining/elapsed time for live tv."
+msgstr "Choose how to display remaining/elapsed time during live TV."
 
 msgid "This option allows you choose how to display the remaining/elapsed time for media playback."
-msgstr "This option allows you choose how to display the remaining/elapsed time for media playback."
+msgstr "Choose how to display remaining/elapsed time during media playback."
 
 msgid "This option allows you choose the background colour of transparent picons."
-msgstr "This option allows you choose the background colour of transparent picons."
+msgstr "Choose which color to show behind channel picons with transparent backgrounds."
 
 msgid "This option allows you enable smoothing filter to control the dithering process."
-msgstr "This option allows you enable smoothing filter to control the dithering process."
+msgstr "Choose whether to enable a smoothing filter to control the dithering process."
 
 msgid "This option allows you enable the vertical scaler dejagging."
-msgstr "This option allows you enable the vertical scaler dejagging."
+msgstr "Choose whether to enable vertical scaler dejagging."
 
 msgid "This option allows you set the layout view (Text or Graphics)."
-msgstr "This option allows you set the layout view (Text or Graphics)."
+msgstr "Choose how you'd like the EPG content to look."
 
 msgid "This option allows you to Power Off the display."
-msgstr "This option allows you to Power Off the display."
+msgstr "Choose whether to power off the front panel display."
 
 msgid "This option allows you to always use e.g. 1080p50 for TV/.ts, and 1080p24/p50/p60 for videos"
-msgstr "This option allows you to always use e.g. 1080p50 for TV/.ts, and 1080p24/p50/p60 for videos"
+msgstr "This option lets you force, for example, 1080p50 for TV/.ts and 1080p24/p50/p60 for videos"
 
 msgid "This option allows you to boost the blue tones in the picture."
-msgstr "This option allows you to boost the blue tones in the picture."
+msgstr "This option lets you boost the blue tones in the picture."
 
 msgid "This option allows you to boost the green tones in the picture."
-msgstr "This option allows you to boost the green tones in the picture."
+msgstr "This option lets you boost the green tones in the picture."
 
 msgid "This option allows you to bypass HDMI EDID check"
-msgstr "This option allows you to bypass HDMI EDID check"
+msgstr "Choose whether to bypass HDMI EDID check (Extended Display Identification Data)"
 
 msgid "This option allows you to change the virtuell loadspeaker position."
-msgstr "This option allows you to change the virtuell loadspeaker position."
+msgstr "Configure the virtual speaker position."
 
 msgid "This option allows you to choose from the two channel lists that are available."
-msgstr "This option allows you to choose from the two channel lists that are available."
+msgstr "Choose from the two channel lists that are available."
 
 msgid "This option allows you to choose how to display 1080p 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 24Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "Choose how to display 1080p 24Hz on your TV (as not all television sets support this resolution)."
 
 msgid "This option allows you to choose how to display 1080p 25Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 25Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "Choose how to display 1080p 25Hz on your TV (as not all television sets support this resolution)."
 
 msgid "This option allows you to choose how to display 1080p 30Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 30Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "Choose how to display 1080p 30Hz on your TV (as not all television sets support this resolution)."
 
-#, fuzzy
 msgid "This option allows you to choose how to display 2160p 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 720p 24Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "Choose how to display 2160p 24Hz on your TV (as not all television sets support this resolution)."
 
-#, fuzzy
 msgid "This option allows you to choose how to display 2160p 25Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 25Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "Choose how to display 2160p 25Hz on your TV (as not all television sets support this resolution)."
 
-#, fuzzy
 msgid "This option allows you to choose how to display 2160p 30Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 30Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "Choose how to display 2160p 30Hz on your TV (as not all television sets support this resolution)."
 
 msgid "This option allows you to choose how to display 720p 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 720p 24Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "Choose how to display 720p 24Hz on your TV (as not all television sets support this resolution)."
 
 msgid "This option allows you to choose how to display SD progressive 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display SD progressive 24Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "Choose how to display SD progressive 24Hz on your TV (as not all television sets support this resolution)."
 
 msgid "This option allows you to choose how to display standard definition video on your TV."
-msgstr "This option allows you to choose how to display standard definition video on your TV."
+msgstr "Choose how to display standard definition (SD) content on your TV."
 
 msgid "This option allows you to choose what the first button press jumps to in channel list screen, (so pressing '2' jumps to 'A' or '2' first), when 'Quick Actions' preset actions are performed. "
-msgstr "This option allows you to choose what the first button press jumps to in channel list screen, (so pressing '2' jumps to 'A' or '2' first), when 'Quick Actions' preset actions are performed. "
+msgstr "Choose what the first button press should jump to on the channel list, (eg, whether pressing the 2 button should jump to 'A' or '2' first), when 'Quick Actions' preset actions are performed. "
 
-#, fuzzy
 msgid "This option allows you to choose whether or not to display genre information for the event."
-msgstr "This option allows you choose how to display the remaining/elapsed time for live tv."
+msgstr "Choose whether to display genre information for events."
 
 msgid "This option allows you to disable show Restart Network in Extensions list."
-msgstr "This option allows you to disable show Restart Network in Extensions list."
+msgstr "Choose whether to show Restart Network on the Extensions screen."
 
 msgid "This option allows you to disable sorting of the Extensions list."
-msgstr "This option allows you to disable sorting of the Extensions list."
+msgstr "Choose whether to sort the Extensions list."
 
 msgid "This option allows you to disable sorting of the option in setting screen's"
-msgstr "This option allows you to disable sorting of the option in setting screen's"
+msgstr "Choose whether to sort items on settings screens."
 
 msgid "This option allows you to enable 3D Surround Sound."
-msgstr "This option allows you to enable 3D Surround Sound."
+msgstr "Choose whether to enable 3D Surround Sound."
 
 msgid "This option allows you to hide and sorting of the menus"
-msgstr "This option allows you to hide and sorting of the menus"
+msgstr "This option lets you hide and sort menus."
 
 msgid "This option allows you to hide and sorting of the plugin browser."
-msgstr "This option allows you to hide and sorting of the plugin browser."
+msgstr "This option lets you hide and sort items in the Plugin Browser."
 
 msgid "This option allows you to show menu number quick links."
-msgstr "This option allows you to show menu number quick links."
+msgstr "Choose whether to show menu item numbers for easy access."
 
 msgid "This option allows you to the SNR as a percentage (not all receivers support this)."
-msgstr "This option allows you to the SNR as a percentage (not all receivers support this)."
+msgstr "Choose whether to show SNR as a percentage (not all receivers support this)."
 
-#, fuzzy
 msgid "This option allows you to use all HDMI Modes"
-msgstr "This option allows you to bypass HDMI EDID check"
+msgstr "Choose whether to use list all HDMI modes (not all television sets support all modes)."
 
 msgid "This option allows you to view the old and new settings side by side."
-msgstr "This option allows you to view the old and new settings side by side."
+msgstr "This option lets you see the effect of the previous and new settings side-by-side."
 
-#, fuzzy
 msgid "This option configures the general audio delay for BT Speakers."
-msgstr "This option configures the general audio delay of stereo sound tracks."
+msgstr "Configure the general audio delay for BT Speakers."
 
 msgid "This option configures the general audio delay of Dolby Digital sound tracks."
-msgstr "This option configures the general audio delay of Dolby Digital sound tracks."
+msgstr "Configure the general audio delay for Dolby Digital (also known as Dolby AC-3) audio tracks."
 
 msgid "This option configures the general audio delay of stereo sound tracks."
-msgstr "This option configures the general audio delay of stereo sound tracks."
+msgstr "Configure the general audio delay for stereo audio tracks."
 
 msgid "This option configures the picture sharpness."
-msgstr "This option configures the picture sharpness."
+msgstr "Configure the picture sharpness."
 
 msgid "This option configures the screen resolution in PC output mode."
-msgstr "This option configures the screen resolution in PC output mode."
+msgstr "Configure the screen resolution in PC output mode."
 
 msgid "This option configures the video output mode (or resolution)."
-msgstr "This option configures the video output mode (or resolution)."
+msgstr "Configure the video output mode/resolution."
 
 msgid "This option configures you can set Auto Volume Level."
-msgstr "This option configures you can set Auto Volume Level."
+msgstr "Configure the Auto Volume Level."
 
 msgid "This option lets you adjust the 3D depth"
-msgstr "This option lets you adjust the 3D depth"
+msgstr "Adjust the 3D depth"
 
 msgid "This option lets you adjust the transparency of the user interface"
-msgstr "This option lets you adjust the transparency of the user interface"
+msgstr "Adjust the user interface background transparency."
 
 msgid "This option lets you choose the 3D mode"
-msgstr "This option lets you choose the 3D mode"
+msgstr "Choose the 3D mode"
 
 msgid "This option lets you show the option in the extension screen"
-msgstr "This option lets you show the option in the extension screen"
+msgstr "Choose whether to show the option on the Extensions screen"
 
 msgid "This option moves the PVR status from the separate window into the MoviePlayer infobar."
-msgstr "This option moves the PVR status from the separate window into the MoviePlayer infobar."
+msgstr "This option lets you move the PVR status from a separate window into the movie player's infobar."
 
 msgid "This option set the level of suppression of mosquito noise (Mosquito Noise is random aliasing as a result of strong compression). Obviously this goes at the cost of picture details."
-msgstr "This option set the level of suppression of mosquito noise (Mosquito Noise is random aliasing as a result of strong compression). Obviously this goes at the cost of picture details."
+msgstr ""
+"This option lets you set the mosquito noise suppression level. This happens at the expense of picture detail.\n"
+"Mosquito noise is random aliasing as a result of strong compression."
 
 msgid "This option sets  the picture contrast."
-msgstr "This option sets  the picture contrast."
+msgstr "This option lets you set the picture contrast level."
 
 msgid "This option sets the picture brightness."
-msgstr "This option sets the picture brightness."
+msgstr "This option lets you set the picture brightness level."
 
 msgid "This option sets the picture color space."
-msgstr "This option sets the picture color space."
+msgstr "This option lets you set the picture color space."
 
 msgid "This option sets the picture flesh tones."
-msgstr "This option sets the picture flesh tones."
+msgstr "This option lets you set the picture flesh tone level."
 
 msgid "This option sets the picture hue."
-msgstr "This option sets the picture hue."
+msgstr "This option lets you set the picture hue level."
 
 msgid "This option sets the picture saturation."
-msgstr "This option sets the picture saturation."
+msgstr "This option lets you set the picture saturation level."
 
 msgid "This option sets the scaler sharpness, used when stretching picture from 4:3 to 16:9."
-msgstr "This option sets the scaler sharpness, used when stretching picture from 4:3 to 16:9."
+msgstr "This option lets you set the scaler sharpness level, used when stretching the picture from 4:3 to 16:9 ratio."
 
 msgid "This option sets the surpression of false digital contours, that are the result of a limited number of discrete values."
-msgstr "This option sets the surpression of false digital contours, that are the result of a limited number of discrete values."
+msgstr "This option lets you set the supression level of false digital contours."
 
 msgid "This option sets up the picture sharpness, used when the picture is being upscaled."
-msgstr "This option sets up the picture sharpness, used when the picture is being upscaled."
+msgstr "This option lets you set the picture sharpness level, used when upscaling the picture."
 
-#, fuzzy, python-format
 msgid ""
 "This plugin creates a USB stick which can be used to update the firmware of your %s %s without the need for a network or WLAN connection.\n"
 "First, a USB stick needs to be prepared so that it becomes bootable.\n"
 "In the next step, an NFI image file can be downloaded from the update server and saved on the USB stick.\n"
 "If you already have a prepared bootable USB stick, please insert it now. Otherwise plug in a USB stick with a minimum size of 64 MB!"
-msgstr "\"\"This plugin creates a USB stick which can be used to update the firmware of your %s %s without the need for a network or WLAN connection.First, a USB stick needs to be prepared so that it becomes bootable.In the next step, an NFI image file can be downloaded from the update server and saved on the USB stick.If you already have a prepared bootable USB stick, please insert it now. Otherwise plug in a USB stick with a minimum size of 64 MB!\"\""
+msgstr ""
+"This plugin creates a USB stick which can be used to update your %s %s's image without the need for a network connection.\n"
+"First, a USB stick needs to be prepared so that it becomes bootable.\n"
+"In the next step, an NFI image file can be downloaded from the update server and saved on the USB stick.\n"
+"If you have already prepared a bootable USB stick, please insert it now. Otherwise plug in a USB stick with a minimum size of 64 MB!"
 
 msgid "This plugin is installed."
 msgstr "This plugin is installed."
@@ -17492,9 +17585,10 @@ msgid ""
 "- if you configured your nameservers manually please verify your entries in the \"Nameserver\" configuration"
 msgstr ""
 "This test checks for configured nameservers.\n"
-"If you get a \"unconfirmed\" message:\n"
-"- please check your DHCP, cabling and adapter setup\n"
-"- if you configured your nameservers manually please verify your entries in the \"Nameserver\" configuration"
+"\n"
+"If you get an \"unconfirmed\" result:\n"
+"• check your DHCP settings, adapter setup and wireless network or cable\n"
+"• if your nameservers were configured manually, please verify the details that were entered"
 
 msgid ""
 "This test checks whether a network cable is connected to your LAN adapter.\n"
@@ -17502,10 +17596,11 @@ msgid ""
 "- verify that a network cable is attached\n"
 "- verify that the cable is not broken"
 msgstr ""
-"This test checks whether a network cable is connected to your LAN adapter.\n"
-"If you get a \"disconnected\" message:\n"
-"- verify that a network cable is attached\n"
-"- verify that the cable is not broken"
+"This test checks whether there's a network cable connected to your LAN adapter.\n"
+"\n"
+"If you get a \"disconnected\" result:\n"
+"• check there's a network cable attached\n"
+"• check that the cable isn't damaged"
 
 msgid ""
 "This test checks whether a valid IP address is found for your LAN adapter.\n"
@@ -17513,10 +17608,10 @@ msgid ""
 "- no valid IP address was found\n"
 "- please check your DHCP, cabling and adapter setup"
 msgstr ""
-"This test checks whether a valid IP address is found for your LAN adapter.\n"
-"If you get a \"unconfirmed\" message:\n"
-"- no valid IP address was found\n"
-"- please check your DHCP, cabling and adapter setup"
+"This test checks whether your receiver's LAN adapter has a valid IP address.\n"
+"\n"
+"If you get an \"unconfirmed\" message, a valid IP address wasn't found:\n"
+"• please check your DHCP config, cabling and adapter setup"
 
 msgid ""
 "This test checks whether your LAN adapter is set up for automatic IP address configuration with DHCP.\n"
@@ -17527,11 +17622,12 @@ msgid ""
 "-verify that you have a configured and working DHCP server in your network."
 msgstr ""
 "This test checks whether your LAN adapter is set up for automatic IP address configuration with DHCP.\n"
-"If you get a \"disabled\" message:\n"
-" - then your LAN adapter is configured for manual IP setup\n"
-"- verify thay you have entered correct IP informations in the adapter setup dialog.\n"
-"If you get an \"enabled\" message:\n"
-"-verify that you have a configured and working DHCP server in your network."
+"\n"
+"If you get a \"disabled\" result, your LAN adapter's IP address is configured manually:\n"
+"• verify that you have entered the correct details in the adapter's DHCP configuration.\n"
+"\n"
+"If you get an \"enabled\" result:\n"
+"• verify that you have a working and properly-configured DHCP server on your network."
 
 msgid "This test detects your configured LAN adapter."
 msgstr "This test detects your configured LAN adapter."
@@ -17540,11 +17636,11 @@ msgid ""
 "This will (re-)calculate all positions of your rotor and may remove previously memorised positions and fine-tuning!\n"
 "Are you sure?"
 msgstr ""
-"This will (re-)calculate all positions of your rotor and may remove previously memorised positions and fine-tuning!\n"
+"This will (re-)calculate all rotator positions and may remove previously memorized positions and fine-tuning!\n"
 "Are you sure?"
 
 msgid "This will go fast forward/backward with time frames of x secs"
-msgstr "This will go fast forward/backward with time frames of x secs"
+msgstr "This will go fast forward/backward with time frames of # seconds"
 
 msgid "Three"
 msgstr "Three"
@@ -17552,6 +17648,7 @@ msgstr "Three"
 msgid "Threshold"
 msgstr "Threshold"
 
+#. TRANSLATORS: genre category
 msgid "Thriller"
 msgstr ""
 
@@ -17567,8 +17664,9 @@ msgstr "Thursday"
 msgid "TiVo support"
 msgstr "TiVo support"
 
+#. TRANSLATORS: genre category
 msgid "Tiere"
-msgstr ""
+msgstr "Animals"
 
 msgid "Time"
 msgstr "Time"
@@ -17583,25 +17681,22 @@ msgid "Time between slides in image viewer slideshow."
 msgstr ""
 
 msgid "Time delay for the repeated transmission"
-msgstr ""
+msgstr "Repeat transmission delay"
 
 msgid "Time delay of the shutdown messages"
-msgstr ""
+msgstr "Shutdown message delay"
 
-#, fuzzy
 msgid "Time delay until standby or deep standby"
-msgstr "Regard deep standby as standby"
+msgstr "Standby or deep standby message duration"
 
-#, fuzzy
 msgid "Time for Slideshow"
-msgstr "Timer overview"
+msgstr "Slideshow interval"
 
 msgid "Time for next LCD scrolling"
-msgstr "Time for next LCD scrolling"
+msgstr "Time for next front panel display scrolling"
 
-#, fuzzy
 msgid "Time history"
-msgstr "Timer editor"
+msgstr "Initial history"
 
 msgid "Time jump avoid zero step size"
 msgstr "Time jump avoid zero step size"
@@ -17618,9 +17713,8 @@ msgstr "Time jump repeat interval for fast forward/backward"
 msgid "Time jump: Use normal fast forward for speeds"
 msgstr "Time jump: Use normal fast forward for speeds"
 
-#, fuzzy
 msgid "Time long"
-msgstr "Timer log"
+msgstr "Time button hold"
 
 msgid "Time range:"
 msgstr "Time range:"
@@ -17630,30 +17724,28 @@ msgid "Time required for this process: %s"
 msgstr ""
 
 msgid "Time scale"
-msgstr "Time scale"
+msgstr "Time range"
 
 msgid "Time settings"
-msgstr "Time settings"
+msgstr "Time Settings"
 
-#, fuzzy
 msgid "Time style"
-msgstr "Time scale"
+msgstr "Time format"
 
 msgid "Time to execute command or script"
-msgstr "Time to execute command or script"
+msgstr "Run command or script at"
 
 msgid "Time window for detection of the wakeup by a timer [mins]"
-msgstr "Time window for detection of the wakeup by a timer [mins]"
+msgstr "Time window for detection of the wake-up by a timer (in minutes)"
 
-#, fuzzy
 msgid "Time zone settings"
-msgstr "Time settings"
+msgstr "Time zone settings"
 
 msgid "Timeline 24 Hour"
-msgstr "Timeline 24 Hour"
+msgstr "24-hour format timeline"
 
 msgid "Timeline font size"
-msgstr "Timeline font size"
+msgstr "Timeline text size"
 
 msgid "Timer"
 msgstr "Timer"
@@ -17671,14 +17763,14 @@ msgid "Timer editor"
 msgstr "Timer editor"
 
 msgid "Timer entry"
-msgstr "Timer entry"
+msgstr "Timer Entry"
 
 #, python-format
 msgid "Timer is activated: +%d min"
-msgstr "Timer is activated: +%d min"
+msgstr "Timer is active: +%d min"
 
 msgid "Timer is not activated"
-msgstr "Timer is not activated"
+msgstr "Timer isn't active"
 
 msgid "Timer log"
 msgstr "Timer log"
@@ -17687,18 +17779,18 @@ msgid ""
 "Timer overlap in pm_timers.xml detected!\n"
 "Please recheck it!"
 msgstr ""
-"Timer overlap in pm_timers.xml detected!\n"
-"Please recheck it!"
+"A timer overlap was found in the pm_timers.xml file\n"
+"Please check your timers."
 
 msgid ""
 "Timer overlap in timers.xml detected!\n"
 "Please recheck it!"
 msgstr ""
-"Timer overlap in timers.xml detected!\n"
-"Please recheck it!"
+"A timer overlap was found in the timers.xml file\n"
+"Please check your timers."
 
 msgid "Timer overview"
-msgstr "Timer overview"
+msgstr "Timer Overview"
 
 msgid "Timer record location"
 msgstr "Timer record location"
@@ -17707,10 +17799,10 @@ msgid "Timer recording location"
 msgstr "Timer recording location"
 
 msgid "Timer sanity error"
-msgstr "Timer sanity error"
+msgstr "Timer Sanity Check"
 
 msgid "Timer selection"
-msgstr "Timer selection"
+msgstr "Timer Selection"
 
 msgid "Timer selection..."
 msgstr "Timer selection..."
@@ -17725,53 +17817,54 @@ msgid "Timeshift"
 msgstr "Timeshift"
 
 msgid "Timeshift buffer delete after zap?"
-msgstr "Timeshift buffer delete after zap?"
+msgstr "Delete timeshift buffer after zap"
 
 msgid "Timeshift buffer limit [in hours]"
-msgstr "Timeshift buffer limit [in hours]"
+msgstr "Timeshift buffer time limit (in hours)"
 
 msgid "Timeshift checking for free space?"
-msgstr "Timeshift checking for free space?"
+msgstr "Timeshift checking for free space"
 
 msgid "Timeshift checking for older files [in minutes]"
-msgstr "Timeshift checking for older files [in minutes]"
+msgstr "Timeshift checking for older files (in minutes)"
 
 msgid "Timeshift event based file splitting"
-msgstr "Timeshift event based file splitting"
+msgstr "Event-based timeshift buffer file splitting"
 
 msgid "Timeshift last events limit [number of events]"
-msgstr "Timeshift last events limit [number of events]"
+msgstr "Timeshift last events limit (number of events)"
 
 msgid "Timeshift location"
-msgstr "Timeshift location"
+msgstr "Timeshift buffer location"
 
 msgid "Timeshift not possible!"
-msgstr "Timeshift not possible!"
+msgstr "Can't start timeshift mode!"
 
 msgid "Timeshift save failed!"
-msgstr "Timeshift save failed!"
+msgstr "Couldn't save timeshift buffer!"
 
 msgid "Timeshift save recording (Select event)"
-msgstr "Timeshift save recording (Select event)"
+msgstr "Timeshift save recording (select event)"
 
 msgid "Timeshift save recording (stop after current event)"
 msgstr "Timeshift save recording (stop after current event)"
 
 msgid "Timeshift saved to your harddisk!"
-msgstr "Timeshift saved to your harddisk!"
+msgstr "Timeshift buffer saved!"
 
 msgid "Timeshift settings"
-msgstr "Timeshift settings"
+msgstr "Timeshift Settings"
 
 msgid "Timeshift will get saved at end of event!"
-msgstr "Timeshift will get saved at end of event!"
+msgstr "Timeshift buffer will be saved at the end of event."
 
 msgid "Timeshift-save action on zap"
-msgstr "Timeshift-save action on zap"
+msgstr "Timeshift action on zap"
 
 msgid "Timezone"
-msgstr "Timezone"
+msgstr "Time zone"
 
+#. TRANSLATORS: regional option
 msgid "Timor-Leste"
 msgstr "Timor-Leste"
 
@@ -17784,9 +17877,8 @@ msgstr "Title properties"
 msgid "Titleset mode"
 msgstr "Titleset mode"
 
-#, fuzzy
 msgid "To restore the image:"
-msgstr "no resource manager"
+msgstr "To restore the image:"
 
 #, python-format
 msgid ""
@@ -17795,37 +17887,37 @@ msgid ""
 "2) Turn mains back on and hold the DOWN button on the front panel pressed for 10 seconds.\n"
 "3) Wait for bootup and follow instructions of the wizard."
 msgstr ""
-"To update your %s %s firmware, please follow these steps:\n"
-"1) Turn off your box with the rear power switch and make sure the bootable USB stick is plugged in.\n"
-"2) Turn mains back on and hold the DOWN button on the front panel pressed for 10 seconds.\n"
-"3) Wait for bootup and follow instructions of the wizard."
+"To update your %s %s's image, please follow these steps:\n"
+"• Turn your receiver off using the rear switch or power supply and make sure the bootable USB stick is connected.\n"
+"• Turn the power back on and hold the ▼ Down or Power button on the front panel for 10 seconds.\n"
+"• Wait for startup, then follow the steps in the wizard."
 
 msgid "Today"
 msgstr "Today"
 
 msgid "Toggels between tv and radio..."
-msgstr "Toggels between tv and radio..."
+msgstr "Toggles between TV and radio modes..."
 
 msgid "Toggle Digital downmix..."
-msgstr "Toggle Digital downmix..."
+msgstr "Toggle digital downmix..."
 
 msgid "Toggle HDMI-In PiP"
-msgstr "Toggle HDMI-In PiP"
+msgstr "Toggle PiP HDMI-in"
 
 msgid "Toggle HDMI-In full screen"
-msgstr "Toggle HDMI-In full screen"
+msgstr "Toggle full-screen HDMI-in"
 
 msgid "Toggle LCD LiveTV"
-msgstr "Toggle LCD LiveTV"
+msgstr "Toggle live TV on front panel display"
 
 msgid "Toggle PIPzap"
-msgstr "Toggle PIPzap"
+msgstr "Toggle PiP zap"
 
 msgid "Toggle Picture In Graphics"
-msgstr "Toggle Picture In Graphics"
+msgstr "Toggle mini TV mode"
 
 msgid "Toggle Pillarbox <> Pan&Scan"
-msgstr "Toggle Pillarbox <> Pan&Scan"
+msgstr "Toggle between pillarbox / pan and scan modes"
 
 msgid "Toggle a cut mark at the current position"
 msgstr "Toggle a cut mark at the current position"
@@ -17834,14 +17926,16 @@ msgid "Toggle aspect ratio..."
 msgstr "Toggle aspect ratio..."
 
 msgid "Toggle between bouquet/epg lists"
-msgstr "Toggle between bouquet/epg lists"
+msgstr "Toggle between bouquet/EPG lists"
 
 msgid "Toggle new text inserts before or overwrites existing text"
-msgstr ""
+msgstr "Choose whether new text should be inserted before, or overwrite existing text"
 
+#. TRANSLATORS: regional option
 msgid "Togo"
 msgstr "Togo"
 
+#. TRANSLATORS: regional option
 msgid "Tokelau"
 msgstr "Tokelau"
 
@@ -17857,6 +17951,7 @@ msgstr "Toneburst"
 msgid "Toneburst A/B"
 msgstr "Toneburst A/B"
 
+#. TRANSLATORS: regional option
 msgid "Tonga"
 msgstr "Tonga"
 
@@ -17870,10 +17965,10 @@ msgid "Total"
 msgstr "Total"
 
 msgid "Total Memory:"
-msgstr "Total Memory:"
+msgstr "Total memory:"
 
 msgid "Total Swap:"
-msgstr "Total Swap:"
+msgstr "Total swap:"
 
 msgid "Total cards:"
 msgstr "Total cards:"
@@ -17883,10 +17978,10 @@ msgid "Total clients streaming: %d ( %s )"
 msgstr "Total clients streaming: %d (%s)"
 
 msgid "Total handled client ecm's"
-msgstr "Total handled client ecm's"
+msgstr "Total handled client ECMs"
 
 msgid "Total handled client emm's"
-msgstr "Total handled client emm's"
+msgstr "Total handled client EMMs"
 
 msgid "Total:"
 msgstr "Total:"
@@ -17894,11 +17989,13 @@ msgstr "Total:"
 msgid "Track"
 msgstr "Track"
 
+#. TRANSLATORS: regional option
 msgid "Traditional Chinese"
 msgstr "Traditional Chinese"
 
+#. TRANSLATORS: genre category
 msgid "Tragödie"
-msgstr ""
+msgstr "Tragedy"
 
 msgid "Transcode"
 msgstr "Transcode"
@@ -17930,25 +18027,26 @@ msgstr "Transponder Time"
 msgid "Transponder type"
 msgstr "Transponder type"
 
-#, fuzzy
 msgid "Transport Stream Type"
-msgstr "Transponder type"
+msgstr "Transport Stream Type"
 
 msgid "Trashcan"
-msgstr "Trashcan"
+msgstr "Trash can"
 
 msgid "Trashcan:"
-msgstr "Trashcan:"
+msgstr "Trash can:"
 
+#. TRANSLATORS: genre category
 msgid "Travel"
 msgstr ""
 
 msgid "Tried to disable PIP, suddenly found no InfoBar.instance.\n"
-msgstr "Tried to disable PIP, suddenly found no InfoBar.instance.\n"
+msgstr "Tried to disable PiP, suddenly found no InfoBar.instance.\n"
 
 msgid "Tries left:"
-msgstr "Tries left:"
+msgstr "Attempts remaining:"
 
+#. TRANSLATORS: regional option
 msgid "Trinidad and Tobago"
 msgstr "Trinidad and Tobago"
 
@@ -17962,13 +18060,13 @@ msgid "TrueType font (SD)"
 msgstr "TrueType font (SD)"
 
 msgid "TrueType font (full-HD)"
-msgstr "TrueType font (full-HD)"
+msgstr "TrueType font (Full HD)"
 
 msgid "Try to find used transponders in cable network.. please wait..."
-msgstr "Try to find used transponders in cable network.. please wait..."
+msgstr "Trying to find transponders used in cable network, please wait..."
 
 msgid "Try to find used transponders in terrestrial network.. please wait..."
-msgstr "Try to find used transponders in terrestrial network.. please wait..."
+msgstr "Trying to find transponders used in terrestrial network, please wait..."
 
 msgid "Try to prevent reboots for software errors and maintain of the availability for the receiver."
 msgstr ""
@@ -17980,10 +18078,10 @@ msgid "Try to slow down the send interval if not all commands are executed."
 msgstr ""
 
 msgid "Trying to download a new packetlist. Please wait..."
-msgstr "Trying to download a new packetlist. Please wait..."
+msgstr "Trying to download a list of packages, please wait..."
 
 msgid "Trying to download a new updatelist. Please wait..."
-msgstr "Trying to download a new updatelist. Please wait..."
+msgstr "Trying to download a list of updates..."
 
 msgid "Tue"
 msgstr "Tue"
@@ -17998,11 +18096,10 @@ msgid "Tune and focus"
 msgstr "Tune and focus"
 
 msgid "Tune failed!"
-msgstr "Tune failed!"
+msgstr "Signal lost!"
 
-#, fuzzy
 msgid "Tuned for recording"
-msgstr "Preferred tuner for recordings"
+msgstr "Tuned for recording"
 
 msgid "Tuner"
 msgstr "Tuner"
@@ -18020,7 +18117,7 @@ msgid "Tuner Setup"
 msgstr "Tuner Setup"
 
 msgid "Tuner configuration"
-msgstr "Tuner configuration"
+msgstr "Tuner Configuration"
 
 msgid "Tuner is not supported"
 msgstr "Tuner is not supported"
@@ -18035,22 +18132,22 @@ msgid "Tuner status"
 msgstr "Tuner status"
 
 msgid "Tuner status FAILED"
-msgstr "Tuner status FAILED"
+msgstr "Tuner status: FAILED"
 
 msgid "Tuner status IDLE"
-msgstr "Tuner status IDLE"
+msgstr "Tuner status: IDLE"
 
 msgid "Tuner status LOCKED"
-msgstr "Tuner status LOCKED"
+msgstr "Tuner status: LOCKED"
 
 msgid "Tuner status LOSTLOCK"
-msgstr "Tuner status LOSTLOCK"
+msgstr "Tuner status: LOSTLOCK"
 
 msgid "Tuner status TUNING"
-msgstr "Tuner status TUNING"
+msgstr "Tuner status: TUNING"
 
 msgid "Tuner status UNKNOWN"
-msgstr "Tuner status UNKNOWN"
+msgstr "Tuner status: UNKNOWN"
 
 #, python-format
 msgid "Tuner type %s"
@@ -18059,6 +18156,7 @@ msgstr "Tuner type %s"
 msgid "Tuning algorithm"
 msgstr "Tuning algorithm"
 
+#. TRANSLATORS: regional option
 msgid "Tunisia"
 msgstr "Tunisia"
 
@@ -18067,33 +18165,37 @@ msgid ""
 "Fast: One reboot after flash, one reboot after restore\n"
 "Slow: One reboot after flash, one reboot after restore in GUI"
 msgstr ""
-"Turbo: One reboot after flash\n"
-"Fast: One reboot after flash, one reboot after restore\n"
-"Slow: One reboot after flash, one reboot after restore in GUI"
+"Turbo: Reboot once, after flash\n"
+"Fast: Reboot after flash and after restore\n"
+"Slow: Reboot after flash, and after restore in user interface"
 
+#. TRANSLATORS: regional option
 msgid "Turkey"
 msgstr "Turkey"
 
+#. TRANSLATORS: regional option
 msgid "Turkish"
 msgstr "Turkish"
 
+#. TRANSLATORS: regional option
 msgid "Turkmenistan"
 msgstr "Turkmenistan"
 
+#. TRANSLATORS: regional option
 msgid "Turks and Caicos Islands"
 msgstr "Turks and Caicos Islands"
 
 msgid "Turn off HDMI-IN Full screen mode"
-msgstr "Turn off HDMI-IN Full screen mode"
+msgstr "Turn off HDMI-in full-screen mode"
 
 msgid "Turn off HDMI-IN PiP mode"
-msgstr "Turn off HDMI-IN PiP mode"
+msgstr "Turn off HDMI-in PiP mode"
 
 msgid "Turn on HDMI-IN Full screen mode"
-msgstr "Turn on HDMI-IN Full screen mode"
+msgstr "Turn on HDMI-in full-screen mode"
 
 msgid "Turn on HDMI-IN PiP mode"
-msgstr "Turn on HDMI-IN PiP mode"
+msgstr "Turn on HDMI-in PiP mode"
 
 msgid "Turn on the power LED."
 msgstr ""
@@ -18101,6 +18203,7 @@ msgstr ""
 msgid "Turning step size"
 msgstr "Turning step size"
 
+#. TRANSLATORS: regional option
 msgid "Tuvalu"
 msgstr "Tuvalu"
 
@@ -18116,9 +18219,8 @@ msgstr "Type"
 msgid "Type of scan"
 msgstr "Type of scan"
 
-#, fuzzy
 msgid "Type:"
-msgstr "Type: "
+msgstr "Type:"
 
 msgid "Type: "
 msgstr "Type: "
@@ -18139,7 +18241,7 @@ msgid "USALS"
 msgstr "USALS"
 
 msgid "USALS automatically moves a motorised dish to the correct satellite based on the coordinates entered by the user. Without USALS each satellite will need to be setup and saved individually."
-msgstr ""
+msgstr "USALS automatically moves a motorized dish to the correct satellite based on the co-ordinates entered by the user. Without USALS, each satellite will need to be set up and saved individually."
 
 msgid "USALS calibration"
 msgstr "USALS calibration"
@@ -18156,37 +18258,39 @@ msgstr ""
 msgid "USB switch ERROR! - root files not transferred to USB"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Uganda"
 msgstr "Uganda"
 
+#. TRANSLATORS: regional option
 msgid "Ukraine"
 msgstr "Ukraine"
 
+#. TRANSLATORS: regional option
 msgid "Ukrainian"
 msgstr "Ukrainian"
 
+#. TRANSLATORS: genre category
 msgid "Umweltbewusstsein"
-msgstr ""
+msgstr "Environmental awareness"
 
-#, fuzzy
 msgid "Unable to change password"
-msgstr "Please enter new name:"
+msgstr "Unable to change password"
 
 msgid "Unable to create the required directories on the media (e.g. USB stick or Harddisk) - Please verify media and try again!"
-msgstr ""
+msgstr "Couldn't create the required folders. Please verify the media (e.g. USB stick or hard disk) and try again!"
 
 msgid "Unattended upgrade without GUI"
-msgstr "Unattended upgrade without GUI"
+msgstr "Unattended upgrade without user interface"
 
 msgid "Unattended upgrade without GUI and reboot system"
-msgstr "Unattended upgrade without GUI and reboot system"
+msgstr "Unattended upgrade without user interface and reboot system"
 
-#, fuzzy
 msgid "Undefined"
-msgstr "User defined"
+msgstr "Undefined"
 
 msgid "Undetermined"
-msgstr "Undetermined"
+msgstr "undetermined"
 
 msgid "Undo install"
 msgstr "Undo install"
@@ -18198,7 +18302,7 @@ msgid "Unencrypted"
 msgstr "Unencrypted"
 
 msgid "UnhandledKey"
-msgstr "UnhandledKey"
+msgstr "Unhandled Key"
 
 msgid "Unhide parental control services"
 msgstr "Unhide parental control services"
@@ -18222,19 +18326,22 @@ msgstr "Uninstall"
 msgid "Uninstall '%s' package and disable '%s'"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "United Arab Emirates"
 msgstr "United Arab Emirates"
 
 msgid "United Kingdom"
 msgstr "United Kingdom"
 
-#, fuzzy
+#. TRANSLATORS: regional option
 msgid "United States"
 msgstr "United States of America"
 
+#. TRANSLATORS: regional option
 msgid "United States Minor Outlying Islands"
 msgstr "United States Minor Outlying Islands"
 
+#. TRANSLATORS: regional option
 msgid "United States of America"
 msgstr "United States of America"
 
@@ -18248,16 +18355,15 @@ msgid ""
 "Unknown Error creating Skin.\n"
 "Please check after reboot MyMetrixLite-Plugin and apply your settings."
 msgstr ""
-"Unknown Error creating Skin.\n"
-"Please check after reboot MyMetrixLite-Plugin and apply your settings."
+"Unknown error creating skin.\n"
+"Please check after reboot MyMetrixLite plugin and apply your settings."
 
-#, fuzzy
 msgid "Unknown error code"
-msgstr "unknown error"
+msgstr "Unknown error code"
 
-#, fuzzy, python-format
+#, python-format
 msgid "Unknown group: %d"
-msgstr "unknown error"
+msgstr "Unknown group: %d"
 
 #, fuzzy
 msgid "Unknown recording event"
@@ -18267,9 +18373,8 @@ msgstr "Stop recording now"
 msgid "Unknown user: %d"
 msgstr "unknown service"
 
-#, fuzzy
 msgid "Unless set to 'disabled' you get a preview of channels inside the EPG list."
-msgstr "If set to 'yes' you can preview channels in the EPG list."
+msgstr "Choose whether you'd like to preview channels from the EPG."
 
 msgid "Unmark service as dedicated 3D service"
 msgstr "Unmark service as dedicated 3D service"
@@ -18281,16 +18386,15 @@ msgstr "Unmount"
 msgid "Unpack to %s"
 msgstr ""
 
-#, fuzzy
 msgid "Unpack to current folder"
-msgstr "Jump to current time"
+msgstr "Unpack to current folder"
 
 msgid "Unsupported"
 msgstr "Unsupported"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Unterhaltung"
-msgstr "Internal"
+msgstr "Entertainment"
 
 msgid "Unused 0x22"
 msgstr ""
@@ -18320,16 +18424,16 @@ msgid "Unused 0xb2"
 msgstr ""
 
 msgid "Unzipping Image"
-msgstr ""
+msgstr "Extracting image..."
 
 msgid "Up"
-msgstr "Up"
+msgstr "▲ Up"
 
 msgid "Up/Down button mode"
-msgstr "Up/Down button mode"
+msgstr "▲ Up / ▼ Down buttons"
 
 msgid "Up/Down buttons also for 'all up/down'?"
-msgstr ""
+msgstr "Synchronize column scrolling"
 
 msgid "Update"
 msgstr "Update"
@@ -18350,17 +18454,17 @@ msgstr[0] "Update completed, %d package was installed."
 msgstr[1] "Update completed, %d packages were installed."
 
 msgid "Update delay for Events in List"
-msgstr "Update delay for Events in List"
+msgstr "Update delay for events in list"
 
 msgid "Update delay for Events in List. Scrolling in List is faster with higher delay, especially on big Lists !"
-msgstr "Update delay for Events in List. Scrolling in List is faster with higher delay, especially on big Lists !"
+msgstr "Update delay for events in list. Scrolling list will be faster with a higher delay, especially on large lists!"
 
 msgid "Update failed!"
 msgstr "Update failed!"
 
 #, python-format
 msgid "Update failed. Your %s %s does not have a working internet connection."
-msgstr "Update failed. Your %s %s does not have a working internet connection."
+msgstr "Update failed. Your %s %s doesn't seem to have a working internet connection."
 
 msgid "Update finished!"
 msgstr "Update finished!"
@@ -18369,36 +18473,35 @@ msgid "Update interval (in seconds)"
 msgstr "Update interval (in seconds)"
 
 msgid "Update is reported as faulty !!"
-msgstr "Update is reported as faulty !!"
+msgstr "Update is reported as faulty!"
 
 msgid ""
 "Update succeeded!\n"
 "Your Bootloader is now up-to-date!"
 msgstr ""
 "Update succeeded!\n"
-"Your Bootloader is now up-to-date!"
+"Your bootloader is now up to date!"
 
 msgid "Update/Backup your firmware, Backup/Restore settings"
-msgstr "Update/Backup your firmware, Backup/Restore settings"
+msgstr "Update or back up your image / back up or restore your settings"
 
 msgid "Update/Backup/Restore your box"
-msgstr "Update/Backup/Restore your box"
+msgstr "Update/Back Up/Restore Your Receiver"
 
 msgid "Updatefeed not available."
-msgstr "Updatefeed not available."
+msgstr "Update feed not available."
 
 msgid "Updates Available:"
 msgstr "Updates Available:"
 
-#, fuzzy
 msgid "Updating cache"
-msgstr "Update Cache"
+msgstr "Updating cache"
 
 msgid "Updating cache, please wait..."
 msgstr "Updating cache, please wait..."
 
 msgid "Updating mount locations."
-msgstr "Updating mount locations."
+msgstr "Updating mount locations..."
 
 msgid "Updating software catalog"
 msgstr "Updating software catalog"
@@ -18418,12 +18521,12 @@ msgid ""
 "Please wait until your %s %s reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Upgrade in progress\n"
-"Please wait until your %s %s reboots\n"
-"This may take a few minutes"
+"Upgrade in progress.\n"
+"Please wait until your %s %s reboots!\n"
+"This could take a while..."
 
 msgid "Upgrade with GUI"
-msgstr "Upgrade with GUI"
+msgstr "Upgrade with user interface"
 
 msgid "Upgrading"
 msgstr "Upgrading"
@@ -18438,20 +18541,20 @@ msgid "Uphops: "
 msgstr "Uphops: "
 
 msgid "Upper USB"
-msgstr "Upper USB"
+msgstr "Top USB"
 
-#, fuzzy
 msgid "Upper case"
-msgstr "Upper USB"
+msgstr "Uppercase"
 
 msgid "Uptime"
 msgstr "Uptime"
 
+#. TRANSLATORS: regional option
 msgid "Uruguay"
 msgstr "Uruguay"
 
 msgid "Usage & GUI"
-msgstr "Usage & GUI"
+msgstr "Usage & User Interface"
 
 msgid "Usage Setup"
 msgstr "Usage Setup"
@@ -18463,39 +18566,52 @@ msgid "Use DHCP"
 msgstr "Use DHCP"
 
 msgid "Use Deinterlacing for 1080i Videosignal?"
-msgstr "Use Deinterlacing for 1080i Videosignal?"
+msgstr "Use deinterlacing for 1080i video signal?"
 
 msgid "Use EIT EPG information when it is available."
-msgstr "Use EIT EPG information when it is available."
+msgstr ""
+"Use EIT EPG information when available.\n"
+"Event Information Table data is broadcast with the video signal and provides information such as title, length, description and more.\n"
+"EIT is the most common EPG data source."
 
+# override source: https://wiki.openpli.org/EPG
 msgid "Use FreeSat EPG information when it is available."
-msgstr "Use FreeSat EPG information when it is available."
+msgstr ""
+"Use Freesat EPG information when available.\n"
+"This is available on 28.2°E Freesat (UK & Ireland)"
 
 msgid "Use HDMI-preemphasis"
-msgstr "Use HDMI-preemphasis"
+msgstr "Use HDMI pre-emphasis"
 
 msgid "Use Harddisk Hardware Standby Timer"
-msgstr "Use Harddisk Hardware Standby Timer"
+msgstr "Use hard disk hardware standby timer"
 
 msgid "Use Keymap"
-msgstr "Use Keymap"
+msgstr "Use keymap"
 
+# override source: https://wiki.openpli.org/EPG
 msgid "Use MHW EPG information when it is available."
-msgstr "Use MHW EPG information when it is available."
+msgstr ""
+"Use MHW EPG information when available.\n"
+"MediaHighWay is available on 13.0°E and 19.2°E Cyfra+ (Poland) or DIGITAL+ (Spain)"
 
 msgid "Use Manual dns-nameserver"
-msgstr "Use Manual dns-nameserver"
+msgstr "Use manual DNS nameserver"
 
+# override source: https://wiki.openpli.org/EPG
 msgid "Use Netmed EPG information when it is available."
-msgstr "Use Netmed EPG information when it is available."
+msgstr ""
+"Use Netmed EPG information when available.\n"
+"This is available on 13.0°E Nova (Greece)"
 
-#, fuzzy
 msgid "Use OnlineFlash in SoftwareManager"
-msgstr "Software Manager"
+msgstr "Use Online Flash in Software Manager"
 
-#, fuzzy
+# override source: https://wiki.openpli.org/EPG
 msgid "Use OpenTV EPG information when it is available."
-msgstr "Use EIT EPG information when it is available."
+msgstr ""
+"Use OpenTV EPG information when available.\n"
+"This is available on Sky 28.2°E (UK & Ireland) and Sky 13°E (Italy), and is only transmitted on channel 'IEPG Data 1' at 28.2, DVB-S, 11778 V, 27500 Symbols, FEC 2/3"
 
 msgid "Use TV remote control"
 msgstr "Use TV remote control"
@@ -18503,11 +18619,17 @@ msgstr "Use TV remote control"
 msgid "Use USALS for this sat"
 msgstr "Use USALS for this sat"
 
+# override source: https://wiki.openpli.org/EPG
 msgid "Use ViaSat EPG information when it is available."
-msgstr "Use ViaSat EPG information when it is available."
+msgstr ""
+"Use ViaSat EPG information when available.\n"
+"This is available on 4.8°E (Sweden)"
 
+# override source: https://wiki.openpli.org/EPG
 msgid "Use Virgin EPG information when it is available."
-msgstr "Use Virgin EPG information when it is available."
+msgstr ""
+"Use Virgin EPG information when available.\n"
+"This is available on Virgin Media (UK and Ireland)"
 
 msgid "Use a gateway"
 msgstr "Use a gateway"
@@ -18525,7 +18647,7 @@ msgid "Use circular LNB"
 msgstr "Use circular LNB"
 
 msgid "Use extended List"
-msgstr "Use extended List"
+msgstr "Use extended list"
 
 msgid "Use fastscan channel names"
 msgstr "Use fastscan channel names"
@@ -18534,22 +18656,22 @@ msgid "Use fastscan channel numbering"
 msgstr "Use fastscan channel numbering"
 
 msgid "Use for load only x days in EPG"
-msgstr "Use for load only x days in EPG"
+msgstr "Use for load only # days in EPG"
 
 msgid "Use frequency or channel"
 msgstr "Use frequency or channel"
 
 msgid "Use individual settings for each directory"
-msgstr "Use individual settings for each directory"
+msgstr "Use per-folder settings"
 
 msgid "Use interface"
-msgstr "Use interface"
+msgstr "Use this interface"
 
 msgid "Use official channel numbering"
 msgstr "Use official channel numbering"
 
 msgid "Use only for Wake on WLan (WoW)"
-msgstr "Use only for Wake on WLan (WoW)"
+msgstr "Use only for Wake on WLAN (WoW)"
 
 msgid "Use original DVB subtitle position"
 msgstr "Use original DVB subtitle position"
@@ -18564,34 +18686,34 @@ msgid "Use slim screen"
 msgstr "Use slim screen"
 
 msgid "Use the Left/Right buttons on your remote to adjust the size of the user interface. Left button decreases the size, Right increases the size."
-msgstr "Use the Left/Right buttons on your remote to adjust the size of the user interface. Left button decreases the size, Right increases the size."
+msgstr "Use the ◀︎ Left and ▶︎ Right buttons on your remote to decrease or increase the size of the user interface respectively."
 
 msgid "Use the Left/Right buttons on your remote to move the user interface left/right"
-msgstr "Use the Left/Right buttons on your remote to move the user interface left/right"
+msgstr "Use the ◀︎ Left and ▶︎ Right buttons on your remote to move the user interface left or right, respectively."
 
 msgid "Use the Left/Right buttons on your remote to move the user interface up/down"
-msgstr "Use the Left/Right buttons on your remote to move the user interface up/down"
+msgstr "Use the ◀︎ Left and ▶︎ Right buttons on your remote to move the user interface up or down, respectively."
 
 msgid "Use the Networkwizard to configure your Network. The wizard will help you to setup your network"
-msgstr "Use the Networkwizard to configure your Network. The wizard will help you to setup your network"
+msgstr "Use the Network Wizard to configure your Network. The wizard will help you to setup your network"
 
 msgid "Use the Softcam Panel to control your Cam. This let you start/stop/select a cam"
-msgstr "Use the Softcam Panel to control your Cam. This let you start/stop/select a cam"
+msgstr "Use the Softcam Panel to control your Cam. This lets you start/stop/select a cam"
 
 msgid "Use the alternative or the conventional radio mode."
-msgstr "Use the alternative or the conventional radio mode."
+msgstr "Choose between conventional or alternative radio mode."
 
 msgid "Use the alternative screen"
 msgstr "Use the alternative screen"
 
 msgid "Use the cursor keys to select an installed image and then Erase button."
-msgstr ""
+msgstr "Use the ▲ Up and ▼ Down buttons to select an installed image to erase."
 
 msgid "Use the cursor keys to select an installed image and then Reboot button."
-msgstr ""
+msgstr "Use the ▲ Up and ▼ Down buttons to select an installed image to reboot to."
 
 msgid "Use the cursor keys to select an installed image and then Start button."
-msgstr ""
+msgstr "Use the ▲ Up and ▼ Down buttons to select an installed image to start."
 
 msgid "Use the extended List"
 msgstr "Use the extended List"
@@ -18600,10 +18722,10 @@ msgid "Use the network wizard to configure selected network adapter"
 msgstr "Use the network wizard to configure selected network adapter"
 
 msgid "Use the network wizard to configure your Network\n"
-msgstr "Use the network wizard to configure your Network\n"
+msgstr "Use the network wizard to configure your network\n"
 
 msgid "Use the up/down keys on your remote control to select an option. After that, press OK."
-msgstr "Use the up/down keys on your remote control to select an option. After that, press OK."
+msgstr "Use the ▲ Up and ▼ Down buttons on your remote to select an option, then press OK."
 
 msgid "Use the wizard to set up basic features"
 msgstr "Use the wizard to set up basic features"
@@ -18615,19 +18737,22 @@ msgid "Use these settings?"
 msgstr "Use these settings?"
 
 msgid "Use this video enhancement settings?"
-msgstr "Use this video enhancement settings?"
+msgstr "Use these video enhancement settings?"
 
 msgid "Use time jumps for fast forward/backward"
 msgstr "Use time jumps for fast forward/backward"
 
 msgid "Use timeshift seekbar while timeshifting?"
-msgstr "Use timeshift seekbar while timeshifting?"
+msgstr "Use timeshift seekbar while timeshifting"
 
 msgid "Use trash can in movielist"
-msgstr "Use trash can in movielist"
+msgstr "Use trash can in the movie list"
 
 msgid "Use workaround for wakeup from deep-standby?"
-msgstr "Use workaround for wakeup from deep-standby?"
+msgstr "Use workaround for wake-up from deep standby"
+
+msgid "Use workaround for wake-up from deep-standby?"
+msgstr "Use workaround for wake-up from deep standby"
 
 msgid "Used service scan type"
 msgstr "Used service scan type"
@@ -18639,7 +18764,7 @@ msgid "User  (keymap.usr)"
 msgstr "User  (keymap.usr)"
 
 msgid "User - bouquets"
-msgstr "User - bouquets"
+msgstr "User bouquets"
 
 msgid "User defined"
 msgstr "User defined"
@@ -18664,7 +18789,7 @@ msgid "User interface visibility"
 msgstr "User interface visibility"
 
 msgid "Userlogo:"
-msgstr ""
+msgstr "User logo:"
 
 msgid "Username"
 msgstr "Username"
@@ -18692,6 +18817,7 @@ msgstr "Using tuner %s"
 msgid "Usually when the subtitle language is the same as the audio language, the subtitles will not be used. Enable this option to allow these subtitles to be used."
 msgstr "Usually when the subtitle language is the same as the audio language, the subtitles will not be used. Enable this option to allow these subtitles to be used."
 
+#. TRANSLATORS: regional option
 msgid "Uzbekistan"
 msgstr "Uzbekistan"
 
@@ -18704,25 +18830,24 @@ msgstr "VLAN connection"
 msgid "VMGM (intro trailer)"
 msgstr "VMGM (intro trailer)"
 
-#, fuzzy
 msgid "VOD"
-msgstr "OSD"
+msgstr "VOD button"
 
-#, fuzzy
 msgid "VOD long"
-msgstr "OK long"
+msgstr "VOD button hold"
 
 #, fuzzy
 msgid "VPN"
 msgstr "OpenVPN"
 
 msgid "VU+"
-msgstr "VU+"
+msgstr "Vu+"
 
+#. TRANSLATORS: regional option
 msgid "Vanuatu"
 msgstr "Vanuatu"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Variety"
 msgstr "variety show"
 
@@ -18730,15 +18855,17 @@ msgstr "variety show"
 msgid "Various"
 msgstr "Previous"
 
+#. TRANSLATORS: regional option
 msgid "Venezuela (Bolivarian Republic of)"
-msgstr "Venezuela (Bolivarian Republic of)"
+msgstr "Venezuela, Bolivarian Republic of"
 
+#. TRANSLATORS: genre category
 msgid "Verkehr"
-msgstr ""
+msgstr "Traffic"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Verschiedenes"
-msgstr "Version"
+msgstr "Various"
 
 msgid "Version"
 msgstr "Version"
@@ -18761,23 +18888,20 @@ msgstr "Version: %s"
 msgid "Vertical"
 msgstr "Vertical"
 
-#, fuzzy
 msgid "Vertical EPG"
-msgstr "Vertical"
+msgstr "Vertical EPG"
 
 msgid "Vertical alignement for the event-progress."
-msgstr ""
+msgstr "Vertical alignement for the event progress."
 
-#, fuzzy
 msgid "Vertical alignement for the service number."
-msgstr "Configure the alignment of service names."
+msgstr "Choose how channel numbers should be vertically aligned."
 
 msgid "Vertical turning speed"
 msgstr "Vertical turning speed"
 
-#, fuzzy
 msgid "VerticalEPG settings"
-msgstr "GraphicalEPG settings"
+msgstr "Vertical EPG Settings"
 
 msgid "Very short filenames"
 msgstr "Very short filenames"
@@ -18824,7 +18948,7 @@ msgstr ""
 "\n"
 "Please press OK if you can see this page on your TV (or select a different input port).\n"
 "\n"
-"The next input port will be automatically probed in 10 seconds."
+"The next input will be checked automatically in 10 seconds."
 
 msgid "Video mode selection."
 msgstr "Video mode selection."
@@ -18856,19 +18980,19 @@ msgid "Video output mode"
 msgstr "Video output mode"
 
 msgid "Video output mode for FHD"
-msgstr "Video output mode for FHD"
+msgstr "FHD video output mode"
 
 msgid "Video output mode for HD"
-msgstr "Video output mode for HD"
+msgstr "HD video output mode"
 
 msgid "Video output mode for SD"
-msgstr "Video output mode for SD"
+msgstr "SD video output mode"
 
 msgid "Video output mode for UHD"
-msgstr "Video output mode for UHD"
+msgstr "UHD video output mode"
 
 msgid "Video settings"
-msgstr "Video settings"
+msgstr "Video Settings"
 
 msgid "Video: "
 msgstr "Video: "
@@ -18878,42 +19002,41 @@ msgid "Video: %s fps"
 msgstr "Video: %s fps"
 
 msgid "VideoEnhancement"
-msgstr "VideoEnhancement"
+msgstr "Video Enhancement"
 
 msgid "VideoEnhancement Setup"
-msgstr "VideoEnhancement Setup"
+msgstr "Video Enhancement Setup"
 
 msgid "VideoEnhancementPreview"
-msgstr "VideoEnhancementPreview"
+msgstr "Video Enhancement Preview"
 
-#, fuzzy
 msgid "VideoFinetune"
-msgstr "Finetune"
+msgstr "Video Fine-Tune"
 
 msgid "VideoWizard"
-msgstr "VideoWizard"
+msgstr "Video Wizard"
 
-#, fuzzy
 msgid "Videoclip"
-msgstr "Video clipping"
+msgstr "Video clip"
 
 msgid "Videocodec"
-msgstr "Videocodec"
+msgstr "Video codec"
 
 msgid "Videoformat"
-msgstr "Videoformat"
+msgstr "Video format"
 
 msgid "Videomode"
-msgstr "Videomode"
+msgstr "Video mode"
 
 msgid "Videosetup"
-msgstr "Videosetup"
+msgstr "Video setup"
 
 msgid "Videosize"
-msgstr "Videosize"
+msgstr "Video size"
 
+#. TRANSLATORS: regional option
 msgid "Viet Nam"
-msgstr "Viet Nam"
+msgstr "Vietnam"
 
 msgid "View"
 msgstr "View"
@@ -18925,46 +19048,46 @@ msgid "View details"
 msgstr "View details"
 
 msgid "View list of available "
-msgstr "View list of available "
+msgstr "List available "
 
 msgid "View list of available CommonInterface extensions"
-msgstr "View list of available CommonInterface extensions"
+msgstr "List available Common Interface extensions"
 
 msgid "View list of available EPG extensions."
-msgstr "View list of available EPG extensions."
+msgstr "List available EPG extensions"
 
 msgid "View list of available Satellite equipment extensions."
-msgstr "View list of available Satellite equipment extensions."
+msgstr "List available satellite equipment extensions"
 
 msgid "View list of available communication extensions."
-msgstr "View list of available communication extensions."
+msgstr "List available communication extensions"
 
 msgid "View list of available default settings"
-msgstr "View list of available default settings"
+msgstr "List available default settings"
 
 msgid "View list of available display and userinterface extensions."
-msgstr "View list of available display and userinterface extensions."
+msgstr "List available display and user interface extensions"
 
 msgid "View list of available multimedia extensions."
-msgstr "View list of available multimedia extensions."
+msgstr "List available multimedia extensions"
 
 msgid "View list of available networking extensions"
-msgstr "View list of available networking extensions"
+msgstr "List available networking extensions"
 
 msgid "View list of available recording extensions"
-msgstr "View list of available recording extensions"
+msgstr "List available recording extensions"
 
 msgid "View list of available skins"
-msgstr "View list of available skins"
+msgstr "List available skins"
 
 msgid "View list of available software extensions"
-msgstr "View list of available software extensions"
+msgstr "List available software extensions"
 
 msgid "View list of available system extensions"
-msgstr "View list of available system extensions"
+msgstr "List available system extensions"
 
 msgid "View mode"
-msgstr "View mode"
+msgstr "Layout style"
 
 msgid "View or edit file (if size < 1MB)"
 msgstr ""
@@ -18985,25 +19108,26 @@ msgstr "View the changes"
 msgid "View video CD..."
 msgstr "View video CD..."
 
+#. TRANSLATORS: genre category
 msgid "Violence"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Virgin Islands (British)"
 msgstr "Virgin Islands (British)"
 
+#. TRANSLATORS: regional option
 msgid "Virgin Islands (U.S.)"
-msgstr "Virgin Islands (U.S.)"
+msgstr "Virgin Islands, U.S."
 
-#, fuzzy
 msgid "Virtual KeyBoard Functions"
-msgstr "Virtual KeyBoard"
+msgstr "Virtual Keyboard Functions"
 
-#, fuzzy
 msgid "Virtual KeyBoard Text:"
-msgstr "Virtual KeyBoard"
+msgstr "Virtual Keyboard Text:"
 
 msgid "Virtual keyboard"
-msgstr "Virtual keyboard"
+msgstr "Virtual Keyboard"
 
 msgid "Vol"
 msgstr "Vol"
@@ -19021,13 +19145,13 @@ msgid "Volume Config"
 msgstr "Volume Config"
 
 msgid "Volume down"
-msgstr "Volume down"
+msgstr "Volume Down"
 
 msgid "Volume up"
-msgstr "Volume up"
+msgstr "Volume Up"
 
 msgid "Vorschau"
-msgstr ""
+msgstr "Preview"
 
 msgid "W"
 msgstr "W"
@@ -19039,21 +19163,22 @@ msgid "WEP"
 msgstr "WEP"
 
 msgid "WLAN connection"
-msgstr "WLAN connection"
+msgstr "Wireless network connection"
+
+msgid "W-LAN Status"
+msgstr "Wireless Network Status"
 
 msgid "WMA Pro"
 msgstr "WMA Pro"
 
-#, fuzzy
 msgid "WMA Pro downmix"
-msgstr "AAC downmix"
+msgstr "WMA Pro downmix"
 
 msgid "WOL Standby"
 msgstr "WOL Standby"
 
-#, fuzzy
 msgid "WPA"
-msgstr "PAL"
+msgstr "WPA"
 
 msgid "WPA or WPA2"
 msgstr "WPA or WPA2"
@@ -19070,24 +19195,25 @@ msgstr ""
 msgid "WWIO_BRE2ZE_TC"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "Waffen"
-msgstr ""
+msgstr "Weapons"
 
 msgid "Wait for timesync at startup"
-msgstr ""
+msgstr "Wait for time sync at startup"
 
 msgid "Wait please while creating swapfile..."
-msgstr "Wait please while creating swapfile..."
+msgstr "Creating swap file..."
 
 msgid "Wait please while scanning for devices..."
-msgstr "Wait please while scanning for devices..."
+msgstr "Scanning for devices, please wait..."
 
 #, python-format
 msgid "Wait please while scanning your %s %s devices..."
-msgstr "Wait please while scanning your %s %s devices..."
+msgstr "Scanning your %s %s's devices, please wait..."
 
 msgid "Wait please while scanning..."
-msgstr "Wait please while scanning..."
+msgstr "Scanning, please wait..."
 
 msgid "Waiting"
 msgstr "Waiting"
@@ -19102,39 +19228,40 @@ msgid "Wake Up"
 msgstr "Wake Up"
 
 msgid "Wake Up To Standby"
-msgstr "Wake Up To Standby"
+msgstr "Wake Up to Standby"
 
 msgid "Wakeup"
-msgstr "Wakeup"
+msgstr "Wake-Up"
 
 msgid "Wakeup TV from standby"
-msgstr "Wakeup TV from standby"
+msgstr "Wake TV from standby"
 
 msgid "Wakeup time before a timer begins [mins]"
-msgstr "Wakeup time before a timer begins [mins]"
+msgstr "Wake-up time before a timer begins (in minutes)"
 
 msgid "Wakeup your AV Receiver from standby"
-msgstr "Wakeup your AV Receiver from standby"
+msgstr "Wake your AV receiver from standby"
 
+#. TRANSLATORS: regional option
 msgid "Wallis and Futuna"
 msgstr "Wallis and Futuna"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "War"
-msgstr "Warning"
+msgstr ""
 
 msgid "Warning"
 msgstr "Warning"
 
 msgid "Warning: This is the last crash before an automatic restart is performed.\n"
-msgstr ""
+msgstr "* Note that your receiver will restart after the next crash.\n"
 
 msgid "Warning: no LNB; using factory defaults."
 msgstr "Warning: no LNB; using factory defaults."
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Wassersport"
-msgstr "water sport"
+msgstr "Watersports"
 
 msgid "Watch movies..."
 msgstr "Watch movies..."
@@ -19149,14 +19276,13 @@ msgid ""
 "Your receiver restarts in 10 seconds!\n"
 "Component: enigma2"
 msgstr ""
-"We are really sorry. Your receiver encountered a software problem, and needs to be restarted.\n"
-"Please send the logfile %senigma2_crash_xxxxxx.log to www.opena.tv.\n"
-"Your receiver restarts in 10 seconds!\n"
+"Oops, your receiver has encountered a software problem and needs to be restarted.\n"
+"Please send the logfile at %senigma2_crash_xxxxxx.log to www.opena.tv\n"
+"Your receiver will restart in 10 seconds...\n"
 "Component: enigma2"
 
-#, fuzzy
 msgid "Weather"
-msgstr "---Weather---"
+msgstr ""
 
 msgid "Web Interface"
 msgstr "Web Interface"
@@ -19182,9 +19308,8 @@ msgstr "Weekly"
 msgid "Weighted position"
 msgstr "Weighted position"
 
-#, fuzzy
 msgid "Welcome to IceTV"
-msgstr "Welcome to CCcam"
+msgstr "Welcome to IceTV"
 
 msgid ""
 "Welcome to the Cutlist editor.\n"
@@ -19195,7 +19320,7 @@ msgid ""
 msgstr ""
 "Welcome to the Cutlist editor.\n"
 "\n"
-"Seek to the start of the stuff you want to cut away. Press OK, select 'start cut'.\n"
+"Seek to the start of the stuff you'd like to to cut away. Press OK, select 'start cut'.\n"
 "\n"
 "Then seek to the end, press OK, select 'end cut'. That's it."
 
@@ -19208,12 +19333,15 @@ msgid ""
 msgstr ""
 "Welcome to the cutlist editor.\n"
 "\n"
-"Seek to the start of the stuff you want to cut away. Press OK, select 'start cut'.\n"
+"Seek to the start of the stuff you'd like to cut away. Press OK, select 'start cut'.\n"
 "\n"
 "Then seek to the end, press OK, select 'end cut'. That's it."
 
 msgid "Welcome to the image upgrade wizard. The wizard will assist you in upgrading the firmware of your %s %s by providing a backup facility for your current settings and a short explanation of how to upgrade your firmware."
-msgstr "Welcome to the image upgrade wizard. The wizard will assist you in upgrading the firmware of your %s %s by providing a backup facility for your current settings and a short explanation of how to upgrade your firmware."
+msgstr ""
+"Welcome to the image upgrade wizard.\n"
+"\n"
+"This wizard will help you to upgrade your %s %s's image by providing a backup facility for your current settings and a short explanation of how to upgrade."
 
 msgid ""
 "Welcome.\n"
@@ -19222,11 +19350,11 @@ msgid ""
 "\n"
 "Press OK to start configuring your network"
 msgstr ""
-"Welcome.\n"
+"Welcome!\n"
 "\n"
-"If you want to connect your %s %s to the Internet, this wizard will guide you through the basic network setup of your %s %s.\n"
+"This wizard will guide you through the basic network set up to connect your %s %s to the internet.\n"
 "\n"
-"Press OK to start configuring your network"
+"Press OK to start configuring your network..."
 
 msgid ""
 "Welcome.\n"
@@ -19234,16 +19362,17 @@ msgid ""
 "This start wizard will guide you through the basic setup of your %s %s.\n"
 "Press the OK button on your remote control to move to the next step."
 msgstr ""
-"Welcome.\n"
+"Welcome!\n"
 "\n"
 "This start wizard will guide you through the basic setup of your %s %s.\n"
-"Press the OK button on your remote control to move to the next step."
+"Press the OK button on your remote control to continue to the next step..."
 
 msgid "Welcome..."
 msgstr "Welcome..."
 
+#. TRANSLATORS: genre category
 msgid "Werbung"
-msgstr ""
+msgstr "Advertising"
 
 msgid "West"
 msgstr "West"
@@ -19251,188 +19380,190 @@ msgstr "West"
 msgid "West limit set"
 msgstr "West limit set"
 
-#, fuzzy
 msgid "Western"
-msgstr "West"
+msgstr "Western"
 
+#. TRANSLATORS: regional option
 msgid "Western Sahara"
 msgstr "Western Sahara"
 
+#. TRANSLATORS: genre category
 msgid "Wettbewerb"
-msgstr ""
+msgstr "Competition"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Wetter"
-msgstr "better"
+msgstr "Weather"
 
 msgid "What Day of month ?"
-msgstr "What Day of month ?"
+msgstr "Day of the month"
 
 msgid "What Day of week ?"
-msgstr "What Day of week ?"
+msgstr "Day of the week"
 
 msgid "What action is required on completion of the timer? 'Auto' lets the box return to the state it had when the timer started. 'Do nothing', 'Go to standby' and 'Go to deep standby' do exactly that."
-msgstr "What action is required on completion of the timer? 'Auto' lets the box return to the state it had when the timer started. 'Do nothing', 'Go to standby' and 'Go to deep standby' do exactly that."
+msgstr ""
+"Choose what should happen when the timer completes.\n"
+"'auto' will return your receiver to the state it was in (eg. standby) before the timer started; 'do nothing' will leave it in normal operation."
 
-#, fuzzy
 msgid "What do you want to play?\n"
-msgstr "What do you want to scan?"
+msgstr "What would you like to play?\n"
 
 msgid "What do you want to scan?"
-msgstr "What do you want to scan?"
+msgstr "What would you like to scan?"
 
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
-msgstr "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgstr "Choose whether to load bouquets that are available in the /etc/enigma2 settings folder (eg. userbouquet.[mychannels].tv) but not included in bouquets.tv or bouquets.radio. This would let you keep your custom bouquets while installed settings are upgraded"
 
 msgid "When enabled the PiP can be closed by the exit button."
-msgstr "When enabled the PiP can be closed by the exit button."
+msgstr "Choose whether picture-in-picture mode can be stopped by using the Exit button."
 
 msgid "When enabled the online checker will also check for experimental versions"
-msgstr "When enabled the online checker will also check for experimental versions"
+msgstr "Choose whether to check for experimental versions during an online update check."
 
 msgid "When enabled, AIT data will be included in http streams. This allows a client receiver to use HbbTV."
-msgstr "When enabled, AIT data will be included in http streams. This allows a client receiver to use HbbTV."
+msgstr "Choose whether to include AIT data in HTTP streams. This would allow a client receiver to use HbbTV."
 
 msgid "When enabled, EIT data will be included in http streams. This allows a client receiver to show EPG."
-msgstr "When enabled, EIT data will be included in http streams. This allows a client receiver to show EPG."
+msgstr "Choose whether to include EIT data in HTTP streams. This allows client receivers to show EPG information.The Event Information Table provides data such as title, length, description, etc."
 
 msgid "When enabled, Enigma2 will load unlinked bouquets. This means that bouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
-msgstr "When enabled, Enigma2 will load unlinked bouquets. This means that bouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgstr "Choose whether to load bouquets that are available in the /etc/enigma2 settings folder (eg. userbouquet.[mychannels].tv) but not included in bouquets.tv or bouquets.radio. This would let you keep your custom bouquets while installed settings are upgraded"
 
 msgid "When enabled, a popup message will be shown when a movie has finished and the next one will start."
-msgstr "When enabled, a popup message will be shown when a movie has finished and the next one will start."
+msgstr "Choose whether to show a notification when a movie has finished and the next one is about to start."
 
 msgid "When enabled, a popup message will be shown when a recording starts."
-msgstr "When enabled, a popup message will be shown when a recording starts."
+msgstr "Choose whether to show a notification when a recording begins."
 
 msgid "When enabled, a recording is allowed to abort picture-in-picture mode, when there are no free tuners."
-msgstr "When enabled, a recording is allowed to abort picture-in-picture mode, when there are no free tuners."
+msgstr "Choose whether recordings should be allowed to stop picture-in-picture mode when there are no other tuners available."
 
 msgid "When enabled, a recording is allowed to abort pseudo recordings, when there are no free tuners."
-msgstr "When enabled, a recording is allowed to abort pseudo recordings, when there are no free tuners."
+msgstr "Choose whether recordings should be allowed to stop pseudo recordings when there are no other tuners available."
 
 msgid "When enabled, a recording is allowed to abort streaming, when there are no free tuners."
-msgstr "When enabled, a recording is allowed to abort streaming, when there are no free tuners."
+msgstr "Choose whether recordings should be allowed to stop a stream when there are no other tuners available."
 
 msgid "When enabled, a recording is allowed to interrupt live tv, when there are no free tuners."
-msgstr "When enabled, a recording is allowed to interrupt live tv, when there are no free tuners."
+msgstr "Choose whether recordings should be allowed to interrupt live TV when there are no other tuners available."
 
 msgid "When enabled, a warning will be displayed and the user will get an option to stop or to continue the timeshift."
-msgstr "When enabled, a warning will be displayed and the user will get an option to stop or to continue the timeshift."
+msgstr "Choose whether to show a prompt with options when timeshift mode is about to be stopped."
 
 msgid "When enabled, always descramble receiving http streams. This takes up more resources (descrambling demuxers), only enable if necessary. Individual streams are always descrambled if 0x100 is added to the service type, regardless of this setting."
-msgstr "When enabled, always descramble receiving http streams. This takes up more resources (descrambling demuxers), only enable if necessary. Individual streams are always descrambled if 0x100 is added to the service type, regardless of this setting."
+msgstr "Choose whether to decrypt incoming HTTP streams. This will use more resources (decrypting demuxers), so only enable if necessary. Individual streams will always be decrypted when 0x100 is added to the service type, regardless of this setting."
 
 msgid "When enabled, authentication is required to watch http streams."
-msgstr "When enabled, authentication is required to watch http streams."
+msgstr "Choose whether authentication should be required to watch HTTP streams."
 
 msgid "When enabled, channel numbering will start at '1' for each bouquet."
-msgstr "When enabled, channel numbering will start at '1' for each bouquet."
+msgstr "Choose whether channel numbering should start at '1' within each bouquet."
 
 msgid "When enabled, content with an aspect ratio of 4:3 will be stretched to fit the screen."
-msgstr "When enabled, content with an aspect ratio of 4:3 will be stretched to fit the screen."
+msgstr "Choose how 4:3 aspect ratio content should be stretched to fit the screen."
 
 msgid "When enabled, continue to the next bouquet when the last channel of the current bouquet is reached while changing channels."
-msgstr "When enabled, continue to the next bouquet when the last channel of the current bouquet is reached while changing channels."
+msgstr "Choose whether changing channels should continue to the next bouquet when the last channel of the current bouquet has been reached."
 
 msgid "When enabled, deleted recordings are moved to the trash can, instead of being deleted immediately."
-msgstr "When enabled, deleted recordings are moved to the trash can, instead of being deleted immediately."
+msgstr "Choose whether deleted recordings should be moved to the trash can instead of being deleted immediately."
 
 msgid "When enabled, external subtitles will be always turned on for playback movie."
-msgstr "When enabled, external subtitles will be always turned on for playback movie."
+msgstr "Choose whether external subtitles (if available) should be activated automatically on movie playback."
 
 msgid "When enabled, graphical DVB subtitles are preferred over teletext subtitles, when both types are available."
-msgstr "When enabled, graphical DVB subtitles are preferred over teletext subtitles, when both types are available."
+msgstr "Choose whether DVB subtitles should be preferred over teletext subtitles when both types are available."
 
 msgid "When enabled, graphical DVB subtitles will be displayed at their original position."
-msgstr "When enabled, graphical DVB subtitles will be displayed at their original position."
+msgstr "Choose whether DVB subtitles should be displayed at their original position."
 
 msgid "When enabled, graphical DVB subtitles will be displayed in yellow, instead of the original color."
-msgstr "When enabled, graphical DVB subtitles will be displayed in yellow, instead of the original color."
+msgstr "Choose whether DVB subtitles should be displayed in yellow instead of their original color."
 
 msgid "When enabled, it is possible to leave the movieplayer with exit."
-msgstr "When enabled, it is possible to leave the movieplayer with exit."
+msgstr "Choose whether the Exit button should quit movie player."
 
 msgid "When enabled, measure power consumption to detect when the rotor stops turning (when supported by the tuner)."
-msgstr "When enabled, measure power consumption to detect when the rotor stops turning (when supported by the tuner)."
+msgstr "Choose whether to detect when the rotator stops turning by measuring power consumption (when supported by the tuner)."
 
 msgid "When enabled, network trash cans are probed for cleaning."
-msgstr "When enabled, network trash cans are probed for cleaning."
+msgstr "Choose whether to check network trash cans for cleaning."
 
 msgid "When enabled, number markers will be hidden."
-msgstr ""
+msgstr "Choose whether number markers should be hidden from the channel list."
 
 msgid "When enabled, pressing '0' will zap you to the first channel in your first bouquet and delete your zap-history."
-msgstr "When enabled, pressing '0' will zap you to the first channel in your first bouquet and delete your zap-history."
+msgstr "Choose whether pressing the 0 button should zap you to the first channel in your first bouquet and delete your zap history."
 
 msgid "When enabled, reformat subtitles to match the width of the screen."
-msgstr "When enabled, reformat subtitles to match the width of the screen."
+msgstr "Choose whether subtitles should be reformatted to match the width of the screen."
 
 msgid "When enabled, show channel numbers in the channel selection screen."
-msgstr "When enabled, show channel numbers in the channel selection screen."
+msgstr "Choose whether channel numbers should appear on the channel selection screen."
 
 msgid "When enabled, show status or error messages."
-msgstr "When enabled, show status or error messages."
+msgstr "Choose whether status or error messages should be shown."
 
 msgid "When enabled, subtitles for the hearing impaired can be used."
-msgstr "When enabled, subtitles for the hearing impaired can be used."
+msgstr "Choose whether subtitles for the hearing impaired can be used."
 
 msgid "When enabled, subtitles for the hearing impaired will be preferred over normal subtitles, when both types are available."
-msgstr "When enabled, subtitles for the hearing impaired will be preferred over normal subtitles, when both types are available."
+msgstr "Choose whether subtitles for the hearing impaired should be preferred over regular subtitles when both types are available."
 
 msgid "When enabled, teletext pages will be cached, allowing faster access."
-msgstr "When enabled, teletext pages will be cached, allowing faster access."
+msgstr "Choose whether teletext pages should be cached, allowing for faster access."
 
 msgid "When enabled, teletext subtitles will be displayed at their original position."
-msgstr "When enabled, teletext subtitles will be displayed at their original position."
+msgstr "Choose whether teletext subtitles should be shown at their original position."
 
 msgid "When enabled, the VCR scart option will be shown on the main menu"
-msgstr "When enabled, the VCR scart option will be shown on the main menu"
+msgstr "Choose whether to show the VCR scart option on the Main menu"
 
 msgid "When enabled, the length of each recording will be shown in the movielist (this might cause some additional loading time)."
-msgstr "When enabled, the length of each recording will be shown in the movielist (this might cause some additional loading time)."
+msgstr "Choose whether the duration of each recording should appear in the movie list (this might cause a delay)."
 
 msgid "When enabled, the receiver will automatically use the audio track which you selected before."
-msgstr "When enabled, the receiver will automatically use the audio track which you selected before."
+msgstr "Choose whether your receiver should automatically activate the audio track which you selected previously."
 
 msgid "When enabled, the receiver will automatically use the subtitles which you selected before."
-msgstr "When enabled, the receiver will automatically use the subtitles which you selected before."
+msgstr "Choose whether the receiver should automatically activate the subtitles which you selected previously."
 
 msgid "When enabled, the receiver will select an AC3 track (when available)."
-msgstr "When enabled, the receiver will select an AC3 track (when available)."
+msgstr "Choose whether the receiver should select a Dolby Digital (also known as Dolby AC-3 track) if available."
 
 msgid "When enabled, the receiver will select an AC3+ track (when available)."
-msgstr "When enabled, the receiver will select an AC3+ track (when available)."
+msgstr "Choose whether the receiver should select an AC3+ track (if available)."
 
 msgid "When enabled, timeshift starts automatically in background after specified time."
-msgstr "When enabled, timeshift starts automatically in background after specified time."
+msgstr "Choose whether timeshift should start automatically in the background after the specified time."
 
 msgid "When enabled, use DHCP for the IP configuration."
-msgstr "When enabled, use DHCP for the IP configuration."
+msgstr "Choose whether to enable Dynamic Host Configuration Protocol (DHCP) to automatically assign an IP address and other network configuration settings to your network adapter."
 
 msgid "When enabled, your receiver will detect activity on the VCR SCART input."
-msgstr "When enabled, your receiver will detect activity on the VCR SCART input."
+msgstr "Choose whether your receiver should detect activity on the VCR SCART input."
 
 msgid "When nonzero, a recording will start earlier than the starting time indicated by the EPG."
-msgstr "When nonzero, a recording will start earlier than the starting time indicated by the EPG."
+msgstr "When non-zero, a recording will begin earlier than the start time shown on the EPG."
 
 msgid "When nonzero, a recording will stop later than the ending time indicated by the EPG."
-msgstr "When nonzero, a recording will stop later than the ending time indicated by the EPG."
+msgstr "When non-zero, a recording will end later than the end time shown on the EPG."
 
 msgid "When set each folder will show the previous state used, when off the default values will be shown."
-msgstr "When set each folder will show the previous state used, when off the default values will be shown."
+msgstr "When set, each folder will show the previous state used, when 'off', the default values will be shown."
 
 msgid "When set the PIG will return to live after a movie has stopped playing."
-msgstr "When set the PIG will return to live after a movie has stopped playing."
+msgstr "When set, the mini TV window will return to live TV after a movie has stopped playing."
 
 msgid "When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture."
-msgstr "When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture."
+msgstr "Choose how to scale or stretch the picture when video content has an aspect ratio of 16:9."
 
 msgid "When the content has an aspect ratio of 4:3, choose whether to scale/stretch the picture."
-msgstr "When the content has an aspect ratio of 4:3, choose whether to scale/stretch the picture."
+msgstr "Choose how to scale or stretch the picture when the content has an aspect ratio of 4:3."
 
 msgid "When tuned to a service the system will normally scan the transponder for any changes and save them. Only set to 'yes' if you're absolutely sure what you're doing."
-msgstr "When tuned to a service the system will normally scan the transponder for any changes and save them. Only set to 'yes' if you're absolutely sure what you're doing."
+msgstr "When tuned to a service, your receiver will normally scan the transponder for any changes and save them. Only set to 'yes' if you know exactly you're doing!"
 
 #, python-format
 msgid ""
@@ -19442,26 +19573,26 @@ msgid ""
 "\n"
 "Really do a factory reset?"
 msgstr ""
-"When you do a factory reset, you will lose ALL your configuration data\n"
-"(including bouquets, services, satellite data ...)\n"
-"After completion of factory reset, your %s %s will restart automatically!\n"
+"When you do a factory reset, you'll LOSE ALL OF YOUR CONFIGURATION DATA\n"
+"including bouquets, services, satellite data, etc... !\n"
+"Your %s %s will restart automatically when the process is complete.\n"
 "\n"
-"Really do a factory reset?"
+"Are you sure you want to continue?"
 
 msgid "Where do you want to backup your settings?"
-msgstr "Where do you want to backup your settings?"
+msgstr "Where would you like to back up your settings?"
 
 msgid "Where should the recording be saved?"
-msgstr "Where should the recording be saved?"
+msgstr "Choose where to save the recording."
 
 msgid "Where to save temporary timeshift recordings?"
-msgstr "Where to save temporary timeshift recordings?"
+msgstr "Choose where to save timeshift buffers."
 
 msgid "Which event do you want to save permanently?"
-msgstr "Which event do you want to save permanently?"
+msgstr "Which event would you like to save permanently?"
 
 msgid "Which remote control gets shown. Only influences graphical representation."
-msgstr "Which remote control gets shown. Only influences graphical representation."
+msgstr "Select which remote control style should be shown. Only affects the OSD representation."
 
 msgid "While available"
 msgstr "While available"
@@ -19472,13 +19603,13 @@ msgstr "White"
 msgid "Width"
 msgstr "Width"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Winter Sports"
-msgstr "winter sport"
+msgstr "Winter sports"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Wintersport"
-msgstr "winter sport"
+msgstr "Winter sports"
 
 msgid "Wireless LAN"
 msgstr "Wireless LAN"
@@ -19498,11 +19629,13 @@ msgstr "Wireless network connection setup."
 msgid "Wireless network state"
 msgstr "Wireless network state"
 
+#. TRANSLATORS: genre category
 msgid "Wirtschaft"
-msgstr ""
+msgstr "Economy"
 
+#. TRANSLATORS: genre category
 msgid "Wissenschaft"
-msgstr ""
+msgstr "Science"
 
 msgid "With T2MI RAW mode disabled (default) we can use single T2MI PLP de-encapsulation. With T2MI RAW mode enabled we can use astra-sm to analyze T2MI"
 msgstr ""
@@ -19514,22 +19647,22 @@ msgid "With popup"
 msgstr "With popup"
 
 msgid "With this option set to 'yes' the channel lists will always show you the bouquet screen first. If set to 'no' the current bouquet will be opened."
-msgstr "With this option set to 'yes' the channel lists will always show you the bouquet screen first. If set to 'no' the current bouquet will be opened."
+msgstr "Choose whether channel lists should always show the bouquet selection screen first or show the current bouquet."
 
 msgid "With this option you can hide Job Tasks from the extension screen (short blue button press)."
-msgstr "With this option you can hide Job Tasks from the extension screen (short blue button press)."
+msgstr "Choose whether to show or hide Job Tasks from the Extensions screen (Blue button)."
 
 msgid "With this option you can switch off the display during operation."
-msgstr ""
+msgstr "Choose whether to switch off the display during normal use."
 
 msgid "With this option you can switch off the display in Deep Standby Mode."
-msgstr ""
+msgstr "Choose whether to switch off the display in deep standby mode."
 
 msgid "With this option you can switch off the display in Standby Mode."
-msgstr ""
+msgstr "Choose whether to switch off the display in standby mode."
 
 msgid "With this option you can switch the LED color or deactivate the LED."
-msgstr ""
+msgstr "Change the LED color or deactivate it."
 
 msgid "With this setting, you can probably improve the signal quality or eliminate problems that can occur with longer HDMI cables."
 msgstr ""
@@ -19542,34 +19675,36 @@ msgstr "Workaround for old tuner driver"
 
 #, python-format
 msgid "Would you save the entered PIN %s persistent?"
-msgstr "Would you save the entered PIN %s persistent?"
+msgstr "Would you like to save the entered PIN %s persistently?"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Wrestling"
-msgstr "Installing"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Write error at start of recording. %s\n"
 "%s"
 msgstr ""
-"Write error while recording. Disk full?\n"
+"Couldn't start recording.\n"
+"%s\n"
 "%s"
 
-#, fuzzy, python-format
+#, python-format
 msgid "Write error while recording. %s"
 msgstr ""
-"Write error while recording. Disk full?\n"
+"Can't continue recording.\n"
+"Disk full?\n"
 "%s"
 
 msgid "Write failed!"
 msgstr "Write failed!"
 
 msgid "Www"
-msgstr "Www"
+msgstr "WWW button"
 
 msgid "Www long"
-msgstr "Www long"
+msgstr "WWW button hold"
 
 msgid "XBox 360 support"
 msgstr "XBox 360 support"
@@ -19599,7 +19734,7 @@ msgid "Year"
 msgstr "Year"
 
 msgid "Yellow"
-msgstr "Yellow"
+msgstr "Yellow button"
 
 msgid "Yellow DVB subtitles"
 msgstr "Yellow DVB subtitles"
@@ -19608,8 +19743,9 @@ msgid "Yellow button"
 msgstr "Yellow button"
 
 msgid "Yellow long"
-msgstr "Yellow long"
+msgstr "Yellow button hold"
 
+#. TRANSLATORS: regional option
 msgid "Yemen"
 msgstr "Yemen"
 
@@ -19620,38 +19756,37 @@ msgid "Yes to all"
 msgstr "Yes to all"
 
 msgid "Yes, always"
-msgstr "Yes, always"
+msgstr "yes, always"
 
 msgid "Yes, and delete this movie"
 msgstr "Yes, and delete this movie"
 
 msgid "Yes, backup my settings!"
-msgstr "Yes, backup my settings!"
+msgstr "Yes, please back up my settings!"
 
 msgid "Yes, but don't save timeshift as movie"
-msgstr "Yes, but don't save timeshift as movie"
+msgstr "Stop timeshift without saving buffer"
 
-#, fuzzy
 msgid "Yes, but if not available show the plugin browser"
-msgstr "This option allows you to disable sorting of the plugin browser."
+msgstr "yes if available, otherwise show Plugin Browser"
 
 msgid "Yes, but if not available show the timer list"
-msgstr ""
+msgstr "yes if available, otherwise show the timer list"
 
 msgid "Yes, but save timeshift as movie and continue recording"
-msgstr "Yes, but save timeshift as movie and continue recording"
+msgstr "Stop timeshift, save buffer and continue recording"
 
 msgid "Yes, but save timeshift as movie and stop recording"
-msgstr "Yes, but save timeshift as movie and stop recording"
+msgstr "Stop timeshift and save buffer"
 
 msgid "Yes, delete from Timerlist"
-msgstr "Yes, delete from Timerlist"
+msgstr "Yes, delete from timer list"
 
 msgid "Yes, delete from Timerlist and delete recording"
-msgstr "Yes, delete from Timerlist and delete recording"
+msgstr "Yes, delete from timer list and delete recording"
 
 msgid "Yes, delete this movie and return to movie list"
-msgstr "Yes, delete this movie and return to movie list"
+msgstr "Yes, delete this movie and return to the movie list"
 
 msgid "Yes, do a manual scan now"
 msgstr "Yes, do a manual scan now"
@@ -19663,13 +19798,13 @@ msgid "Yes, do another manual scan now"
 msgstr "Yes, do another manual scan now"
 
 msgid "Yes, restore the settings now"
-msgstr "Yes, restore the settings now"
+msgstr "Yes, restore my settings now..."
 
 msgid "Yes, returning to movie list"
 msgstr "Yes, returning to movie list"
 
 msgid "Yes, shut down now."
-msgstr "Yes, shut down now."
+msgstr "Yes, shut down now"
 
 msgid "Yesterday"
 msgstr "Yesterday"
@@ -19680,7 +19815,7 @@ msgid ""
 "would you like to remove\n"
 "\"%s\"?"
 msgstr ""
-"You already have a bootlogo installed,\n"
+"You already have a boot logo installed,\n"
 "would you like to remove\n"
 "\"%s\"?"
 
@@ -19695,10 +19830,10 @@ msgstr ""
 "\"%s\"?"
 
 msgid "You can Display MiniTV with or without OSD Menu"
-msgstr "You can Display MiniTV with or without OSD Menu"
+msgstr "You can display the mini TV with or without an OSD menu"
 
 msgid "You can Display PIP with or without OSD Menu"
-msgstr "You can Display PIP with or without OSD Menu"
+msgstr "Choose whether to show an OSD menu in the PiP window"
 
 msgid "You can cancel the installation."
 msgstr "You can cancel the installation."
@@ -19707,10 +19842,10 @@ msgid "You can cancel the removal."
 msgstr "You can cancel the removal."
 
 msgid "You can continue watching TV etc. while this is running."
-msgstr "You can continue watching TV etc. while this is running."
+msgstr "You can continue watching TV etc. while this runs."
 
 msgid "You can have the list sorted by time or alphanumerical."
-msgstr "You can have the list sorted by time or alphanumerical."
+msgstr "Choose whether to sort the list by time or alpha-numerically."
 
 msgid "You can install this plugin."
 msgstr "You can install this plugin."
@@ -19730,39 +19865,39 @@ msgstr "You can switch with left and right this tuner types %s"
 
 #, python-format
 msgid "You can't usefully run '%s' on '%s'."
-msgstr ""
+msgstr "'%s' can't be run on '%s'."
 
 #, python-format
 msgid "You can't usefully run '%s' on a directory."
-msgstr ""
+msgstr "'%s' can't be run on a folder."
 
 msgid "You cannot delete this!"
-msgstr "You cannot delete this!"
+msgstr "You can't delete this!"
 
 msgid "You didn't select a channel to record from."
-msgstr "You didn't select a channel to record from."
+msgstr "You haven't selected a channel to record."
 
 msgid "You have already sent this log, are you sure you want to resend this log:\n"
-msgstr "You have already sent this log, are you sure you want to resend this log:\n"
+msgstr "You've already sent this log, are you sure you want to send it again?\n"
 
 msgid "You have chosen to backup your settings. Please press OK to start the backup now."
-msgstr "You have chosen to backup your settings. Please press OK to start the backup now."
+msgstr "You've chosen to back up your settings, press OK to continue..."
 
 msgid "You have chosen to create a new .NFI flasher bootable USB stick. This will repartition the USB stick and therefore all data on it will be erased."
-msgstr "You have chosen to create a new .NFI flasher bootable USB stick. This will repartition the USB stick and therefore all data on it will be erased."
+msgstr "You've chosen to create a new .NFI flasher bootable USB stick. This will repartition the USB stick and ALL DATA on it will be LOST."
 
 msgid "You have chosen to restore your settings. Enigma2 will restart after restore. Please press OK to start the restore now."
-msgstr "You have chosen to restore your settings. Enigma2 will restart after restore. Please press OK to start the restore now."
+msgstr "You've chosen to restore your settings, after which your receiver will restart. Press OK to continue or EXIT to cancel..."
 
 msgid "You have chosen to save the current timeshift"
-msgstr "You have chosen to save the current timeshift"
+msgstr "You've chosen to save the current timeshift buffer"
 
 msgid ""
 "You have chosen to save the current timeshift event, but the event has not yet finished\n"
 "What do you want to do ?"
 msgstr ""
-"You have chosen to save the current timeshift event, but the event has not yet finished\n"
-"What do you want to do ?"
+"You have chosen to save the current timeshift buffer, but the event hasn't finished yet.\n"
+"What would you like do?"
 
 msgid "You have no script to run."
 msgstr "You have no script to run."
@@ -19771,64 +19906,64 @@ msgid ""
 "You have not setup your user info in the setup screen\n"
 "Press MENU, and enter your info, then try again"
 msgstr ""
-"You have not setup your user info in the setup screen\n"
-"Press MENU, and enter your info, then try again"
+"You don't seem to have enetered your user info on the setup screen.\n"
+"Please press MENU, enter your info, then try again."
 
 msgid "You have selected no logs to delete."
-msgstr "You have selected no logs to delete."
+msgstr "You haven't selected any logs to delete."
 
 msgid "You have selected no logs to send."
-msgstr "You have selected no logs to send."
+msgstr "You haven't selected a log to send."
 
 msgid "You have to create a Swap File before to activate the autostart."
-msgstr "You have to create a Swap File before to activate the autostart."
+msgstr "You need to create a swap file to activate autostart."
 
 #, python-format
 msgid "You have to wait %s!"
-msgstr "You have to wait %s!"
+msgstr "Please wait %s!"
 
 msgid "You must set a root password in order to be able to use network services, such as FTP, telnet or ssh."
-msgstr ""
+msgstr "You need to set a root password to be able to use network services such as FTP, Telnet, SSH, etc."
 
 msgid "You must set at least one Command"
-msgstr "You must set at least one Command"
+msgstr "Please specify at least one command"
 
 msgid ""
 "You need a PC connected to your %s %s. If you need further instructions, please visit the website http://www.opena.tv.\n"
 "Your %s %s will now be halted. After you have performed the update instructions from the website, your new firmware will ask you to restore your settings."
 msgstr ""
-"You need a PC connected to your %s %s. If you need further instructions, please visit the website http://www.opena.tv.\n"
-"Your %s %s will now be halted. After you have performed the update instructions from the website, your new firmware will ask you to restore your settings."
+"You will need to connect a computer to your %s %s. For further instructions, please visit http://www.opena.tv\n"
+"Your %s %s will now be halted. After you have followed the update instructions from the website, your new image will prompt you to restore your settings."
 
 msgid "You seem to be in timeshft, the service will briefly stop as timeshfit stops."
-msgstr "You seem to be in timeshft, the service will briefly stop as timeshfit stops."
+msgstr "You seem to be in timeshift mode, the service will stop briefly while timeshift stops."
 
 msgid "You seem to be in timeshift!"
-msgstr "You seem to be in timeshift!"
+msgstr "You seem to be in timeshift mode!"
 
 msgid "You seem to be in timeshift, Do you want to leave timeshift ?"
-msgstr "You seem to be in timeshift, Do you want to leave timeshift ?"
+msgstr "You're currently in timeshift mode, what would you like to do?"
 
 msgid "You system does not support ext4"
-msgstr "You system does not support ext4"
+msgstr "You system doesn't support the ext4 filesystem format"
 
 msgid "Your %s %s does not have an internet connection"
-msgstr "Your %s %s does not have an internet connection"
+msgstr "Your %s %s doesn't seem to be connected to the internet"
 
 #, python-format
 msgid "Your %s %s does not support PiP HD"
-msgstr "Your %s %s does not support PiP HD"
+msgstr "Your %s %s doesn't support HD PiP"
 
 #, python-format
 msgid "Your %s %s goes to WOL"
-msgstr "Your %s %s goes to WOL"
+msgstr "Your %s %s is going to WoL"
 
 msgid "Your %s %s is not connected to the internet"
-msgstr "Your %s %s is not connected to the internet"
+msgstr "Your %s %s doesn't seem to be connected to the internet"
 
 #, python-format
 msgid "Your %s %s is not connected to the internet, please check your network settings and try again."
-msgstr "Your %s %s is not connected to the internet, please check your network settings and try again."
+msgstr "Your %s %s doesn't seem to be connected to the internet, please check your network settings and try again."
 
 #, python-format
 msgid ""
@@ -19837,9 +19972,7 @@ msgid ""
 "Your internet connection is working now.\n"
 "\n"
 msgstr ""
-"Your %s %s is now ready to be used.\n"
-"\n"
-"Your internet connection is working now.\n"
+"Your %s %s is now connected to the internet and is ready to use!\n"
 "\n"
 
 msgid ""
@@ -19849,34 +19982,33 @@ msgid ""
 "\n"
 "Please press OK to continue."
 msgstr ""
-"Your %s %s is now ready to use.\n"
+"Your %s %s is now connected to the internet and is ready to use!\n"
 "\n"
-"Your internet connection is working now.\n"
-"\n"
-"Please press OK to continue."
+"Press OK to continue..."
 
 #, python-format
 msgid "Your %s %s is rebooting"
-msgstr "Your %s %s is rebooting"
+msgstr "Your %s %s is restarting..."
 
 #, python-format
 msgid "Your %s %s is rebooting into Recovery Mode"
-msgstr "Your %s %s is rebooting into Recovery Mode"
+msgstr "Your %s %s is rebooting into recovery mode..."
 
 #, python-format
 msgid "Your %s %s is shutting down"
-msgstr "Your %s %s is shutting down"
+msgstr "Your %s %s is shutting down..."
 
 msgid "Your %s %s is shutting down. Please wait..."
-msgstr "Your %s %s is shutting down. Please wait..."
+msgstr "Your %s %s is shutting down..."
 
 #, python-format
 msgid "Your %s %s isn't connected to the internet properly. Please check it and try again."
-msgstr "Your %s %s isn't connected to the internet properly. Please check it and try again."
+msgstr "Your %s %s doesn't seem to be connected to the internet. Please check your connection and try again."
 
+# source needs improvement (remove repetition)
 #, python-format
 msgid "Your %s %s might be unusable now. Please consult the manual for further assistance before rebooting your %s %s."
-msgstr "Your %s %s might be unusable now. Please consult the manual for further assistance before rebooting your %s %s."
+msgstr "Your %s %s might no longer be usable. Please refer to your receiver’s documentation for further assistance before rebooting your %s %s."
 
 #, python-format
 msgid ""
@@ -19884,25 +20016,25 @@ msgid ""
 "\n"
 "Do you want to put it in %s?"
 msgstr ""
-"Your %s %s was not shutdown properly.\n"
+"Your %s %s wasn't shut down properly.\n"
 "\n"
-"Do you want to put it in %s?"
+"Would you like to put it into %s?"
 
 #, python-format
 msgid "Your %s %s will Reboot..."
-msgstr "Your %s %s will Reboot..."
+msgstr "Your %s %s is about to reboot..."
 
 #, python-format
 msgid "Your %s %s will Restart..."
-msgstr "Your %s %s will Restart..."
+msgstr "Your %s %s is about to restart..."
 
 #, python-format
 msgid ""
 "Your %s %s will be restarted after the installation of service\n"
 "Ready to install %s ?"
 msgstr ""
-"Your %s %s will be restarted after the installation of service\n"
-"Ready to install %s ?"
+"Your %s %s will be restarted after the %s service has been installed.\n"
+"Would you like to continue?"
 
 #, python-format
 msgid ""
@@ -19910,44 +20042,46 @@ msgid ""
 "\n"
 "Do you want to install now ?"
 msgstr ""
-"Your %s %s will be restarted after the installation of service.\n"
+"Your %s %s will be restarted after the service has been installed.\n"
 "\n"
-"Do you want to install now ?"
+"Would you like to continue?"
 
 #, python-format
 msgid ""
 "Your %s %s will be restarted after the removal of service\n"
 "Do you want to remove now ?"
 msgstr ""
-"Your %s %s will be restarted after the removal of service\n"
-"Do you want to remove now ?"
+"Your %s %s will be restarted after the service has been removed.\n"
+"Would you like to continue?"
 
 msgid "Your Hardware can detect ci mode self or work only in legacy mode."
-msgstr "Your Hardware can detect ci mode self or work only in legacy mode."
+msgstr "Your hardware can detect CI mode self or work only in legacy mode."
 
 #, python-format
 msgid "Your Receiver has a Software problem detected. Since the last reboot it has occurred %d times.\n"
 msgstr ""
+"Your receiver has experienced a software problem\n"
+"which has occurred %d times since the last restart.\n"
 
 msgid "Your STB will restart after pressing OK on your remote control."
-msgstr "Your STB will restart after pressing OK on your remote control."
+msgstr "Your receiver will restart after you press OK on your remote..."
 
 msgid "Your backup succeeded. We will now continue to explain the further upgrade process."
-msgstr "Your backup succeeded. We will now continue to explain the further upgrade process."
+msgstr "Backup successful! We'll now continue to explain the rest of the upgrade process."
 
 msgid "Your collection exceeds the size of a single layer medium, you will need a blank dual layer DVD!"
-msgstr "Your collection exceeds the size of a single layer medium, you will need a blank dual layer DVD!"
+msgstr "Your collection exceeds the size of a single-layer disc, you'll need a blank dual-layer DVD!"
 
 #, python-format
 msgid ""
 "Your config file is not well-formed:\n"
 "%s"
 msgstr ""
-"Your config file is not well-formed:\n"
+"Your config file seems to be corrupt:\n"
 "%s"
 
 msgid "Your current collection will get lost!"
-msgstr "Your current collection will get lost!"
+msgstr "You'll lost your current collection!"
 
 msgid "Your email address is used to login to IceTV services."
 msgstr ""
@@ -19959,15 +20093,15 @@ msgid ""
 "Your front panel will be upgraded\n"
 "This may take a few minutes"
 msgstr ""
-"Your front panel will be upgraded\n"
-"This may take a few minutes"
+"Your front panel will be upgraded.\n"
+"This could take a while..."
 
 msgid ""
 "Your frontprocessor firmware must be upgraded.\n"
 "Press OK to start upgrade."
 msgstr ""
-"Your frontprocessor firmware must be upgraded.\n"
-"Press OK to start upgrade."
+"Your front processor firmware needs to be upgraded.\n"
+"Press OK to begin the process..."
 
 #, python-format
 msgid ""
@@ -19975,9 +20109,9 @@ msgid ""
 "Please wait until your %s %s reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Your frontprocessor will be upgraded\n"
-"Please wait until your %s %s reboots\n"
-"This may take a few minutes"
+"Your front processor is about to be upgraded.\n"
+"Please wait until your %s %s reboots!\n"
+"This could take a while..."
 
 #, python-format
 msgid ""
@@ -19995,12 +20129,12 @@ msgid ""
 msgstr ""
 "Your image is out of date!\n"
 "\n"
-"After such a long time, there is a risk that your %s %s will not\n"
-"boot after online-update, or will show disfunction in running Image.\n"
+"After such a long time, there's a risk that your %s %s will not\n"
+"boot properly or will experience issues after an online update.\n"
 "\n"
-"A new flash will increase the stability\n"
+"A fresh image flash would increase stability.\n"
 "\n"
-"An online update is done at your own risk !!\n"
+"An online update is done at your own risk!\n"
 "\n"
 "\n"
 "Do you still want to update?"
@@ -20009,20 +20143,20 @@ msgid ""
 "Your internet connection is not working!\n"
 "Please choose what you want to do next."
 msgstr ""
-"Your internet connection is not working!\n"
-"Please choose what you want to do next."
+"Your internet connection doesn't seem to be working!\n"
+"Please choose what you'd like to do next."
 
 msgid "Your network configuration has been activated."
 msgstr "Your network configuration has been activated."
 
 msgid "Your password must have at least 5 characters."
-msgstr ""
+msgstr "Your password must be at least 5 characters long."
 
 msgid "Your receiver can use SCPC optimized search range. Consult your receiver's manual for more information."
-msgstr ""
+msgstr "Your receiver can use SCPC optimized search range. Refer to your receiver's documentation for more information."
 
 msgid "Your receiver can use tone amplitude. Consult your receiver's manual for more information."
-msgstr ""
+msgstr "Your receiver can use tone amplitude. Refer to your receiver's documentation for more information."
 
 msgid ""
 "Your wireless LAN internet connection could not be started!\n"
@@ -20030,14 +20164,14 @@ msgid ""
 "\n"
 "Please choose what you want to do next."
 msgstr ""
-"Your wireless LAN internet connection could not be started!\n"
-"Have you attached your USB WLAN Stick?\n"
+"Your wireless network connection could't be activated!\n"
+"Have you attached a USB wireless network adapter?\n"
 "\n"
-"Please choose what you want to do next."
+"Please choose what you'd like to do next."
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "Youth"
-msgstr "South"
+msgstr ""
 
 msgid "Youtube TV"
 msgstr ""
@@ -20048,29 +20182,27 @@ msgstr "ZAP"
 msgid "ZOOM"
 msgstr ""
 
-#, fuzzy
 msgid "ZOOM long"
-msgstr "OK long"
+msgstr "ZOOM button hold"
 
-#, fuzzy
 msgid "ZPicon"
-msgstr "Picon"
+msgstr "ZPicon"
 
-#, fuzzy
 msgid "ZZPicon"
-msgstr "Picon"
+msgstr "ZZPicon"
 
+#. TRANSLATORS: regional option
 msgid "Zambia"
 msgstr "Zambia"
 
 msgid "Zap"
-msgstr "Zap"
+msgstr "zap"
 
 msgid "Zap + Exit"
-msgstr "Zap + Exit"
+msgstr "zap + exit"
 
 msgid "Zap back to previously tuned service?"
-msgstr "Zap back to previously tuned service?"
+msgstr "Zap back to the previously tuned service?"
 
 msgid "Zap back to service before positioner setup?"
 msgstr "Zap back to service before positioner setup?"
@@ -20082,45 +20214,44 @@ msgid "Zap down"
 msgstr "Zap down"
 
 msgid "Zap focus to Picture in Picture"
-msgstr "Zap focus to Picture in Picture"
+msgstr "Zap focus to picture-in-picture"
 
 msgid "Zap focus to main screen"
 msgstr "Zap focus to main screen"
 
 msgid "Zap focused channel on full screen"
-msgstr "Zap focused channel on full screen"
+msgstr "Zap focused channel on full-screen"
 
 msgid "Zap mode"
 msgstr "Zap mode"
 
-#, fuzzy
 msgid "Zap next"
-msgstr "Zap to"
+msgstr "Zap next"
 
 msgid "Zap to"
 msgstr "Zap to"
 
 msgid "Zap to channel (setup in menu)"
-msgstr "Zap to channel (setup in menu)"
+msgstr "Zap to channel (set up in menu)"
 
 msgid "Zap to channel and close (setup in menu)"
-msgstr "Zap to channel and close (setup in menu)"
+msgstr "Zap to channel and close (set up in menu)"
 
 msgid "Zap to selected channel"
 msgstr "Zap to selected channel"
 
 msgid "Zap to selected channel, or show detailed event info (depends on configuration)"
-msgstr "Zap to selected channel, or show detailed event info (depends on configuration)"
+msgstr "Zap to selected channel, or show detailed event info (depending on configuration)"
 
 msgid "Zap up"
 msgstr "Zap up"
 
-#, fuzzy
 msgid "Zap+Record next"
-msgstr "Record next"
+msgstr "Zap + Record next"
 
+#. TRANSLATORS: genre category
 msgid "Zeichentrick"
-msgstr ""
+msgstr "Cartoon"
 
 msgid "Zgemma H.S/H.2S/H.2H/H5/H7"
 msgstr ""
@@ -20137,11 +20268,13 @@ msgstr ""
 msgid "Zgemma i55"
 msgstr ""
 
+#. TRANSLATORS: regional option
 msgid "Zimbabwe"
 msgstr "Zimbabwe"
 
+#. TRANSLATORS: genre category
 msgid "Zirkus"
-msgstr ""
+msgstr "Circus"
 
 msgid "Zoom In/Out TV..."
 msgstr "Zoom In/Out TV..."
@@ -20168,31 +20301,31 @@ msgid "[Timeshift] Merging records failed!"
 msgstr "[Timeshift] Merging records failed!"
 
 msgid "[alternative edit]"
-msgstr "[alternative edit]"
+msgstr "[editing alternative]"
 
 msgid "[bouquet edit]"
-msgstr "[bouquet edit]"
+msgstr "[editing bouquet]"
 
 msgid "[favourite edit]"
-msgstr "[favourite edit]"
+msgstr "[editing favourite]"
 
 msgid "[move mode]"
 msgstr "[move mode]"
 
 msgid "a gui to assign services/providers to common interface modules"
-msgstr "a gui to assign services/providers to common interface modules"
+msgstr "an interface to assign services/providers to Common Interface modules"
 
 msgid "a gui to assign services/providers/caids to common interface modules"
-msgstr "a gui to assign services/providers/caids to common interface modules"
+msgstr "an interface to assign services/providers/CAIds to Common Interface modules"
 
 msgid "abort alternatives edit"
-msgstr "abort alternatives edit"
+msgstr "Cancel alternatives editing"
 
 msgid "abort bouquet edit"
-msgstr "abort bouquet edit"
+msgstr "Cancel bouquet editing"
 
 msgid "abort favourites edit"
-msgstr "abort favourites edit"
+msgstr "Cancel favourites editing"
 
 msgid "about to start"
 msgstr "about to start"
@@ -20201,16 +20334,16 @@ msgid "activate network adapter configuration"
 msgstr "activate network adapter configuration"
 
 msgid "activatePiP"
-msgstr "activatePiP"
+msgstr "start PiP"
 
 msgid "add Current"
-msgstr "add Current"
+msgstr "add current"
 
 msgid "add Service"
-msgstr "add Service"
+msgstr "add Channel"
 
 msgid "add alternatives"
-msgstr "add alternatives"
+msgstr "Add alternatives"
 
 msgid "add bookmark"
 msgstr "add bookmark"
@@ -20222,13 +20355,13 @@ msgid "add bouquet to parental protection"
 msgstr "add bouquet to parental protection"
 
 msgid "add marker"
-msgstr "add marker"
+msgstr "Add a marker"
 
 msgid "add service to bouquet"
-msgstr "add service to bouquet"
+msgstr "Add channel to bouquet..."
 
 msgid "add service to favourites"
-msgstr "add service to favourites"
+msgstr "add channel to favorites"
 
 msgid "add to parental protection"
 msgstr "add to parental protection"
@@ -20236,15 +20369,18 @@ msgstr "add to parental protection"
 msgid "address:"
 msgstr "address:"
 
+#. TRANSLATORS: genre category
 msgid "adult movie/drama"
 msgstr "adult movie/drama"
 
 msgid "advanced"
 msgstr "advanced"
 
+#. TRANSLATORS: genre category
 msgid "adventure/western/war"
 msgstr "adventure/western/war"
 
+#. TRANSLATORS: genre category
 msgid "advertisement/shopping"
 msgstr "advertisement/shopping"
 
@@ -20264,10 +20400,10 @@ msgid "alpha then oldest"
 msgstr "alpha then oldest"
 
 msgid "alphabetic"
-msgstr "alphabetic"
+msgstr "alphabetic (a-z)"
 
 msgid "alphabetic reverse"
-msgstr "alphabetic reverse"
+msgstr "alphabetic (z-a)"
 
 msgid "alphabetical"
 msgstr "alphabetical"
@@ -20282,10 +20418,10 @@ msgid "am"
 msgstr "am"
 
 msgid "an internal error has occur"
-msgstr "an internal error has occur"
+msgstr "an internal error has occurred"
 
 msgid "and never ask again this session again"
-msgstr "and never ask again this session again"
+msgstr "don't ask again during this session"
 
 msgid "any recordings"
 msgstr "any recordings"
@@ -20294,16 +20430,19 @@ msgid ""
 "are you sure you want to restore\n"
 "following backup:\n"
 msgstr ""
-"are you sure you want to restore\n"
-"following backup:\n"
+"Are you sure you want to restore\n"
+"the following backup?\n"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "arts/culture (general)"
 msgstr "arts/culture (without music, general)"
 
+#. TRANSLATORS: genre category
 msgid "arts/culture (without music, general)"
 msgstr "arts/culture (without music, general)"
 
+#. TRANSLATORS: genre category
 msgid "arts/culture magazine"
 msgstr "arts/culture magazine"
 
@@ -20319,6 +20458,7 @@ msgstr "at beginning"
 msgid "at end"
 msgstr "at end"
 
+#. TRANSLATORS: genre category
 msgid "athletics"
 msgstr "athletics"
 
@@ -20337,7 +20477,7 @@ msgid "auto"
 msgstr "auto"
 
 msgid "auto deepstandby"
-msgstr "auto deepstandby"
+msgstr "auto deep standby"
 
 msgid "auto standby"
 msgstr "auto standby"
@@ -20351,6 +20491,7 @@ msgstr "back"
 msgid "background image"
 msgstr "background image"
 
+#. TRANSLATORS: genre category
 msgid "ballet"
 msgstr "ballet"
 
@@ -20359,7 +20500,7 @@ msgid "bc%d"
 msgstr "bc%d"
 
 msgid "because of the used filesystem the back-up\n"
-msgstr "because of the used filesystem the back-up\n"
+msgstr "because of the filesystem on the device, the backup\n"
 
 msgid "better"
 msgstr "better"
@@ -20379,6 +20520,7 @@ msgstr "blue"
 msgid "bottom"
 msgstr "bottom"
 
+#. TRANSLATORS: genre category
 msgid "broadcasting/press"
 msgstr "broadcasting/press"
 
@@ -20390,7 +20532,7 @@ msgid "by date"
 msgstr "by date"
 
 msgid "caid:"
-msgstr "caid:"
+msgstr "CAId:"
 
 msgid "card"
 msgstr "card"
@@ -20398,6 +20540,7 @@ msgstr "card"
 msgid "card reader"
 msgstr "card reader"
 
+#. TRANSLATORS: genre category
 msgid "cartoon/puppets"
 msgstr "cartoon/puppets"
 
@@ -20422,9 +20565,11 @@ msgstr "change Volume up"
 msgid "chapters"
 msgstr "chapters"
 
+#. TRANSLATORS: genre category
 msgid "children's/youth program (general)"
 msgstr "children's/youth program (general)"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "childrens (general)"
 msgstr "children's/youth program (general)"
@@ -20441,9 +20586,11 @@ msgstr "clip overscan / letterbox borders"
 msgid "close share view"
 msgstr "close share view"
 
+#. TRANSLATORS: genre category
 msgid "comedy"
 msgstr "comedy"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "comedy (general)"
 msgstr "movie/drama (general)"
@@ -20464,7 +20611,7 @@ msgid "controlled by HDMI"
 msgstr "controlled by HDMI"
 
 msgid "convert to AC3"
-msgstr "convert to AC3"
+msgstr "convert to Dolby Digital / Dolby AC-3"
 
 msgid "convert to DTS"
 msgstr "convert to DTS"
@@ -20472,6 +20619,7 @@ msgstr "convert to DTS"
 msgid "convert to multi-channel PCM"
 msgstr "convert to multi-channel PCM"
 
+#. TRANSLATORS: genre category
 msgid "cooking"
 msgstr "cooking"
 
@@ -20490,10 +20638,10 @@ msgid "copy to bouquets"
 msgstr "copy to bouquets"
 
 msgid "create directory"
-msgstr "create directory"
+msgstr "create folder"
 
 msgid "create symlink ..."
-msgstr ""
+msgstr "create symlink..."
 
 #, fuzzy
 msgid "current affairs (general)"
@@ -20512,11 +20660,14 @@ msgstr "day"
 msgid "decrease uphop by 1"
 msgstr "decrease uphop by 1"
 
+msgid "deepstandby"
+msgstr "deep standby"
+
 msgid "default"
 msgstr "default"
 
 msgid "default Astra (13e-19e)"
-msgstr ""
+msgstr "default (Hot Bird 13°E - Astra 19.2°E)"
 
 msgid "delete"
 msgstr "delete"
@@ -20525,8 +20676,9 @@ msgid "delete cut"
 msgstr "delete cut"
 
 msgid "descramble and record ecm"
-msgstr "descramble and record ecm"
+msgstr "decrypt and record ECM"
 
+#. TRANSLATORS: genre category
 msgid "detective/thriller"
 msgstr "detective/thriller"
 
@@ -20534,7 +20686,7 @@ msgid "disable"
 msgstr "disable"
 
 msgid "disable move mode"
-msgstr "disable move mode"
+msgstr "Disable move mode"
 
 msgid "disabled"
 msgstr "disabled"
@@ -20542,6 +20694,7 @@ msgstr "disabled"
 msgid "disconnected"
 msgstr "disconnected"
 
+#. TRANSLATORS: genre category
 msgid "discussion/interview/debate"
 msgstr "discussion/interview/debate"
 
@@ -20554,19 +20707,21 @@ msgstr "do nothing"
 msgid "documentary"
 msgstr "documentary"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "documentary (general)"
 msgstr "documentary"
 
 msgid "dolby"
-msgstr ""
+msgstr "Dolby"
 
 msgid "don't descramble, record ecm"
-msgstr "don't descramble, record ecm"
+msgstr "don't decrypt, record ECM"
 
 msgid "done!"
 msgstr "done!"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "drama (general)"
 msgstr "movie/drama (general)"
@@ -20584,21 +20739,24 @@ msgid "east"
 msgstr "east"
 
 msgid "ecm time:"
-msgstr "ecm time:"
+msgstr "ECM time:"
 
 msgid "ecm.info"
 msgstr "ecm.info"
 
+#. TRANSLATORS: genre category
 msgid "economics/social advisory"
 msgstr "economics/social advisory"
 
 msgid "edit alternatives"
-msgstr "edit alternatives"
+msgstr "Edit alternatives"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "education/information (general)"
 msgstr "education/science/factual topics (general)"
 
+#. TRANSLATORS: genre category
 msgid "education/science/factual topics (general)"
 msgstr "education/science/factual topics (general)"
 
@@ -20609,47 +20767,50 @@ msgid "enable"
 msgstr "enable"
 
 msgid "enable PIP no HDR"
-msgstr "enable PIP no HDR"
+msgstr "enable PiP without HDR"
 
 msgid "enable bouquet edit"
-msgstr "enable bouquet edit"
+msgstr "Edit bouquet"
 
 msgid "enable favourite edit"
 msgstr "enable favourite edit"
 
 msgid "enable move mode"
-msgstr "enable move mode"
+msgstr "Enable move mode"
 
 msgid "enabled"
 msgstr "enabled"
 
 msgid "end alternatives edit"
-msgstr "end alternatives edit"
+msgstr "Finish editing alternatives"
 
 msgid "end bouquet edit"
-msgstr "end bouquet edit"
+msgstr "Finish editing bouquet"
 
 msgid "end cut here"
 msgstr "end cut here"
 
 msgid "end favourites edit"
-msgstr "end favourites edit"
+msgstr "Finish editing favourites"
 
 msgid "end zapping"
 msgstr "end zapping"
 
 msgid "enigma2 and network"
-msgstr "enigma2 and network"
+msgstr "Enigma2 and network"
 
 msgid "enter number to jump to channel."
-msgstr "enter number to jump to channel."
+msgstr "enter channel number to jump to."
 
+#. TRANSLATORS: genre category
 msgid "entertainment (10-16 year old)"
 msgstr "entertainment (10-16 year old)"
 
+#. TRANSLATORS: genre category
 msgid "entertainment (6-14 year old)"
 msgstr "entertainment (6-14 year old)"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "entertainment (general)"
 msgstr "entertainment (6-14 year old)"
@@ -20714,7 +20875,6 @@ msgstr "externally loopthrough to"
 msgid "extra wide"
 msgstr "extra wide"
 
-#, fuzzy
 msgid "extrawide"
 msgstr "extra wide"
 
@@ -20731,26 +20891,29 @@ msgid "fast"
 msgstr "fast"
 
 msgid "feed status"
-msgstr "feed status"
+msgstr "Feed status"
 
 msgid "file can not displayed - file not found"
-msgstr "file can not displayed - file not found"
+msgstr "file can't be displayed - file not found"
 
 msgid "fileformats (BMP, PNG, JPG, GIF)"
-msgstr "fileformats (BMP, PNG, JPG, GIF)"
+msgstr "file formats (BMP, PNG, JPG, GIF)"
 
 msgid "filename"
 msgstr "filename"
 
+#. TRANSLATORS: genre category
 msgid "film/cinema"
 msgstr "film/cinema"
 
 msgid "find currently played service"
-msgstr "find currently played service"
+msgstr "Find current channel in channel list"
 
+#. TRANSLATORS: genre category
 msgid "fine arts"
 msgstr "fine arts"
 
+#. TRANSLATORS: genre category
 msgid "fitness & health"
 msgstr "fitness & health"
 
@@ -20760,17 +20923,19 @@ msgstr "flat alphabetic"
 msgid "flat alphabetic reverse"
 msgstr "flat alphabetic reverse"
 
+#. TRANSLATORS: genre category
 msgid "folk/traditional music"
 msgstr "folk/traditional music"
 
+#. TRANSLATORS: genre category
 msgid "football/soccer"
 msgstr "football/soccer"
 
-msgid "for DATA LOSS OR DAMAGE !!!"
+msgid "for DATA LOSS OR DAMAGE!!!"
 msgstr ""
 
 msgid "force AC3plus"
-msgstr "force AC3plus"
+msgstr "force Dolby Digital Plus (AC3+ / DD+ / E-AC-3 / EC-3)"
 
 #, fuzzy
 msgid "force disabled"
@@ -20780,6 +20945,7 @@ msgstr "disabled"
 msgid "force enabled"
 msgstr "enabled"
 
+#. TRANSLATORS: genre category
 msgid "foreign countries/expeditions"
 msgstr "foreign countries/expeditions"
 
@@ -20795,9 +20961,8 @@ msgstr "free diskspace"
 msgid "from"
 msgstr "from"
 
-#, fuzzy
 msgid "from dir"
-msgstr "from"
+msgstr "from folder"
 
 msgid "full"
 msgstr "full"
@@ -20805,9 +20970,11 @@ msgstr "full"
 msgid "further education"
 msgstr "further education"
 
+#. TRANSLATORS: genre category
 msgid "game show/quiz/contest"
 msgstr "game show/quiz/contest"
 
+#. TRANSLATORS: genre category
 msgid "gardening"
 msgstr "gardening"
 
@@ -20820,27 +20987,23 @@ msgstr "go to deep standby"
 msgid "go to standby"
 msgstr "go to standby"
 
-#, fuzzy
 msgid "goto current channel and now"
-msgstr "Goto next channel"
+msgstr "go to current channel and now"
 
 msgid "goto deep-standby"
-msgstr "goto deep-standby"
+msgstr "go to deep standby"
 
-#, fuzzy
 msgid "goto first channel"
-msgstr "Goto next channel"
+msgstr "go to first channel"
 
-#, fuzzy
 msgid "goto last channel"
-msgstr "Goto next channel"
+msgstr "go to last channel"
 
-#, fuzzy
 msgid "goto now"
-msgstr "goto standby"
+msgstr "go to now"
 
 msgid "goto standby"
-msgstr "goto standby"
+msgstr "go to standby"
 
 msgid "grab this frame as bitmap"
 msgstr "grab this frame as bitmap"
@@ -20866,15 +21029,15 @@ msgstr ""
 msgid "h:mmam/pm"
 msgstr ""
 
+#. TRANSLATORS: genre category
 msgid "handicraft"
 msgstr "handicraft"
 
 msgid "handled"
 msgstr "handled"
 
-#, fuzzy
 msgid "has been CHANGED! Do you want to save it?"
-msgstr "Which event do you want to save permanently?"
+msgstr "has been changed! Would you like to save it?"
 
 msgid ""
 "has been sent to the SVN team team.\n"
@@ -20884,7 +21047,7 @@ msgstr ""
 "please quote"
 
 msgid "hdr10"
-msgstr ""
+msgstr "HDR10"
 
 msgid "height"
 msgstr "height"
@@ -20918,10 +21081,10 @@ msgid "hide"
 msgstr "hide"
 
 msgid "highest Resolution"
-msgstr "highest Resolution"
+msgstr "highest resolution"
 
 msgid "hlg"
-msgstr ""
+msgstr "HLG"
 
 msgid "hops:"
 msgstr "hops:"
@@ -20930,14 +21093,16 @@ msgid "horizontal"
 msgstr "horizontal"
 
 msgid "if set to 'no', only an debug message is written to the Debug log "
-msgstr "if set to 'no', only an debug message is written to the Debug log "
+msgstr "When set to 'no', only debug messages will be written to the debug log "
 
 msgid "increase uphop by 1"
 msgstr "increase uphop by 1"
 
+#. TRANSLATORS: genre category
 msgid "information/education/school program"
 msgstr "information/education/school program"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "infotainment (general)"
 msgstr "sports (general)"
@@ -20954,16 +21119,16 @@ msgstr "insert mark here"
 msgid "install/unpack ipk Files"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "internal flash:  %s %s "
-msgstr "Internal flash"
+msgstr "internal flash:  %s %s "
 
 #, python-format
 msgid "internal flash: %s %s as USB Recovery"
 msgstr ""
 
 msgid "internally loopthrough to"
-msgstr "internally loopthrough to"
+msgstr "loop through internally to"
 
 msgid "invalid type"
 msgstr "invalid type"
@@ -20992,14 +21157,15 @@ msgid "jump to previous page or all down (setup in menu)"
 msgstr "Go to previous page of service"
 
 msgid "just abort, no message"
-msgstr "just abort, no message"
+msgstr "abort without message"
 
 msgid "just abort, show message"
-msgstr "just abort, show message"
+msgstr "abort and show message"
 
 msgid "just boot"
 msgstr "just boot"
 
+#. TRANSLATORS: plugin type
 msgid "kernel modules"
 msgstr "kernel modules"
 
@@ -21007,14 +21173,15 @@ msgid "languages"
 msgstr "languages"
 
 msgid "leave movie player..."
-msgstr "leave movie player..."
+msgstr "quit movie player..."
 
 msgid "left"
-msgstr "left"
+msgstr "◀︎ Left"
 
 msgid "left, wrapped"
 msgstr "left, wrapped"
 
+#. TRANSLATORS: genre category
 msgid "leisure hobbies (general)"
 msgstr "leisure hobbies (general)"
 
@@ -21022,8 +21189,9 @@ msgid "length"
 msgstr "length"
 
 msgid "limit ..., aborting !"
-msgstr "limit ..., aborting !"
+msgstr "limit, aborting!"
 
+#. TRANSLATORS: genre category
 msgid "literature"
 msgstr "literature"
 
@@ -21042,6 +21210,7 @@ msgstr "loopthrough to"
 msgid "m2k"
 msgstr "m2k"
 
+#. TRANSLATORS: genre category
 msgid "magazines/reports/documentary"
 msgstr "magazines/reports/documentary"
 
@@ -21054,9 +21223,11 @@ msgstr ""
 msgid "manual"
 msgstr "manual"
 
+#. TRANSLATORS: genre category
 msgid "martial sports"
-msgstr "martial sports"
+msgstr "martial arts"
 
+#. TRANSLATORS: genre category
 msgid "medicine/physiology/psychology"
 msgstr "medicine/physiology/psychology"
 
@@ -21066,9 +21237,8 @@ msgstr "menu"
 msgid "middle"
 msgstr "middle"
 
-#, fuzzy
 msgid "min"
-msgstr "mins"
+msgstr "min"
 
 msgid "mins"
 msgstr "mins"
@@ -21082,9 +21252,11 @@ msgstr "minutes"
 msgid "month"
 msgstr "month"
 
+#. TRANSLATORS: genre category
 msgid "motor sport"
-msgstr "motor sport"
+msgstr "motorsports"
 
+#. TRANSLATORS: genre category
 msgid "motoring"
 msgstr "motoring"
 
@@ -21097,13 +21269,11 @@ msgstr "move down to last entry"
 msgid "move down to next entry"
 msgstr "move down to next entry"
 
-#, fuzzy
 msgid "move file"
-msgstr "Remove title"
+msgstr "move file"
 
-#, fuzzy
 msgid "move folder"
-msgstr "[move mode]"
+msgstr "move folder"
 
 msgid "move up to first entry"
 msgstr "move up to first entry"
@@ -21111,10 +21281,12 @@ msgstr "move up to first entry"
 msgid "move up to previous entry"
 msgstr "move up to previous entry"
 
+#. TRANSLATORS: genre category
 #, fuzzy
 msgid "movie (general)"
 msgstr "movie/drama (general)"
 
+#. TRANSLATORS: genre category
 msgid "movie/drama (general)"
 msgstr "movie/drama (general)"
 
@@ -21127,22 +21299,25 @@ msgstr "multi"
 msgid "multinorm"
 msgstr "multinorm"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "music (general)"
-msgstr "sports (general)"
+msgstr "music (general)"
 
+#. TRANSLATORS: genre category
 msgid "music/ballet/dance (general)"
 msgstr "music/ballet/dance (general)"
 
+#. TRANSLATORS: genre category
 msgid "musical/opera"
 msgstr "musical/opera"
 
 msgid "n/A"
-msgstr "n/A"
+msgstr "N/A"
 
 msgid "n/a"
 msgstr "n/a"
 
+#. TRANSLATORS: genre category
 msgid "nature/animals/environment"
 msgstr "nature/animals/environment"
 
@@ -21155,25 +21330,27 @@ msgstr "never abort"
 msgid "new media"
 msgstr "new media"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "news (general)"
-msgstr "sports (general)"
+msgstr "news (general)"
 
+#. TRANSLATORS: genre category
 msgid "news magazine"
 msgstr "news magazine"
 
+#. TRANSLATORS: genre category
 msgid "news/current affairs (general)"
 msgstr "news/current affairs (general)"
 
+#. TRANSLATORS: genre category
 msgid "news/weather report"
 msgstr "news/weather report"
 
-#, fuzzy
 msgid "next channel page"
-msgstr "Input channel name."
+msgstr "next channel page"
 
 msgid "next higher Resolution"
-msgstr "next higher Resolution"
+msgstr "next higher resolution"
 
 msgid "no"
 msgstr "no"
@@ -21194,7 +21371,7 @@ msgid "no module found"
 msgstr "no module found"
 
 msgid "no or unknown card inserted"
-msgstr "no or unknown card inserted"
+msgstr "no card or unrecognized card inserted"
 
 msgid "no resource manager"
 msgstr "no resource manager"
@@ -21208,9 +21385,8 @@ msgstr "none"
 msgid "normal"
 msgstr "normal"
 
-#, fuzzy
 msgid "not"
-msgstr "no"
+msgstr "not"
 
 msgid "not activated"
 msgstr "not activated"
@@ -21224,9 +21400,8 @@ msgstr "not locked"
 msgid "not supported"
 msgstr "not supported"
 
-#, fuzzy
 msgid "not tested"
-msgstr "Not tested:"
+msgstr "not tested"
 
 msgid "not used"
 msgstr "not used"
@@ -21239,16 +21414,16 @@ msgid "nothing connected"
 msgstr "nothing connected"
 
 msgid "of a DUAL layer medium used."
-msgstr "of a DUAL layer medium used."
+msgstr "of a dual-layer disc used."
 
 msgid "of a SINGLE layer medium used."
-msgstr "of a SINGLE layer medium used."
+msgstr "of a single-layer disc used."
 
 msgid "off"
 msgstr "off"
 
 msgid "off or wpa2 on"
-msgstr "off or wpa2 on"
+msgstr "WPA2 or off"
 
 msgid "offset is"
 msgstr "offset is"
@@ -21257,11 +21432,10 @@ msgid "on"
 msgstr "on"
 
 msgid "on READ ONLY medium."
-msgstr "on READ ONLY medium."
+msgstr "on read-only disc."
 
-#, fuzzy
 msgid "on how to restore the image"
-msgstr "Do you want to remove the package:\n"
+msgstr "on how to restore the image"
 
 msgid "once"
 msgstr "once"
@@ -21270,7 +21444,7 @@ msgid "only HD"
 msgstr "only HD"
 
 msgid "only in Standby"
-msgstr "only in Standby"
+msgstr "only in standby"
 
 msgid "openATV"
 msgstr "openATV"
@@ -21297,54 +21471,55 @@ msgid "performing arts"
 msgstr "performing arts"
 
 msgid "picons"
-msgstr "picons"
+msgstr "channel picons"
 
 msgid "pid:"
 msgstr "pid:"
 
-#, fuzzy
 msgid "play Files"
-msgstr "Copying files"
+msgstr "play files"
 
 msgid "play as picture in picture"
-msgstr "play as picture in picture"
+msgstr "play as picture-in-picture"
 
 msgid "play in mainwindow"
-msgstr "play in mainwindow"
+msgstr "play in main window"
 
 msgid "play/show Files"
-msgstr ""
+msgstr "play/show files"
 
 msgid "please press OK when ready"
 msgstr "please press OK when ready"
 
 msgid "please wait, loading picture..."
-msgstr "please wait, loading picture..."
+msgstr "loading picture, please wait..."
 
 msgid "please wait..."
 msgstr "please wait..."
 
+#. TRANSLATORS: plugin type
 msgid "pli"
 msgstr "pli"
 
 msgid "pm"
 msgstr "pm"
 
+#. TRANSLATORS: genre category
 msgid "popular culture/traditional arts"
 msgstr "popular culture/traditional arts"
 
+#. TRANSLATORS: genre category
 msgid "pre-school children's program"
-msgstr "pre-school children's program"
+msgstr "pre-school childrens' program"
 
 msgid "press the menu button to set a general AC3/Dolby offset"
-msgstr "press the menu button to set a general AC3/Dolby offset"
+msgstr "Press MENU to set a general Dolby Digital / Dolby AC-3 offset."
 
-#, fuzzy
 msgid "previous channel page"
-msgstr "Goto previous channel"
+msgstr "previous channel page"
 
 msgid "previous/next Page"
-msgstr ""
+msgstr "previous/next page"
 
 msgid "provid:"
 msgstr "provid:"
@@ -21353,11 +21528,10 @@ msgid "provider:"
 msgstr "provider:"
 
 msgid "purge deleted userbouquets"
-msgstr "purge deleted userbouquets"
+msgstr "purge deleted custom bouquets"
 
-#, fuzzy
 msgid "python"
-msgstr "Python:\t%s"
+msgstr "python"
 
 msgid "real or pseudo recordings"
 msgstr "real or pseudo recordings"
@@ -21390,9 +21564,11 @@ msgstr "reliable"
 msgid "reliable, retune"
 msgstr "reliable, retune"
 
+#. TRANSLATORS: genre category
 msgid "religion"
 msgstr "religion"
 
+#. TRANSLATORS: genre category
 msgid "remarkable people"
 msgstr "remarkable people"
 
@@ -21400,7 +21576,7 @@ msgid "remove after this position"
 msgstr "remove after this position"
 
 msgid "remove all alternatives"
-msgstr "remove all alternatives"
+msgstr "Remove all alternatives"
 
 msgid "remove all new found flags"
 msgstr "remove all new found flags"
@@ -21418,10 +21594,10 @@ msgid "remove cable services"
 msgstr "remove cable services"
 
 msgid "remove directory"
-msgstr "remove directory"
+msgstr "remove folder"
 
 msgid "remove entry"
-msgstr "remove entry"
+msgstr "Remove entry"
 
 msgid "remove from parental protection"
 msgstr "remove from parental protection"
@@ -21442,7 +21618,7 @@ msgid "rename"
 msgstr "rename"
 
 msgid "rename entry"
-msgstr "rename entry"
+msgstr "Rename entry"
 
 msgid "repeat playlist"
 msgstr "repeat playlist"
@@ -21451,10 +21627,10 @@ msgid "repeated"
 msgstr "repeated"
 
 msgid "restart GUI"
-msgstr "restart GUI"
+msgstr "restart user interface"
 
 msgid "restore deleted userbouquets"
-msgstr "restore deleted userbouquets"
+msgstr "restore previously deleted custom bouquets"
 
 msgid "restoring satellites.xml not possible!"
 msgstr "restoring satellites.xml not possible!"
@@ -21469,7 +21645,7 @@ msgid "rgb"
 msgstr "rgb"
 
 msgid "right"
-msgstr "right"
+msgstr "Right ▶︎"
 
 msgid "right, wrapped"
 msgstr "right, wrapped"
@@ -21489,23 +21665,22 @@ msgid ""
 "but it's not possible to search for new TV channels\n"
 "or to configure tuner settings"
 msgstr ""
-"satellites.xml not found or corrupted!\n"
-"It is possible to watch TV,\n"
-"but it's not possible to search for new TV channels\n"
-"or to configure tuner settings"
+"satellites.xml wasn't found or is corrupt!\n"
+"It's still possible to watch TV,\n"
+"but it won't be possible to search for new channels\n"
+"or configure tuner settings"
 
 msgid "save"
-msgstr "save"
+msgstr "Save"
 
 msgid "save last directory on exit"
-msgstr "save last directory on exit"
+msgstr "remember last folder on exit"
 
 msgid "save playlist on exit"
 msgstr "save playlist on exit"
 
-#, fuzzy
 msgid "scan new"
-msgstr "scan state"
+msgstr "scan new"
 
 msgid "scan state"
 msgstr "scan state"
@@ -21523,7 +21698,7 @@ msgid "sdr"
 msgstr ""
 
 msgid "search EPG..."
-msgstr "search EPG..."
+msgstr "Search EPG..."
 
 msgid "second cable of motorized LNB"
 msgstr "second cable of motorized LNB"
@@ -21538,10 +21713,10 @@ msgid "select"
 msgstr "select"
 
 msgid "select CAId's"
-msgstr "select CAId's"
+msgstr "select CAIds"
 
 msgid "select channels to add a offset to the Volume"
-msgstr "select channels to add a offset to the Volume"
+msgstr "select channels to add a Volume offset for"
 
 msgid "select menu entry"
 msgstr "select menu entry"
@@ -21556,7 +21731,7 @@ msgid "service PIN"
 msgstr "service PIN"
 
 msgid "set as startup service"
-msgstr "set as startup service"
+msgstr "Set as startup channel"
 
 msgid "settings"
 msgstr "settings"
@@ -21583,7 +21758,7 @@ msgid "show all tags"
 msgstr "show all tags"
 
 msgid "show alternatives"
-msgstr "show alternatives"
+msgstr "Show alternatives"
 
 msgid "show cards with uphop 0"
 msgstr "show cards with uphop 0"
@@ -21619,19 +21794,19 @@ msgid "show event details"
 msgstr "show event details"
 
 msgid "show mediaplayer on mainmenu"
-msgstr "show mediaplayer on mainmenu"
+msgstr "show media player on Main menu"
 
 msgid "show picons in quickzap"
-msgstr "show picons in quickzap"
+msgstr "Show channel picons in quick zap mode"
 
 msgid "show picons in service list"
-msgstr "show picons in service list"
+msgstr "Show channel picons in the channel list"
 
 msgid "show program information..."
 msgstr "show program information..."
 
 msgid "show transponder info"
-msgstr "show transponder info"
+msgstr "Show transponder info"
 
 msgid "show/game show (general)"
 msgstr "show/game show (general)"
@@ -21707,12 +21882,15 @@ msgstr ""
 msgid "slow"
 msgstr "slow"
 
+#. TRANSLATORS: genre category
 msgid "soap/melodrama/folkloric"
 msgstr "soap/melodrama/folkloric"
 
+#. TRANSLATORS: genre category
 msgid "social/political issues/economics (general)"
 msgstr "social/political issues/economics (general)"
 
+#. TRANSLATORS: genre category
 msgid "social/spiritual science"
 msgstr "social/spiritual science"
 
@@ -21720,22 +21898,24 @@ msgid "softcams"
 msgstr "softcams"
 
 msgid "sorting of playlists"
-msgstr "sorting of playlists"
+msgstr "playlist sorting"
 
-#, fuzzy
 msgid "special (general)"
-msgstr "sports (general)"
+msgstr "special (general)"
 
+#. TRANSLATORS: genre category
 msgid "special events"
 msgstr "special events"
 
-#, fuzzy
+#. TRANSLATORS: genre category
 msgid "sport (general)"
 msgstr "sports (general)"
 
+#. TRANSLATORS: genre category
 msgid "sports (general)"
 msgstr "sports (general)"
 
+#. TRANSLATORS: genre category
 msgid "sports magazine"
 msgstr "sports magazine"
 
@@ -21752,7 +21932,7 @@ msgid "start recording"
 msgstr "start recording"
 
 msgid "stepsize"
-msgstr "stepsize"
+msgstr "step size"
 
 msgid "stereo"
 msgstr "stereo"
@@ -21761,7 +21941,7 @@ msgid "stop recording"
 msgstr "stop recording"
 
 msgid "stop using as startup service"
-msgstr "stop using as startup service"
+msgstr "Don't use as startup service"
 
 msgid "successful"
 msgstr ""
@@ -21776,7 +21956,7 @@ msgid "switch to bookmarks"
 msgstr "switch to bookmarks"
 
 msgid "switch to filelist"
-msgstr "switch to filelist"
+msgstr "switch to file list"
 
 msgid "switch to the next angle"
 msgstr "switch to the next angle"
@@ -21791,20 +21971,24 @@ msgid "system:"
 msgstr "system:"
 
 msgid "systemplugins"
-msgstr "systemplugins"
+msgstr "system plugins"
 
+#. TRANSLATORS: genre category
 msgid "talk show"
 msgstr "talk show"
 
+#. TRANSLATORS: genre category
 msgid "team sports"
 msgstr "team sports"
 
+#. TRANSLATORS: genre category
 msgid "technology/natural science"
 msgstr "technology/natural science"
 
 msgid "template file"
 msgstr "template file"
 
+#. TRANSLATORS: genre category
 msgid "tennis/squash"
 msgstr "tennis/squash"
 
@@ -21821,7 +22005,7 @@ msgid "this service is protected by a parental control pin"
 msgstr "this service is protected by a parental control pin"
 
 msgid "to dir"
-msgstr ""
+msgstr "to folder"
 
 msgid "toggle time, chapter, audio, subtitle info"
 msgstr "toggle time, chapter, audio, subtitle info"
@@ -21829,6 +22013,7 @@ msgstr "toggle time, chapter, audio, subtitle info"
 msgid "top"
 msgstr "top"
 
+#. TRANSLATORS: genre category
 msgid "tourism/travel"
 msgstr "tourism/travel"
 
@@ -21865,7 +22050,6 @@ msgstr "unavailable"
 msgid "unconfirmed"
 msgstr "unconfirmed"
 
-#, fuzzy
 msgid "unknow"
 msgstr "unknown"
 
@@ -21901,7 +22085,7 @@ msgid "untestable"
 msgstr "enable"
 
 msgid "until standby/restart"
-msgstr "until standby/restart"
+msgstr "until standby or restart"
 
 msgid "update"
 msgstr "update"
@@ -21917,7 +22101,7 @@ msgid "use best / controlled by HDMI"
 msgstr "use best / controlled by HDMI"
 
 msgid "use increased voltage '14/18V' if there are problems when switching the lnb"
-msgstr ""
+msgstr "use increased voltage '14/18V' if there are problems when switching LNB"
 
 #, fuzzy
 msgid "use_hdmi_cacenter"
@@ -21936,6 +22120,7 @@ msgstr "user defined"
 msgid "using:"
 msgstr "using:"
 
+#. TRANSLATORS: genre category
 msgid "variety show"
 msgstr "variety show"
 
@@ -21952,19 +22137,20 @@ msgid "vix"
 msgstr "vix"
 
 msgid "wait for mmi..."
-msgstr "wait for mmi..."
+msgstr "wait for MMI..."
 
 msgid "waiting"
-msgstr "waiting"
+msgstr "waiting..."
 
 msgid "wakeup"
-msgstr "wakeup"
+msgstr "wake up"
 
 msgid "wakeup to standby"
-msgstr "wakeup to standby"
+msgstr "wake up to standby"
 
+#. TRANSLATORS: genre category
 msgid "water sport"
-msgstr "water sport"
+msgstr "water sports"
 
 msgid "weblinks"
 msgstr "weblinks"
@@ -22003,8 +22189,9 @@ msgstr "will take about 1-4 minutes for this system\n"
 msgid "will take about 30 minutes for this system\n"
 msgstr "will take about 30 minutes for this system\n"
 
+#. TRANSLATORS: genre category
 msgid "winter sport"
-msgstr "winter sport"
+msgstr "winter sports"
 
 msgid "wireless network interface"
 msgstr "wireless network interface"
@@ -22015,26 +22202,24 @@ msgid_plural "with %d errors"
 msgstr[0] "with %d error"
 msgstr[1] "with %d errors"
 
-#, fuzzy
 msgid "with errors"
-msgstr "With errors:"
+msgstr "with errors"
 
 msgid "with exit button"
-msgstr "with exit button"
+msgstr "with EXIT button"
 
 msgid "with left/right buttons"
-msgstr "with left/right buttons"
+msgstr "with ◀︎ Left and ▶︎ Right buttons"
 
 msgid "with long OK press"
-msgstr "with long OK press"
+msgstr "with OK button held down"
 
 #, fuzzy
 msgid "with_errors"
 msgstr "With errors:"
 
-#, fuzzy
 msgid "without"
-msgstr "without Query"
+msgstr "without"
 
 msgid "without Query"
 msgstr "without Query"
@@ -22053,7 +22238,7 @@ msgstr "yes (keep feeds)"
 
 #, python-format
 msgid "your %s %s might be unusable now. Please consult the manual for further assistance before rebooting your %s %s."
-msgstr "your %s %s might be unusable now. Please consult the manual for further assistance before rebooting your %s %s."
+msgstr "your %s %s might now be unusable, please refer to your %s %s's documentation for further assistance before rebooting it."
 
 msgid "zap"
 msgstr "zap"
@@ -22066,6 +22251,15 @@ msgstr "zapped"
 
 msgid "zapping"
 msgstr "zapping"
+
+msgid "IPKGMenu"
+msgstr "IPKG Menu"
+
+msgid "IPKGSource"
+msgstr "IPKG Source"
+
+msgid "PacketManager"
+msgstr "Packet Manager"
 
 #~ msgid ""
 #~ "\n"
@@ -22532,17 +22726,11 @@ msgstr "zapping"
 #~ msgid "INFO Panel"
 #~ msgstr "INFO Panel"
 
-#~ msgid "IPKGMenu"
-#~ msgstr "IPKGMenu"
-
-#~ msgid "IPKGSource"
-#~ msgstr "IPKGSource"
-
 #~ msgid "If enabled, will checks for the time after the start of the receiver is within the time window and optionally switched to standby. If disabled, must additional be available a signal for the successful wakeup detection. (some receiver send a false or none signal)"
 #~ msgstr "If enabled, will checks for the time after the start of the receiver is within the time window and optionally switched to standby. If disabled, must additional be available a signal for the successful wakeup detection. (some receiver send a false or none signal)"
 
 #~ msgid "If set to 'yes' the EPG will alway open at the first channel. If set to 'no' the EPG will open on the present channel."
-#~ msgstr "If set to 'yes' the EPG will alway open at the first channel. If set to 'no' the EPG will open on the present channel."
+#~ msgstr "When set to 'yes' the EPG will alway open at the first channel. If set to 'no' the EPG will open on the present channel."
 
 #~ msgid "Image flash utility"
 #~ msgstr "Image flash utility"
@@ -22730,9 +22918,6 @@ msgstr "zapping"
 #~ msgid "PU_Restore"
 #~ msgstr "PU_Restore"
 
-#~ msgid "PacketManager"
-#~ msgstr "PacketManager"
-
 #~ msgid "Panel-Info"
 #~ msgstr "Panel-Info"
 
@@ -22878,7 +23063,7 @@ msgstr "zapping"
 #~ msgstr "Select all"
 
 #~ msgid "Select if you want to use the image coloured Buttons (set to 'no' if you want to use (Multi) Quick Button)."
-#~ msgstr "Select if you want to use the image coloured Buttons (set to 'no' if you want to use (Multi) Quick Button)."
+#~ msgstr "Select if you want to use the image colored Buttons (set to 'no' if you want to use (Multi) Quick Button)."
 
 #~ msgid "SelectSatsEntryScreen"
 #~ msgstr "SelectSatsEntryScreen"
@@ -23005,7 +23190,7 @@ msgstr "zapping"
 #~ msgstr "There is no [webif] section in oscam.conf"
 
 #~ msgid "This option allows you to disable sorting of the menus"
-#~ msgstr "This option allows you to disable sorting of the menus"
+#~ msgstr "This option lets you to disable sorting of the menus"
 
 #~ msgid "Time between start attempts (sec.)"
 #~ msgstr "Time between start attempts (sec.)"
@@ -23065,7 +23250,7 @@ msgstr "zapping"
 #~ msgstr "UpdatePluginMenu"
 
 #~ msgid "Use image coloured Buttons *"
-#~ msgstr "Use image coloured Buttons *"
+#~ msgstr "Use image colored Buttons *"
 
 #~ msgid "User name"
 #~ msgstr "User name"
@@ -23205,7 +23390,7 @@ msgstr "zapping"
 #~ msgstr "lamedb.%d"
 
 #~ msgid "markername"
-#~ msgstr "markername"
+#~ msgstr "name"
 
 #~ msgid "myChannelSelection"
 #~ msgstr "myChannelSelection"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -8,16 +8,16 @@ msgstr ""
 "Project-Id-Version: OpenATV\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-30 14:34+0100\n"
-"PO-Revision-Date: 2019-08-26 19:09+0200\n"
-"Last-Translator: mike99 <mike99@gmx.net>\n"
-"Language-Team: ViX\n"
+"PO-Revision-Date: 2020-07-02 11:04+0100\n"
+"Last-Translator: Web Dev Ben <9741693+wedebe@users.noreply.github.com>\n"
+"Language-Team: \n"
 "Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 2.3.1\n"
 
 msgid ""
 "\n"
@@ -25,11 +25,10 @@ msgid ""
 "[User - bouquets (TV)]\n"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "\n"
 "   Please press OK to start Kodi..."
-msgstr "Please press OK to continue."
+msgstr ""
 
 msgid ""
 "\n"
@@ -42,11 +41,10 @@ msgid ""
 " Kodi not present. Proceed with install?"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "\n"
 "%Y/%m/%d  %H:%M - "
-msgstr "%a %e/%m  %-H:%M"
+msgstr ""
 
 msgid ""
 "\n"
@@ -62,23 +60,17 @@ msgid ""
 "\n"
 "Advanced options and settings."
 msgstr ""
-"\n"
-"Advanced options and settings."
 
 msgid ""
 "\n"
 "After pressing OK, please wait!"
 msgstr ""
-"\n"
-"After pressing OK, please wait!"
 
 #, python-format
 msgid ""
 "\n"
 "Backup your %s %s settings."
 msgstr ""
-"\n"
-"Backup your %s %s settings."
 
 #, python-format
 msgid ""
@@ -90,8 +82,6 @@ msgid ""
 "\n"
 "Edit the upgrade source address."
 msgstr ""
-"\n"
-"Edit the upgrade source address."
 
 #, python-format
 msgid ""
@@ -109,23 +99,17 @@ msgid ""
 "\n"
 "Manage extensions or plugins for your %s %s"
 msgstr ""
-"\n"
-"Manage extensions or plugins for your %s %s"
 
 #, python-format
 msgid ""
 "\n"
 "Online update of your %s %s software."
 msgstr ""
-"\n"
-"Online update of your %s %s software."
 
 msgid ""
 "\n"
 "Press OK on your remote control to continue."
 msgstr ""
-"\n"
-"Press OK on your remote control to continue."
 
 msgid ""
 "\n"
@@ -137,46 +121,33 @@ msgid ""
 "\n"
 "Restore your %s %s settings."
 msgstr ""
-"\n"
-"Restore your %s %s settings."
 
 #, python-format
 msgid ""
 "\n"
 "Restore your %s %s with a new firmware."
 msgstr ""
-"\n"
-"Restore your %s %s with a new firmware."
 
 msgid ""
 "\n"
 "Restore your backups by date."
 msgstr ""
-"\n"
-"Restore your backups by date."
 
 msgid ""
 "\n"
 "Scan for local extensions and install them."
 msgstr ""
-"\n"
-"Scan for local extensions and install them."
 
 msgid ""
 "\n"
 "Select your backup device.\n"
 "Current device: "
 msgstr ""
-"\n"
-"Select your backup device.\n"
-"Current device: "
 
 msgid ""
 "\n"
 "View, install and remove available or installed packages."
 msgstr ""
-"\n"
-"View, install and remove available or installed packages."
 
 msgid ""
 "\n"
@@ -207,8 +178,11 @@ msgstr ""
 msgid "     wrong back-up destination "
 msgstr ""
 
-#, python-format
 msgid "   (%s MHz)"
+msgstr ""
+
+#, python-format
+msgid "  (%s x %s)"
 msgstr ""
 
 msgid "   (1.0 GHz)"
@@ -242,9 +216,9 @@ msgstr ""
 msgid " ('%s') ends successfully."
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid " ('%s') ends with error messages."
-msgstr "Hide any zap error messages."
+msgstr ""
 
 #, python-format
 msgid " ('%s') ends with error number [%d]."
@@ -259,17 +233,16 @@ msgid " (Partition %d)"
 msgstr ""
 
 msgid " (PiP)"
-msgstr " (PiP)"
+msgstr ""
 
 msgid " (Radio)"
-msgstr " (Radio)"
+msgstr ""
 
 msgid " (TV)"
-msgstr " (TV)"
+msgstr ""
 
-#, fuzzy
 msgid " (current channel)"
-msgstr "Show EPG for current channel..."
+msgstr ""
 
 msgid " (disabled)"
 msgstr ""
@@ -296,23 +269,24 @@ msgstr ""
 msgid " - folder exist! Overwrite"
 msgstr ""
 
-#, fuzzy
 msgid " <No Channel>"
-msgstr "Channel"
+msgstr ""
 
-#, fuzzy
 msgid " <empty>"
-msgstr "empty"
+msgstr ""
 
 msgid " and"
-msgstr " and"
+msgstr ""
 
-#, fuzzy
 msgid ""
 " available !!\n"
 "\n"
 "Do you want to install the new settingslist?"
-msgstr "Do you want to restore your settings?"
+msgstr ""
+
+#, python-format
+msgid " bootmode = %s"
+msgstr ""
 
 msgid " of "
 msgstr ""
@@ -320,22 +294,20 @@ msgstr ""
 msgid " or save additional the picture to a file"
 msgstr ""
 
-#, fuzzy
 msgid " updated"
-msgstr "Update"
+msgstr ""
 
 msgid "!! Bootloader Upgrade !!"
 msgstr ""
 
 msgid "%-H:%M"
-msgstr "%-H:%M"
+msgstr ""
 
 msgid "%-H:%M - "
 msgstr ""
 
-#, fuzzy
 msgid "%-H:%M:%S"
-msgstr "%-H:%M"
+msgstr ""
 
 msgid "%-I:%M"
 msgstr ""
@@ -356,18 +328,20 @@ msgid "%-I:%M:%S%^p"
 msgstr ""
 
 #. TRANSLATORS: full date representation daynum monthname year in strftime() format! See 'man strftime'
-#, fuzzy
+#. TRANSLATORS: used on Timer Entry pages
 msgid "%-d %B %Y"
-msgstr "%d.%B %Y"
+msgstr "{%a %-d %b %Y"
 
 #. TRANSLATORS: small date representation daynum short monthname in strftime() format! See 'man strftime'
 #. TRANSLATORS: compact date representation (for VFD) daynum short monthname in strftime() format! See 'man strftime'
+#. TRANSLATORS: used on EPG Search results
 msgid "%-d %b"
-msgstr ""
+msgstr "{%a %-d %b"
 
 #. TRANSLATORS: long date representation daynum short monthname year in strftime() format! See 'man strftime'
+#. TRANSLATORS: used in 'Similar broadcasts' list and Timer Log
 msgid "%-d %b %Y"
-msgstr ""
+msgstr "{%a %-d %b %Y"
 
 msgid "%-d+%b_"
 msgstr ""
@@ -379,6 +353,27 @@ msgid "%-d-%b"
 msgstr ""
 
 msgid "%-d-%b-%Y"
+msgstr ""
+
+msgid "%-d. %B %Y"
+msgstr ""
+
+msgid "%-d. %b"
+msgstr ""
+
+msgid "%-d. %b %Y"
+msgstr ""
+
+msgid "%-d.%-m"
+msgstr ""
+
+msgid "%-d.%-m.%Y"
+msgstr ""
+
+msgid "%-d.%m"
+msgstr ""
+
+msgid "%-d.%m.%Y"
 msgstr ""
 
 msgid "%-d/%-m"
@@ -432,55 +427,72 @@ msgstr ""
 msgid "%.2f GB"
 msgstr ""
 
-#, python-format
 msgid "%02d.%02d - %02d.%02d (%s%d min)"
-msgstr "%02d.%02d - %02d.%02d (%s%d min)"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
+msgid "%02d.%02d - %02d.%02d (%s%s)"
+msgstr ""
+
+#. TRANSLATORS: used on menu clock?
+#, python-format
 msgid "%02d.%02d."
-msgstr "%2d:%02d"
+msgstr "%02d.%02d"
 
-#, fuzzy, python-format
+#, python-format
 msgid "%02d.%02d.%d"
-msgstr "%2d:%02d:%02d"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%02d:%02d"
-msgstr "%2d:%02d"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%02d:%02d - %02d:%02d"
-msgstr "%2d:%02d:%02d"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%03d MB"
-msgstr "%d MB"
+msgstr ""
 
 #, python-format
 msgid "%2.1f sec"
 msgstr ""
 
-#, fuzzy
 msgid "%A"
-msgstr "A"
+msgstr ""
 
 #. TRANSLATORS: short date representation dayname daynum short monthname in strftime() format! See 'man strftime'
-#, fuzzy
 msgid "%A %-d %B"
-msgstr "%A %e %B"
+msgstr ""
 
 #. TRANSLATORS: full date representation dayname daynum monthname year in strftime() format! See 'man strftime'
-#, fuzzy
 msgid "%A %-d %B %Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %-d-%B"
-msgstr "%A %e %B"
+msgstr ""
 
-#, fuzzy
 msgid "%A %-d-%B-%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
+
+msgid "%A %-d. %B"
+msgstr ""
+
+msgid "%A %-d. %B %Y"
+msgstr ""
+
+msgid "%A %-d.%-m"
+msgstr ""
+
+msgid "%A %-d.%-m.%Y"
+msgstr ""
+
+msgid "%A %-d.%m"
+msgstr ""
+
+msgid "%A %-d.%m.%Y"
+msgstr ""
 
 msgid "%A %-d/%-m"
 msgstr ""
@@ -491,9 +503,8 @@ msgstr ""
 msgid "%A %-d/%m"
 msgstr ""
 
-#, fuzzy
 msgid "%A %-d/%m/%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
 msgid "%A %-m/%-d"
 msgstr ""
@@ -504,57 +515,44 @@ msgstr ""
 msgid "%A %-m/%d"
 msgstr ""
 
-#, fuzzy
 msgid "%A %-m/%d/%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %B %-d"
-msgstr "%A %e %B"
+msgstr ""
 
-#, fuzzy
 msgid "%A %B %-d %Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %B %d"
-msgstr "%A %e %B"
+msgstr ""
 
-#, fuzzy
 msgid "%A %B %d %Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %B-%-d"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %B-%-d-%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %B-%d"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %B-%d-%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %Y %B %-d"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %Y %B %d"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %Y-%B-%-d"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %Y-%B-%d"
-msgstr "%A %e %B %Y"
+msgstr ""
 
 msgid "%A %Y/%-m/%-d"
 msgstr ""
@@ -571,58 +569,65 @@ msgstr ""
 msgid "%A %d %B"
 msgstr ""
 
-#, fuzzy
 msgid "%A %d %B %Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %d-%B"
-msgstr "%A %e %B"
+msgstr ""
 
-#, fuzzy
 msgid "%A %d-%B-%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
+
+msgid "%A %d. %B"
+msgstr ""
+
+msgid "%A %d. %B %Y"
+msgstr ""
+
+msgid "%A %d.%-m"
+msgstr ""
+
+msgid "%A %d.%-m.%Y"
+msgstr ""
+
+msgid "%A %d.%m"
+msgstr ""
+
+msgid "%A %d.%m.%Y"
+msgstr ""
 
 msgid "%A %d/%-m"
 msgstr ""
 
-#, fuzzy
 msgid "%A %d/%-m/%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %d/%m"
-msgstr "%A %e %B"
+msgstr ""
 
-#, fuzzy
 msgid "%A %d/%m/%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
 msgid "%A %e %b"
-msgstr "%A %e %b"
+msgstr ""
 
 msgid "%A %m/%-d"
 msgstr ""
 
-#, fuzzy
 msgid "%A %m/%-d/%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%A %m/%d"
-msgstr "%A %e %B"
+msgstr ""
 
-#, fuzzy
 msgid "%A %m/%d/%Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%B %-d %Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%B %d %Y"
-msgstr "%A %e %B %Y"
+msgstr ""
 
 msgid "%B-%-d-%Y"
 msgstr ""
@@ -631,7 +636,7 @@ msgid "%B-%d-%Y"
 msgstr ""
 
 msgid "%H:%M"
-msgstr "%H:%M"
+msgstr ""
 
 msgid "%I:%M"
 msgstr ""
@@ -659,13 +664,11 @@ msgstr ""
 msgid "%T"
 msgstr ""
 
-#, fuzzy
 msgid "%Y %B %-d"
-msgstr "%A %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%Y %B %d"
-msgstr "%A %e %B %Y"
+msgstr ""
 
 msgid "%Y %b %-d"
 msgstr ""
@@ -711,104 +714,103 @@ msgid "%a %-d"
 msgstr ""
 
 #. TRANSLATORS: long date representation short dayname daynum monthname year in strftime() format! See 'man strftime'
-#, fuzzy
 msgid "%a %-d %B %Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
 #. TRANSLATORS: short date representation short dayname daynum short monthname in strftime() format! See 'man strftime'
-#, fuzzy
 msgid "%a %-d %b"
-msgstr "%a %e %B %Y"
+msgstr ""
 
 #. TRANSLATORS: long date representation short dayname daynum short monthname year in strftime() format! See 'man strftime'
-#, fuzzy
 msgid "%a %-d %b %Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
 msgid "%a %-d+%b_"
 msgstr ""
 
-#, fuzzy
 msgid "%a %-d-%B-%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
 msgid "%a %-d-%b"
 msgstr ""
 
-#, fuzzy
 msgid "%a %-d-%b-%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
+msgid "%a %-d. %B %Y"
+msgstr ""
+
+msgid "%a %-d. %b"
+msgstr ""
+
+msgid "%a %-d. %b %Y"
+msgstr ""
+
+msgid "%a %-d.%-m"
+msgstr ""
+
+msgid "%a %-d.%-m.%Y"
+msgstr ""
+
+msgid "%a %-d.%m"
+msgstr ""
+
+msgid "%a %-d.%m.%Y"
+msgstr ""
+
 msgid "%a %-d/%-m"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %-d/%-m/%Y"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %-d/%m"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %-d/%m/%Y"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %-m/%-d"
-msgstr "%a %e/%m"
+msgstr ""
 
 msgid "%a %-m/%-d/%Y"
 msgstr ""
 
-#, fuzzy
 msgid "%a %-m/%d"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %-m/%d/%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %B %-d %Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %B %d %Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %B-%-d-%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %B-%d-%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %Y %B %-d"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %Y %B %d"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %Y %b %-d"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %Y %b %d"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %Y-%B-%-d"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %Y-%B-%d"
-msgstr "%a %e %B %Y"
+msgstr ""
 
 msgid "%a %Y-%b-%-d"
 msgstr ""
@@ -816,116 +818,110 @@ msgstr ""
 msgid "%a %Y-%b-%d"
 msgstr ""
 
-#, fuzzy
 msgid "%a %Y/%-m/%-d"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %Y/%-m/%d"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %Y/%m/%-d"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %Y/%m/%d"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %b %-d"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %b %-d %Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %b %d"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %b %d %Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
 msgid "%a %b-%-d"
 msgstr ""
 
-#, fuzzy
 msgid "%a %b-%-d-%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %b-%d"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %b-%d-%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d %B"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d %B %Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d %b"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d %b %Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d-%B-%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d-%b"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d-%b-%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
+msgid "%a %d. %B %Y"
+msgstr ""
+
+msgid "%a %d. %b"
+msgstr ""
+
+msgid "%a %d. %b %Y"
+msgstr ""
+
+msgid "%a %d.%-m"
+msgstr ""
+
+msgid "%a %d.%-m.%Y"
+msgstr ""
+
+msgid "%a %d.%m"
+msgstr ""
+
+msgid "%a %d.%m.%Y"
+msgstr ""
+
 msgid "%a %d/%-m"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d/%-m/%Y"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d/%m"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %d/%m/%Y"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %m/%-d"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %m/%-d/%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
-#, fuzzy
 msgid "%a %m/%d"
-msgstr "%a %e/%m"
+msgstr ""
 
-#, fuzzy
 msgid "%a %m/%d/%Y"
-msgstr "%a %e %B %Y"
+msgstr ""
 
 msgid "%b %-d"
 msgstr ""
@@ -980,19 +976,19 @@ msgstr ""
 
 #, python-format
 msgid "%d GB"
-msgstr "%d GB"
+msgstr ""
 
 #, python-format
 msgid "%d Gb"
-msgstr "%d Gb"
+msgstr ""
 
 #, python-format
 msgid "%d KB"
-msgstr "%d KB"
+msgstr ""
 
 #, python-format
 msgid "%d MB"
-msgstr "%d MB"
+msgstr ""
 
 #. TRANSLATORS: full date representation dayname daynum monthname year in strftime() format! See 'man strftime'
 #. _("%A %e %B %Y")
@@ -1011,11 +1007,12 @@ msgstr "%d MB"
 #. TRANSLATORS: full date representations short dayname daynum monthname long year in strftime() format! See 'man strftime'
 #. _("%a %e %B %Y")
 #.
+#. TRANSLATORS: used for time elapsed/remaining
 #, python-format
 msgid "%d Min"
 msgid_plural "%d Mins"
-msgstr[0] "%d Min"
-msgstr[1] "%d Mins"
+msgstr[0] "{%d min"
+msgstr[1] "{%d mins"
 
 #, python-format
 msgid "%d Mins"
@@ -1025,36 +1022,40 @@ msgstr ""
 #, python-format
 msgid "%d channel found"
 msgid_plural "%d channels found"
-msgstr[0] "%d channel found"
-msgstr[1] "%d channels found"
+msgstr[0] ""
+msgstr[1] ""
 
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
-msgstr[0] "%d hour"
-msgstr[1] "%d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "%d hour %d min"
+msgstr ""
 
 #, python-format
 msgid "%d kB"
-msgstr "%d kB"
+msgstr ""
 
 #, python-format
 msgid "%d min"
-msgstr "%d min"
+msgstr ""
 
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
-msgstr[0] "%d minute"
-msgstr[1] "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
 
 #, python-format
 msgid "%d minutes"
-msgstr "%d minutes"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%d ms"
-msgstr "%d min"
+msgstr ""
 
 #, python-format
 msgid "%d pixel wide"
@@ -1062,25 +1063,25 @@ msgid_plural "%d pixels wide"
 msgstr[0] ""
 msgstr[1] ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%d sec"
-msgstr "%d second"
+msgstr ""
 
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
-msgstr[0] "%d second"
-msgstr[1] "%d seconds"
+msgstr[0] ""
+msgstr[1] ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%d times"
-msgstr "End time"
+msgstr ""
 
 #, python-format
 msgid "%d wireless network found!"
 msgid_plural "%d wireless networks found!"
-msgstr[0] "%d wireless network found!"
-msgstr[1] "%d wireless networks found!"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "%d+%b_"
 msgstr ""
@@ -1097,12 +1098,33 @@ msgstr ""
 msgid "%d-%m"
 msgstr ""
 
-#, fuzzy, python-format
+msgid "%d. %B %Y"
+msgstr ""
+
+msgid "%d. %b"
+msgstr ""
+
+msgid "%d. %b %Y"
+msgstr ""
+
+msgid "%d.%-m"
+msgstr ""
+
+msgid "%d.%-m.%Y"
+msgstr ""
+
+#, python-format
 msgid "%d.%03d GB"
-msgstr "%d GB"
+msgstr ""
+
+msgid "%d.%m"
+msgstr ""
+
+msgid "%d.%m.%Y"
+msgstr ""
 
 msgid "%d.%B %Y"
-msgstr "%d.%B %Y"
+msgstr ""
 
 msgid "%d.%m.   "
 msgstr ""
@@ -1128,9 +1150,8 @@ msgstr ""
 msgid "%d=%b_"
 msgstr ""
 
-#, fuzzy
 msgid "%e/%m, %-H:%M"
-msgstr "%a %e/%m  %-H:%M"
+msgstr ""
 
 msgid "%m/%-d"
 msgstr ""
@@ -1150,9 +1171,9 @@ msgstr ""
 msgid "%m/%d/%Y"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s"
-msgstr "bc%s"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -1160,92 +1181,100 @@ msgid ""
 "(%s, %d MB free)"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "%s\n"
-"Press ok to close"
-msgstr "Press OK to scan"
+"Press ok for multiboot selection\n"
+"Press exit to close"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s %02d.%02d."
-msgstr "%2d:%02d:%02d"
+msgstr ""
 
 #, python-format
 msgid "%s %s advanced remote control (native)"
-msgstr "%s %s advanced remote control (native)"
+msgstr ""
 
 #, python-format
 msgid "%s %s front panel"
-msgstr "%s %s front panel"
+msgstr ""
 
 #, python-format
 msgid "%s %s ir keyboard"
-msgstr "%s %s ir keyboard"
+msgstr ""
 
 #, python-format
 msgid "%s %s ir mouse"
-msgstr "%s %s ir mouse"
+msgstr ""
 
 #, python-format
 msgid "%s %s remote control (native)"
-msgstr "%s %s remote control (native)"
+msgstr ""
 
 #, python-format
 msgid "%s %s software because updates are available."
-msgstr "%s %s software because updates are available."
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s ( %s Cards )"
-msgstr "%s (%s)\n"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s (%04o)"
-msgstr "%s (%s)\n"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s (%s"
-msgstr "%s (%s)\n"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s (%s)"
-msgstr "%s (%s)\n"
+msgstr ""
 
 #, python-format
 msgid "%s (%s)\n"
-msgstr "%s (%s)\n"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s - Setup"
-msgstr "Setup"
+msgstr ""
 
 #, python-format
 msgid "%s - extraction errors."
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
+msgid "%s GHz"
+msgstr ""
+
+#, python-format
+msgid "%s MHz"
+msgstr ""
+
+#, python-format
 msgid "%s Setup"
-msgstr "Setup"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s additional screens"
-msgstr "Scan additional SR"
+msgstr ""
 
-#, fuzzy, python-format
 msgid "%s build date %s"
-msgstr "Last update: %s"
+msgstr ""
 
 #. TRANSLATORS: The satellite with name '%s' is no longer used after a configuration change. The user is asked whether or not the satellite should be deleted.
 #, python-format
 msgid "%s is no longer used. Should it be deleted?"
-msgstr "%s is no longer used. Should it be deleted?"
+msgstr ""
 
 #, python-format
 msgid "%s is password protected."
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s not available."
-msgstr "Update feed not available."
+msgstr ""
 
 #, python-format
 msgid "%s successfully extracted."
@@ -1254,20 +1283,20 @@ msgstr ""
 #, python-format
 msgid "%s updated package available"
 msgid_plural "%s updated packages available"
-msgstr[0] "%s updated package available"
-msgstr[1] "%s updated packages available"
+msgstr[0] ""
+msgstr[1] ""
 
 #, python-format
 msgid "%s%d min"
-msgstr "%s%d min"
+msgstr ""
 
 #, python-format
 msgid "%s/%s: %s"
-msgstr "%s/%s: %s"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s: %s"
-msgstr "%s/%s: %s"
+msgstr ""
 
 #, python-format
 msgid "%sMode for FHD (up to 1080p)"
@@ -1285,29 +1314,29 @@ msgstr ""
 msgid "%sMode for UHD (up to 2160p)"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%sRefresh rate for FHD"
-msgstr "Refresh rate"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%sRefresh rate for HD"
-msgstr "Refresh rate"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%sRefresh rate for SD"
-msgstr "Refresh rate"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%sRefresh rate for UHD"
-msgstr "Refresh rate"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "%sShow 1080i as 1080p"
-msgstr "Show 1080p 24fps as"
+msgstr ""
 
 #, python-format
 msgid "'%s' contains %d file(s) and %d sub-directories.\n"
-msgstr "'%s' contains %d file(s) and %d sub-directories.\n"
+msgstr ""
 
 #, python-format
 msgid "'%s' not installed and no known package"
@@ -1319,12 +1348,11 @@ msgstr ""
 msgid "'Handle standby from TV' has a higher priority as 'Handle input from TV'"
 msgstr ""
 
-#, fuzzy
 msgid "'weatherplugin' is not installed!"
-msgstr "This plugin is not installed."
+msgstr ""
 
 msgid "( All readers)"
-msgstr "( All readers)"
+msgstr ""
 
 #, python-format
 msgid "(%d jobs)"
@@ -1337,27 +1365,29 @@ msgstr ""
 msgid "(Attention: There will be a restart after %d crashes.)"
 msgstr ""
 
-#, fuzzy
 msgid "(Selectmode)"
-msgstr "Select movie"
+msgstr ""
 
 msgid "(Show only reader:"
-msgstr "(Show only reader:"
+msgstr ""
+
+msgid "(current image)"
+msgstr ""
 
 msgid "(e.g. TV wakeup, but not switched to correct input)"
 msgstr ""
 
 msgid "(empty)"
-msgstr "(empty)"
+msgstr ""
 
 msgid "(show optional DVD audio menu)"
-msgstr "(show optional DVD audio menu)"
+msgstr ""
 
 msgid "* = Restart Required"
-msgstr "* = Restart Required"
+msgstr ""
 
 msgid "* Only available if more than one interface is active."
-msgstr "* Only available if more than one interface is active."
+msgstr ""
 
 msgid "* current animation"
 msgstr ""
@@ -1365,13 +1395,11 @@ msgstr ""
 msgid "+/-"
 msgstr ""
 
-#, fuzzy
 msgid "+24"
-msgstr "24"
+msgstr ""
 
-#, fuzzy
 msgid "-24"
-msgstr "24"
+msgstr ""
 
 msgid "-24h/+24 Hours"
 msgstr ""
@@ -1384,7 +1412,7 @@ msgid "-SERVICE ERROR:%d\n"
 msgstr ""
 
 msgid "/s"
-msgstr "/s"
+msgstr ""
 
 msgid "/sec]"
 msgstr ""
@@ -1428,21 +1456,20 @@ msgstr ""
 msgid "1 GB"
 msgstr ""
 
-#, fuzzy
 msgid "1 hour"
-msgstr "%d hour"
+msgstr ""
 
 msgid "1 min."
 msgstr ""
 
 msgid "1.0"
-msgstr "1.0"
+msgstr ""
 
 msgid "1.1"
-msgstr "1.1"
+msgstr ""
 
 msgid "1.2"
-msgstr "1.2"
+msgstr ""
 
 msgid "1.2s"
 msgstr ""
@@ -1459,9 +1486,8 @@ msgstr ""
 msgid "10 min."
 msgstr ""
 
-#, fuzzy
 msgid "10 minutes"
-msgstr "minutes"
+msgstr ""
 
 msgid "100 MB/s"
 msgstr ""
@@ -1470,7 +1496,7 @@ msgid "1024 Mb"
 msgstr ""
 
 msgid "1080i"
-msgstr "1080i"
+msgstr ""
 
 msgid "1080i 50Hz"
 msgstr ""
@@ -1485,19 +1511,19 @@ msgid "1080i50: 24p/50i/60i"
 msgstr ""
 
 msgid "1080p 24Hz"
-msgstr "1080p 24Hz"
+msgstr ""
 
 msgid "1080p 25Hz"
-msgstr "1080p 25Hz"
+msgstr ""
 
 msgid "1080p 30Hz"
-msgstr "1080p 30Hz"
+msgstr ""
 
 msgid "1080p 50Hz"
-msgstr "1080p 50Hz"
+msgstr ""
 
 msgid "1080p 60Hz"
-msgstr "1080p 60Hz"
+msgstr ""
 
 msgid "1080p50: 24p/50p/60p"
 msgstr ""
@@ -1505,29 +1531,26 @@ msgstr ""
 msgid "10bit"
 msgstr ""
 
-#, fuzzy
 msgid "12 character"
-msgstr "special characters"
+msgstr ""
 
-#, fuzzy
 msgid "12 hours"
-msgstr "Hour"
+msgstr ""
 
 msgid "12, show latin-1 characters except for greek and cyrillic, switch to 8 if needed."
 msgstr ""
 
-#, fuzzy
 msgid "128"
-msgstr "1.2"
+msgstr ""
 
 msgid "128 Mb"
 msgstr ""
 
 msgid "12V output"
-msgstr "12V output"
+msgstr ""
 
 msgid "12V output."
-msgstr "12V output."
+msgstr ""
 
 msgid "12bit"
 msgstr ""
@@ -1536,43 +1559,40 @@ msgid "12bit 4:2:0/4:2:2 no PIP"
 msgstr ""
 
 msgid "13 V"
-msgstr "13 V"
+msgstr ""
 
 msgid "15 min."
 msgstr ""
 
-#, fuzzy
 msgid "15 minutes"
-msgstr "minutes"
+msgstr ""
 
 msgid "1536 Mb"
 msgstr ""
 
-#, fuzzy
 msgid "16"
-msgstr "16:9"
+msgstr ""
 
 msgid "16:10"
-msgstr "16:10"
+msgstr ""
 
 msgid "16:10 Letterbox"
-msgstr "16:10 Letterbox"
+msgstr ""
 
 msgid "16:10 PanScan"
-msgstr "16:10 PanScan"
+msgstr ""
 
 msgid "16:9"
-msgstr "16:9"
+msgstr ""
 
 msgid "16:9 Letterbox"
-msgstr "16:9 Letterbox"
+msgstr ""
 
 msgid "16:9 always"
-msgstr "16:9 always"
+msgstr ""
 
-#, fuzzy
 msgid "16_10_letterbox"
-msgstr "16:10 Letterbox"
+msgstr ""
 
 msgid "16_10_panscan"
 msgstr ""
@@ -1580,25 +1600,23 @@ msgstr ""
 msgid "16_9"
 msgstr ""
 
-#, fuzzy
 msgid "16_9_always"
-msgstr "16:9 always"
+msgstr ""
 
-#, fuzzy
 msgid "16_9_letterbox"
-msgstr "16:9 Letterbox"
+msgstr ""
 
 msgid "18 V"
-msgstr "18 V"
+msgstr ""
 
 msgid "1X"
-msgstr "1X"
+msgstr ""
 
 msgid "1s"
 msgstr ""
 
 msgid "1st Infobar timeout"
-msgstr "1st Infobar timeout"
+msgstr ""
 
 msgid "2"
 msgstr ""
@@ -1606,13 +1624,11 @@ msgstr ""
 msgid "2 GB"
 msgstr ""
 
-#, fuzzy
 msgid "2 hours"
-msgstr "Hour"
+msgstr ""
 
-#, fuzzy
 msgid "2 minutes"
-msgstr "minutes"
+msgstr ""
 
 msgid "2.5s"
 msgstr ""
@@ -1623,46 +1639,38 @@ msgstr ""
 msgid "2048 Mb"
 msgstr ""
 
-#, fuzzy
 msgid "2160p 24Hz"
-msgstr "720p 24Hz"
+msgstr ""
 
-#, fuzzy
 msgid "2160p 25Hz"
-msgstr "1080p 25Hz"
+msgstr ""
 
-#, fuzzy
 msgid "2160p 30Hz"
-msgstr "1080p 30Hz"
+msgstr ""
 
-#, fuzzy
 msgid "2160p 50Hz"
-msgstr "1080p 50Hz"
+msgstr ""
 
-#, fuzzy
 msgid "2160p 60Hz"
-msgstr "1080p 60Hz"
+msgstr ""
 
 msgid "2160p50: 24p/50p/60p"
 msgstr ""
 
 msgid "23.976"
-msgstr "23.976"
+msgstr ""
 
 msgid "24"
-msgstr "24"
+msgstr ""
 
-#, fuzzy
 msgid "24 hours"
-msgstr "Hour"
+msgstr ""
 
-#, fuzzy
 msgid "24+ Hours"
-msgstr "Hour"
+msgstr ""
 
-#, fuzzy
 msgid "24- Hours"
-msgstr "Hour"
+msgstr ""
 
 msgid "24p/24p"
 msgstr ""
@@ -1680,11 +1688,10 @@ msgid "24p/60p"
 msgstr ""
 
 msgid "25"
-msgstr "25"
+msgstr ""
 
-#, fuzzy
 msgid "256"
-msgstr "25"
+msgstr ""
 
 msgid "256 Mb"
 msgstr ""
@@ -1705,10 +1712,10 @@ msgid "25p/60p"
 msgstr ""
 
 msgid "29.97"
-msgstr "29.97"
+msgstr ""
 
 msgid "2X"
-msgstr "2X"
+msgstr ""
 
 msgid "2nd Infobar ECM"
 msgstr ""
@@ -1740,15 +1747,14 @@ msgstr ""
 msgid "3"
 msgstr ""
 
-#, fuzzy
 msgid "3 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "3.5s"
 msgstr ""
 
 msgid "30"
-msgstr "30"
+msgstr ""
 
 msgid "30 min."
 msgstr ""
@@ -1778,19 +1784,19 @@ msgid "32 Mb"
 msgstr ""
 
 msgid "3D Mode"
-msgstr "3D Mode"
+msgstr ""
 
 msgid "3D Surround"
-msgstr "3D Surround"
+msgstr ""
 
 msgid "3D Surround Speaker Position"
 msgstr ""
 
 msgid "3X"
-msgstr "3X"
+msgstr ""
 
 msgid "3d mode"
-msgstr "3d mode"
+msgstr ""
 
 msgid "3s"
 msgstr ""
@@ -1801,9 +1807,8 @@ msgstr ""
 msgid "4 GB"
 msgstr ""
 
-#, fuzzy
 msgid "4 hours"
-msgstr "Hour"
+msgstr ""
 
 msgid "420"
 msgstr ""
@@ -1818,24 +1823,22 @@ msgid "480p 24Hz"
 msgstr ""
 
 msgid "4:3"
-msgstr "4:3"
+msgstr ""
 
 msgid "4:3 Letterbox"
-msgstr "4:3 Letterbox"
+msgstr ""
 
 msgid "4:3 PanScan"
-msgstr "4:3 PanScan"
+msgstr ""
 
 msgid "4X"
-msgstr "4X"
+msgstr ""
 
-#, fuzzy
 msgid "4_3_letterbox"
-msgstr "4:3 Letterbox"
+msgstr ""
 
-#, fuzzy
 msgid "4_3_panscan"
-msgstr "Pan&scan"
+msgstr ""
 
 msgid "4s"
 msgstr ""
@@ -1843,9 +1846,8 @@ msgstr ""
 msgid "5"
 msgstr ""
 
-#, fuzzy
 msgid "5 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "5 min."
 msgstr ""
@@ -1880,9 +1882,8 @@ msgstr ""
 msgid "6"
 msgstr ""
 
-#, fuzzy
 msgid "6 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "60 minutes"
 msgstr ""
@@ -1911,15 +1912,14 @@ msgstr ""
 msgid "7"
 msgstr ""
 
-#, fuzzy
 msgid "7 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "720p"
-msgstr "720p"
+msgstr ""
 
 msgid "720p 24Hz"
-msgstr "720p 24Hz"
+msgstr ""
 
 msgid "720p50"
 msgstr ""
@@ -1933,13 +1933,11 @@ msgstr ""
 msgid "8 GB"
 msgstr ""
 
-#, fuzzy
 msgid "8 character"
-msgstr "special characters"
+msgstr ""
 
-#, fuzzy
 msgid "8 hours"
-msgstr "%d hour"
+msgstr ""
 
 msgid "8bit"
 msgstr ""
@@ -1950,9 +1948,8 @@ msgstr ""
 msgid ": "
 msgstr ""
 
-#, fuzzy
 msgid "< Alternate Skin >"
-msgstr "Alternative"
+msgstr ""
 
 msgid "< Default >"
 msgstr ""
@@ -1964,29 +1961,28 @@ msgid "< User Skin >"
 msgstr ""
 
 msgid "<Current movielist location>"
-msgstr "<Current movie list location>"
+msgstr ""
 
 msgid "<Default movie location>"
-msgstr "<Default movie location>"
+msgstr ""
 
 msgid "<Last timer location>"
-msgstr "<Last timer location>"
+msgstr ""
 
 msgid "<unknown>"
-msgstr "<unknown>"
+msgstr ""
 
 msgid "=NO STREAM\n"
 msgstr ""
 
-#, fuzzy
 msgid "?"
-msgstr "??"
+msgstr ""
 
 msgid "??"
-msgstr "??"
+msgstr ""
 
 msgid "A"
-msgstr "A"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -1996,23 +1992,19 @@ msgid ""
 msgstr ""
 
 msgid "A background update check is in progress, please wait a few minutes and try again."
-msgstr "A background update check is in progress, please wait a few minutes and try again."
+msgstr ""
 
 #, python-format
 msgid ""
 "A configuration file (%s) has been modified since it was installed.\n"
 "Do you want to keep your modifications?"
 msgstr ""
-"A configuration file (%s) has been modified since it was installed.\n"
-"Do you want to keep your modifications?"
 
 #, python-format
 msgid ""
 "A configuration file (%s) was modified since Installation.\n"
 "Do you want to keep your version?"
 msgstr ""
-"A configuration file (%s) was modified since Installation.\n"
-"Do you want to keep your version?"
 
 #, python-format
 msgid "A crashlog was %s created in '%s'"
@@ -2023,98 +2015,77 @@ msgid ""
 "A finished powertimer wants to reboot your %s %s.\n"
 "Do that now?"
 msgstr ""
-"A finished powertimer wants to reboot your %s %s.\n"
-"Do that now?"
 
 msgid ""
 "A finished powertimer wants to restart the user interface.\n"
 "Do that now?"
 msgstr ""
-"A finished powertimer wants to restart the user interface.\n"
-"Do that now?"
 
 #, python-format
 msgid ""
 "A finished powertimer wants to set your\n"
 "%s %s to standby. Do that now?"
 msgstr ""
-"A finished powertimer wants to set your\n"
-"%s %s to standby. Do that now?"
 
 #, python-format
 msgid ""
 "A finished powertimer wants to shutdown your %s %s.\n"
 "Do that now?"
 msgstr ""
-"A finished powertimer wants to shutdown your %s %s.\n"
-"Do that now?"
 
 #, python-format
 msgid ""
 "A finished record timer wants to set your\n"
 "%s %s to standby. Do that now?"
 msgstr ""
-"A finished record timer wants to set your\n"
-"%s %s to standby. Do that now?"
 
 #, python-format
 msgid ""
 "A finished record timer wants to shut down\n"
 "your %s %s. Shutdown now?"
 msgstr ""
-"A finished record timer wants to shut down\n"
-"your %s %s. Shutdown now?"
 
 #, python-format
 msgid ""
 "A recording has been started:\n"
 "%s"
 msgstr ""
-"A recording has been started:\n"
-"%s"
 
 msgid ""
 "A recording is currently running.\n"
 "What do you want to do?"
 msgstr ""
-"A recording is currently running.\n"
-"What do you want to do?"
 
 msgid "A recording is currently running. Please stop the recording before trying to configure the positioner."
-msgstr "A recording is currently running. Please stop the recording before trying to configure the positioner."
+msgstr ""
 
 msgid "A recording is currently running. Please stop the recording before trying to scan."
-msgstr "A recording is currently running. Please stop the recording before trying to scan."
+msgstr ""
 
 msgid "A recording is currently running. Please stop the recording before trying to start the satfinder."
-msgstr "A recording is currently running. Please stop the recording before trying to start the sat finder."
+msgstr ""
 
 msgid "A repeating timer or just once?"
-msgstr "A repeating timer or just once?"
+msgstr ""
 
 #, python-format
 msgid "A required tool (%s) was not found."
-msgstr "A required tool (%s) was not found."
+msgstr ""
 
 msgid "A search for available updates is currently in progress."
-msgstr "A search for available updates is currently in progress."
+msgstr ""
 
 msgid ""
 "A second configured interface has been found.\n"
 "\n"
 "Do you want to disable the second network interface?"
 msgstr ""
-"A second configured interface has been found.\n"
-"\n"
-"Do you want to disable the second network interface?"
 
 #, python-format
 msgid ""
 "A sleep timer wants to set your\n"
 "%s %s to standby. Do that now?"
 msgstr ""
-"A sleep timer wants to set your\n"
-"%s %s to standby. Do that now?"
 
 #, python-format
 msgid ""
@@ -2127,8 +2098,6 @@ msgid ""
 "A sleep timer wants to shut down\n"
 "your %s %s. Shutdown now?"
 msgstr ""
-"A sleep timer wants to shut down\n"
-"your %s %s. Shutdown now?"
 
 #, python-format
 msgid ""
@@ -2137,7 +2106,7 @@ msgid ""
 msgstr ""
 
 msgid "A small overview of the available icon states and actions."
-msgstr "A small overview of the available icon states and actions."
+msgstr ""
 
 msgid ""
 "A timer failed to record!\n"
@@ -2158,19 +2127,15 @@ msgid ""
 "A timer failed to record!\n"
 "Disable TV and try again?\n"
 msgstr ""
-"A timer failed to record!\n"
-"Disable TV and try again?\n"
 
-#, fuzzy
 msgid "AAC Plus downmix"
-msgstr "AAC downmix"
+msgstr ""
 
 msgid "AAC downmix"
-msgstr "AAC downmix"
+msgstr ""
 
-#, fuzzy
 msgid "AAC plus downmix"
-msgstr "AAC downmix"
+msgstr ""
 
 msgid "AAC transcoding"
 msgstr ""
@@ -2178,9 +2143,8 @@ msgstr ""
 msgid "AC3"
 msgstr ""
 
-#, fuzzy
 msgid "AC3 downmix"
-msgstr "AAC downmix"
+msgstr ""
 
 msgid "AC3 plus transcoding"
 msgstr ""
@@ -2191,40 +2155,36 @@ msgstr ""
 msgid "AC3plus transcoding"
 msgstr ""
 
-#, fuzzy
 msgid "AFL"
-msgstr "PAL"
+msgstr ""
 
 msgid "AFP"
 msgstr ""
 
 msgid "AFP Setup"
-msgstr "AFP Setup"
+msgstr ""
 
 msgid "ATSC"
 msgstr ""
 
-#, fuzzy
 msgid "ATSC provider"
-msgstr "Add provider"
+msgstr ""
 
 msgid "AV Setup"
 msgstr ""
 
 #, python-format
 msgid "AV aspect is %s."
-msgstr "AV aspect is %s."
+msgstr ""
 
-#, fuzzy
 msgid "AZPlay"
-msgstr "Play"
+msgstr ""
 
-#, fuzzy
 msgid "Abenteuer"
-msgstr "centre"
+msgstr ""
 
 msgid "Abort"
-msgstr "Abort"
+msgstr ""
 
 msgid "Aborted a pseudo recording.\n"
 msgstr ""
@@ -2233,28 +2193,25 @@ msgid "Aborted a streaming service.\n"
 msgstr ""
 
 msgid "Aborting updateprogress"
-msgstr ""
+msgstr "Cancelling update progress..."
 
 msgid "About"
-msgstr "About"
+msgstr ""
 
 msgid "About..."
-msgstr "About..."
+msgstr ""
 
-#, fuzzy
 msgid "Accept the current selection"
-msgstr "Activate current configuration"
+msgstr ""
 
-#, fuzzy
 msgid "Accessed:"
-msgstr "Access point:"
+msgstr ""
 
 msgid "Accesspoint:"
-msgstr "Access point:"
+msgstr ""
 
-#, fuzzy
 msgid "Action"
-msgstr "Location"
+msgstr ""
 
 msgid "Action on long powerbutton press"
 msgstr ""
@@ -2263,23 +2220,23 @@ msgid "Action on short powerbutton press"
 msgstr ""
 
 msgid "Activate"
-msgstr "Activate"
+msgstr ""
 
 msgid "Activate HbbTV (Redbutton)"
 msgstr ""
 
 msgid "Activate MAC-address configuration"
-msgstr "Activate MAC-address configuration"
+msgstr ""
 
 msgid "Activate Picture in Picture"
-msgstr "Activate Picture in Picture"
+msgstr ""
 
 #, python-format
 msgid "Activate an way to send individual or specific internal HDMI-CEC commands from the command line. Type on command line 'echo help > %s' and then read the file '%s' for a short help."
 msgstr ""
 
 msgid "Activate current configuration"
-msgstr "Activate current configuration"
+msgstr ""
 
 msgid "Activate left-hand file list as multi-select source"
 msgstr ""
@@ -2288,7 +2245,7 @@ msgid "Activate left-hand file list as source"
 msgstr ""
 
 msgid "Activate network settings"
-msgstr "Activate network settings"
+msgstr ""
 
 msgid "Activate right-hand file list as multi-select source"
 msgstr ""
@@ -2297,7 +2254,7 @@ msgid "Activate right-hand file list as source"
 msgstr ""
 
 msgid "Activate the configured network settings."
-msgstr "Activate the configured network settings."
+msgstr ""
 
 msgid "Activate timeshift End"
 msgstr ""
@@ -2312,76 +2269,79 @@ msgid "Activation takes place immediately. If this feature is not supported, the
 msgstr ""
 
 msgid "Active"
-msgstr "Active"
+msgstr ""
 
 msgid "Active clients"
-msgstr "Active clients"
+msgstr ""
+
+msgid "Active screen"
+msgstr ""
+
+msgid "Active status change"
+msgstr ""
 
 msgid "Adapter settings"
-msgstr "Adapter settings"
+msgstr ""
 
 msgid "Add"
-msgstr "Add"
+msgstr ""
 
 msgid "Add AutoTimer"
-msgstr "Add AutoTimer"
+msgstr ""
 
 msgid "Add New Quad Channel Entry"
 msgstr ""
 
-#, fuzzy
 msgid "Add Record Timer"
-msgstr "Add a record timer"
+msgstr ""
 
 msgid "Add Timer"
-msgstr "Add Timer"
+msgstr ""
 
-#, fuzzy
 msgid "Add Zap Timer"
-msgstr "Add Timer"
+msgstr ""
 
-#, fuzzy
 msgid "Add Zap+Record Timer"
-msgstr "Add a record timer"
+msgstr ""
 
 msgid "Add a auto timer for current event"
-msgstr "Add an auto timer for current event"
+msgstr ""
 
 msgid "Add a mark"
-msgstr "Add a mark"
+msgstr ""
 
 msgid "Add a nameserver entry"
-msgstr "Add a nameserver entry"
+msgstr ""
 
 msgid "Add a new title"
-msgstr "Add a new title"
+msgstr ""
 
 msgid "Add a record timer"
-msgstr "Add a record timer"
+msgstr ""
 
 msgid "Add a record timer for current event"
-msgstr "Add a record timer for current event"
+msgstr ""
 
 msgid "Add a zap timer for current event"
-msgstr "Add a zap timer for current event"
+msgstr ""
 
 msgid "Add a zap timer for next event"
-msgstr "Add a zap timer for next event"
+msgstr ""
 
 msgid "Add bookmark"
-msgstr "Add bookmark"
+msgstr ""
 
 msgid "Add current folder to bookmarks"
 msgstr ""
 
 msgid "Add directory to playlist"
-msgstr "Add directory to playlist"
+msgstr ""
 
 msgid "Add file to playlist"
-msgstr "Add file to playlist"
+msgstr ""
 
 msgid "Add files to playlist"
-msgstr "Add files to playlist"
+msgstr ""
 
 msgid "Add plugin to Extensions menu*"
 msgstr ""
@@ -2390,48 +2350,46 @@ msgid "Add plugin to main menu*"
 msgstr ""
 
 msgid "Add provider"
-msgstr "Add provider"
+msgstr ""
 
 msgid "Add recording (enter recording duration)"
-msgstr "Add recording (enter recording duration)"
+msgstr ""
 
 msgid "Add recording (enter recording endtime)"
-msgstr "Add recording (enter recording endtime)"
+msgstr ""
 
 msgid "Add recording (indefinitely)"
-msgstr "Add recording (indefinitely)"
+msgstr ""
 
 msgid "Add recording (stop after current event)"
-msgstr "Add recording (stop after current event)"
+msgstr ""
 
-#, fuzzy
 msgid "Add selected folder to bookmarks"
-msgstr "Select files/folders to backup"
+msgstr ""
 
 msgid "Add service"
-msgstr "Add service"
+msgstr ""
 
 msgid "Add timer"
-msgstr "Add timer"
+msgstr ""
 
 msgid "Add title"
-msgstr "Add title"
+msgstr ""
 
-#, fuzzy
 msgid "Add/Remove Timer"
-msgstr "Remove timer"
+msgstr ""
 
 msgid "Add/Remove timer for current event"
-msgstr "Add/Remove timer for current event"
+msgstr ""
 
 msgid "Add/remove change timer for current event"
 msgstr ""
 
 msgid "Adding schedule..."
-msgstr "Adding schedule..."
+msgstr ""
 
 msgid "Additional Info"
-msgstr "Additional Info"
+msgstr ""
 
 msgid "Additional files/folders to backup"
 msgstr ""
@@ -2443,23 +2401,27 @@ msgid "Additional motor options allow you to enter details from your motor's spe
 msgstr ""
 
 msgid "Address"
-msgstr "Address"
+msgstr ""
 
 msgid "Adel"
 msgstr ""
 
 msgid "Adjust 3D settings"
-msgstr "Adjust 3D settings"
+msgstr ""
 
 msgid "Adjust the color settings so that all the color shades are distinguishable, but appear as saturated as possible. If you are happy with the result, press OK to close the video fine-tuning, or use the number keys to select other test screens."
-msgstr "Adjust the colour settings so that all the colour shades are distinguishable, but appear as saturated as possible. If you are happy with the result, press OK to close the video fine-tuning, or use the number keys to select other test screens."
+msgstr ""
+"Adjust the color settings so that all of the color shades are distinguishable, but appear as saturated (rich) as possible.\n"
+"Press OK to close the video fine-tuning wizard when you're happy with the result; otherwise use the number buttons to show other test screens."
 
 msgid "Adjust the horizontal position of the letters used for teletext."
 msgstr ""
 
-#, fuzzy
 msgid "Adjust the vertical position of the letters used for teletext."
-msgstr "Configure the vertical position of the subtitles, measured from the bottom of the screen."
+msgstr ""
+
+msgid "Ads filtering mode"
+msgstr ""
 
 msgid "Adult"
 msgstr ""
@@ -2473,24 +2435,23 @@ msgstr ""
 msgid "Advanced Options"
 msgstr ""
 
-#, fuzzy
 msgid "Advanced Settings"
-msgstr "Advanced options"
+msgstr ""
 
 msgid "Advanced options"
-msgstr "Advanced options"
+msgstr ""
 
 msgid "Advanced restore"
-msgstr "Advanced restore"
+msgstr ""
 
 msgid "Advanced software"
-msgstr "Advanced software"
+msgstr ""
 
 msgid "Advanced software plugin"
-msgstr "Advanced software plugin"
+msgstr ""
 
 msgid "Advanced video enhancement setup"
-msgstr "Advanced video enhancement setup"
+msgstr ""
 
 msgid "Adventure"
 msgstr ""
@@ -2498,22 +2459,29 @@ msgstr ""
 msgid "Afghanistan"
 msgstr ""
 
+msgid "After 3 minutes"
+msgstr ""
+
+msgid "After 30 minutes"
+msgstr ""
+
+msgid "After 5 minutes"
+msgstr ""
+
 msgid "After PowerLost"
 msgstr ""
 
-#, fuzzy
 msgid "After Recording"
-msgstr "Recording"
+msgstr ""
 
 msgid "After event"
-msgstr "After event"
+msgstr ""
 
 msgid "After pressing OK, please wait!"
 msgstr ""
 
-#, fuzzy
 msgid "Agenten"
-msgstr "centre"
+msgstr ""
 
 msgid "Aland Islands"
 msgstr ""
@@ -2522,41 +2490,37 @@ msgid "Albania"
 msgstr ""
 
 msgid "Album"
-msgstr "Album"
+msgstr ""
 
 msgid "Algeria"
 msgstr ""
 
 msgid "Alias"
-msgstr "Alias"
+msgstr ""
 
-#, fuzzy
 msgid "Alignment channel number"
-msgstr "Use fastscan channel names"
+msgstr ""
 
-#, fuzzy
 msgid "Alignment event-progress"
-msgstr "Right from servicename"
+msgstr ""
 
 msgid "Alignment of events"
 msgstr ""
 
-#, fuzzy
 msgid "Alignment of service names"
-msgstr "Right from servicename"
+msgstr ""
 
 msgid "All"
-msgstr "All"
+msgstr ""
 
-#, fuzzy
 msgid "All Services"
-msgstr "Services"
+msgstr ""
 
 msgid "All ages"
-msgstr "All ages"
+msgstr ""
 
 msgid "All resolutions"
-msgstr "All resolutions"
+msgstr ""
 
 msgid "All satellites 1 (USALS)"
 msgstr ""
@@ -2570,18 +2534,17 @@ msgstr ""
 msgid "All satellites 4 (USALS)"
 msgstr ""
 
-#, fuzzy
 msgid "All services provider"
-msgstr "Assigned services/provider:"
-
-msgid "Allocate"
-msgstr "Allocate"
-
-msgid "Allocate a number to the physical LNB you are configuring. You will be able to select this LNB again for other satellites (e.g. motorised dishes) to save setting up the same LNB multiple times."
 msgstr ""
 
+msgid "Allocate"
+msgstr ""
+
+msgid "Allocate a number to the physical LNB you are configuring. You will be able to select this LNB again for other satellites (e.g. motorised dishes) to save setting up the same LNB multiple times."
+msgstr "Allocate a number to the physical LNB you're configuring. You'll be able to select this LNB again for other satellites (e.g. motorised dishes) to avoid having to set up the same LNB multiple times."
+
 msgid "Allocate unused memory index"
-msgstr "Allocate unused memory index"
+msgstr ""
 
 msgid "Allow 10bit"
 msgstr ""
@@ -2593,51 +2556,49 @@ msgid "Allow quit movieplayer with exit"
 msgstr ""
 
 msgid "Allow subtitle language to equal audio language"
-msgstr "Allow subtitle language to equal audio language"
+msgstr ""
 
 msgid "Allow subtitles for hearing impaired"
-msgstr "Allow subtitles for hearing impaired"
+msgstr ""
 
 msgid "Allow unstable (untested) updates"
 msgstr ""
 
-#, fuzzy
 msgid "Allow unsupported modes"
-msgstr "not supported"
+msgstr ""
 
 msgid "Allows the %s %s to read the stored EPG data regularly."
-msgstr "Allows the %s %s to read the stored EPG data regularly."
+msgstr ""
 
 msgid "Allows the %s %s to store the EPG data regularly."
-msgstr "Allows the %s %s to store the EPG data regularly."
+msgstr ""
 
 msgid "Allows you to adjust the amount of time the resolution information display on screen."
-msgstr "Allows you to adjust the amount of time the resolution information display on screen."
+msgstr ""
 
 msgid "Allows you to enable the debug log. They contain very detailed information of everything the system does."
 msgstr ""
 
-#, fuzzy
 msgid "Allows you to enable the twisted log. They contain very detailed information of everything the twisted does. ('/tmp/twisted.log')"
-msgstr "Allows you to enable the debug logs. They contain very detailed information about everything the system does."
+msgstr ""
 
 msgid "Allows you to enable/disable displaying icons on the frontpanel."
 msgstr ""
 
 msgid "Allows you to hide the extensions of known file types."
-msgstr "Allows you to hide the extensions of known file types."
+msgstr ""
 
 msgid "Allows you to set the maximum size of the Debug log size (MB). When that size is reached, a new file will be created."
 msgstr ""
 
 msgid "Allows you to setup the button to do what you choose."
-msgstr "Allows you to setup the button to do what you choose."
+msgstr ""
 
 msgid "Allows you to show/hide CCcam in extensions (blue button)."
 msgstr ""
 
 msgid "Allows you to show/hide Log Manager in extensions (blue button)."
-msgstr "Allows you to show/hide Log Manager in extensions (blue button)."
+msgstr ""
 
 msgid "Allows you to show/hide OScam in extensions (blue button)."
 msgstr ""
@@ -2646,39 +2607,37 @@ msgid "Almost there... "
 msgstr ""
 
 msgid "Alpha"
-msgstr "Alpha"
+msgstr ""
 
 msgid "Alphanumeric"
-msgstr "Alphanumeric"
+msgstr ""
 
 msgid "Also on standby"
 msgstr ""
 
 msgid "Alternative"
-msgstr "Alternative"
+msgstr ""
 
-#, fuzzy
 msgid "Alternative 1"
-msgstr "Alternative"
+msgstr ""
 
-#, fuzzy
 msgid "Alternative 2"
-msgstr "Alternative"
+msgstr ""
 
 msgid "Alternative numbering mode"
-msgstr "Alternative numbering mode"
+msgstr ""
 
 msgid "Alternative radio mode"
-msgstr "Alternative radio mode"
+msgstr ""
 
 msgid "Alternative services tuner priority"
-msgstr "Alternative services tuner priority"
+msgstr ""
 
 msgid "Always ask"
-msgstr "Always ask"
+msgstr ""
 
 msgid "Always hide infobar"
-msgstr "Always hide infobar"
+msgstr ""
 
 msgid "Always include ECM in recordings"
 msgstr ""
@@ -2686,12 +2645,11 @@ msgstr ""
 msgid "Always include ECM messages in recordings. This overrides the individual timer settings globally. It allows recordings to be always decrypted afterwards (sometimes called offline decoding), if supported by your receiver. Default: off."
 msgstr ""
 
-#, fuzzy
 msgid "Always select OK"
-msgstr "Always ask"
+msgstr ""
 
 msgid "Always show bouquets"
-msgstr "Always show bouquets"
+msgstr ""
 
 msgid "Always use smart1080p mode"
 msgstr ""
@@ -2702,9 +2660,8 @@ msgstr ""
 msgid "American Samoa"
 msgstr ""
 
-#, fuzzy
 msgid "American Sports"
-msgstr "martial sports"
+msgstr ""
 
 msgid ""
 "An attempt is made to capture the current TV status. If this is not possible due to incorrect or missing status messages, it may cause the receiver to respond unexpectedly.\n"
@@ -2712,13 +2669,13 @@ msgid ""
 msgstr ""
 
 msgid "An empty filename is illegal."
-msgstr "An empty filename is illegal."
+msgstr ""
 
 msgid "An error occurred while downloading the packetlist. Please try again."
-msgstr "An error occurred while downloading the packetlist. Please try again."
+msgstr ""
 
 msgid "An unknown error occurred!"
-msgstr "An unknown error occurred!"
+msgstr ""
 
 msgid "Andorra"
 msgstr ""
@@ -2729,9 +2686,8 @@ msgstr ""
 msgid "Anguilla"
 msgstr ""
 
-#, fuzzy
 msgid "Animation"
-msgstr "Information"
+msgstr ""
 
 msgid "Animation Setup"
 msgstr ""
@@ -2752,10 +2708,10 @@ msgid "Antigua and Barbuda"
 msgstr ""
 
 msgid "Any activity"
-msgstr "Any activity"
+msgstr ""
 
 msgid "Arabic"
-msgstr "Arabic"
+msgstr ""
 
 msgid "Architektur"
 msgstr ""
@@ -2766,9 +2722,8 @@ msgstr ""
 msgid "Are you sure to cancel all changes?"
 msgstr ""
 
-#, fuzzy
 msgid "Are you sure to delete all cuts and marks?"
-msgstr "Are you sure you want to delete all selected logs:\n"
+msgstr ""
 
 msgid "Are you sure to purge all deleted userbouquets?"
 msgstr ""
@@ -2784,56 +2739,46 @@ msgid "Are you sure to remove all terrestrial services?"
 msgstr ""
 
 msgid "Are you sure to remove this entry?"
-msgstr "Are you sure to remove this entry?"
+msgstr ""
 
 msgid ""
 "Are you sure you want to activate this network configuration?\n"
 "\n"
 msgstr ""
-"Are you sure you want to activate this network configuration?\n"
-"\n"
 
 msgid ""
 "Are you sure you want to delete\n"
 "the following backup:\n"
 msgstr ""
-"Are you sure you want to delete\n"
-"the following backup:\n"
 
 msgid "Are you sure you want to delete all selected logs:\n"
-msgstr "Are you sure you want to delete all selected logs:\n"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Are you sure you want to delete image slot %s ?"
 msgstr ""
-"Are you sure you want to delete this:\n"
-" "
 
 msgid "Are you sure you want to delete the EPG data from:\n"
 msgstr ""
 
 msgid "Are you sure you want to delete this log:\n"
-msgstr "Are you sure you want to delete this log:\n"
+msgstr ""
 
 msgid ""
 "Are you sure you want to delete this:\n"
 " "
 msgstr ""
-"Are you sure you want to delete this:\n"
-" "
 
 msgid "Are you sure you want to exit this wizard?"
-msgstr "Are you sure you want to exit this wizard?"
+msgstr ""
 
 msgid "Are you sure you want to reload the EPG data from:\n"
-msgstr "Are you sure you want to reload the EPG data from:\n"
+msgstr ""
 
 msgid ""
 "Are you sure you want to restart your network interfaces?\n"
 "\n"
 msgstr ""
-"Are you sure you want to restart your network interfaces?\n"
-"\n"
 
 #, python-format
 msgid ""
@@ -2842,17 +2787,11 @@ msgid ""
 "%s\n"
 "Your receiver will restart after the backup has been restored!"
 msgstr ""
-"Are you sure you want to restore\n"
-"the following backup:\n"
-"%s\n"
-"Your receiver will restart after the backup has been restored!"
 
 msgid ""
 "Are you sure you want to restore the backup?\n"
 "Your receiver will restart after the backup has been restored!"
 msgstr ""
-"Are you sure you want to restore the backup?\n"
-"Your receiver will restart after the backup has been restored!"
 
 #, python-format
 msgid ""
@@ -2866,14 +2805,14 @@ msgid ""
 msgstr ""
 
 msgid "Are you sure you want to save the EPG Cache to:\n"
-msgstr "Are you sure you want to save the EPG cache to:\n"
+msgstr ""
 
 msgid "Are you sure you want to send this log:\n"
-msgstr "Are you sure you want to send this log:\n"
+msgstr ""
 
 #, python-format
 msgid "Are you sure you want to update your %s %s ?"
-msgstr "Are you sure you want to update your %s %s ?"
+msgstr ""
 
 msgid "Argentina"
 msgstr ""
@@ -2882,14 +2821,13 @@ msgid "Armenia"
 msgstr ""
 
 msgid "Artist"
-msgstr "Artist"
+msgstr ""
 
-#, fuzzy
 msgid "Arts & Culture"
-msgstr "Arts/Culture"
+msgstr ""
 
 msgid "Arts/Culture"
-msgstr "Arts/Culture"
+msgstr ""
 
 msgid "Aruba"
 msgstr ""
@@ -2898,7 +2836,7 @@ msgid "Arzt"
 msgstr ""
 
 msgid "Ask user"
-msgstr "Ask user"
+msgstr ""
 
 msgid "Ask user (with default as 'no')"
 msgstr ""
@@ -2906,9 +2844,8 @@ msgstr ""
 msgid "Ask user (with default as 'yes')"
 msgstr ""
 
-#, fuzzy
 msgid "Aspect"
-msgstr "Aspect ratio"
+msgstr ""
 
 msgid "Aspect Ratio"
 msgstr ""
@@ -2916,18 +2853,17 @@ msgstr ""
 msgid "Aspect list..."
 msgstr ""
 
-#, fuzzy
 msgid "Aspect long"
-msgstr "Aspect ratio"
+msgstr ""
 
 msgid "Aspect ratio"
-msgstr "Aspect ratio"
+msgstr ""
 
 msgid "Assigned CAIds:"
-msgstr "Assigned CAIds:"
+msgstr ""
 
 msgid "Assigned services/provider:"
-msgstr "Assigned services/provider:"
+msgstr ""
 
 msgid "Astra 1 19.2e"
 msgstr ""
@@ -2939,14 +2875,13 @@ msgid "Astra 3 23.5e"
 msgstr ""
 
 msgid "At End:"
-msgstr "At End:"
+msgstr ""
 
-#, fuzzy
 msgid "Athletics"
-msgstr "athletics"
+msgstr ""
 
 msgid "Attach a file"
-msgstr "Attach a file"
+msgstr ""
 
 msgid "Audio"
 msgstr ""
@@ -2954,12 +2889,11 @@ msgstr ""
 msgid "Audio Auto Volume Level"
 msgstr ""
 
-#, fuzzy
 msgid "Audio Channel"
-msgstr "Channel"
+msgstr ""
 
 msgid "Audio PID"
-msgstr "Audio PID"
+msgstr ""
 
 msgid "Audio Selection"
 msgstr ""
@@ -2974,61 +2908,55 @@ msgid "Audio Sync"
 msgstr ""
 
 msgid "Audio language selection 1"
-msgstr "Audio language selection 1"
+msgstr ""
 
 msgid "Audio language selection 2"
-msgstr "Audio language selection 2"
+msgstr ""
 
 msgid "Audio language selection 3"
-msgstr "Audio language selection 3"
+msgstr ""
 
 msgid "Audio language selection 4"
-msgstr "Audio language selection 4"
+msgstr ""
 
-#, fuzzy
 msgid "Audio long"
-msgstr "Audio PID"
+msgstr ""
 
 msgid "Audio options..."
-msgstr "Audio options..."
+msgstr ""
 
 msgid "Audio settings"
 msgstr ""
 
-#, fuzzy
 msgid "Audio volume step size"
-msgstr "Tuning step size"
+msgstr ""
 
 msgid "Audio volume step size fast mode"
 msgstr ""
 
-#, fuzzy
 msgid "Australia"
-msgstr "Italian"
+msgstr ""
 
-#, fuzzy
 msgid "Australian"
-msgstr "Italian"
+msgstr ""
 
-#, fuzzy
 msgid "Austria"
-msgstr "equestrian"
+msgstr ""
 
 msgid "Author: "
-msgstr "Author: "
+msgstr ""
 
 msgid "Authoring mode"
-msgstr "Authoring mode"
+msgstr ""
 
 msgid "Auto"
-msgstr "Auto"
+msgstr ""
 
 msgid "Auto Deep Standby"
-msgstr "Auto Deep Standby"
+msgstr ""
 
-#, fuzzy
 msgid "Auto Detect"
-msgstr "Auto Deep Standby"
+msgstr ""
 
 msgid "Auto Language"
 msgstr ""
@@ -3036,40 +2964,38 @@ msgstr ""
 msgid "Auto Language Selection"
 msgstr ""
 
-#, fuzzy
 msgid "Auto Modes Selected."
-msgstr "no CAId selected"
+msgstr ""
 
 msgid "Auto Standby"
-msgstr "Auto Standby"
+msgstr ""
 
-#, fuzzy
 msgid "Auto Timer"
-msgstr "Auto Timers"
+msgstr ""
 
 msgid "Auto Timers"
-msgstr "Auto Timers"
+msgstr ""
 
 msgid "Auto Volume Level"
 msgstr ""
 
 msgid "Auto chapter split every ? minutes (0=never)"
-msgstr "Auto chapter split every ? minutes (0=never)"
+msgstr ""
 
 msgid "Auto flesh"
-msgstr "Auto flesh"
+msgstr ""
 
 msgid "Auto focus"
-msgstr "Auto focus"
+msgstr ""
 
 msgid "Auto focus commencing ..."
-msgstr "Auto focus commencing ..."
+msgstr ""
 
 msgid "Auto language selection"
-msgstr "Auto language selection"
+msgstr ""
 
 msgid "Auto scart switching"
-msgstr "Auto scart switching"
+msgstr ""
 
 msgid "Auto(not available)"
 msgstr ""
@@ -3077,37 +3003,35 @@ msgstr ""
 msgid "AutoMountManager"
 msgstr ""
 
-#, fuzzy
 msgid "AutoUpdate"
-msgstr "Update"
+msgstr ""
 
 msgid "Automatic"
-msgstr "Automatic"
+msgstr ""
 
 msgid "Automatic Scan"
-msgstr "Automatic Scan"
+msgstr ""
 
-#, fuzzy
 msgid "Automatic Service Searching"
-msgstr "Service searching"
+msgstr ""
 
 msgid "Automatic image backup"
-msgstr "Automatic image backup"
+msgstr ""
 
 msgid "Automatic refresh"
-msgstr "Automatic refresh"
+msgstr ""
 
 msgid "Automatic resolution"
-msgstr "Automatic resolution"
+msgstr ""
 
 msgid "Automatic resolution label"
-msgstr "Automatic resolution label"
+msgstr ""
 
 msgid "Automatic save"
-msgstr "Automatic save"
+msgstr ""
 
 msgid "Automatic scan"
-msgstr "Automatic scan"
+msgstr ""
 
 msgid "Automatic scan for services"
 msgstr ""
@@ -3116,36 +3040,34 @@ msgid "Automatic setting backup"
 msgstr ""
 
 msgid "Automatically start timeshift after"
-msgstr "Automatically start timeshift after"
+msgstr ""
 
 msgid "Automatically turn on external subtitles"
-msgstr "Automatically turn on external subtitles"
+msgstr ""
 
 msgid "Automatically update Client/Server View?"
-msgstr "Automatically update Client/Server View?"
+msgstr ""
 
-#, fuzzy
 msgid "Automobil"
-msgstr "Automatic"
+msgstr ""
 
 msgid "Autorecord location"
 msgstr ""
 
 msgid "Autostart"
-msgstr "Autostart"
+msgstr ""
 
 msgid "Autostart:"
-msgstr "Autostart:"
+msgstr ""
 
 msgid "Available format variables"
-msgstr "Available format variables"
+msgstr ""
 
-#, fuzzy
 msgid "Available locales are:"
-msgstr "Available shares:"
+msgstr ""
 
 msgid "Available shares:"
-msgstr "Available shares:"
+msgstr ""
 
 msgid "Avoid getting stuck (at the expense of some stuttering) when the jump time is smaller than the time between I-frames."
 msgstr ""
@@ -3157,11 +3079,10 @@ msgid "Azerbaijan"
 msgstr ""
 
 msgid "B"
-msgstr "B"
+msgstr ""
 
-#, fuzzy
 msgid "B-Movie"
-msgstr "Moving"
+msgstr ""
 
 #, python-format
 msgid "BC%d"
@@ -3207,11 +3128,10 @@ msgid "BT709 XvYCC"
 msgstr ""
 
 msgid "Back"
-msgstr "Back"
+msgstr ""
 
-#, fuzzy
 msgid "Back USB"
-msgstr "Back"
+msgstr ""
 
 msgid "Back USB 3.0"
 msgstr ""
@@ -3240,27 +3160,25 @@ msgid "Back/Recall"
 msgstr ""
 
 msgid "Background"
-msgstr "Background"
+msgstr ""
 
 msgid "Background check"
-msgstr "Background check"
+msgstr ""
 
 msgid "Background color"
 msgstr "Background colour"
 
 msgid "Background delete option"
-msgstr "Background delete option"
+msgstr ""
 
 msgid "Background delete speed"
-msgstr "Background delete speed"
+msgstr ""
 
-#, fuzzy
 msgid "Background:"
-msgstr "Background"
+msgstr ""
 
-#, fuzzy
 msgid "Backgroundselected:"
-msgstr "Background delete speed"
+msgstr ""
 
 msgid "Backup"
 msgstr ""
@@ -3279,41 +3197,46 @@ msgid "Backup Log"
 msgstr ""
 
 msgid "Backup Manager"
-msgstr "Backup Manager"
+msgstr ""
 
 msgid "Backup Mode"
+msgstr ""
+
+msgid "Backup Mode: Flash Online\n"
+msgstr ""
+
+msgid "Backup Mode: USB Recovery\n"
 msgstr ""
 
 msgid "Backup Settings"
 msgstr ""
 
 msgid "Backup completed."
-msgstr "Backup completed."
+msgstr ""
 
 msgid "Backup done."
 msgstr ""
 
 msgid "Backup failed."
-msgstr "Backup failed."
+msgstr ""
 
 msgid "Backup is running..."
-msgstr "Backup is running..."
+msgstr ""
 
 msgid ""
 "Backup plugins found\n"
 "do you want to install now?"
 msgstr ""
 
-#, fuzzy
 msgid "Backup settings"
-msgstr "Backup system settings"
+msgstr ""
 
 msgid "Backup system settings"
-msgstr "Backup system settings"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Backup to destination: %s"
-msgstr "Backup system settings"
+msgstr ""
 
 msgid "Backup your current image"
 msgstr ""
@@ -3340,10 +3263,10 @@ msgid "Bahrain"
 msgstr ""
 
 msgid "Band"
-msgstr "Band"
+msgstr ""
 
 msgid "Bandwidth"
-msgstr "Bandwidth"
+msgstr ""
 
 msgid "Bangladesh"
 msgstr ""
@@ -3352,7 +3275,7 @@ msgid "Barbados"
 msgstr ""
 
 msgid "Base time"
-msgstr "Base time"
+msgstr ""
 
 msgid "Base transparency for OpenOpera web browser"
 msgstr ""
@@ -3370,19 +3293,19 @@ msgid "Basketball"
 msgstr ""
 
 msgid "Basque"
-msgstr "Basque"
+msgstr ""
 
 msgid "Begin time"
-msgstr "Begin time"
+msgstr ""
 
 msgid "Behave like stop-button"
 msgstr ""
 
 msgid "Behavior of 'pause' when paused"
-msgstr "Behaviour of 'pause' when paused"
+msgstr "Behaviour of the Pause button when paused"
 
 msgid "Behavior of 0 key in PiP-mode"
-msgstr "Behaviour of 0 key in PiP-mode"
+msgstr "Behaviour of the 0 button in PiP mode"
 
 msgid "Behavior when a movie is started"
 msgstr "Behaviour when a movie is started"
@@ -3396,9 +3319,8 @@ msgstr "Behaviour when a movie reaches the end"
 msgid "Belarus"
 msgstr ""
 
-#, fuzzy
 msgid "Belgian"
-msgstr "Norwegian"
+msgstr ""
 
 msgid "Belgium"
 msgstr ""
@@ -3439,21 +3361,20 @@ msgstr ""
 msgid "Biography"
 msgstr ""
 
-#, fuzzy
 msgid "Bitrate"
-msgstr "Bitrate:"
+msgstr ""
 
 msgid "Bitrate:"
-msgstr "Bitrate:"
+msgstr ""
 
 msgid "Black"
-msgstr "Black"
+msgstr ""
 
 msgid "Black screen"
-msgstr "Black screen"
+msgstr ""
 
 msgid "Black screen till locked"
-msgstr "Black screen till locked"
+msgstr ""
 
 msgid "Blinking REC"
 msgstr ""
@@ -3461,19 +3382,17 @@ msgstr ""
 msgid "Blinking REC Symbol"
 msgstr ""
 
-#, fuzzy
 msgid "Block device"
-msgstr "No service"
+msgstr ""
 
 msgid "Block noise reduction"
-msgstr "Block noise reduction"
+msgstr ""
 
 msgid "Blue"
-msgstr "Blue"
+msgstr ""
 
-#, fuzzy
 msgid "Blue button"
-msgstr "Button"
+msgstr ""
 
 msgid "Blue long"
 msgstr ""
@@ -3481,9 +3400,8 @@ msgstr ""
 msgid "BlueSwitch: Blue-Short/Blue-Long"
 msgstr ""
 
-#, fuzzy
 msgid "Bluetooth Setup"
-msgstr "Telnet Setup"
+msgstr ""
 
 msgid "Bolivia (Plurinational State of)"
 msgstr ""
@@ -3495,13 +3413,13 @@ msgid "Bonaire, Sint Eustatius and Saba"
 msgstr ""
 
 msgid "Bookmarks"
-msgstr "Bookmarks"
+msgstr ""
 
 msgid "Boost blue"
-msgstr "Boost blue"
+msgstr ""
 
 msgid "Boost green"
-msgstr "Boost green"
+msgstr ""
 
 msgid "Boot-up action"
 msgstr ""
@@ -3523,18 +3441,16 @@ msgid "Boulevard"
 msgstr ""
 
 msgid "Bouquet List"
-msgstr "Bouquet List"
+msgstr ""
 
-#, fuzzy
 msgid "BouquetList"
-msgstr "Bouquet List"
+msgstr ""
 
 msgid "Bouvet Island"
 msgstr ""
 
-#, fuzzy
 msgid "Box or driver is not support Quad PiP."
-msgstr "tuner is not supported"
+msgstr ""
 
 msgid "Boxen"
 msgstr ""
@@ -3546,16 +3462,16 @@ msgid "Brazil"
 msgstr ""
 
 msgid "Brightness"
-msgstr "Brightness"
+msgstr ""
 
 msgid "Brightness (Dimmed)"
 msgstr ""
 
 msgid "Brightness (Normal)"
-msgstr "Brightness (Normal)"
+msgstr ""
 
 msgid "Brightness (Standby)"
-msgstr "Brightness (Standby)"
+msgstr ""
 
 msgid "British Indian Ocean Territory"
 msgstr ""
@@ -3568,22 +3484,20 @@ msgid "Buffering %d%%"
 msgstr ""
 
 msgid "Buffers:"
-msgstr "Buffers:"
+msgstr ""
 
-#, fuzzy, python-format
 msgid "Build:\t\t%s"
-msgstr "Build:\t%s"
+msgstr ""
 
 #, python-format
 msgid "Build: %s"
-msgstr "Build: %s"
+msgstr ""
 
-#, fuzzy
 msgid "Bulgaria"
-msgstr "Bulgarian"
+msgstr ""
 
 msgid "Bulgarian"
-msgstr "Bulgarian"
+msgstr ""
 
 msgid "Burkina Faso"
 msgstr ""
@@ -3592,7 +3506,7 @@ msgid "Burn Bludisc"
 msgstr ""
 
 msgid "Burn DVD"
-msgstr "Burn DVD"
+msgstr ""
 
 msgid "Burn existing image to medium"
 msgstr ""
@@ -3604,13 +3518,13 @@ msgid "Burundi"
 msgstr ""
 
 msgid "Bus: "
-msgstr "Bus: "
+msgstr ""
 
 msgid "Business & Finance"
 msgstr ""
 
 msgid "Button"
-msgstr "Button"
+msgstr ""
 
 msgid "Button Setup"
 msgstr ""
@@ -3622,34 +3536,34 @@ msgid "By openATV Image Team"
 msgstr ""
 
 msgid "Bypass HDMI EDID Check"
-msgstr "Bypass HDMI EDID Check"
+msgstr ""
 
 msgid "Bytes received:"
-msgstr "Bytes received:"
+msgstr ""
 
 msgid "Bytes sent:"
-msgstr "Bytes sent:"
+msgstr ""
 
 msgid "C-Band"
-msgstr "C-Band"
+msgstr ""
 
 msgid "CAID"
-msgstr "CAID"
+msgstr ""
 
 msgid "CAID:SrvID"
 msgstr ""
 
 msgid "CCcam Client Info"
-msgstr "CCcam Client Info"
+msgstr ""
 
 msgid "CCcam Config Switcher"
-msgstr "CCcam Config Switcher"
+msgstr ""
 
 msgid "CCcam ECM Info"
-msgstr "CCcam ECM Info"
+msgstr ""
 
 msgid "CCcam Info"
-msgstr "CCcam Info"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -3658,31 +3572,27 @@ msgid ""
 "\n"
 "This plugin shows you the status of your CCcam."
 msgstr ""
-"CCcam Info %s\n"
-"by AliAbdul %s\n"
-"\n"
-"This plugin shows you the status of your CCcam."
 
 msgid "CCcam Info Config"
-msgstr "CCcam Info Config"
+msgstr ""
 
 msgid "CCcam Info Setup"
-msgstr "CCcam Info Setup"
+msgstr ""
 
 msgid "CCcam Provider Info"
-msgstr "CCcam Provider Info"
+msgstr ""
 
 msgid "CCcam Remote Info"
-msgstr "CCcam Remote Info"
+msgstr ""
 
 msgid "CCcam Server Info"
-msgstr "CCcam Server Info"
+msgstr ""
 
 msgid "CCcam Share Info"
-msgstr "CCcam Share Info"
+msgstr ""
 
 msgid "CCcam Shares Info"
-msgstr "CCcam Shares Info"
+msgstr ""
 
 msgid "CCcamInfo Mainmenu"
 msgstr ""
@@ -3691,28 +3601,26 @@ msgid "CF Drive"
 msgstr ""
 
 msgid "CH"
-msgstr "CH"
+msgstr ""
 
 #, python-format
 msgid "CH%s"
 msgstr ""
 
 msgid "CHANGE BOUQUET"
-msgstr "CHANGE BOUQUET"
+msgstr ""
 
 msgid "CI (Common Interface) Setup"
 msgstr ""
 
-#, fuzzy
 msgid "CI Basic settings"
-msgstr "Edit settings"
+msgstr ""
 
 msgid "CI Legacy"
 msgstr ""
 
-#, fuzzy
 msgid "CI Operation Mode"
-msgstr "Configuration mode"
+msgstr ""
 
 msgid "CI Plus 1.2"
 msgstr ""
@@ -3721,13 +3629,13 @@ msgid "CI Plus 1.3"
 msgstr ""
 
 msgid "CI assignment"
-msgstr "CI assignment"
+msgstr ""
 
 msgid "CI slot: "
 msgstr ""
 
 msgid "CIFS/Samba Setup"
-msgstr "Samba Setup"
+msgstr ""
 
 msgid "CIHelper Setup"
 msgstr ""
@@ -3741,56 +3649,59 @@ msgstr ""
 msgid "CIselectMainMenu"
 msgstr ""
 
-#, fuzzy
 msgid "CPU"
-msgstr "CPU:\t%s"
+msgstr ""
 
 msgid "CPU priority for script execution"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "CPU:\t\t%s"
-msgstr "CPU:\t%s"
+msgstr ""
+
+#, python-format
+msgid "CPU:\t\t%s  (%s)  %s cores"
+msgstr ""
 
 #, python-format
 msgid "CPU: %s"
 msgstr ""
 
 msgid "CVBS"
-msgstr "CVBS"
+msgstr ""
 
 msgid "CaID: "
-msgstr "CaID: "
+msgstr ""
 
 msgid "Cable"
-msgstr "Cable"
+msgstr ""
 
 msgid "Cable Scan"
-msgstr "Cable Scan"
+msgstr ""
 
 msgid "Cabo Verde"
 msgstr ""
 
 msgid "Cache thumbnails"
-msgstr "Cache thumbnails"
+msgstr ""
 
 msgid "Cached:"
-msgstr "Cached:"
+msgstr ""
 
 msgid "Calculate"
-msgstr "Calculate"
+msgstr ""
 
 msgid "Calculate all positions"
-msgstr "Calculate all positions"
+msgstr ""
 
 msgid "Calculate file checksums"
 msgstr ""
 
 msgid "Calculation complete"
-msgstr "Calculation complete"
+msgstr ""
 
 msgid "Calibrate"
-msgstr "Calibrate"
+msgstr ""
 
 msgid "Call-in"
 msgstr ""
@@ -3802,15 +3713,31 @@ msgid "Cameroon"
 msgstr ""
 
 msgid "Can be used for different fps between external subtitles and video."
-msgstr "Can be used for different fps between external subtitles and video."
+msgstr ""
 
-#, fuzzy
+msgid ""
+"Can be used to test defect pixels on TV screen.\n"
+"\n"
+"Available color test screens:\n"
+"\n"
+"red\n"
+"green\n"
+"blue\n"
+"white\n"
+"black\n"
+"cyan\n"
+"magenta\n"
+"yellow\n"
+"\n"
+"Screens change with left/right buttons or use red, green, blue to toggle.\n"
+"Yellow for returning back to this intro"
+msgstr ""
+
 msgid "Can not delete timer"
-msgstr "Cannot delete file"
+msgstr ""
 
-#, fuzzy
 msgid "Can not download EPG"
-msgstr "Cannot delete file"
+msgstr ""
 
 msgid "Can not download current region details"
 msgstr ""
@@ -3818,16 +3745,14 @@ msgstr ""
 msgid "Can not download list of regions"
 msgstr ""
 
-#, fuzzy
 msgid "Can not download timers"
-msgstr "Cannot delete file"
+msgstr ""
 
 msgid "Can not post PVR log information"
 msgstr ""
 
-#, fuzzy
 msgid "Can not post scan information"
-msgstr "Translation Information"
+msgstr ""
 
 msgid "Can not retrieve IceTV settings"
 msgstr ""
@@ -3841,20 +3766,17 @@ msgid ""
 "%s may be in a plugin that is not installed."
 msgstr ""
 
-#, fuzzy
 msgid "Can not update timer"
-msgstr "Cannot delete file"
+msgstr ""
 
 msgid "Can not update timer status"
 msgstr ""
 
-#, fuzzy
 msgid "Can not update timers"
-msgstr "Cannot delete file"
+msgstr ""
 
-#, fuzzy
 msgid "Can not upload timer"
-msgstr "Change next timer"
+msgstr ""
 
 msgid "Can only find a network drive to store the backup this means after the flash the autorestore will not work. Alternatively you can mount the network drive after the flash and perform a manufacturer reset to autorestore"
 msgstr ""
@@ -3886,69 +3808,71 @@ msgid "Canada"
 msgstr ""
 
 msgid "Cancel"
-msgstr "Cancel"
+msgstr ""
 
 msgid "Cancel any text changes and exit"
 msgstr ""
 
-#, fuzzy
 msgid "Cancel execution?"
-msgstr "Channel selection"
-
-msgid "Cancel save timeshift as movie"
-msgstr "Cancel save timeshift as movie"
-
-#, fuzzy
-msgid "Cancel the selection"
-msgstr "Channel selection"
-
-msgid "Cancelled upon user request"
 msgstr ""
 
-#, fuzzy
-msgid "Cannot create backup directory"
-msgstr "create directory"
+msgid "Cancel save timeshift as movie"
+msgstr ""
 
-#, fuzzy
+msgid "Cancel the image selection and exit"
+msgstr ""
+
+msgid "Cancel the image selection and exit all menus"
+msgstr ""
+
+msgid "Cancel the selection"
+msgstr ""
+
+#. TRANSLATORS: override en_US
+msgid "Cancelled upon user request"
+msgstr "Cancelled by user"
+
+msgid "Cannot create backup directory"
+msgstr ""
+
 msgid "Cannot delete downloaded image"
-msgstr "Cannot delete file"
+msgstr ""
 
 msgid "Cannot delete file"
-msgstr "Cannot delete file"
+msgstr ""
 
 msgid "Cannot determine"
-msgstr "Cannot determine"
+msgstr ""
 
 msgid "Cannot find any signal ..., aborting !"
-msgstr "Cannot find any signal ..., aborting !"
+msgstr ""
 
 msgid "Cannot find images - please try later"
 msgstr ""
 
 msgid "Cannot move to trash can"
-msgstr "Cannot move to trash can"
+msgstr ""
 
-#, fuzzy
 msgid "Capabilities: "
-msgstr "Capacity: "
+msgstr ""
 
 msgid "Capacity: "
-msgstr "Capacity: "
+msgstr ""
 
 msgid "Card infos (CCcam-Reader)"
-msgstr "Card infos (CCcam-Reader)"
+msgstr ""
 
 msgid "Cards:"
-msgstr "Cards:"
+msgstr ""
 
 msgid "Cards: "
-msgstr "Cards: "
+msgstr ""
 
 msgid "Cards: 0"
-msgstr "Cards: 0"
+msgstr ""
 
 msgid "Cardserial"
-msgstr "Cardserial"
+msgstr ""
 
 msgid "Cartoon"
 msgstr ""
@@ -3956,9 +3880,8 @@ msgstr ""
 msgid "Cascade PiP"
 msgstr ""
 
-#, fuzzy
 msgid "Casting"
-msgstr "Waiting"
+msgstr ""
 
 msgid "Caution update not yet tested !!"
 msgstr ""
@@ -3985,7 +3908,7 @@ msgid "Change Volume offset"
 msgstr ""
 
 msgid "Change bouquets in quickzap"
-msgstr "Change bouquets in quickzap"
+msgstr ""
 
 msgid "Change buttons for list navigation"
 msgstr ""
@@ -3994,35 +3917,37 @@ msgid "Change execute permissions (755/644)"
 msgstr ""
 
 msgid "Change next timer"
-msgstr "Change next timer"
+msgstr ""
 
 msgid "Change pin code"
-msgstr "Change pin code"
+msgstr ""
 
 msgid "Change recording (duration)"
-msgstr "Change recording (duration)"
+msgstr ""
 
 msgid "Change recording (endtime)"
-msgstr "Change recording (endtime)"
+msgstr ""
 
 msgid "Change repeat and delay settings?"
-msgstr "Change repeat and delay settings?"
+msgstr ""
 
-#, fuzzy
 msgid "Change skin"
-msgstr "Change timer"
+msgstr ""
 
 msgid "Change step size"
-msgstr "Change step size"
+msgstr ""
 
 msgid "Change timer"
-msgstr "Change timer"
+msgstr ""
+
+msgid "Change to Side by Side mode"
+msgstr ""
 
 msgid "Change to bouquet"
-msgstr "Change to bouquet"
+msgstr ""
 
 msgid "Changelog"
-msgstr "Changelog"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -4031,86 +3956,82 @@ msgid ""
 msgstr ""
 
 msgid "Channel"
-msgstr "Channel"
+msgstr ""
 
 msgid "Channel \t\t\tVolume +"
 msgstr ""
 
 msgid "Channel +/- button mode"
-msgstr "Channel +/- button mode"
+msgstr ""
 
-#, fuzzy
 msgid "Channel 1"
-msgstr "Channel"
+msgstr ""
 
-#, fuzzy
 msgid "Channel 1 with Primetime"
-msgstr "Channel list preview"
+msgstr ""
 
 msgid "Channel Info"
-msgstr "Channel Info"
+msgstr ""
 
 msgid "Channel List"
-msgstr "Channel List"
+msgstr ""
 
 msgid "Channel Name"
 msgstr ""
 
-#, fuzzy
 msgid "Channel button always changes sides"
-msgstr "Channel list on mode change"
+msgstr ""
 
-#, fuzzy
 msgid "Channel buttons"
-msgstr "Channel +/- button mode"
+msgstr ""
 
-#, fuzzy
 msgid "Channel buttons invert"
-msgstr "Channel +/- button mode"
+msgstr ""
+
+msgid "Channel change +/-"
+msgstr ""
 
 msgid "Channel down"
 msgstr ""
 
 msgid "Channel list context menu"
-msgstr "Channel list context menu"
+msgstr ""
 
 msgid "Channel list cursor behavior"
-msgstr "Channel list cursor behaviour"
+msgstr ""
 
 msgid "Channel list on mode change"
-msgstr "Channel list on mode change"
+msgstr ""
 
 msgid "Channel list preview"
-msgstr "Channel list preview"
+msgstr ""
 
 msgid "Channel list service mode*"
-msgstr "Channel list service mode*"
+msgstr ""
 
-#, fuzzy
 msgid "Channel list show MiniTV when Skin use."
-msgstr "Channel list on mode change"
+msgstr ""
 
-#, fuzzy
 msgid "Channel list show MiniTV*"
-msgstr "Channel list cursor behaviour"
+msgstr ""
 
 msgid "Channel list type"
-msgstr "Channel list type"
+msgstr ""
 
 msgid "Channel not in services list"
-msgstr "Channel not in services list"
+msgstr ""
 
 msgid "Channel preview mode"
-msgstr "Channel preview mode"
+msgstr ""
 
 msgid "Channel selection"
-msgstr "Channel selection"
+msgstr ""
 
 msgid "Channel selection configuration"
 msgstr ""
 
 msgid "Channel selection settings"
-msgstr "Channel selection settings"
+msgstr ""
 
 msgid "Channel up"
 msgstr ""
@@ -4125,10 +4046,10 @@ msgid "Channel zap delay mode"
 msgstr ""
 
 msgid "Channel:"
-msgstr "Channel:"
+msgstr ""
 
 msgid "ChannelEPG settings"
-msgstr "ChannelEPG settings"
+msgstr ""
 
 msgid "Channellist menu"
 msgstr ""
@@ -4136,77 +4057,71 @@ msgstr ""
 msgid "Channelname"
 msgstr ""
 
-#, fuzzy
 msgid "Channelselection:"
-msgstr "Channel selection"
+msgstr ""
 
 msgid "Chap."
-msgstr "Chap."
+msgstr ""
 
 msgid "Chapter"
-msgstr "Chapter"
+msgstr ""
 
 msgid "Chapter:"
-msgstr "Chapter:"
+msgstr ""
 
-#, fuzzy
 msgid "Character device"
-msgstr "Storage devices"
+msgstr ""
 
 msgid "Check"
-msgstr "Check"
+msgstr ""
 
 msgid "Check HDD"
 msgstr ""
 
 msgid "Check every (hours)"
-msgstr "Check every (hours)"
+msgstr ""
 
 msgid "Check power and input state from TV"
 msgstr ""
 
 msgid "Check the internet connection"
-msgstr "Check the internet connection"
+msgstr ""
 
 msgid "Check the internet connection again"
-msgstr "Check the internet connection again"
+msgstr ""
 
 msgid "Check/Install online updates (you must have a working internet connection)"
 msgstr ""
 
 msgid "Checking Feeds"
-msgstr "Checking Feeds"
+msgstr ""
 
 msgid "Checking Logs..."
-msgstr "Checking Logs..."
+msgstr ""
 
 msgid "Checking filesystem..."
-msgstr "Checking filesystem..."
+msgstr ""
 
 msgid "Checking for Updates..."
-msgstr "Checking for Updates..."
+msgstr ""
 
 msgid "Checking the internet connection"
-msgstr "Checking the internet connection"
+msgstr ""
 
 #, python-format
 msgid ""
 "Checking tuner %d\n"
 "DiSEqC port %s for %s"
 msgstr ""
-"Checking tuner %d\n"
-"DiSEqC port %s for %s"
 
-#, fuzzy
 msgid "Children"
-msgstr "Children/Youth"
+msgstr ""
 
 msgid "Children/Youth"
-msgstr "Children/Youth"
+msgstr ""
 
-#, fuzzy
 msgid "Childrens"
-msgstr "Children/Youth"
+msgstr ""
 
 msgid "Chile"
 msgstr ""
@@ -4214,17 +4129,16 @@ msgstr ""
 msgid "China"
 msgstr ""
 
-#, fuzzy
 msgid "Chipset"
-msgstr "Chipset: BCM%s"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Chipset:\t\t%s"
-msgstr "Chipset:\tBCM%s"
+msgstr ""
 
 #, python-format
 msgid "Chipset: BCM%s"
-msgstr "Chipset: BCM%s"
+msgstr ""
 
 msgid "Choice Box"
 msgstr ""
@@ -4234,7 +4148,7 @@ msgid "Choice where to put \"%s\""
 msgstr ""
 
 msgid "Choose Bouquet"
-msgstr "Choose Bouquet"
+msgstr ""
 
 msgid "Choose Tuner"
 msgstr ""
@@ -4252,10 +4166,10 @@ msgid "Choose a setting where your receiver wakes up from standby."
 msgstr ""
 
 msgid "Choose a tag for easy finding a recording."
-msgstr "Choose a tag for easy finding a recording."
+msgstr ""
 
 msgid "Choose between Daily, Weekly, Weekdays or user defined."
-msgstr "Choose between Daily, Weekly, Weekdays or user defined."
+msgstr ""
 
 msgid "Choose dvb wait delay for ci response."
 msgstr ""
@@ -4263,9 +4177,8 @@ msgstr ""
 msgid "Choose how often to connect to IceTV server to check for updates."
 msgstr ""
 
-#, fuzzy
 msgid "Choose style of main menus"
-msgstr "Show VCR scart on main menu"
+msgstr ""
 
 msgid "Choose the CI protocol operation mode for standard ci or ciplus."
 msgstr ""
@@ -4286,13 +4199,13 @@ msgid "Choose the location for crash and debuglogs."
 msgstr ""
 
 msgid "Choose the location where the EPG data will be stored when the %s %s is shut down. The location must be available at boot time."
-msgstr "Choose the location where the EPG data will be stored when the %s %s is shut down. The location must be available at boot time."
+msgstr ""
 
 msgid "Choose the name of the file that holds the EPG data when the %s %s is shut down. This can be handy to differentiate between several boxes."
-msgstr "Choose the name of the file that holds the EPG data when the %s %s is shut down. This can be handy to differentiate between several boxes."
+msgstr ""
 
 msgid "Choose time interval to which the graphics will be rounded off."
-msgstr "Choose time interval to which the graphics will be rounded off."
+msgstr ""
 
 msgid "Choose what you want the button '0' to do when PIP is active."
 msgstr ""
@@ -4303,46 +4216,41 @@ msgstr ""
 msgid "Choose whether AAC sound tracks should be transcoded."
 msgstr ""
 
-#, fuzzy
 msgid "Choose whether AC3 Plus sound tracks should be transcoded to AC3."
-msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr ""
 
-#, fuzzy
 msgid "Choose whether AC3 sound tracks should be downmixed to stereo."
-msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr ""
 
-#, fuzzy
 msgid "Choose whether DTS channel sound tracks should be downmixed or transcoded."
-msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr ""
 
-#, fuzzy
 msgid "Choose whether DTS channel sound tracks should be downmixed to stereo."
-msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr ""
 
-#, fuzzy
 msgid "Choose whether WMA Pro channel sound tracks should be downmixed or transcoded."
-msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr ""
 
 msgid "Choose whether multi channel sound tracks should be convert to PCM or SPDIF."
 msgstr ""
 
 msgid "Choose whether multi channel sound tracks should be downmixed to stereo."
-msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr ""
 
 msgid "Choose whether multi channel sound tracks should be output as PCM."
 msgstr ""
 
 msgid "Choose whether or not to show an icon when a motorized dish is moving."
-msgstr ""
+msgstr "Choose whether or not to show an indicator while a motorised dish is moving."
 
 msgid "Choose which level of menu/setting's to display. 'Expert'-level shows all items."
 msgstr ""
 
 msgid "Choose which tuner to configure."
-msgstr "Choose which tuner to configure."
+msgstr ""
 
 msgid "Chose between record and ZAP."
-msgstr "Chose between record and ZAP."
+msgstr ""
 
 msgid "Christmas Island"
 msgstr ""
@@ -4354,37 +4262,37 @@ msgid "Circular LNB"
 msgstr ""
 
 msgid "Circular left"
-msgstr "Circular left"
+msgstr ""
 
 msgid "Circular right"
-msgstr "Circular right"
+msgstr ""
 
 msgid "Clean (Just flash and start clean)"
 msgstr ""
 
 msgid "Clean network trash cans"
-msgstr "Clean network trash cans"
+msgstr "Empty the network trash"
 
 msgid "Cleaning Trashes"
-msgstr "Cleaning Trashes"
+msgstr "Emptying Trashes..."
 
 msgid "Cleanup"
-msgstr "Cleanup"
+msgstr ""
 
 msgid "Clear"
-msgstr "Clear"
+msgstr ""
 
 msgid "Clear before scan"
-msgstr "Clear before scan"
+msgstr ""
 
 msgid "Clear fixed"
-msgstr "Clear fixed"
+msgstr ""
 
 msgid "Clear log"
-msgstr "Clear log"
+msgstr ""
 
 msgid "Clear playlist"
-msgstr "Clear playlist"
+msgstr ""
 
 msgid "Click on your remote on the button you want to change"
 msgstr ""
@@ -4393,70 +4301,74 @@ msgstr ""
 msgid "Client Info ( Oscam-Version: %s )"
 msgstr ""
 
-#, fuzzy
 msgid "ClientIP"
-msgstr "Clients"
+msgstr ""
 
 msgid "Clients"
-msgstr "Clients"
+msgstr ""
 
 msgid "Clock"
 msgstr ""
 
-#, fuzzy
 msgid "Clock:"
-msgstr "locked"
+msgstr ""
 
 msgid "Clone TV screen to LCD"
 msgstr ""
 
 msgid "Close"
-msgstr "Close"
+msgstr ""
+
+msgid "Close Main screen"
+msgstr ""
+
+msgid "Close PIP and try again!"
+msgstr ""
+
+msgid "Close Picture in Picture screen"
+msgstr ""
 
 msgid "Close PiP on exit"
-msgstr "Close PiP on exit"
+msgstr ""
 
 msgid "Close bouquet list."
-msgstr "Close bouquet list."
+msgstr ""
 
 msgid "Close dialog"
-msgstr "Close dialog"
+msgstr ""
 
 msgid "Close title selection"
-msgstr "Close title selection"
+msgstr ""
 
 msgid "Cocos (Keeling) Islands"
 msgstr ""
 
 msgid "Code rate HP"
-msgstr "Code rate HP"
+msgstr ""
 
 msgid "Code rate LP"
-msgstr "Code rate LP"
+msgstr ""
 
 msgid "Coderate HP"
-msgstr "Coderate HP"
+msgstr ""
 
 msgid "Coderate LP"
-msgstr "Coderate LP"
+msgstr ""
 
-#, fuzzy
 msgid "Collapse"
-msgstr "Elapsed"
+msgstr ""
 
 msgid "Collection name"
-msgstr "Collection name"
+msgstr ""
 
 msgid "Collection settings"
-msgstr "Collection settings"
+msgstr ""
 
-#, fuzzy
 msgid "Colombia"
-msgstr "Colour format"
+msgstr ""
 
-#, fuzzy
 msgid "Color"
-msgstr "Colour space"
+msgstr "Colour"
 
 msgid "Color format"
 msgstr "Colour format"
@@ -4467,81 +4379,79 @@ msgstr "Colour space"
 msgid "Combo"
 msgstr ""
 
-#, fuzzy
 msgid "Comedy"
-msgstr "comedy"
+msgstr ""
 
 msgid "Comic"
 msgstr ""
 
 msgid "Command To Run"
-msgstr "Command To Run"
+msgstr ""
 
 msgid "Command execution..."
 msgstr ""
 
 msgid "Command order"
-msgstr "Command order"
+msgstr ""
 
 msgid "Command type"
-msgstr "Command type"
+msgstr ""
 
 msgid "Common Interface"
-msgstr "Common Interface"
+msgstr ""
 
 msgid "Common Interface Assignment"
-msgstr "Common Interface Assignment"
+msgstr ""
 
 msgid "Common Interface assignment"
-msgstr "Common Interface assignment"
+msgstr ""
 
 msgid "Communication"
-msgstr "Communication"
+msgstr ""
 
 msgid "Comoros"
 msgstr ""
 
-#, fuzzy
 msgid "Compensate for overscan"
-msgstr "Clear before scan"
+msgstr ""
 
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 msgid "Complete Backup"
 msgstr ""
 
 msgid "Complex (allows mixing audio tracks and aspects)"
-msgstr "Complex (allows mixing audio tracks and aspects)"
+msgstr ""
 
 msgid "Composition of the recording filenames"
-msgstr "Composition of the recording filenames"
+msgstr ""
 
-#, fuzzy
 msgid "Computer"
-msgstr "Complete"
+msgstr ""
 
-#, fuzzy
 msgid "Config"
-msgstr "Configuring"
+msgstr ""
 
 msgid "Config file name (ok to change):"
 msgstr ""
 
 #, python-format
 msgid "Configfile %s saved."
-msgstr "Config file %s saved."
+msgstr ""
 
 msgid "Configuration mode"
-msgstr "Configuration mode"
+msgstr ""
 
 #, python-format
 msgid "Configuration mode: %s"
-msgstr "Configuration mode: %s"
+msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "Configure an additional delay to improve external subtitle synchronisation."
 msgstr "Configure an additional delay to improve external subtitle synchronisation."
 
+#. TRANSLATORS: override en_US
 msgid "Configure an additional delay to improve subtitle synchronisation."
 msgstr "Configure an additional delay to improve subtitle synchronisation."
 
@@ -4549,7 +4459,7 @@ msgid "Configure default setting for new timers. Need a restart after changing."
 msgstr ""
 
 msgid "Configure for how many minutes finished events should remain visible in the EPG. Useful when you need information about an event which has just finished, or has been delayed."
-msgstr "Configure for how many minutes finished events should remain visible in the EPG. Useful when you need information about an event which has just finished, or has been delayed."
+msgstr ""
 
 msgid "Configure for which types of recordings a warning about active recordings is shown when attempting to restart the box or the GUI."
 msgstr ""
@@ -4564,7 +4474,7 @@ msgid "Configure if and how long the latest service in the PiP will be remembere
 msgstr ""
 
 msgid "Configure if and how service type icons will be shown."
-msgstr "Configure if and how service type icons will be shown."
+msgstr ""
 
 msgid "Configure if and how the record indicator will be shown in the channel selection list."
 msgstr ""
@@ -4575,9 +4485,8 @@ msgstr ""
 msgid "Configure if epg.dat should be saved at all."
 msgstr ""
 
-#, fuzzy
 msgid "Configure if service picons will be shown in quickzap."
-msgstr "Configure if and how service type icons will be shown."
+msgstr ""
 
 msgid "Configure if service picons will be shown in the servicelist."
 msgstr ""
@@ -4586,76 +4495,73 @@ msgid "Configure if the subtitle should switch between normal, italic, bold and 
 msgstr ""
 
 msgid "Configure interface"
-msgstr "Configure interface"
+msgstr ""
 
 msgid "Configure nameservers"
-msgstr "Configure nameservers"
+msgstr ""
 
 msgid "Configure on which devices the background delete option should be used."
-msgstr "Configure on which devices the background delete option should be used."
+msgstr ""
 
 msgid "Configure remote control type"
-msgstr "Configure remote control type"
+msgstr ""
 
 msgid "Configure the DiSEqC mode for this LNB."
-msgstr "Configure the DiSEqC mode for this LNB."
+msgstr ""
 
 msgid "Configure the IP address."
-msgstr "Configure the IP address."
+msgstr ""
 
-#, fuzzy
 msgid "Configure the alignment of events."
-msgstr "Configure the horizontal alignment of the subtitles."
+msgstr ""
 
-#, fuzzy
 msgid "Configure the alignment of service names."
-msgstr "Configure the width allocated to the service name."
+msgstr ""
 
 msgid "Configure the amount of time that will be presented."
-msgstr "Configure the amount of time that will be presented."
+msgstr ""
 
 msgid "Configure the aspect ratio of the screen."
 msgstr ""
 
 msgid "Configure the behavior of the 'pause' key when movie playback is already paused."
-msgstr "Configure the behaviour of the 'pause' key when movie playback is already paused."
+msgstr ""
 
 msgid "Configure the behavior when movie playback is manually stopped."
-msgstr "Configure the behaviour when movie playback is manually stopped."
+msgstr ""
 
 msgid "Configure the behavior when movie playback is started."
-msgstr "Configure the behaviour when movie playback is started."
+msgstr ""
 
 msgid "Configure the behavior when reaching the end of a movie, during movie playback."
-msgstr "Configure the behaviour when reaching the end of a movie, during movie playback."
+msgstr ""
 
 msgid "Configure the border width of the subtitles. The dark border makes the subtitles easier to read on a light background."
-msgstr "Configure the border width of the subtitles. The dark border makes the subtitles easier to read on a light background."
+msgstr ""
 
 msgid "Configure the brightness level of the front panel display for dimmed operation."
 msgstr ""
 
 msgid "Configure the brightness level of the front panel display for normal operation."
-msgstr "Configure the brightness level of the front panel display for normal operation."
+msgstr ""
 
 msgid "Configure the brightness level of the front panel display for standby."
-msgstr "Configure the brightness level of the front panel display for standby."
+msgstr ""
 
 msgid "Configure the color of the external subtitles, alternative (normal in white, italic in yellow, bold in cyan, underscore in green), white or yellow."
-msgstr "Configure the colour of the external subtitles, alternative (normal in white, italic in yellow, bold in cyan, underscore in green), white or yellow."
+msgstr "Choose the colour to use for external subtitles - white, yellow or alternative (normal in white, italic in yellow, bold in cyan, underscore in green)."
 
 msgid "Configure the color of the teletext subtitles."
-msgstr "Configure the colour of the teletext subtitles."
+msgstr "Configure the teletext subtitle text colour."
 
 msgid "Configure the contrast level of the front panel display."
-msgstr "Configure the contrast level of the front panel display."
+msgstr ""
 
 msgid "Configure the cursor behaviour in the channel selection list. When opening the channel selection list you can remain on the current service or already select up/down and you are able to revert the B+/B- buttons."
 msgstr ""
 
-#, fuzzy
 msgid "Configure the display resolution and the font used for teletext."
-msgstr "Configure the duration (in minutes) for the screensaver."
+msgstr ""
 
 msgid "Configure the duration in minutes for the screensaver."
 msgstr ""
@@ -4663,38 +4569,35 @@ msgstr ""
 msgid "Configure the duration in minutes for the sleep timer."
 msgstr ""
 
-#, fuzzy
 msgid "Configure the end coordinate in x of the teletext display area."
-msgstr "Configure the colour of the teletext subtitles."
+msgstr ""
 
-#, fuzzy
 msgid "Configure the end coordinate in y of the teletext display area."
-msgstr "Configure the colour of the teletext subtitles."
+msgstr ""
 
 msgid "Configure the fast mode audio volume step size (limit 1-10). Activated when volume key permanent press or press fast in a row."
 msgstr ""
 
 msgid "Configure the first audio language (highest priority)."
-msgstr "Configure the first audio language (highest priority)."
+msgstr ""
 
 msgid "Configure the first subtitle language (highest priority)."
-msgstr "Configure the first subtitle language (highest priority)."
+msgstr ""
 
 msgid "Configure the font size of the subtitles."
-msgstr "Configure the font size of the subtitles."
+msgstr ""
 
-#, fuzzy
 msgid "Configure the font size relative to default size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
-msgstr "Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
+msgstr ""
 
 msgid "Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
-msgstr "Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
+msgstr ""
 
 msgid "Configure the fourth audio language."
-msgstr "Configure the fourth audio language."
+msgstr ""
 
 msgid "Configure the fourth subtitle language."
-msgstr "Configure the fourth subtitle language."
+msgstr ""
 
 msgid "Configure the function of a long press on the power button."
 msgstr ""
@@ -4703,14 +4606,13 @@ msgid "Configure the function of a short press on the power button."
 msgstr ""
 
 msgid "Configure the function of the <  > buttons."
-msgstr "Configure the function of the <  > buttons."
+msgstr ""
 
 msgid "Configure the gateway."
-msgstr "Configure the gateway."
+msgstr ""
 
-#, fuzzy
 msgid "Configure the general audio volume step size (limit 1-10)."
-msgstr "Configure the first audio language (highest priority)."
+msgstr ""
 
 msgid "Configure the hard disk drive to go to standby after the specified idle time when the box is in standby."
 msgstr ""
@@ -4721,72 +4623,71 @@ msgstr ""
 msgid "Configure the height of the TrueType font letters used for teletext."
 msgstr ""
 
-#, fuzzy
 msgid "Configure the history of time that will be presented."
-msgstr "Configure the amount of time that will be presented."
+msgstr ""
 
 msgid "Configure the horizontal alignment of the subtitles."
-msgstr "Configure the horizontal alignment of the subtitles."
+msgstr ""
 
 msgid "Configure the initial fast forward speed. When you press the fast forward button, winding will start at this speed."
-msgstr "Configure the initial fast forward speed. When you press the fast forward button, winding will start at this speed."
+msgstr ""
 
 msgid "Configure the initial rewind speed. When you press the rewind button, winding will start at this speed."
 msgstr ""
 
 msgid "Configure the latitude of your location."
-msgstr "Configure the latitude of your location."
+msgstr ""
 
 msgid "Configure the longitude of your location."
-msgstr "Configure the longitude of your location."
+msgstr ""
 
 msgid "Configure the minimum amount of disk space to be available for recordings. When the amount of space drops below this value, deleted items will be removed from the trash can."
-msgstr "Configure the minimum amount of disk space to be available for recordings. When the amount of space drops below this value, deleted items will be removed from the trash can."
+msgstr "Configure the minimum amount of disk space required for recordings. When the amount of space drops below this value, deleted items will be removed from the trash."
 
 msgid "Configure the minimum width before showing the 'i' icon, '0' is equal to not showing the icon at all."
 msgstr ""
 
 msgid "Configure the nameserver (DNS)."
-msgstr "Configure the nameserver (DNS)."
+msgstr ""
 
 msgid "Configure the netmask."
-msgstr "Configure the netmask."
+msgstr ""
 
 msgid "Configure the number of days after which items are automatically removed from the trash can."
-msgstr "Configure the number of days after which items are automatically removed from the trash can."
+msgstr "Configure the number of days after which deleted items should be removed from the trash."
 
 msgid "Configure the number of days old timers are kept before they are automatically removed from the timer list."
-msgstr "Configure the number of days old timers are kept before they are automatically removed from the timer list."
+msgstr ""
 
 msgid "Configure the number of rows shown."
-msgstr "Configure the number of rows shown."
+msgstr ""
 
 msgid "Configure the offline decoding delay in milliseconds. The configured delay is observed at each control word parity change."
 msgstr ""
 
 msgid "Configure the possible fast forward speeds."
-msgstr "Configure the possible fast forward speeds."
+msgstr ""
 
 msgid "Configure the possible rewind speeds."
-msgstr "Configure the possible rewind speeds."
+msgstr ""
 
 msgid "Configure the primary EPG language."
-msgstr "Configure the primary EPG language."
+msgstr ""
 
 msgid "Configure the refresh rate of the screen."
-msgstr "Configure the refresh rate of the screen."
+msgstr ""
 
 msgid "Configure the screen resolution for teletext (Not all skins support full-HD teletext)."
 msgstr ""
 
 msgid "Configure the second audio language."
-msgstr "Configure the second audio language."
+msgstr ""
 
 msgid "Configure the second subtitle language."
-msgstr "Configure the second subtitle language."
+msgstr ""
 
 msgid "Configure the secondary EPG language."
-msgstr "Configure the secondary EPG language."
+msgstr ""
 
 msgid "Configure the skip time interval for the '1'/'3' buttons."
 msgstr ""
@@ -4798,52 +4699,49 @@ msgid "Configure the skip time interval for the '7'/'9' buttons."
 msgstr ""
 
 msgid "Configure the slow motion speeds."
-msgstr "Configure the slow motion speeds."
+msgstr ""
 
 msgid "Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner."
 msgstr ""
 
 msgid "Configure the speed of the background deletion process. Lower speed will consume less hard disk drive performance."
-msgstr "Configure the speed of the background deletion process. Lower speed will consume less hard disk drive performance."
+msgstr ""
 
-#, fuzzy
 msgid "Configure the start coordinate in x of the teletext display area."
-msgstr "Configure the colour of the teletext subtitles."
+msgstr ""
 
-#, fuzzy
 msgid "Configure the start coordinate in y of the teletext display area."
-msgstr "Configure the colour of the teletext subtitles."
+msgstr ""
 
 msgid "Configure the subtitle delay when timing information is not available."
-msgstr "Configure the subtitle delay when timing information is not available."
+msgstr ""
 
 msgid "Configure the third audio language."
-msgstr "Configure the third audio language."
+msgstr ""
 
 msgid "Configure the third subtitle language."
-msgstr "Configure the third subtitle language."
+msgstr ""
 
 msgid "Configure the transparency of the black background of graphical DVB subtitles."
-msgstr "Configure the transparency of the black background of graphical DVB subtitles."
+msgstr ""
 
-#, fuzzy
 msgid "Configure the transparency of the black background of subtitles."
-msgstr "Configure the transparency of the black background of graphical DVB subtitles."
+msgstr ""
 
 msgid "Configure the tuner mode."
-msgstr "Configure the tuner mode."
+msgstr ""
 
 msgid "Configure the type of status indication icons shown in the movielist."
 msgstr ""
 
 msgid "Configure the vertical position of the subtitles, measured from the bottom of the screen."
-msgstr "Configure the vertical position of the subtitles, measured from the bottom of the screen."
+msgstr ""
 
 msgid "Configure the width allocated to the picon."
-msgstr "Configure the width allocated to the picon."
+msgstr ""
 
 msgid "Configure the width allocated to the service name."
-msgstr "Configure the width allocated to the service name."
+msgstr ""
 
 msgid "Configure the width of the TrueType font letters used for teletext."
 msgstr ""
@@ -4851,12 +4749,11 @@ msgstr ""
 msgid "Configure this tuner using simple or advanced options, or loop it through to another tuner, or copy a configuration from another tuner, or disable it."
 msgstr ""
 
-#, fuzzy
 msgid "Configure to show channel names, numbers, picons or all three inside EPG."
-msgstr "Configure to show the channel names, picons, or both in the EPG."
+msgstr ""
 
 msgid "Configure to show the channel names, picons, or both in the EPG."
-msgstr "Configure to show the channel names, picons, or both in the EPG."
+msgstr ""
 
 msgid "Configure whether a bold TrueType font is used for teletext."
 msgstr ""
@@ -4870,9 +4767,8 @@ msgstr ""
 msgid "Configure whether another tuner from the preferred list is allocated instead of sharing a tuner that is already active recording the same channel."
 msgstr ""
 
-#, fuzzy
 msgid "Configure whether multi channel sound tracks should be downmixed to stereo."
-msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr ""
 
 msgid "Configure whether the 'recording' symbol (in the display skin and LCD skin) is visible for real recordings only or also for streaming and pseuso recordings (e.g. EPGrefresh)."
 msgstr ""
@@ -4884,40 +4780,40 @@ msgid "Configure which tuner for recordings will be preferred, when more than on
 msgstr ""
 
 msgid "Configure which tuner type will be preferred, when the same service is available on different types of tuners."
-msgstr "Configure which tuner type will be preferred, when the same service is available on different types of tuners."
-
-msgid "Configure which tuner will be preferred for recordings, when more than one tuner is available. 'Disabled' would select a tuner based on preferred tuner in customise screen. 'Auto' would choose based on E2's default rules, ignoring preferred tuner in customise screen."
 msgstr ""
 
+msgid "Configure which tuner will be preferred for recordings, when more than one tuner is available. 'Disabled' would select a tuner based on preferred tuner in customise screen. 'Auto' would choose based on E2's default rules, ignoring preferred tuner in customise screen."
+msgstr "Select which tuner should be used for recordings when more than one tuner is available. 'disabled' would select based on the preferred tuner on the customise screen. 'auto' will ignore the preferred tuner and select one based on Enigma2's default rules."
+
 msgid "Configure which tuner will be preferred, when more than one tuner is available. If set to 'auto' the system will give priority to the tuner having the lowest number of channels/satellites."
-msgstr "Configure which tuner will be preferred, when more than one tuner is available. If set to 'auto' the system will give priority to the tuner having the lowest number of channels/satellites."
+msgstr ""
 
 msgid "Configure your NTP server."
-msgstr "Configure your NTP server."
+msgstr ""
 
 msgid "Configure your Network"
 msgstr ""
 
 msgid "Configure your internal LAN"
-msgstr "Configure your internal LAN"
+msgstr ""
 
 msgid "Configure your network again"
-msgstr "Configure your network again"
+msgstr ""
 
 msgid "Configure your network settings, and press OK to start the scan"
-msgstr "Configure your network settings, and press OK to start the scan"
+msgstr ""
 
 msgid "Configure your wireless LAN again"
-msgstr "Configure your wireless LAN again"
+msgstr ""
 
 msgid "Configures which video output connector will be used."
-msgstr "Configures which video output connector will be used."
+msgstr ""
 
 msgid "Configuring"
-msgstr "Configuring"
+msgstr ""
 
 msgid "Conflicting timer"
-msgstr "Conflicting timer"
+msgstr ""
 
 msgid "Congo"
 msgstr ""
@@ -4930,32 +4826,31 @@ msgid "Congratulations, you have successfully configured your %s %s for use with
 msgstr ""
 
 msgid "Connect"
-msgstr "Connect"
+msgstr ""
 
-#, fuzzy
 msgid "Connect to IceTV server every"
-msgstr "Could not connect to %s %s .NFI image feed server:"
+msgstr ""
 
 msgid "Connect to a wireless network"
-msgstr "Connect to a wireless network"
+msgstr ""
 
 msgid "Connected clients"
-msgstr "Connected clients"
+msgstr ""
 
 msgid "Connected satellites"
 msgstr ""
 
 msgid "Connected to"
-msgstr "Connected to"
+msgstr ""
 
 msgid "Connected: "
-msgstr "Connected: "
+msgstr ""
 
 msgid "Console"
 msgstr ""
 
 msgid "Constellation"
-msgstr "Constellation"
+msgstr ""
 
 msgid "Consult your SCR device spec sheet for this information."
 msgstr ""
@@ -4968,10 +4863,10 @@ msgid "Contacting IceTV server and setting up your %s %s."
 msgstr ""
 
 msgid "Content"
-msgstr "Content"
+msgstr ""
 
 msgid "Content does not fit on DVD!"
-msgstr "Content does not fit on DVD!"
+msgstr ""
 
 msgid "Context"
 msgstr ""
@@ -4980,25 +4875,25 @@ msgid "Context long"
 msgstr ""
 
 msgid "Continue"
-msgstr "Continue"
+msgstr ""
 
 msgid "Continue in background"
 msgstr ""
 
 msgid "Continue playback"
-msgstr "Continue playback"
+msgstr ""
 
 msgid "Continue playing"
-msgstr "Continue playing"
+msgstr ""
 
 msgid "Continues"
-msgstr "Continues"
+msgstr ""
 
 msgid "Continues play (loop)"
-msgstr "Continues play (loop)"
+msgstr ""
 
 msgid "Contrast"
-msgstr "Contrast"
+msgstr ""
 
 msgid "Control of the position how finished timer are shown in the Timer List."
 msgstr ""
@@ -5010,23 +4905,22 @@ msgid "Control your Softcams"
 msgstr ""
 
 msgid "Convert ext3 filesystem to ext4"
-msgstr "Convert ext3 filesystem to ext4"
+msgstr ""
 
 msgid "Convert ext3 to ext4"
-msgstr "Convert ext3 to ext4"
+msgstr ""
 
 msgid "Convert filesystem ext3 to ext4"
-msgstr "Convert filesystem ext3 to ext4"
+msgstr ""
 
 msgid "Converting ext3 to ext4..."
-msgstr "Converting ext3 to ext4..."
+msgstr ""
 
 msgid "Cook Islands"
 msgstr ""
 
-#, fuzzy
 msgid "Cooking"
-msgstr "cooking"
+msgstr ""
 
 msgid "Cool Channel Guide"
 msgstr ""
@@ -5041,10 +4935,10 @@ msgid "Cool Single Guide"
 msgstr ""
 
 msgid "Cool TV Guide"
-msgstr "Cool TV Guide"
+msgstr ""
 
 msgid "Copy"
-msgstr "Copy"
+msgstr ""
 
 #, python-format
 msgid "Copy %d elements"
@@ -5053,9 +4947,8 @@ msgstr ""
 msgid "Copy 1 element"
 msgstr ""
 
-#, fuzzy
 msgid "Copy file"
-msgstr "Copying files"
+msgstr ""
 
 msgid "Copy file/directory to target directory"
 msgstr ""
@@ -5063,16 +4956,14 @@ msgstr ""
 msgid "Copy files/directories to target directory"
 msgstr ""
 
-#, fuzzy
 msgid "Copy folder"
-msgstr "Copying files"
+msgstr ""
 
 msgid "Copying files"
-msgstr "Copying files"
+msgstr ""
 
-#, fuzzy, python-format
 msgid "Cores:\t\t%s"
-msgstr "Cores:\t%s"
+msgstr ""
 
 #, python-format
 msgid "Cores: %s"
@@ -5086,14 +4977,13 @@ msgstr ""
 
 #, python-format
 msgid "Could not connect to %s %s .NFI image feed server:"
-msgstr "Could not connect to %s %s .NFI image feed server:"
+msgstr ""
 
-#, fuzzy
 msgid "Could not connect to server"
-msgstr "Could not connect to %s %s .NFI image feed server:"
+msgstr ""
 
 msgid "Could not find installed channel list."
-msgstr "Could not find installed channel list."
+msgstr ""
 
 msgid "Could not find suitable media - Please remove some downloaded images or insert a media (e.g. USB stick) with sufficient free space and try again!"
 msgstr ""
@@ -5102,31 +4992,29 @@ msgid "Could not load Medium! No disc inserted?"
 msgstr ""
 
 msgid "Could not open Picture in Picture"
-msgstr "Could not open Picture in Picture"
+msgstr ""
 
 #, python-format
 msgid "Could not open the file %s!"
-msgstr "Could not open the file %s!"
+msgstr ""
 
 #, python-format
 msgid "Could not record due to conflicting timer %s"
-msgstr "Could not record due to conflicting timer %s"
+msgstr ""
 
 #, python-format
 msgid "Could not record due to invalid service %s"
-msgstr "Could not record due to invalid service %s"
+msgstr ""
 
 #, python-format
 msgid "Could not save configfile %s!"
-msgstr "Could not save config file %s!"
+msgstr ""
 
-#, fuzzy
 msgid "Country"
-msgstr "Mount"
+msgstr ""
 
-#, fuzzy
 msgid "Country for EPG event genre information"
-msgstr "Software manager information"
+msgstr ""
 
 msgid "Country for EPG event rating information"
 msgstr ""
@@ -5135,7 +5023,7 @@ msgid "Cpu"
 msgstr ""
 
 msgid "Crash Logs"
-msgstr "Crash Logs"
+msgstr ""
 
 msgid "Crash at skin error for debug reasons ?"
 msgstr ""
@@ -5147,17 +5035,16 @@ msgid "Create Bludisc ISO file"
 msgstr ""
 
 msgid "Create DVD-ISO"
-msgstr "Create DVD-ISO"
+msgstr ""
 
 msgid "Create ISO"
 msgstr ""
 
 msgid "Create directory"
-msgstr "Create directory"
+msgstr ""
 
-#, fuzzy
 msgid "Create directory/folder"
-msgstr "Create directory"
+msgstr ""
 
 msgid "Create separate radio userbouquet"
 msgstr ""
@@ -5168,52 +5055,49 @@ msgstr ""
 msgid "Create user-named symbolic link"
 msgstr ""
 
-#, fuzzy
 msgid "Create:"
-msgstr "Bitrate:"
+msgstr ""
 
 #, python-format
 msgid "Create: Recovery Fullbackup %s"
 msgstr ""
 
 msgid "Creating AP and SC Files"
-msgstr "Creating AP and SC Files"
+msgstr ""
 
 msgid "Creating Hardlink to Timeshift file failed!"
-msgstr "Creating Hardlink to Timeshift file failed!"
+msgstr ""
 
 #, python-format
 msgid "Creating directory %s failed."
-msgstr "Creating directory %s failed."
+msgstr ""
 
 msgid "Creating filesystem"
-msgstr "Creating filesystem"
+msgstr ""
 
 msgid "Creating partition"
-msgstr "Creating partition"
+msgstr ""
 
-#, fuzzy
 msgid "Cricket"
-msgstr "locked"
+msgstr ""
 
 msgid "Crime"
 msgstr ""
 
-#, fuzzy
 msgid "Croatia"
-msgstr "Croatian"
+msgstr ""
 
 msgid "Croatian"
-msgstr "Croatian"
+msgstr ""
 
 msgid "Cron Manager"
-msgstr "Cron Manager"
+msgstr ""
 
 msgid "CronManager"
 msgstr ""
 
 msgid "CronTimers"
-msgstr "CronTimers"
+msgstr ""
 
 msgid "Cuba"
 msgstr ""
@@ -5224,84 +5108,88 @@ msgstr ""
 msgid "Curacao"
 msgstr ""
 
-#, fuzzy
 msgid "Current Affairs"
-msgstr "News Current Affairs"
+msgstr ""
 
 msgid "Current CEC address"
-msgstr "Current CEC address"
+msgstr ""
 
 msgid "Current Event:"
-msgstr "Current Event:"
+msgstr ""
 
 msgid "Current Status:"
-msgstr "Current Status:"
+msgstr ""
 
 msgid "Current device: "
-msgstr "Current device: "
+msgstr ""
 
-#, fuzzy
 msgid "Current installed"
-msgstr "Currently installed image"
+msgstr ""
 
 msgid "Current location"
 msgstr ""
 
 #, python-format
+msgid ""
+"Current mode:   %s\n"
+"\n"
+msgstr ""
+
 msgid "Current mode: %s \n"
 msgstr ""
 
 msgid "Current settings:"
-msgstr "Current settings:"
+msgstr ""
 
 msgid "Current time"
-msgstr "Current time"
+msgstr ""
 
 msgid "Current transponder"
-msgstr "Current transponder"
+msgstr ""
 
 msgid "Current value: "
-msgstr "Current value: "
+msgstr ""
 
 msgid "Current version:"
-msgstr "Current version:"
+msgstr ""
 
 msgid "Currently installed image"
-msgstr "Currently installed image"
+msgstr ""
 
 msgid "Custom"
-msgstr "Custom"
+msgstr ""
 
 msgid "Custom skip time for '1'/'3' buttons"
 msgstr ""
 
 msgid "Custom skip time for '4'/'6' buttons"
-msgstr "Custom skip time for '4'/'6' buttons"
+msgstr ""
 
 msgid "Custom skip time for '7'/'9' buttons"
-msgstr "Custom skip time for '7'/'9' buttons"
+msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "Customise"
-msgstr ""
+msgstr "Customise"
 
+#. TRANSLATORS: override en_US
 msgid "Customise enigma2 personal settings"
-msgstr ""
+msgstr "Customise Enigma2 personal settings"
 
 msgid "Customize"
 msgstr "Customise"
 
 msgid "Cut"
-msgstr "Cut"
+msgstr ""
 
-#, fuzzy
 msgid "Cutlist Editor"
-msgstr "Cutlist editor"
+msgstr ""
 
 msgid "Cutlist editor"
-msgstr "Cutlist editor"
+msgstr ""
 
 msgid "Cutlist editor..."
-msgstr "Cut-list editor..."
+msgstr ""
 
 msgid "Cycling"
 msgstr ""
@@ -5310,26 +5198,25 @@ msgid "Cyprus"
 msgstr ""
 
 msgid "Czech"
-msgstr "Czech"
+msgstr ""
 
-#, fuzzy
 msgid "Czechia"
-msgstr "Czech"
+msgstr ""
 
 msgid "DAC"
-msgstr "DAC"
+msgstr ""
 
 msgid "DHCP"
-msgstr "DHCP"
+msgstr ""
 
 msgid "DLNA support"
-msgstr "DLNA support"
+msgstr ""
 
 msgid "DMM advanced"
-msgstr "DMM advanced"
+msgstr ""
 
 msgid "DMM normal"
-msgstr "DMM normal"
+msgstr ""
 
 msgid ""
 "DO NOT POWER OFF YOUR DEVICE WHILE UPDATING!\n"
@@ -5339,88 +5226,80 @@ msgstr ""
 msgid "DTS"
 msgstr ""
 
-#, fuzzy
 msgid "DTS HD downmix"
-msgstr "AAC downmix"
+msgstr ""
 
-#, fuzzy
 msgid "DTS downmix"
-msgstr "AAC downmix"
+msgstr ""
 
 msgid "DTS/DTS-HD HR/DTS-HD MA/DTS:X"
 msgstr ""
 
 msgid "DUAL LAYER DVD"
-msgstr "DUAL LAYER DVD"
+msgstr ""
 
 msgid "DVB CI Delay"
 msgstr ""
 
 msgid "DVB subtitle black transparency"
-msgstr "DVB subtitle black transparency"
+msgstr ""
 
 msgid "DVB-C"
-msgstr "DVB-C"
+msgstr ""
 
-#, fuzzy
 msgid "DVB-C ANNEX B"
-msgstr "DVB-C ANNEX C"
+msgstr ""
 
 msgid "DVB-C ANNEX C"
-msgstr "DVB-C ANNEX C"
+msgstr ""
 
 msgid "DVB-S"
-msgstr "DVB-S"
+msgstr ""
 
 msgid "DVB-S2"
-msgstr "DVB-S2"
+msgstr ""
 
 msgid "DVB-T"
-msgstr "DVB-T"
+msgstr ""
 
 msgid "DVB-T2"
-msgstr "DVB-T2"
+msgstr ""
 
-#, fuzzy
 msgid "DVD Burn"
-msgstr "Menu"
+msgstr ""
 
 msgid "DVD File Browser"
 msgstr ""
 
-#, fuzzy
 msgid "DVD Menu"
-msgstr "Menu"
+msgstr ""
 
 msgid "DVD Titlelist"
 msgstr ""
 
 msgid "DVD file browser"
-msgstr "DVD file browser"
+msgstr ""
 
 msgid "DVD player"
-msgstr "DVD player"
+msgstr ""
 
-#, fuzzy
 msgid "DVDPlayer"
-msgstr "DVD player"
+msgstr ""
 
 msgid "Daily"
-msgstr "Daily"
+msgstr ""
 
-#, fuzzy
 msgid "Dance"
-msgstr "Cancel"
+msgstr ""
 
 msgid "Danish"
-msgstr "Danish"
+msgstr ""
 
 msgid "Date"
-msgstr "Date"
+msgstr ""
 
-#, fuzzy
 msgid "Date reverse"
-msgstr "alphabetic reverse"
+msgstr ""
 
 msgid "Date style"
 msgstr ""
@@ -5428,9 +5307,8 @@ msgstr ""
 msgid "Date/time input"
 msgstr ""
 
-#, fuzzy
 msgid "Dating"
-msgstr "Waiting"
+msgstr ""
 
 msgid "Day D Mon"
 msgstr ""
@@ -5450,9 +5328,8 @@ msgstr ""
 msgid "Day DD-Mon"
 msgstr ""
 
-#, fuzzy
 msgid "Day DD/M"
-msgstr "Play DVD"
+msgstr ""
 
 msgid "Day DD/MM"
 msgstr ""
@@ -5487,6 +5364,15 @@ msgstr ""
 msgid "Dayname D-Month-Year"
 msgstr ""
 
+msgid "Dayname D. Month Year"
+msgstr ""
+
+msgid "Dayname D.M.Year"
+msgstr ""
+
+msgid "Dayname D.MM.Year"
+msgstr ""
+
 msgid "Dayname D/M/Year"
 msgstr ""
 
@@ -5497,6 +5383,15 @@ msgid "Dayname DD Month Year"
 msgstr ""
 
 msgid "Dayname DD-Month-Year"
+msgstr ""
+
+msgid "Dayname DD. Month Year"
+msgstr ""
+
+msgid "Dayname DD.M.Year"
+msgstr ""
+
+msgid "Dayname DD.MM.Year"
 msgstr ""
 
 msgid "Dayname DD/M/Year"
@@ -5557,31 +5452,28 @@ msgid "Deactivate"
 msgstr ""
 
 msgid "Debug Logs"
-msgstr "Debug Logs"
+msgstr ""
 
-#, fuzzy
 msgid "Decryption & Parental Control"
-msgstr "Parental control"
+msgstr ""
 
 msgid "Deep Standby"
-msgstr "Deep Standby"
+msgstr ""
 
 msgid "Deep standby"
-msgstr "Deep standby"
+msgstr ""
 
 msgid "Default"
-msgstr "Default"
+msgstr ""
 
 msgid "Default  (keymap.xml)"
 msgstr ""
 
-#, fuzzy
 msgid "Default 'After event' *"
-msgstr "After event"
+msgstr ""
 
-#, fuzzy
 msgid "Default 'Timer type' *"
-msgstr "Default recording type"
+msgstr ""
 
 msgid "Default (Instant Record)"
 msgstr ""
@@ -5592,51 +5484,44 @@ msgstr ""
 msgid "Default CPU priority (nice) for executed scripts. This can reduce the load so that scripts do not interfere with the rest of the system. (higher values = lower priority)"
 msgstr ""
 
-#, fuzzy
 msgid "Default Folder"
-msgstr "Default"
+msgstr ""
 
 msgid "Default I/O priority (ionice) for executed scripts. This can reduce the load so that scripts do not interfere with the rest of the system. (higher values = lower priority)"
 msgstr ""
 
-#, fuzzy
 msgid "Default Modes Selected."
-msgstr "Default movie location"
+msgstr ""
 
-#, fuzzy
 msgid "Default Services Scanner"
-msgstr "Default movie location"
+msgstr ""
 
-#, fuzzy
 msgid "Default directory sorting"
-msgstr "Default settings"
+msgstr ""
 
-#, fuzzy
 msgid "Default file sorting left"
-msgstr "Default recording type"
+msgstr ""
 
-#, fuzzy
 msgid "Default file sorting right"
-msgstr "Default recording type"
+msgstr ""
 
 msgid "Default files/folders to backup"
 msgstr ""
 
-#, fuzzy
 msgid "Default folder"
-msgstr "Select folders"
+msgstr ""
 
 msgid "Default folder if the left or right folder isn't saved, and target folder for button 5."
 msgstr ""
 
 msgid "Default movie location"
-msgstr "Default movie location"
+msgstr ""
 
 msgid "Default recording type"
-msgstr "Default recording type"
+msgstr ""
 
 msgid "Default settings"
-msgstr "Default settings"
+msgstr ""
 
 msgid "Default sorting method for directories on both sides."
 msgstr ""
@@ -5648,7 +5533,7 @@ msgid "Default sorting method for files on the right side."
 msgstr ""
 
 msgid "Defaults"
-msgstr "Defaults"
+msgstr ""
 
 msgid "Defines how fast the time jumps are repeated. Values lower than 500ms may be problematic with NAS."
 msgstr ""
@@ -5702,7 +5587,7 @@ msgid "Delay after voltage change before motor command"
 msgstr ""
 
 msgid "Delay before key repeat starts:"
-msgstr "Delay before key repeat starts:"
+msgstr ""
 
 msgid "Delay before sequence repeat"
 msgstr ""
@@ -5714,7 +5599,7 @@ msgid "Delay between switch and motor command"
 msgstr ""
 
 msgid "Delay for external subtitles"
-msgstr "Delay for external subtitles"
+msgstr ""
 
 msgid "Delay in milliseconds after finish scrolling text on display."
 msgstr ""
@@ -5723,32 +5608,30 @@ msgid "Delay in milliseconds before start of scrolling text on display."
 msgstr ""
 
 msgid "Delay time"
-msgstr "Delay time"
+msgstr ""
 
 msgid "Delay:"
-msgstr "Delay:"
+msgstr ""
 
 msgid "Delete"
-msgstr "Delete"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Delete %d elements"
-msgstr "Deleted items"
+msgstr ""
 
 #, python-format
 msgid "Delete %s?"
-msgstr "Delete %s?"
+msgstr ""
 
-#, fuzzy
 msgid "Delete 1 element"
-msgstr "Delete entry"
+msgstr ""
 
 msgid "Delete Confirmation"
-msgstr "Delete Confirmation"
+msgstr ""
 
-#, fuzzy
 msgid "Delete EPG"
-msgstr "Delete"
+msgstr ""
 
 msgid "Delete Language"
 msgstr ""
@@ -5756,43 +5639,49 @@ msgstr ""
 msgid "Delete Plugins"
 msgstr ""
 
+msgid "Delete all the text"
+msgstr ""
+
 msgid "Delete and uninstall Plugins. This will remove the Plugin from your box"
 msgstr ""
 
-#, fuzzy
 msgid "Delete current line"
-msgstr "Delete entry"
+msgstr ""
 
 msgid "Delete entry"
-msgstr "Delete entry"
+msgstr ""
 
 msgid "Delete failed!"
-msgstr "Delete failed!"
+msgstr ""
 
 msgid "Delete file"
-msgstr "Delete file"
+msgstr ""
 
 msgid "Delete file or directory (and all its contents)"
 msgstr ""
 
-#, fuzzy
 msgid "Delete folder"
-msgstr "Delete file"
+msgstr ""
 
-#, fuzzy
 msgid "Delete image"
-msgstr "Delete timer"
+msgstr ""
 
 msgid "Delete playlist entry"
-msgstr "Delete playlist entry"
+msgstr ""
 
 msgid "Delete saved playlist"
-msgstr "Delete saved playlist"
+msgstr ""
 
 msgid "Delete the character to the left of text buffer cursor"
 msgstr ""
 
+msgid "Delete the character to the left of text cursor"
+msgstr ""
+
 msgid "Delete the character under the text buffer cursor"
+msgstr ""
+
+msgid "Delete the character under the text cursor"
 msgstr ""
 
 msgid "Delete the current timeshift buffer and restart timeshift"
@@ -5802,20 +5691,20 @@ msgid "Delete the selected files or directories"
 msgstr ""
 
 msgid "Delete timer"
-msgstr "Delete timer"
+msgstr ""
 
 msgid "Deleted"
-msgstr "Deleted"
+msgstr ""
 
 #, python-format
 msgid "Deleted %s!"
-msgstr "Deleted %s!"
+msgstr ""
 
 msgid "Deleted items"
-msgstr "Deleted items"
+msgstr ""
 
 msgid "Deleting files"
-msgstr "Deleting files"
+msgstr ""
 
 msgid "Delivery system workaround"
 msgstr ""
@@ -5824,42 +5713,40 @@ msgid "Denmark"
 msgstr ""
 
 msgid "Depth"
-msgstr "Depth"
+msgstr ""
 
 msgid "Descramble & record ECM' gives the option to descramble afterwards if descrambling on recording failed. 'Don't descramble, record ECM' save a scramble recording that can be descrambled on playback. 'Normal' means descramble the recording and don't record ECM."
-msgstr "Descramble & record ECM' gives the option to descramble afterwards if descrambling on recording failed. 'Don't descramble, record ECM' save a scramble recording that can be descrambled on playback. 'Normal' means descramble the recording and don't record ECM."
+msgstr ""
 
 msgid "Descramble http streams"
-msgstr "Descramble http streams"
+msgstr ""
 
-#, fuzzy
 msgid "Descramble receiving http streams"
-msgstr "Descramble http streams"
+msgstr ""
 
 msgid "Description"
-msgstr "Description"
+msgstr ""
 
 msgid "Deselect"
-msgstr "Deselect"
+msgstr ""
 
 msgid "Details for plugin: "
-msgstr "Details for plugin: "
+msgstr ""
 
 msgid "Detected Devices:"
-msgstr "Detected Devices:"
+msgstr ""
 
-#, fuzzy
 msgid "Detected HDD:"
-msgstr "Detected NIMs:"
+msgstr ""
 
 msgid "Detected NIMs:"
-msgstr "Detected NIMs:"
+msgstr ""
 
 msgid "Detektiv"
 msgstr ""
 
 msgid "Device Information"
-msgstr "Device Information"
+msgstr ""
 
 msgid "Device Manager"
 msgstr ""
@@ -5868,19 +5755,19 @@ msgid "Device Setup"
 msgstr ""
 
 msgid "Device mounts"
-msgstr "Device mounts"
+msgstr ""
 
 msgid "Device: "
 msgstr ""
 
 msgid "Devicename:"
-msgstr "Device name:"
+msgstr ""
 
 msgid "Devices"
-msgstr "Devices"
+msgstr ""
 
 msgid "DiSEqC"
-msgstr "DiSEqC"
+msgstr ""
 
 msgid "DiSEqC 1.0 command"
 msgstr ""
@@ -5892,24 +5779,23 @@ msgid "DiSEqC 1.1 repeats"
 msgstr ""
 
 msgid "DiSEqC A/B"
-msgstr "DiSEqC A/B"
+msgstr ""
 
 msgid "DiSEqC A/B/C/D"
-msgstr "DiSEqC A/B/C/D"
+msgstr ""
 
-#, fuzzy
 msgid "DiSEqC Tester"
-msgstr "DiSEqC mode"
+msgstr ""
 
 msgid "DiSEqC mode"
-msgstr "DiSEqC mode"
+msgstr ""
 
 #, python-format
 msgid "DiSEqC port %s: %s"
-msgstr "DiSEqC port %s: %s"
+msgstr ""
 
 msgid "DiSEqC-tester settings"
-msgstr "DiSEqC-tester settings"
+msgstr ""
 
 msgid "Diction"
 msgstr ""
@@ -5921,7 +5807,7 @@ msgid ""
 msgstr ""
 
 msgid "Digital contour removal"
-msgstr "Digital contour removal"
+msgstr ""
 
 msgid "Dim delay"
 msgstr ""
@@ -5930,46 +5816,44 @@ msgid "Dim the LCD to the level from 'Brightness (Dimmed)' after specified time.
 msgstr ""
 
 msgid "Direct playback of linked titles without menu"
-msgstr "Direct playback of linked titles without menu"
+msgstr ""
 
 msgid "Directory"
-msgstr "Directory"
+msgstr ""
 
 #, python-format
 msgid "Directory %s does not exist."
-msgstr "Directory %s does not exist."
+msgstr ""
 
 msgid "Directory browser"
-msgstr "Directory browser"
+msgstr ""
 
 msgid "Directory long"
 msgstr ""
 
 msgid "Disable"
-msgstr "Disable"
+msgstr ""
 
 msgid "Disable Animations"
 msgstr ""
 
-#, fuzzy
 msgid "Disable IceTV"
-msgstr "Disable"
+msgstr ""
 
 msgid "Disable MiniTV"
 msgstr ""
 
 msgid "Disable Picture in Picture"
-msgstr "Disable Picture in Picture"
+msgstr ""
 
 msgid "Disable all VFD Symbols"
 msgstr ""
 
 msgid "Disable background scanning"
-msgstr "Disable background scanning"
+msgstr ""
 
-#, fuzzy
 msgid "Disable digital downmix"
-msgstr "Digital downmix"
+msgstr ""
 
 msgid "Disable intro screen"
 msgstr ""
@@ -5978,10 +5862,10 @@ msgid "Disable the HDD Process on VFD"
 msgstr ""
 
 msgid "Disable timer"
-msgstr "Disable timer"
+msgstr ""
 
 msgid "Disabled"
-msgstr "Disabled"
+msgstr ""
 
 msgid "Disabled PIP.\n"
 msgstr ""
@@ -5989,33 +5873,29 @@ msgstr ""
 msgid "Dish"
 msgstr ""
 
-#, fuzzy
 msgid "Disk full"
-msgstr "full"
+msgstr ""
 
-#, fuzzy
 msgid "Disk full?"
-msgstr "full"
+msgstr ""
 
-#, fuzzy
 msgid "Disk is not writable!"
-msgstr "Medium is not a writeable DVD!"
+msgstr ""
 
 msgid "Disk space to reserve for recordings (in GB)"
-msgstr "Disk space to reserve for recordings (in GB)"
+msgstr ""
 
-#, fuzzy
 msgid "Disk was not found!"
-msgstr "no CI slots found"
+msgstr ""
 
 msgid "Display 16:9 content as"
-msgstr "Display 16:9 content as"
+msgstr ""
 
 msgid "Display 4:3 content as"
-msgstr "Display 4:3 content as"
+msgstr ""
 
 msgid "Display >16:9 content as"
-msgstr "Display >16:9 content as"
+msgstr ""
 
 msgid "Display Settings"
 msgstr ""
@@ -6024,126 +5904,115 @@ msgid "Display Setup"
 msgstr ""
 
 msgid "Display and user interface"
-msgstr "Display and user interface"
+msgstr ""
 
 msgid "Display message before playing next movie"
-msgstr "Display message before playing next movie"
+msgstr ""
 
 msgid "Display settings"
 msgstr ""
 
 msgid "Display the EIT now/next eventdata in infobar."
-msgstr "Display the EIT now/next event data in infobar."
+msgstr ""
 
-#, fuzzy
 msgid "Djibouti"
-msgstr "About"
+msgstr ""
 
 msgid "Do center DVB subs on this service"
-msgstr ""
+msgstr "Centre DVB subtitles on this channel"
 
 msgid "Do not center DVB subs on this service"
-msgstr ""
+msgstr "Don't centre DVB subtitles"
 
 msgid "Do not change"
-msgstr "Do not change"
+msgstr ""
 
 msgid "Do not flash image"
 msgstr ""
 
 msgid "Do not record"
-msgstr "Do not record"
+msgstr ""
 
 msgid ""
 "Do you really want to check the filesystem?\n"
 "This could take a long time!"
 msgstr ""
-"Do you really want to check the filesystem?\n"
-"This could take a long time!"
 
 msgid ""
 "Do you really want to convert the filesystem?\n"
 "You cannot go back!"
 msgstr ""
-"Do you really want to convert the filesystem?\n"
-"You cannot go back!"
 
 #, python-format
 msgid "Do you really want to delete %s ?"
-msgstr "Do you really want to delete %s ?"
+msgstr ""
 
 #, python-format
 msgid "Do you really want to delete %s?"
-msgstr "Do you really want to delete %s?"
+msgstr ""
 
 msgid "Do you really want to delete ?"
-msgstr "Do you really want to delete ?"
+msgstr ""
 
 msgid "Do you really want to delete the recording?"
 msgstr ""
 
 msgid "Do you really want to delete this timer ?"
-msgstr "Do you really want to delete this timer ?"
+msgstr ""
 
 #, python-format
 msgid "Do you really want to download the plugin \"%s\"?"
-msgstr "Do you really want to download the plugin \"%s\"?"
+msgstr ""
 
 msgid "Do you really want to exit?"
-msgstr "Do you really want to exit?"
+msgstr ""
 
 msgid ""
 "Do you really want to initialize the device?\n"
 "All data on the disk will be lost!"
 msgstr ""
-"Do you really want to initialise the device?\n"
-"All data on the disk will be lost!"
 
 msgid "Do you really want to move to trashcan ?"
-msgstr ""
+msgstr "Are you sure you want to move to the trash?"
 
 #, python-format
 msgid "Do you really want to permamently remove '%s' from trash can ?"
-msgstr "Do you really want to permanently remove '%s' from trash can ?"
+msgstr "Are you sure you want to permamently remove '%s' from the trash?"
 
 msgid "Do you really want to permanently remove from trash can ?"
-msgstr "Do you really want to permanently remove from trash can ?"
+msgstr "Are you sure you want to permanently remove this from the trash?"
 
 #, python-format
 msgid "Do you really want to remove directory %s from the disk?"
-msgstr "Do you really want to remove directory %s from the disk?"
+msgstr ""
 
 #, python-format
 msgid "Do you really want to remove the plugin \"%s\"?"
-msgstr "Do you really want to remove the plugin \"%s\"?"
+msgstr ""
 
 #, python-format
 msgid "Do you really want to remove the timer for %s?"
-msgstr "Do you really want to remove the timer for %s?"
+msgstr ""
 
 #, python-format
 msgid "Do you really want to remove your bookmark of %s?"
-msgstr "Do you really want to remove your bookmark of %s?"
+msgstr ""
 
 msgid "Do you want change rights?\n"
 msgstr ""
 
 msgid "Do you want to add any additional information ?"
-msgstr "Do you want to add any additional information ?"
+msgstr ""
 
 msgid ""
 "Do you want to also install samba client ?\n"
 "This allows you to mount your windows shares on this device."
 msgstr ""
-"Do you want to also install samba client ?\n"
-"This allows you to mount your windows shares on this device."
 
 msgid ""
 "Do you want to attach a text file to explain the log ?\n"
 "(choose 'No' to type message using virtual keyboard.)"
 msgstr ""
-"Do you want to attach a text file to explain the log ?\n"
-"(choose 'No' to type message using virtual keyboard.)"
 
 msgid ""
 "Do you want to backup now?\n"
@@ -6151,7 +6020,7 @@ msgid ""
 msgstr ""
 
 msgid "Do you want to burn this collection to DVD medium?"
-msgstr "Do you want to burn this collection to DVD medium?"
+msgstr ""
 
 msgid "Do you want to continue?"
 msgstr ""
@@ -6166,99 +6035,90 @@ msgid ""
 "Do you want to delete all selected files:\n"
 "(choose 'No' to only delete the currently selected file.)"
 msgstr ""
-"Do you want to delete all selected files:\n"
-"(choose 'No' to only delete the currently selected file.)"
 
 msgid "Do you want to delete the old settings in /etc/enigma2 first?"
 msgstr ""
 
 msgid "Do you want to do a service scan?"
-msgstr "Do you want to do a service scan?"
+msgstr ""
 
 msgid "Do you want to do another manual service scan?"
-msgstr "Do you want to do another manual service scan?"
+msgstr ""
 
 #, python-format
 msgid "Do you want to download the image to %s ?"
-msgstr "Do you want to download the image to %s ?"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Do you want to flash image\n"
 "%s"
-msgstr "Do you want to download the image to %s ?"
+msgstr ""
 
-#, fuzzy
 msgid "Do you want to install a channel list?"
-msgstr "Do you want to install the package:\n"
+msgstr ""
 
 msgid "Do you want to install the package:\n"
-msgstr "Do you want to install the package:\n"
+msgstr ""
 
 msgid "Do you want to play DVD in drive?"
-msgstr "Do you want to play DVD in drive?"
+msgstr ""
 
 msgid "Do you want to preview this DVD before burning?"
-msgstr "Do you want to preview this DVD before burning?"
+msgstr ""
 
 msgid "Do you want to produce this collection?"
 msgstr ""
 
-#, fuzzy, python-format
 msgid "Do you want to reboot now the image in slot %s?"
-msgstr "Do you want to download the image to %s ?"
+msgstr ""
 
 #, python-format
 msgid "Do you want to reboot your %s %s"
-msgstr "Do you want to reboot your %s %s"
+msgstr ""
 
 #, python-format
 msgid "Do you want to reboot your %s %s?"
 msgstr ""
 
 msgid "Do you want to reboot your receiver?"
-msgstr "Do you want to reboot your receiver?"
+msgstr ""
 
 msgid "Do you want to remove the package:\n"
-msgstr "Do you want to remove the package:\n"
+msgstr ""
 
 msgid "Do you want to restart now?"
 msgstr ""
 
 msgid "Do you want to restore your settings?"
-msgstr "Do you want to restore your settings?"
+msgstr ""
 
 msgid "Do you want to resume this playback?"
-msgstr "Do you want to resume this playback?"
+msgstr ""
 
 msgid ""
 "Do you want to send all selected files:\n"
 "(choose 'No' to only send the currently selected file.)"
 msgstr ""
-"Do you want to send all selected files:\n"
-"(choose 'No' to only send the currently selected file.)"
 
 #, python-format
 msgid "Do you want to update your %s %s ?"
-msgstr "Do you want to update your %s %s ?"
+msgstr ""
 
 msgid "Do you want to update your box?"
 msgstr ""
 
 msgid "Do you want to upgrade the package:\n"
-msgstr "Do you want to upgrade the package:\n"
+msgstr ""
 
-#, fuzzy
 msgid "Do you want to view or run the script?\n"
-msgstr "Do you want to reboot your receiver?"
+msgstr ""
 
-#, fuzzy
 msgid "Documentary"
-msgstr "documentary"
+msgstr ""
 
-#, fuzzy
 msgid "Dokumentation"
-msgstr "Communication"
+msgstr ""
 
 msgid "Dolby Digital downmix is now"
 msgstr ""
@@ -6272,15 +6132,14 @@ msgstr ""
 msgid "Don't add this recording"
 msgstr ""
 
-#, fuzzy
 msgid "Don't ask again!"
-msgstr "Don't save"
+msgstr ""
 
 msgid "Don't save"
-msgstr "Don't save"
+msgstr ""
 
 msgid "Don't stop current event but disable coming events"
-msgstr "Don't stop current event but disable coming events"
+msgstr ""
 
 msgid ""
 "Don't worry your device is still ok! There are several safety mechanisms in place!\n"
@@ -6297,21 +6156,21 @@ msgstr ""
 #, python-format
 msgid "Done - Installed, upgraded or removed %d package (%s)"
 msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
-msgstr[0] "Done - Installed, upgraded or removed %d package (%s)"
-msgstr[1] "Done - Installed, upgraded or removed %d packages (%s)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Down"
 msgstr ""
 
 msgid "Download"
-msgstr "Download"
+msgstr ""
 
 #, python-format
 msgid "Download %s from server"
-msgstr "Download %s from server"
+msgstr ""
 
 msgid "Download .NFI-files for USB-flasher"
-msgstr "Download .NFI-files for USB-flasher"
+msgstr ""
 
 msgid "Download Plugins"
 msgstr ""
@@ -6326,32 +6185,28 @@ msgid "Download and install cam"
 msgstr ""
 
 msgid "Download plugins"
-msgstr "Download plugins"
+msgstr ""
 
 msgid "Downloadable plugins"
 msgstr ""
 
-#, fuzzy
 msgid "Downloaded Images"
-msgstr "Downloading"
+msgstr ""
 
 msgid "Downloading"
-msgstr "Downloading"
+msgstr ""
 
-#, fuzzy
 msgid "Downloading Image"
-msgstr "Downloading"
+msgstr ""
 
 msgid "Downloading plugin information. Please wait..."
-msgstr "Downloading plugin information. Please wait..."
+msgstr ""
 
-#, fuzzy
 msgid "Downmix"
-msgstr "AAC downmix"
+msgstr ""
 
-#, fuzzy
 msgid "Drama"
-msgstr "Movie/Drama"
+msgstr ""
 
 msgid "Dreambox format data DVD (HDTV compatible)"
 msgstr ""
@@ -6359,13 +6214,13 @@ msgstr ""
 msgid "Dreambox format data DVD (won't work in other DVD players)"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Drivers:\t\t%s"
-msgstr "Drivers:\t%s"
+msgstr ""
 
 #, python-format
 msgid "Drivers:\t%s"
-msgstr "Drivers:\t%s"
+msgstr ""
 
 msgid "Drogen"
 msgstr ""
@@ -6374,13 +6229,13 @@ msgid "During this time, the transmitter and the recording destination are check
 msgstr ""
 
 msgid "Dutch"
-msgstr "Dutch"
+msgstr ""
 
 msgid "Dynamic contrast"
-msgstr "Dynamic contrast"
+msgstr ""
 
 msgid "E"
-msgstr "E"
+msgstr ""
 
 msgid "E2 Log"
 msgstr ""
@@ -6389,22 +6244,22 @@ msgid "E3HD/XPEEDLX/GI"
 msgstr ""
 
 msgid "ECM Statistics"
-msgstr "ECM Statistics"
+msgstr ""
 
 msgid "ECM Time"
-msgstr "ECM Time"
+msgstr ""
 
 msgid "ECM avg"
-msgstr "ECM avg."
+msgstr ""
 
 msgid "ECM data will be included in the stream. This enables a client receiver to decode it."
-msgstr "ECM data will be included in the stream. This enables a client receiver to decode it."
+msgstr ""
 
 msgid "ECM last"
-msgstr "ECM last"
+msgstr ""
 
 msgid "ECM-Time"
-msgstr "ECM-Time"
+msgstr ""
 
 msgid "EDID decode"
 msgstr ""
@@ -6416,13 +6271,13 @@ msgid "EJECTCD long"
 msgstr ""
 
 msgid "EPG"
-msgstr "EPG"
+msgstr ""
 
 msgid "EPG Cache Check"
-msgstr "EPG Cache Check"
+msgstr ""
 
 msgid "EPG Search"
-msgstr "EPG Search"
+msgstr ""
 
 msgid "EPG Selection"
 msgstr ""
@@ -6434,7 +6289,7 @@ msgid "EPG button mode"
 msgstr ""
 
 msgid "EPG filename"
-msgstr "EPG filename"
+msgstr ""
 
 msgid ""
 "EPG key : Switch to channel list\n"
@@ -6451,46 +6306,44 @@ msgid ""
 msgstr ""
 
 msgid "EPG language selection 1"
-msgstr "EPG language selection 1"
+msgstr ""
 
 msgid "EPG language selection 2"
-msgstr "EPG language selection 2"
+msgstr ""
 
 msgid "EPG location"
-msgstr "EPG location"
+msgstr ""
 
-#, fuzzy
 msgid "EPG search"
-msgstr "EPG Search"
+msgstr ""
 
 msgid "EPG selection"
 msgstr ""
 
 msgid "EPG settings"
-msgstr "EPG settings"
+msgstr ""
 
 msgid "EPGSearch"
 msgstr ""
 
 #, python-format
 msgid "ERROR - failed to scan (%s)!"
-msgstr "ERROR - failed to scan (%s)!"
+msgstr ""
 
 msgid "East"
-msgstr "East"
+msgstr ""
 
 msgid "East limit set"
-msgstr "East limit set"
+msgstr ""
 
-#, fuzzy
 msgid "Eastern"
-msgstr "East"
+msgstr ""
 
 msgid "Ecuador"
 msgstr ""
 
 msgid "Edit"
-msgstr "Edit"
+msgstr ""
 
 msgid "Edit Quad Channel Entry"
 msgstr ""
@@ -6499,81 +6352,72 @@ msgid "Edit Title"
 msgstr ""
 
 msgid "Edit chapters of current title"
-msgstr "Edit chapters of current title"
+msgstr ""
 
-#, fuzzy
 msgid "Edit current line"
-msgstr "Jump to current time"
+msgstr ""
 
-#, fuzzy
 msgid "Edit line "
-msgstr "Edit timer"
+msgstr ""
 
-#, fuzzy
 msgid "Edit mode off"
-msgstr "Edit timer"
+msgstr ""
 
-#, fuzzy
 msgid "Edit mode on"
-msgstr "Edit timer"
+msgstr ""
 
 msgid "Edit new entry"
 msgstr ""
 
-#, fuzzy
 msgid "Edit position is the line end"
-msgstr "Moved to position at index"
+msgstr ""
 
 msgid "Edit settings"
-msgstr "Edit settings"
+msgstr ""
 
 #, python-format
 msgid "Edit the Nameserver configuration of your %s %s.\n"
-msgstr "Edit the Nameserver configuration of your %s %s.\n"
+msgstr ""
 
 #, python-format
 msgid "Edit the network configuration of your %s %s.\n"
-msgstr "Edit the network configuration of your %s %s.\n"
+msgstr ""
 
 msgid "Edit timer"
-msgstr "Edit timer"
+msgstr ""
 
 msgid "Edit title"
-msgstr "Edit title"
+msgstr ""
 
 msgid "Edit upgrade source url."
-msgstr "Edit upgrade source url."
+msgstr ""
 
-#, fuzzy
 msgid "Education"
-msgstr "Modulation"
+msgstr ""
 
-#, fuzzy
 msgid "Education/Information"
-msgstr "Translation Information"
+msgstr ""
 
-#, fuzzy
 msgid "Education/Science/Factual"
-msgstr "Education/Science/..."
+msgstr ""
 
 msgid "Egypt"
 msgstr ""
 
-#, fuzzy
 msgid "Einzelsportart"
-msgstr "winter sport"
+msgstr ""
 
 msgid "El Salvador"
 msgstr ""
 
 msgid "Elapsed"
-msgstr "Elapsed"
+msgstr ""
 
 msgid "Elapsed & Remaining"
-msgstr "Elapsed & Remaining"
+msgstr ""
 
 msgid "Electronic Program Guide"
-msgstr "Electronic Program Guide"
+msgstr ""
 
 msgid "Email"
 msgstr ""
@@ -6582,14 +6426,14 @@ msgid "Empty slot"
 msgstr ""
 
 msgid "Enable"
-msgstr "Enable"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Enable %s pro:"
-msgstr "Enable"
+msgstr ""
 
 msgid "Enable 5V for active antenna"
-msgstr "Enable 5V for active antenna"
+msgstr ""
 
 msgid "Enable AC3/Dolby"
 msgstr ""
@@ -6597,9 +6441,8 @@ msgstr ""
 msgid "Enable Autorecord"
 msgstr ""
 
-#, fuzzy
 msgid "Enable BT Audio"
-msgstr "Enabled"
+msgstr ""
 
 msgid "Enable CIHelper for SLOT CI0"
 msgstr ""
@@ -6608,23 +6451,22 @@ msgid "Enable CIHelper for SLOT CI1"
 msgstr ""
 
 msgid "Enable EIT EPG"
-msgstr "Enable EIT EPG"
+msgstr ""
 
 msgid "Enable Focus Animation"
 msgstr ""
 
-#, fuzzy
 msgid "Enable IceTV"
-msgstr "Enable EIT EPG"
+msgstr ""
 
 msgid "Enable MHW EPG"
-msgstr "Enable MHW EPG"
+msgstr ""
 
 msgid "Enable MiniTV"
 msgstr ""
 
 msgid "Enable Netmed EPG"
-msgstr "Enable Netmed EPG"
+msgstr ""
 
 msgid "Enable Network IP address check"
 msgstr ""
@@ -6632,13 +6474,11 @@ msgstr ""
 msgid "Enable Network Traffic check"
 msgstr ""
 
-#, fuzzy
 msgid "Enable OpenTV EPG"
-msgstr "Enable EIT EPG"
+msgstr ""
 
-#, fuzzy
 msgid "Enable Quad PIP"
-msgstr "Enabled"
+msgstr ""
 
 msgid "Enable Swap at startup"
 msgstr ""
@@ -6647,7 +6487,7 @@ msgid "Enable Up / Down buttons for the 'all up / down' function? (at the beginn
 msgstr ""
 
 msgid "Enable ViaSat EPG"
-msgstr "Enable ViaSat EPG"
+msgstr ""
 
 msgid "Enable Virgin EPG"
 msgstr ""
@@ -6674,9 +6514,8 @@ msgstr ""
 msgid "Enable chapter support for video files"
 msgstr ""
 
-#, fuzzy
 msgid "Enable command line function"
-msgstr "Enable panic button"
+msgstr ""
 
 msgid "Enable cut file support for audio files"
 msgstr ""
@@ -6693,9 +6532,8 @@ msgstr ""
 msgid "Enable debug log *"
 msgstr ""
 
-#, fuzzy
 msgid "Enable digital downmix"
-msgstr "Digital downmix"
+msgstr ""
 
 msgid "Enable fallback remote receiver"
 msgstr ""
@@ -6710,14 +6548,13 @@ msgid "Enable intro screen"
 msgstr ""
 
 msgid "Enable multiple bouquets"
-msgstr "Enable multiple bouquets"
+msgstr ""
 
 msgid "Enable panic button"
-msgstr "Enable panic button"
+msgstr ""
 
-#, fuzzy
 msgid "Enable preview"
-msgstr "Enable FreeSat EPG"
+msgstr ""
 
 msgid "Enable remote enigma2 receiver to be tried to tune into services that cannot be tuned into locally (e.g. tuner is occupied or service type is unavailable on the local tuner. Specify complete URL including http:// and port number (normally ...:8001), e.g. http://second_box:8001."
 msgstr ""
@@ -6726,7 +6563,7 @@ msgid "Enable screenshot of LCD in /tmp"
 msgstr ""
 
 msgid "Enable teletext caching"
-msgstr "Enable teletext caching"
+msgstr ""
 
 msgid "Enable terrestrial LCN:"
 msgstr ""
@@ -6740,33 +6577,32 @@ msgstr ""
 msgid "Enable to display all true/false, yes/no, on/off and enable/disable set up options as a graphical switch."
 msgstr ""
 
-#, fuzzy
 msgid "Enable twisted log *"
-msgstr "Enable debug logs"
+msgstr ""
 
 msgid "Enable unlinked bouquets"
 msgstr ""
 
 msgid "Enabled"
-msgstr "Enabled"
+msgstr ""
 
 msgid "Enables a feature so that the receiver can decrypt streams (if the ECM data is included in the stream and a valid card is available)."
-msgstr "Enables a feature so that the receiver can decrypt streams (if the ECM data is included in the stream and a valid card is available)."
+msgstr ""
 
 msgid "Encrypted: "
-msgstr "Encrypted: "
+msgstr ""
 
 msgid "Encryption"
-msgstr "Encryption"
+msgstr ""
 
 msgid "Encryption key"
-msgstr "Encryption key"
+msgstr ""
 
 msgid "Encryption key type"
-msgstr "Encryption key type"
+msgstr ""
 
 msgid "Encryption:"
-msgstr "Encryption:"
+msgstr ""
 
 msgid "End"
 msgstr ""
@@ -6775,13 +6611,13 @@ msgid "End long"
 msgstr ""
 
 msgid "End time"
-msgstr "End time"
+msgstr ""
 
 msgid "Energie"
 msgstr ""
 
 msgid "English"
-msgstr "English"
+msgstr ""
 
 msgid "Enhanced Movie Center"
 msgstr ""
@@ -6799,7 +6635,7 @@ msgid ""
 msgstr ""
 
 msgid "Enigma2 skin selector"
-msgstr "Enigma2 skin selector"
+msgstr ""
 
 msgid ""
 "Enjoy how IceTV can enhance your TV viewing experience by downloading the IceTV app to your smartphone or tablet. The IceTV app is available free from the iTunes App Store, the Google Play Store and the Windows Phone Store.\n"
@@ -6807,9 +6643,8 @@ msgid ""
 "Download it today!"
 msgstr ""
 
-#, fuzzy
 msgid "Enter"
-msgstr "centre"
+msgstr ""
 
 msgid "Enter PIN"
 msgstr ""
@@ -6821,17 +6656,16 @@ msgid "Enter if you are north or south of the equator."
 msgstr ""
 
 msgid "Enter main menu..."
-msgstr "Enter main menu..."
+msgstr ""
 
-#, fuzzy
 msgid "Enter multi-file selection mode"
-msgstr "Close title selection"
+msgstr ""
 
 msgid "Enter persistent PIN code"
 msgstr ""
 
 msgid "Enter pin code"
-msgstr "Enter pin code"
+msgstr ""
 
 msgid "Enter the frequency at which you LNB switches between low band and high band. For more information consult the spec sheet of your LNB."
 msgstr ""
@@ -6843,7 +6677,7 @@ msgid "Enter the number stored in the positioner that corresponds to this satell
 msgstr ""
 
 msgid "Enter the service pin"
-msgstr "Enter the service pin"
+msgstr ""
 
 msgid "Enter your current latitude. This is the number of degrees you are from the equator as a decimal."
 msgstr ""
@@ -6857,12 +6691,11 @@ msgstr ""
 msgid "Enter your low band local oscillator frequency. For more information consult the spec sheet of your LNB."
 msgstr ""
 
-#, fuzzy
 msgid "Entertainment"
-msgstr "Enter main menu..."
+msgstr ""
 
 msgid "Entitlements"
-msgstr "Entitlements"
+msgstr ""
 
 msgid "Epg/Guide"
 msgstr ""
@@ -6882,22 +6715,20 @@ msgstr ""
 msgid "Erase"
 msgstr ""
 
-#, fuzzy
 msgid "Eritrea"
-msgstr "Stream"
+msgstr ""
 
 msgid "Erotik"
 msgstr ""
 
 msgid "Error"
-msgstr "Error"
+msgstr ""
 
-#, fuzzy
 msgid "Error Download Setting"
-msgstr "Downloading"
+msgstr ""
 
 msgid "Error code"
-msgstr "Error code"
+msgstr ""
 
 msgid ""
 "Error creating EHD-Skin.\n"
@@ -6927,21 +6758,21 @@ msgid ""
 "Please check after reboot MyMetrixLite-Plugin and apply your settings."
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Error creating directory %s:\n"
 "%s"
-msgstr "Creating directory %s failed."
+msgstr ""
 
 msgid "Error downloading change log."
-msgstr "Error downloading change log."
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Error during downloading image\n"
 "%s\n"
 "%s"
-msgstr "Error downloading change log."
+msgstr ""
 
 #, python-format
 msgid ""
@@ -6950,7 +6781,7 @@ msgid ""
 msgstr ""
 
 msgid "Error executing plugin"
-msgstr "Error executing plugin"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -6961,16 +6792,14 @@ msgstr ""
 msgid "Error opening recording file"
 msgstr ""
 
-#, fuzzy
 msgid "Error reading bouquets.radio"
-msgstr "Error reading webpage!"
+msgstr ""
 
-#, fuzzy
 msgid "Error reading bouquets.tv"
-msgstr "Error reading webpage!"
+msgstr ""
 
 msgid "Error reading webpage!"
-msgstr "Error reading webpage!"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -6981,25 +6810,20 @@ msgstr ""
 msgid "Error, unknown Result!"
 msgstr ""
 
-#, fuzzy
 msgid "Error..."
-msgstr "Error"
+msgstr ""
 
 #, python-format
 msgid ""
 "Error:\n"
 "%s"
 msgstr ""
-"Error:\n"
-"%s"
 
 #, python-format
 msgid ""
 "Error: %s\n"
 "Retry?"
 msgstr ""
-"Error: %s\n"
-"Retry?"
 
 msgid "Es folgt:"
 msgstr ""
@@ -7010,15 +6834,14 @@ msgstr ""
 msgid "Essen"
 msgstr ""
 
-#, fuzzy
 msgid "Estonia"
-msgstr "Estonian"
+msgstr ""
 
 msgid "Estonian"
-msgstr "Estonian"
+msgstr ""
 
 msgid "Ethernet network interface"
-msgstr "Ethernet network interface"
+msgstr ""
 
 msgid "Ethiopia"
 msgstr ""
@@ -7035,18 +6858,17 @@ msgstr ""
 msgid "Even if a 'zap' recording timer starting?"
 msgstr ""
 
-#, fuzzy
 msgid "Event"
-msgstr "Event Info"
+msgstr ""
 
 msgid "Event Info"
-msgstr "Event Info"
+msgstr ""
 
 msgid "Event font size"
-msgstr "Event font size"
+msgstr ""
 
 msgid "Event view"
-msgstr "Event view"
+msgstr ""
 
 msgid "Event view menu"
 msgstr ""
@@ -7060,21 +6882,20 @@ msgstr ""
 msgid "Eventview menu"
 msgstr ""
 
-#, fuzzy
 msgid "Eventview:"
-msgstr "Event view"
+msgstr ""
 
 msgid "Everyday"
 msgstr ""
 
 msgid "Everywhere"
-msgstr "Everywhere"
+msgstr ""
 
 msgid "Exceeds Bludisc medium!"
 msgstr ""
 
 msgid "Exceeds dual layer medium!"
-msgstr "Exceeds dual layer medium!"
+msgstr ""
 
 msgid "Execute after current event"
 msgstr ""
@@ -7086,59 +6907,58 @@ msgid "Execution condition"
 msgstr ""
 
 msgid "Execution finished!!"
-msgstr "Execution finished!!"
+msgstr ""
 
 msgid "Execution progress:"
-msgstr "Execution progress:"
+msgstr ""
 
 msgid "Exif"
-msgstr "Exif"
+msgstr ""
 
 msgid "Existing or trial user"
 msgstr ""
 
 msgid "Exit"
-msgstr "Exit"
+msgstr ""
 
 msgid "Exit EPG"
-msgstr "Exit EPG"
+msgstr ""
 
 msgid "Exit MAC-address configuration"
-msgstr "Exit MAC-address configuration"
+msgstr ""
 
-#, fuzzy
 msgid "Exit Quad Channel Selection"
-msgstr "Channel selection"
+msgstr ""
 
 msgid "Exit editor"
-msgstr "Exit editor"
+msgstr ""
 
 msgid "Exit editor and write changes (if any)"
 msgstr ""
 
 msgid "Exit input device selection."
-msgstr "Exit input device selection."
+msgstr ""
 
 msgid "Exit media player?"
-msgstr "Exit media player?"
+msgstr ""
 
 msgid "Exit mediaplayer"
-msgstr "Exit mediaplayer"
+msgstr ""
 
 msgid "Exit movie list"
-msgstr "Exit movie list"
+msgstr ""
 
 msgid "Exit movie player?"
-msgstr "Exit movie player?"
+msgstr ""
 
 msgid "Exit nameserver configuration"
-msgstr "Exit nameserver configuration"
+msgstr ""
 
 msgid "Exit network interface list"
-msgstr "Exit network interface list"
+msgstr ""
 
 msgid "Exit network wizard"
-msgstr "Exit network wizard"
+msgstr ""
 
 msgid "Exit picture viewer"
 msgstr ""
@@ -7147,14 +6967,13 @@ msgid "Exit quad PiP"
 msgstr ""
 
 msgid "Exit the wizard"
-msgstr "Exit the wizard"
+msgstr ""
 
 msgid "Expand"
 msgstr ""
 
-#, fuzzy
 msgid "Experimental mode"
-msgstr "experimental film/video"
+msgstr ""
 
 msgid "Experimental: strict limitation to preferred tuners"
 msgstr ""
@@ -7163,11 +6982,10 @@ msgid "Experimental: strict limitation to preferred tuners for recordings"
 msgstr ""
 
 msgid "Expert"
-msgstr "Expert"
+msgstr ""
 
-#, fuzzy
 msgid "Expert mode"
-msgstr "Expert"
+msgstr ""
 
 msgid "Extend"
 msgstr ""
@@ -7179,40 +6997,40 @@ msgid "Extended GUI"
 msgstr ""
 
 msgid "Extended Networksetup Plugin..."
-msgstr "Extended Network setup Plugin..."
+msgstr ""
 
 msgid "Extended Setup..."
-msgstr "Extended Setup..."
+msgstr ""
 
 msgid "Extended Shares"
-msgstr "Extended Shares"
+msgstr ""
 
 msgid "Extended Software"
-msgstr "Extended Software"
+msgstr ""
 
 msgid "Extended Software Plugin"
-msgstr "Extended Software Plugin"
+msgstr ""
 
 msgid "Extended network setup plugin..."
-msgstr "Extended network setup plugin..."
+msgstr ""
 
 msgid "Extended settings"
 msgstr ""
 
 msgid "Extended setup..."
-msgstr "Extended setup..."
+msgstr ""
 
 msgid "Extensions"
-msgstr "Extensions"
+msgstr ""
 
 msgid "Extensions management"
-msgstr "Extensions management"
+msgstr ""
 
 msgid "Extensions/QuickMenu"
 msgstr ""
 
 msgid "External"
-msgstr "External"
+msgstr ""
 
 msgid "External PiP"
 msgstr ""
@@ -7222,10 +7040,11 @@ msgid "External Storage %s"
 msgstr ""
 
 msgid "External subtitle color"
-msgstr "External subtitle color"
+msgstr "External subtitle colour"
 
+#. TRANSLATORS: override en_US
 msgid "External subtitle dialog colorisation"
-msgstr ""
+msgstr "External subtitle dialogue colourisation"
 
 msgid "External subtitle switch fonts"
 msgstr ""
@@ -7233,9 +7052,8 @@ msgstr ""
 msgid "Extra motor options"
 msgstr ""
 
-#, fuzzy
 msgid "Extremsport"
-msgstr "team sports"
+msgstr ""
 
 msgid "Extrude from left"
 msgstr ""
@@ -7271,17 +7089,16 @@ msgid "FCC 1953"
 msgstr ""
 
 msgid "FEC"
-msgstr "FEC"
+msgstr ""
 
 msgid "FIFO"
 msgstr ""
 
 msgid "FLASH"
-msgstr "FLASH"
+msgstr ""
 
-#, fuzzy
 msgid "FP Upgrade"
-msgstr "Upgrading"
+msgstr ""
 
 msgid "FSBL Update Check"
 msgstr ""
@@ -7293,10 +7110,10 @@ msgid "FTP"
 msgstr ""
 
 msgid "FTP Setup"
-msgstr "FTP Setup"
+msgstr ""
 
 msgid "Factory reset"
-msgstr "Factory reset"
+msgstr ""
 
 msgid "Fade the Infobar on hide"
 msgstr ""
@@ -7305,14 +7122,13 @@ msgid "Fahrenheit"
 msgstr ""
 
 msgid "Failed"
-msgstr "Failed"
+msgstr ""
 
 msgid "Failed to write /tmp/positionersetup.log: "
-msgstr "Failed to write /tmp/positionersetup.log: "
+msgstr ""
 
-#, fuzzy
 msgid "Failed:"
-msgstr "Failed"
+msgstr ""
 
 msgid "Falkland Islands (Malvinas)"
 msgstr ""
@@ -7320,9 +7136,8 @@ msgstr ""
 msgid "Fallback remote receiver URL"
 msgstr ""
 
-#, fuzzy
 msgid "False"
-msgstr "false"
+msgstr ""
 
 msgid "Familie"
 msgstr ""
@@ -7332,7 +7147,7 @@ msgstr ""
 
 #, python-format
 msgid "Fan %d"
-msgstr "Fan %d"
+msgstr ""
 
 msgid "Fantasy"
 msgstr ""
@@ -7341,29 +7156,30 @@ msgid "Faroe Islands"
 msgstr ""
 
 msgid "Fast"
-msgstr "Fast"
+msgstr ""
 
 msgid "Fast DiSEqC"
-msgstr "Fast DiSEqC"
+msgstr ""
 
 msgid "Fast Scan"
-msgstr "Fast Scan"
+msgstr ""
 
 msgid "Fast epoch"
-msgstr "Fast epoch"
+msgstr ""
 
 msgid "Fast forward speeds"
-msgstr "Fast forward speeds"
+msgstr ""
 
 msgid "Fastforward"
 msgstr ""
 
 msgid "Favorites"
-msgstr ""
+msgstr "Favourites button"
 
 msgid "Favorites long"
-msgstr ""
+msgstr "Favourites hold"
 
+#. TRANSLATORS: override en_US
 msgid "Favourites"
 msgstr "Favourites"
 
@@ -7388,9 +7204,8 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#, fuzzy
 msgid "File Commander"
-msgstr "Command order"
+msgstr ""
 
 msgid "File Commander - Addon File-Viewer"
 msgstr ""
@@ -7404,8 +7219,9 @@ msgstr ""
 msgid "File Commander - all Task's are completed!"
 msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "File Commander - generalised archive handler"
-msgstr ""
+msgstr "File Commander - generalised archive handler"
 
 msgid "File Commander - gzip Addon"
 msgstr ""
@@ -7422,19 +7238,17 @@ msgstr ""
 msgid "File Commander - unzip Addon"
 msgstr ""
 
-#, fuzzy
 msgid "File Commander Settings"
-msgstr "Video Enhancement Settings"
+msgstr ""
 
-#, fuzzy
 msgid "File Commander context menu"
-msgstr "Channel list context menu"
+msgstr ""
 
 msgid "File Commander menu"
 msgstr ""
 
 msgid "File appears to be busy.\n"
-msgstr "File appears to be busy.\n"
+msgstr ""
 
 msgid "File checksums to calculate for button 9"
 msgstr ""
@@ -7445,33 +7259,30 @@ msgstr ""
 msgid "File long"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "File not found: %s"
-msgstr "Video mode: %s"
+msgstr ""
 
 msgid ""
 "File oscam.conf not found.\n"
 "Please enter username/password manually."
 msgstr ""
-"File oscam.conf not found.\n"
-"Please enter username/password manually."
 
 msgid "File transfer was cancelled by user"
-msgstr ""
+msgstr "File transfer was cancelled"
 
 #, python-format
 msgid "File write error: '%s'"
 msgstr ""
 
-#, fuzzy
 msgid "File/Directory Status Information"
-msgstr "Memory Information"
+msgstr ""
 
 msgid "Files/folders to exclude from backup"
 msgstr ""
 
 msgid "Filesystem Check"
-msgstr "Filesystem Check"
+msgstr ""
 
 msgid "Filesystem check your Harddisk"
 msgstr ""
@@ -7489,64 +7300,61 @@ msgid "Filter visible file classes by extension."
 msgstr ""
 
 msgid "Final position at"
-msgstr "Final position at"
+msgstr ""
 
 msgid "Final position at index"
-msgstr "Final position at index"
+msgstr ""
 
 msgid "Final scroll delay"
 msgstr ""
 
-#, fuzzy
 msgid "Finance"
-msgstr "romance"
+msgstr ""
 
 msgid "Fine movement"
-msgstr "Fine movement"
+msgstr ""
 
 msgid "Finetune"
-msgstr "Fine tune"
+msgstr ""
 
 msgid "Finished"
-msgstr "Finished"
+msgstr ""
 
 msgid "Finished configuring your network"
-msgstr "Finished configuring your network"
+msgstr ""
 
 msgid "Finished restarting your network"
-msgstr "Finished restarting your network"
+msgstr ""
 
 msgid "Finland"
 msgstr ""
 
 msgid "Finnish"
-msgstr "Finnish"
+msgstr ""
 
 msgid "First playable timeshift file!"
 msgstr ""
 
-#, fuzzy
 msgid "Fishing"
-msgstr "Flashing"
+msgstr ""
 
 msgid "Fixed"
-msgstr "Fixed"
+msgstr ""
 
 msgid "Fixed X11 font (SD)"
 msgstr ""
 
 msgid "Flash"
-msgstr "Flash"
+msgstr ""
 
-#, fuzzy
 msgid "Flash Image"
-msgstr "Flashing"
+msgstr ""
 
 msgid "Flash On the Fly"
 msgstr ""
 
 msgid "Flash Online"
-msgstr "Flash Online/Local"
+msgstr ""
 
 msgid "Flash Online a new image"
 msgstr ""
@@ -7555,14 +7363,13 @@ msgid "Flash on the fly your your Receiver software."
 msgstr ""
 
 msgid "Flashing"
-msgstr "Flashing"
+msgstr ""
 
-#, fuzzy
 msgid "Flashing Image"
-msgstr "Flashing failed"
+msgstr ""
 
 msgid "Flashing failed"
-msgstr "Flashing failed"
+msgstr ""
 
 msgid "Flashing image successful"
 msgstr ""
@@ -7574,25 +7381,29 @@ msgid ""
 msgstr ""
 
 msgid "Following tasks will be done after you press OK!"
-msgstr "Following tasks will be done after you press OK!"
+msgstr ""
 
-#, fuzzy
 msgid "Font size"
-msgstr "Font size"
+msgstr ""
 
-#, fuzzy
 msgid "Font:"
-msgstr "Font size"
+msgstr ""
 
 msgid "Fontsize"
-msgstr "Font size"
+msgstr ""
 
 msgid "Food/Wine"
 msgstr ""
 
-#, fuzzy
 msgid "Football"
-msgstr "football/soccer"
+msgstr ""
+
+msgid ""
+"For faster operation, the BLUE button only needs to be pressed once to use!\n"
+"BlueSwitch: Blue-Short/Blue-Long  ->  Extensions/QuickMenu\n"
+"\n"
+"Set this option now?"
+msgstr ""
 
 msgid "For more information see http://www.opena.tv"
 msgstr ""
@@ -7600,9 +7411,8 @@ msgstr ""
 msgid "Force LNB Power"
 msgstr ""
 
-#, fuzzy
 msgid "Force LNB Tuner Power settings."
-msgstr "Tuner settings"
+msgstr ""
 
 msgid "Force LNB Tuner ToneBurst settings."
 msgstr ""
@@ -7610,15 +7420,14 @@ msgstr ""
 msgid "Force Legacy Signal stats"
 msgstr ""
 
-#, fuzzy
 msgid "Force ToneBurst"
-msgstr "Toneburst"
+msgstr ""
 
 msgid "Force de-interlace"
-msgstr "Force de-interlace"
+msgstr ""
 
 msgid "Format"
-msgstr "Format"
+msgstr ""
 
 msgid "Format HDD"
 msgstr ""
@@ -7627,49 +7436,46 @@ msgid "Format your Harddisk"
 msgstr ""
 
 msgid "Forward volume keys"
-msgstr "Forward volume keys"
+msgstr ""
 
-#, fuzzy
 msgid "Frame rate"
-msgstr "Refresh rate"
+msgstr ""
 
 msgid "Frame size in full view"
-msgstr "Frame size in full view"
+msgstr ""
 
-#, fuzzy
 msgid "France"
-msgstr "romance"
+msgstr ""
 
 msgid "Frauen"
 msgstr ""
 
 msgid "Free Memory:"
-msgstr "Free Memory:"
+msgstr ""
 
 msgid "Free Swap:"
-msgstr "Free Swap:"
+msgstr ""
 
 msgid "Free memory"
-msgstr "Free memory"
+msgstr ""
 
 msgid "Free memory:"
-msgstr "Free memory:"
+msgstr ""
 
 msgid "Free:"
-msgstr "Free:"
+msgstr ""
 
 msgid "Free: "
-msgstr "Free: "
+msgstr ""
 
 msgid "FreeSpace"
 msgstr ""
 
 msgid "French"
-msgstr "French"
+msgstr ""
 
-#, fuzzy
 msgid "French Guiana"
-msgstr "French"
+msgstr ""
 
 msgid "French Polynesia"
 msgstr ""
@@ -7678,34 +7484,37 @@ msgid "French Southern Territories"
 msgstr ""
 
 msgid "Frequency"
-msgstr "Frequency"
+msgstr ""
 
 msgid "Frequency bands"
-msgstr "Frequency bands"
+msgstr ""
 
 msgid "Frequency scan step size(khz)"
-msgstr "Frequency scan step size(kHz)"
+msgstr ""
 
 msgid "Frequency steps"
-msgstr "Frequency steps"
+msgstr ""
 
-#, fuzzy
 msgid "Frequency: "
-msgstr "Frequency"
+msgstr ""
 
 msgid "Fri"
-msgstr "Fri"
+msgstr ""
 
 msgid "Friday"
-msgstr "Friday"
+msgstr ""
 
 msgid "From :"
-msgstr "From :"
+msgstr ""
 
 msgid "Front USB"
 msgstr ""
 
 msgid "Front USB 3.0"
+msgstr ""
+
+#, python-format
+msgid "Frontprocessor version:\t%s"
 msgstr ""
 
 #, python-format
@@ -7723,14 +7532,13 @@ msgid "Full back-up on %s"
 msgstr ""
 
 msgid "Full transparency"
-msgstr "Full transparency"
+msgstr ""
 
 msgid "FullHD Test"
 msgstr ""
 
-#, fuzzy
 msgid "Fullbackup Images"
-msgstr "Flashing"
+msgstr ""
 
 msgid "Fullscreen"
 msgstr ""
@@ -7745,22 +7553,19 @@ msgid "Für Kinder"
 msgstr ""
 
 msgid "GB"
-msgstr "GB"
+msgstr ""
 
 msgid "GIGABLUE Black"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "GStreamer:\t\t%s"
-msgstr "Stream"
+msgstr ""
 
-#, fuzzy
 msgid ""
 "GUI needs a restart to apply a new language\n"
 "Do you want to restart the GUI now?"
 msgstr ""
-"GUI needs a restart to apply a new skin\n"
-"Do you want to restart the GUI now?"
 
 msgid ""
 "GUI needs a restart to apply a new skin\n"
@@ -7771,8 +7576,6 @@ msgid ""
 "GUI needs a restart to apply a new skin\n"
 "Do you want to restart the GUI now?"
 msgstr ""
-"GUI needs a restart to apply a new skin\n"
-"Do you want to restart the GUI now?"
 
 msgid "Gabon"
 msgstr ""
@@ -7780,77 +7583,71 @@ msgstr ""
 msgid "Gambia"
 msgstr ""
 
-#, fuzzy
 msgid "Game Show"
-msgstr "Show Games show"
+msgstr ""
 
 msgid "Gangster"
 msgstr ""
 
-#, fuzzy
 msgid "Gardening"
-msgstr "gardening"
+msgstr ""
 
 msgid "Garten"
 msgstr ""
 
 msgid "Gateway"
-msgstr "Gateway"
+msgstr ""
 
 msgid "General"
-msgstr "General"
+msgstr ""
 
 msgid "General AC3 delay"
-msgstr "General AC3 delay"
+msgstr ""
 
-#, fuzzy
 msgid "General BT Audio delay"
-msgstr "General AC3 delay"
+msgstr ""
 
 msgid "General PCM delay"
-msgstr "General PCM delay"
+msgstr ""
 
-#, fuzzy
 msgid "Generic"
-msgstr "General"
+msgstr ""
 
 msgid "Genre"
-msgstr "Genre"
+msgstr ""
 
 msgid "Georgia"
 msgstr ""
 
 msgid "German"
-msgstr "German"
+msgstr ""
 
-#, fuzzy
 msgid "Germany"
-msgstr "German"
+msgstr ""
 
 msgid "Geschichte"
 msgstr ""
 
-#, fuzzy
 msgid "Gesellschaft"
-msgstr "Deselect"
+msgstr ""
 
 msgid "Gesundheit"
 msgstr ""
 
 msgid "Get latest experimental image"
-msgstr "Get latest experimental image"
+msgstr ""
 
 msgid "Get latest release image"
-msgstr "Get latest release image"
+msgstr ""
 
 msgid "Getting Event Info failed!"
-msgstr "Getting Event Info failed!"
+msgstr ""
 
 msgid "Getting Softcam list. Please wait..."
 msgstr ""
 
 msgid "Getting plugin information. Please wait..."
-msgstr "Getting plugin information. Please wait..."
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7859,20 +7656,19 @@ msgid "Gibraltar"
 msgstr ""
 
 msgid "Go down the list"
-msgstr "Go down the list"
+msgstr ""
 
 msgid "Go to bookmarked folder"
 msgstr ""
 
-#, fuzzy
 msgid "Go to end of file"
-msgstr "Jump to end of list"
+msgstr ""
 
 msgid "Go to first movie or last item"
-msgstr "Go to first movie or last item"
+msgstr ""
 
 msgid "Go to first movie or top of list"
-msgstr "Go to first movie or top of list"
+msgstr ""
 
 msgid "Go to first service"
 msgstr ""
@@ -7886,9 +7682,8 @@ msgstr ""
 msgid "Go to next page of service"
 msgstr ""
 
-#, fuzzy
 msgid "Go to parent directory"
-msgstr "Parent directory"
+msgstr ""
 
 msgid "Go to previous event"
 msgstr ""
@@ -7896,12 +7691,11 @@ msgstr ""
 msgid "Go to previous page of service"
 msgstr ""
 
-#, fuzzy
 msgid "Go to start of file"
-msgstr "about to start"
+msgstr ""
 
 msgid "Go up the list"
-msgstr "Go up the list"
+msgstr ""
 
 msgid "Gold"
 msgstr ""
@@ -7910,95 +7704,91 @@ msgid "Golf"
 msgstr ""
 
 msgid "Goto"
-msgstr "Goto"
+msgstr ""
 
 msgid "Goto 0"
-msgstr "Goto 0"
+msgstr ""
 
 msgid "Goto :"
-msgstr "Goto :"
+msgstr ""
 
 msgid "Goto Date/Time"
 msgstr ""
 
-#, fuzzy
 msgid "Goto Date/Timer"
-msgstr "Auto Timers"
+msgstr ""
 
-#, fuzzy
 msgid "Goto Primetime"
-msgstr "Jump to prime time"
+msgstr ""
 
 msgid "Goto X"
-msgstr "Goto X"
+msgstr ""
 
 msgid "Goto index position"
-msgstr "Goto index position"
+msgstr ""
 
 msgid "Goto next bouquet"
-msgstr "Goto next bouquet"
+msgstr ""
 
 msgid "Goto next channel"
-msgstr "Goto next channel"
+msgstr ""
 
 msgid "Goto next day of events"
 msgstr ""
 
 msgid "Goto next event"
-msgstr "Goto next event"
+msgstr ""
 
 msgid "Goto next page of events"
 msgstr ""
 
 msgid "Goto position"
-msgstr "Goto position"
+msgstr ""
 
 msgid "Goto previous bouquet"
-msgstr "Goto previous bouquet"
+msgstr ""
 
 msgid "Goto previous channel"
-msgstr "Goto previous channel"
+msgstr ""
 
 msgid "Goto previous day of events"
 msgstr ""
 
 msgid "Goto previous event"
-msgstr "Goto previous event"
+msgstr ""
 
 msgid "Goto previous page of events"
 msgstr ""
 
 msgid "Goto specific data/time"
-msgstr "Goto specific data/time"
+msgstr ""
 
 msgid "GotoX calibration"
-msgstr "GotoX calibration"
+msgstr ""
 
 msgid "Graphical EPG"
-msgstr "Graphical EPG"
+msgstr ""
 
 msgid "Graphical InfobarEPG settings"
 msgstr ""
 
 msgid "GraphicalEPG settings"
-msgstr "GraphicalEPG settings"
+msgstr ""
 
 msgid "Graphics"
-msgstr "Graphics"
+msgstr ""
 
-#, fuzzy
 msgid "Greece"
-msgstr "Greek"
+msgstr ""
 
 msgid "Greek"
-msgstr "Greek"
+msgstr ""
 
 msgid "Green"
 msgstr ""
 
-#, fuzzy
 msgid "Green button"
-msgstr "Red button..."
+msgstr ""
 
 msgid "Green long"
 msgstr ""
@@ -8006,12 +7796,11 @@ msgstr ""
 msgid "Greenland"
 msgstr ""
 
-#, fuzzy
 msgid "Grenada"
-msgstr "rename"
+msgstr ""
 
 msgid "Grey"
-msgstr "Grey"
+msgstr ""
 
 msgid "Group:"
 msgstr ""
@@ -8029,7 +7818,7 @@ msgid "Guam"
 msgstr ""
 
 msgid "Guard interval"
-msgstr "Guard interval"
+msgstr ""
 
 msgid "Guatemala"
 msgstr ""
@@ -8050,7 +7839,7 @@ msgid "H7/H9/H9COMBO/H10 new Model"
 msgstr ""
 
 msgid "H: = Hourly / D: = Daily / W: = Weekly / M: = Monthly"
-msgstr "H: = Hourly / D: = Daily / W: = Weekly / M: = Monthly"
+msgstr ""
 
 msgid "H:mm"
 msgstr ""
@@ -8062,7 +7851,7 @@ msgid "HARD DISK: "
 msgstr ""
 
 msgid "HD list"
-msgstr "HD list"
+msgstr ""
 
 msgid "HD11/HD51/HD1100/HD1200/HD1265/HD1500/HD500C/HD530C/VS1000/VS1500"
 msgstr ""
@@ -8077,40 +7866,37 @@ msgid "HD60"
 msgstr ""
 
 msgid "HDMI"
-msgstr "HDMI"
+msgstr ""
 
 msgid "HDMI CEC"
-msgstr "HDMI CEC"
+msgstr ""
 
 msgid "HDMI CEC Setup"
-msgstr "HDMI CEC Setup"
+msgstr ""
 
 msgid "HDMI Colordepth"
-msgstr ""
+msgstr "HDMI colour depth/bit depth"
 
 msgid "HDMI Colorimetry"
-msgstr ""
+msgstr "HDMI colourimetry"
 
 msgid "HDMI Colorspace"
-msgstr ""
+msgstr "HDMI colour space"
 
 msgid "HDMI HDR Type"
 msgstr ""
 
-#, fuzzy
 msgid "HDMI Recording"
-msgstr "Recording"
+msgstr ""
 
-#, fuzzy
 msgid "HDMI-IN Recording settings"
-msgstr "Recording settings"
+msgstr ""
 
 msgid "HDMIin"
 msgstr ""
 
-#, fuzzy
 msgid "HDR10 Support"
-msgstr "DLNA support"
+msgstr ""
 
 msgid "HELP"
 msgstr ""
@@ -8124,13 +7910,11 @@ msgstr ""
 msgid "HI-cleanup for external subtitles"
 msgstr ""
 
-#, fuzzy
 msgid "HLG Support"
-msgstr "DLNA support"
+msgstr ""
 
-#, fuzzy
 msgid "Haiti"
-msgstr "Waiting"
+msgstr ""
 
 msgid "Handball"
 msgstr ""
@@ -8138,21 +7922,20 @@ msgstr ""
 msgid "Handle Python crashes"
 msgstr ""
 
-#, fuzzy
 msgid "Handle input from TV"
-msgstr "Handle wakeup from TV"
+msgstr ""
 
 msgid "Handle standby from TV"
-msgstr "Handle standby from TV"
+msgstr ""
 
 msgid "Handle wakeup from TV"
-msgstr "Handle wakeup from TV"
+msgstr ""
 
 msgid "Hard disk setup"
-msgstr "Hard disk setup"
+msgstr ""
 
 msgid "Hard disk standby after"
-msgstr "Hard disk standby after"
+msgstr ""
 
 msgid "Hard disk standby in box standby after"
 msgstr ""
@@ -8167,10 +7950,10 @@ msgid "Heard Island and McDonald Islands"
 msgstr ""
 
 msgid "Hebrew"
-msgstr "Hebrew"
+msgstr ""
 
 msgid "Height"
-msgstr "Height"
+msgstr ""
 
 msgid "Heimat"
 msgstr ""
@@ -8205,96 +7988,92 @@ msgstr ""
 msgid "Here you can specify additional files that should be added to the backup file."
 msgstr ""
 
-#, fuzzy
 msgid "Hidden / Blank"
-msgstr "Hidden network"
+msgstr ""
 
 msgid "Hidden network"
-msgstr "Hidden network"
+msgstr ""
 
 msgid "Hide VBI line for this service"
 msgstr ""
 
 msgid "Hide any zap error messages."
-msgstr "Hide any zap error messages."
+msgstr ""
 
 msgid "Hide known extensions"
-msgstr "Hide known extensions"
+msgstr ""
 
 msgid "Hide mute notification"
 msgstr ""
 
-#, fuzzy
 msgid "Hide number markers"
-msgstr "insert mark here"
+msgstr ""
 
 msgid "Hide parental locked services"
 msgstr ""
 
 msgid "Hide player"
-msgstr "Hide player"
+msgstr ""
 
 msgid "Hide zap errors"
-msgstr "Hide zap errors"
+msgstr ""
 
 msgid "Hierarchy info"
-msgstr "Hierarchy info"
+msgstr ""
 
 msgid "Hierarchy information"
-msgstr "Hierarchy information"
+msgstr ""
 
 msgid "High bitrate support"
-msgstr "High bitrate support"
+msgstr ""
 
 msgid "Hispasat 30.0w"
 msgstr ""
 
-#, fuzzy
 msgid "Historical"
-msgstr "History zap..."
+msgstr ""
 
-#, fuzzy
 msgid "History"
-msgstr "History zap..."
+msgstr ""
+
+msgid "History Zap..."
+msgstr ""
 
 msgid "History back"
 msgstr ""
 
 msgid "History buttons mode"
-msgstr "History buttons mode"
+msgstr ""
 
-#, fuzzy
 msgid "History long"
-msgstr "History buttons mode"
+msgstr ""
 
 msgid "History next"
 msgstr ""
 
 msgid "History zap..."
-msgstr "History zap..."
+msgstr ""
 
 msgid "Hobbys"
 msgstr ""
 
-#, fuzzy
 msgid "Hockey"
-msgstr "locked"
+msgstr ""
 
 msgid "Hold screen"
-msgstr "Hold screen"
+msgstr ""
 
 msgid "Hold till locked"
-msgstr "Hold till locked"
+msgstr ""
 
 msgid "Holy See"
 msgstr ""
 
 msgid "Home"
-msgstr "Home"
+msgstr ""
 
-#, fuzzy
 msgid "Home long"
-msgstr "Home"
+msgstr ""
 
 msgid "Homepage"
 msgstr ""
@@ -8308,39 +8087,35 @@ msgstr ""
 msgid "Hong Kong"
 msgstr ""
 
-#, fuzzy
 msgid "Hops"
-msgstr "Hops:"
+msgstr ""
 
 msgid "Hops:"
-msgstr "Hops:"
+msgstr ""
 
 msgid "Horizontal"
-msgstr "Horizontal"
+msgstr ""
 
-#, fuzzy
 msgid "Horizontal icons"
-msgstr "Horizontal"
+msgstr ""
 
-#, fuzzy
 msgid "Horizontal menu"
-msgstr "Horizontal"
+msgstr ""
 
 msgid "Horizontal turning speed"
-msgstr "Horizontal turning speed"
+msgstr ""
 
-#, fuzzy
 msgid "Horror"
-msgstr "Error"
+msgstr ""
 
 msgid "Horse Racing"
 msgstr ""
 
 msgid "Hostname:"
-msgstr "Hostname:"
+msgstr ""
 
 msgid "Hostname: "
-msgstr "Hostname: "
+msgstr ""
 
 msgid "Hotbird 13.0e"
 msgstr ""
@@ -8355,45 +8130,43 @@ msgid "Hotkey Setup for"
 msgstr ""
 
 msgid "Hour"
-msgstr "Hour"
+msgstr ""
 
 msgid "Hourly"
-msgstr "Hourly"
+msgstr ""
 
 msgid "Hours Mins"
-msgstr "Hours Mins"
+msgstr ""
 
 msgid "Hours Mins Secs"
-msgstr "Hours Mins Secs"
+msgstr ""
 
 msgid "How many minutes do you want to record?"
-msgstr "How many minutes do you want to record?"
+msgstr ""
 
 msgid "Hue"
-msgstr "Hue"
+msgstr ""
 
 msgid "Hungarian"
-msgstr "Hungarian"
+msgstr ""
 
-#, fuzzy
 msgid "Hungary"
-msgstr "Hungarian"
+msgstr ""
 
 msgid "I/O priority for script execution"
 msgstr ""
 
-#, fuzzy
 msgid "IMDB search"
-msgstr "IMDB Search"
+msgstr ""
 
 msgid "IMDB search for current event"
-msgstr "IMDB search for current event"
+msgstr ""
 
 msgid "IMDb Details"
 msgstr ""
 
 msgid "IMDb Search"
-msgstr "IMDB Search"
+msgstr ""
 
 msgid "INFO"
 msgstr ""
@@ -8407,24 +8180,23 @@ msgstr ""
 msgid "INS"
 msgstr ""
 
-#, fuzzy
 msgid "IP"
-msgstr "IP:"
+msgstr ""
 
 msgid "IP address"
-msgstr "IP address"
+msgstr ""
 
 msgid "IP:"
-msgstr "IP:"
+msgstr ""
 
 msgid "IPK Installer"
 msgstr ""
 
 msgid "ISO file is too large for this filesystem!"
-msgstr "ISO file is too large for this filesystem!"
+msgstr ""
 
 msgid "ISO path"
-msgstr "ISO path"
+msgstr ""
 
 msgid "IceTV"
 msgstr ""
@@ -8441,33 +8213,26 @@ msgstr ""
 msgid "IceTV - Region"
 msgstr ""
 
-#, fuzzy
 msgid "IceTV - Service selection"
-msgstr "Movie selection"
+msgstr ""
 
-#, fuzzy
 msgid "IceTV - Setup"
-msgstr "Setup"
+msgstr ""
 
-#, fuzzy
 msgid "IceTV - User Information"
-msgstr "Image Information"
+msgstr ""
 
-#, fuzzy
 msgid "IceTV disabled"
-msgstr "disabled"
+msgstr ""
 
-#, fuzzy
 msgid "IceTV enabled"
-msgstr "enabled"
+msgstr ""
 
-#, fuzzy
 msgid "IceTV setup wizard"
-msgstr "Video wizard"
+msgstr ""
 
-#, fuzzy
 msgid "IceTV update completed OK"
-msgstr "Backup completed."
+msgstr ""
 
 msgid ""
 "IceTV update completed with errors.\n"
@@ -8475,18 +8240,18 @@ msgid ""
 "Please check the log for details."
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "IceTV version %s"
-msgstr "Version: %s"
+msgstr ""
 
 msgid "Iceland"
 msgstr ""
 
 msgid "Icons"
-msgstr "Icons"
+msgstr ""
 
 msgid "Idle Time: "
-msgstr "Idle Time: "
+msgstr ""
 
 msgid "If 'never', will force restart despite that after 100 crashes."
 msgstr ""
@@ -8498,10 +8263,10 @@ msgid "If editing a file, can you set the cursor start position at end or begin 
 msgstr ""
 
 msgid "If enabled the output resolution of the box will try to match the resolution of the video contents resolution"
-msgstr "If enabled the output resolution of the box will try to match the resolution of the video contents resolution"
+msgstr ""
 
 msgid "If enabled the video will always be de-interlaced."
-msgstr "If enabled the video will always be de-interlaced."
+msgstr ""
 
 msgid "If enabled, AIT data is included in recordings."
 msgstr ""
@@ -8522,40 +8287,40 @@ msgid "If set to 'no', timeshift used only one buffer file. It's recommend 'Time
 msgstr ""
 
 msgid "If set to 'yes' channels without EPG will not be shown."
-msgstr "If set to 'yes' channels without EPG will not be shown."
+msgstr ""
 
 msgid "If set to 'yes' it will show the 'PO' packages in browser."
-msgstr "If set to 'yes' it will show the 'PO' packages in browser."
+msgstr ""
 
 msgid "If set to 'yes' it will show the 'SRC' packages in browser."
-msgstr "If set to 'yes' it will show the 'SRC' packages in browser."
+msgstr ""
 
 msgid "If set to 'yes' shows a small TV-screen in the EPG."
-msgstr "If set to 'yes' shows a small TV-screen in the EPG."
+msgstr ""
 
 msgid "If set to 'yes' signal values (SNR, etc) will be calculated from API V3. This is an old API version that has now been superseded."
 msgstr ""
 
 msgid "If set to 'yes' the bouquets will be shown each time you open the EPG."
-msgstr "If set to 'yes' the bouquets will be shown each time you open the EPG."
+msgstr ""
 
 msgid "If set to 'yes' the channel list will be shown after switching between radio and TV modes."
-msgstr "If set to 'yes' the channel list will be shown after switching between radio and TV modes."
+msgstr ""
 
 msgid "If set to 'yes' the channel number will be displayed in the infobar."
-msgstr "If set to 'yes' the channel number will be displayed in the infobar."
+msgstr ""
 
 msgid "If set to 'yes' the infobar will be displayed when a new event starts."
-msgstr "If set to 'yes' the infobar will be displayed when a new event starts."
+msgstr ""
 
 msgid "If set to 'yes' the infobar will be displayed when changing channels."
-msgstr "If set to 'yes' the infobar will be displayed when changing channels."
+msgstr ""
 
 msgid "If set to 'yes' you can preview channels in the EPG list."
-msgstr "If set to 'yes' you can preview channels in the EPG list."
+msgstr ""
 
 msgid "If set to 'yes' you can preview channels in the channel list. Press 'OK' to preview the selected channel, press a 2nd 'OK' to exit and zap to that channel, pressing 'EXIT' to return to the channel you started at."
-msgstr "If set to 'yes' you can preview channels in the channel list. Press 'OK' to preview the selected channel, press a 2nd 'OK' to exit and zap to that channel, pressing 'EXIT' to return to the channel you started at."
+msgstr ""
 
 msgid "If set to 'yes', allows you use the seekbar to jump to a point within the event."
 msgstr ""
@@ -8566,24 +8331,24 @@ msgstr ""
 msgid "If set to 'yes; the infobar will be displayed when Fast Forwarding or Rewinding during media playback."
 msgstr ""
 
-#, fuzzy
 msgid "If set to 'yes; the infobar will remain shown permanently in 'paused' state (no timeout)."
-msgstr "If set to 'yes' the infobar will be displayed when a new event starts."
+msgstr ""
 
 msgid "If the 'deep standby workaround' is enabled, it waits until the system time is synchronized. Depending on the requirement, the devices wake up will continuing after a maximum of 2 minutes."
-msgstr ""
+msgstr "If the 'deep standby workaround' is enabled, it will wait until the system time is synchronised. Depending on the requirement, the devices wake up will continuing after a maximum of 2 minutes."
 
 msgid "If the free space is less than setting value, then an attempt is made to delete the old timeshift files."
 msgstr ""
 
 msgid "If the text is too long to be displayed on the front panel, it will be repeated (number of times):"
-msgstr "If the text is too long to be displayed on the front panel, it will be repeated (number of times):"
+msgstr ""
 
 msgid "If using multiple uncommitted switches the DiSEqC commands must be sent multiple times. Set to the number of uncommitted switches in the chain minus one."
 msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "If you are using a Circular polarised LNB select 'yes', otherwise select 'no'."
-msgstr ""
+msgstr "If you're using a circular polarised LNB, select 'yes', otherwise select 'no'."
 
 msgid "If you are using a DiSEqC committed switch enter the port letter required to access the LNB used for this satellite."
 msgstr ""
@@ -8595,8 +8360,6 @@ msgid ""
 "If you see this, something is wrong with\n"
 "your scart connection. Press OK to return."
 msgstr ""
-"If you see this, something is wrong with\n"
-"your scart connection. Press OK to return."
 
 msgid ""
 "If your TV has a brightness or contrast enhancement, disable it. If there is something called \"dynamic\", set it to standard. Adjust the backlight level to a value suiting your taste. Turn down contrast on your TV as much as possible.\n"
@@ -8604,10 +8367,6 @@ msgid ""
 "Do not care about the bright shades now. They will be set up in the next step.\n"
 "If you are happy with the result, press OK."
 msgstr ""
-"If your TV has a brightness or contrast enhancement, disable it. If there is something called \"dynamic\", set it to standard. Adjust the backlight level to a value suiting your taste. Turn down contrast on your TV as much as possible.\n"
-"Then turn the brightness setting as low as possible, but make sure that the two lowermost shades of grey stay distinguishable.\n"
-"Do not care about the bright shades now. They will be set up in the next step.\n"
-"If you are happy with the result, press OK."
 
 msgid "Ignore DVB-C namespace sub network"
 msgstr ""
@@ -8624,28 +8383,29 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#, fuzzy
 msgid "Image Backup"
-msgstr "Page up"
+msgstr ""
 
 msgid "Image Info"
 msgstr ""
 
 msgid "Image Information"
-msgstr "Image Information"
+msgstr ""
 
 msgid "Image Manager"
-msgstr "Image Manager"
+msgstr ""
 
 msgid "Image Version"
 msgstr ""
 
-#, fuzzy, python-format
 msgid "Image Version %s"
-msgstr "Version: %s"
+msgstr ""
+
+msgid "Image created on: %s/%s-%s-%s-backup-%s_mmc.zip"
+msgstr ""
 
 #, python-format
-msgid "Image created on: %s/%s-%s-%s-backup-%s_mmc.zip"
+msgid "Image created on: %s/%s-%s-%s-backup-%s_recovery_emmc.zip"
 msgstr ""
 
 #, python-format
@@ -8668,11 +8428,12 @@ msgstr ""
 msgid "Image-Version"
 msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "ImageWizard"
-msgstr ""
+msgstr "Initialisation Wizard"
 
 msgid "Immediate shutdown"
-msgstr "Immediate shutdown"
+msgstr ""
 
 msgid "In addition to the check at an event start, a repetitive check can be used, so that the conditions 'buffer limit in hours' or 'check free space' are detected earlier."
 msgstr ""
@@ -8680,9 +8441,8 @@ msgstr ""
 msgid "In expert mode, configure which tuners will be preferred for recordings, when more than one tuner is available."
 msgstr ""
 
-#, fuzzy
 msgid "In expert mode, configure which tuners will be preferred, when more than one tuner is available."
-msgstr "Configure which tuner type will be preferred, when the same service is available on different types of tuners."
+msgstr ""
 
 msgid "In most cases this should be set to No. Only enable if you have a very specific need."
 msgstr ""
@@ -8699,7 +8459,7 @@ msgid ""
 msgstr ""
 
 msgid "In progress"
-msgstr "In progress"
+msgstr ""
 
 msgid "In the Standby Record on the LCD Display"
 msgstr ""
@@ -8711,13 +8471,13 @@ msgid "Inadyn"
 msgstr ""
 
 msgid "Inadyn Log"
-msgstr "Inadyn Log"
+msgstr ""
 
 msgid "Inadyn Setup"
-msgstr "Inadyn Setup"
+msgstr ""
 
 msgid "Include AIT in http streams"
-msgstr "Include AIT in http streams"
+msgstr ""
 
 msgid "Include AIT in recordings"
 msgstr ""
@@ -8726,19 +8486,19 @@ msgid "Include CI assignment"
 msgstr ""
 
 msgid "Include ECM in http streams"
-msgstr "Include ECM in http streams"
+msgstr ""
 
 msgid "Include EIT in http streams"
-msgstr "Include EIT in http streams"
+msgstr ""
 
 msgid "Incorrect type service for PiP!"
-msgstr "Incorrect type service for PiP!"
+msgstr ""
 
 msgid "Increase time scale"
-msgstr "Increase time scale"
+msgstr ""
 
 msgid "Increased voltage"
-msgstr "Increased voltage"
+msgstr ""
 
 msgid "Independent"
 msgstr ""
@@ -8747,7 +8507,7 @@ msgid "Index"
 msgstr ""
 
 msgid "Index allocated:"
-msgstr "Index allocated:"
+msgstr ""
 
 msgid "India"
 msgstr ""
@@ -8759,7 +8519,7 @@ msgid "Indonesian"
 msgstr ""
 
 msgid "Info"
-msgstr "Info"
+msgstr ""
 
 msgid "Info (EPG)"
 msgstr ""
@@ -8771,10 +8531,10 @@ msgid "Info Panel"
 msgstr ""
 
 msgid "Info button (long)"
-msgstr "Info button (long)"
+msgstr ""
 
 msgid "Info button (short)"
-msgstr "Info button (short)"
+msgstr ""
 
 msgid "Info icon width"
 msgstr ""
@@ -8783,13 +8543,13 @@ msgid "InfoBar"
 msgstr ""
 
 msgid "InfoBar EPG mode"
-msgstr "InfoBar EPG mode"
+msgstr ""
 
 msgid "InfoPanel"
 msgstr ""
 
 msgid "Infobar EPG"
-msgstr "Infobar EPG"
+msgstr ""
 
 msgid "Infobar fade-out speed"
 msgstr ""
@@ -8797,28 +8557,26 @@ msgstr ""
 msgid "Infobar frontend data source"
 msgstr ""
 
-#, fuzzy
 msgid "Infobar:"
-msgstr "Infobar EPG"
+msgstr ""
 
 msgid "InfobarEPG settings"
-msgstr "InfobarEPG settings"
+msgstr ""
 
 msgid "Infopanel"
 msgstr ""
 
 msgid "Information"
-msgstr "Information"
+msgstr ""
 
 msgid "Infos"
 msgstr ""
 
-#, fuzzy
 msgid "Infotainment"
-msgstr "CI assignment"
+msgstr ""
 
 msgid "Init"
-msgstr "Init"
+msgstr ""
 
 msgid "Init SDCARD"
 msgstr ""
@@ -8827,22 +8585,22 @@ msgid "Init SDcard"
 msgstr ""
 
 msgid "Initial fast forward speed"
-msgstr "Initial fast forward speed"
+msgstr ""
 
 msgid "Initial lock ratio"
-msgstr "Initial lock ratio"
+msgstr ""
 
 msgid "Initial rewind speed"
-msgstr "Initial rewind speed"
+msgstr ""
 
 msgid "Initial scroll delay"
 msgstr ""
 
 msgid "Initial signal quality"
-msgstr "Initial signal quality"
+msgstr ""
 
 msgid "Initial signal quality:"
-msgstr "Initial signal quality:"
+msgstr ""
 
 msgid "Initialization"
 msgstr "Initialisation"
@@ -8851,44 +8609,40 @@ msgid "Initialize"
 msgstr "Initialise"
 
 msgid "Initializing storage device..."
-msgstr "Initialising storage device..."
+msgstr ""
 
 msgid "Inode:"
 msgstr ""
 
 msgid "Inotify Monitoring"
-msgstr "Inotify Monitoring"
+msgstr ""
 
 msgid "Input"
-msgstr "Input"
+msgstr ""
 
-#, fuzzy
 msgid "Input "
-msgstr "Input"
+msgstr ""
 
 msgid "Input Stream ID"
 msgstr ""
 
-#, fuzzy
 msgid "Input channel name."
-msgstr "Use fastscan channel names"
+msgstr ""
 
-#, fuzzy
 msgid "Input config file name:"
-msgstr "Long filenames"
+msgstr ""
 
 msgid "Input devices"
-msgstr "Input devices"
+msgstr ""
 
 msgid "Insert"
 msgstr ""
 
-#, fuzzy
 msgid "Insert line before current line"
-msgstr "Properties of current title"
+msgstr ""
 
 msgid "Install"
-msgstr "Install"
+msgstr ""
 
 #, python-format
 msgid "Install '%s' and enable this operation"
@@ -8907,70 +8661,65 @@ msgid "Install Softcams"
 msgstr ""
 
 msgid "Install a new image with a USB stick"
-msgstr "Install a new image with a USB stick"
+msgstr ""
 
 msgid "Install a new image with your web browser"
-msgstr "Install a new image with your web browser"
+msgstr ""
 
 msgid "Install extensions"
 msgstr ""
 
 msgid "Install extensions."
-msgstr "Install extensions."
+msgstr ""
 
 msgid "Install lcd picons on"
-msgstr "Install lcd picons on"
+msgstr ""
 
 msgid "Install local extension"
-msgstr "Install local extension"
+msgstr ""
 
 msgid "Install or remove finished."
-msgstr "Install or remove finished."
+msgstr ""
 
 msgid "Install picons on"
-msgstr "Install picons on"
+msgstr ""
 
 msgid "Install plugins"
-msgstr "Install plugins"
+msgstr ""
 
 msgid "Install settings, skins, software..."
 msgstr ""
 
 msgid "Installation finished."
-msgstr "Installation finished."
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Installed:\t\t%s"
-msgstr "Install"
+msgstr ""
 
 msgid "Installing"
-msgstr "Installing"
+msgstr ""
 
-#, fuzzy
 msgid "Installing Plugin ..."
-msgstr "Install plugins"
+msgstr ""
 
 msgid "Installing Service"
-msgstr "Installing Service"
+msgstr ""
 
-#, fuzzy
 msgid "Installing Software..."
-msgstr "Installing Service"
+msgstr ""
 
-#, fuzzy
 msgid "Installing feeds from IPK ..."
-msgstr "Install plugins"
+msgstr ""
 
 msgid "Installing feeds from feed ..."
 msgstr ""
 
-#, fuzzy
 msgid "Installing plugins from IPK ..."
-msgstr "Install plugins"
+msgstr ""
 
-#, fuzzy
 msgid "Installing plugins from feed ..."
-msgstr "Install plugins"
+msgstr ""
 
 msgid "Installing software..."
 msgstr ""
@@ -8979,85 +8728,80 @@ msgid "Instant record"
 msgstr ""
 
 msgid "Instant record location"
-msgstr "Instant record location"
+msgstr ""
 
 msgid "Instant recording location"
-msgstr "Instant recording location"
+msgstr ""
 
 msgid "Instant recording..."
-msgstr "Instant recording..."
+msgstr ""
 
 msgid "Instant recordings location"
-msgstr "Instant recordings location"
+msgstr ""
 
 msgid "Interface"
-msgstr "Interface"
+msgstr ""
 
-#, fuzzy
 msgid "Interface:"
-msgstr "Interface: "
+msgstr ""
 
 msgid "Interface: "
-msgstr "Interface: "
+msgstr ""
 
-#, fuzzy
 msgid "Interlaced"
-msgstr "Interface"
+msgstr ""
 
 msgid "Intermediate"
-msgstr "Intermediate"
+msgstr ""
 
 msgid "Internal"
-msgstr "Internal"
+msgstr ""
 
-#, fuzzy
 msgid "Internal Flash"
-msgstr "Internal flash"
+msgstr ""
 
 msgid "Internal USB"
 msgstr ""
 
 msgid "Internal flash"
-msgstr "Internal flash"
+msgstr ""
 
 msgid "Internal hdd only"
-msgstr "Internal hdd only"
+msgstr ""
 
-#, fuzzy
 msgid "International"
-msgstr "Internal"
+msgstr ""
 
 msgid "Internet"
 msgstr ""
 
 msgid "Interval between keys when repeating:"
-msgstr "Interval between keys when repeating:"
+msgstr ""
 
-#, fuzzy
 msgid "Invalid"
-msgstr "invalid type"
+msgstr ""
 
 #, python-format
 msgid "Invalid directory selected: %s"
-msgstr "Invalid directory selected: %s"
+msgstr ""
 
 msgid "Invalid location"
-msgstr "Invalid location"
+msgstr ""
 
 msgid "Invalid transponder data"
-msgstr "Invalid transponder data"
+msgstr ""
 
 msgid "Inversion"
-msgstr "Inversion"
+msgstr ""
 
 msgid "Invert"
-msgstr "Invert"
+msgstr ""
 
 msgid "Inverts the button function."
 msgstr ""
 
 msgid "Ipkg"
-msgstr "Ipkg"
+msgstr ""
 
 msgid "Iran (Islamic Republic of)"
 msgstr ""
@@ -9075,14 +8819,13 @@ msgid "Is not necessary in most cases."
 msgstr ""
 
 msgid "Is this setting ok?"
-msgstr "Is this setting ok?"
+msgstr ""
 
 msgid "Is this video mode ok?"
-msgstr "Is this video mode ok?"
+msgstr ""
 
-#, fuzzy
 msgid "Isle of Man"
-msgstr "Type of scan"
+msgstr ""
 
 msgid "Israel"
 msgstr ""
@@ -9107,14 +8850,13 @@ msgid "It's not possible to rename the filesystem root."
 msgstr ""
 
 msgid "Italian"
-msgstr "Italian"
+msgstr ""
 
-#, fuzzy
 msgid "Italy"
-msgstr "Italian"
+msgstr ""
 
 msgid "JUMP 24 HOURS"
-msgstr "JUMP 24 HOURS"
+msgstr ""
 
 msgid "Jamaica"
 msgstr ""
@@ -9129,7 +8871,7 @@ msgid "Job Manager"
 msgstr ""
 
 msgid "Job View"
-msgstr "Job View"
+msgstr ""
 
 msgid "Job overview"
 msgstr ""
@@ -9144,55 +8886,52 @@ msgid "Jugend"
 msgstr ""
 
 msgid "Jump back 24 hours"
-msgstr "Jump back 24 hours"
+msgstr ""
 
 msgid "Jump first press in channel selection"
 msgstr ""
 
 msgid "Jump forward 24 hours"
-msgstr "Jump forward 24 hours"
+msgstr ""
 
 msgid "Jump to beginning of list"
-msgstr "Jump to beginning of list"
+msgstr ""
 
 msgid "Jump to current time"
-msgstr "Jump to current time"
+msgstr ""
 
 msgid "Jump to end of list"
-msgstr "Jump to end of list"
+msgstr ""
 
 msgid "Jump to next marked position"
-msgstr "Jump to next marked position"
+msgstr ""
 
 msgid "Jump to previous marked position"
-msgstr "Jump to previous marked position"
+msgstr ""
 
 msgid "Jump to prime time"
-msgstr "Jump to prime time"
+msgstr ""
 
 msgid "Just change Bouquet"
 msgstr ""
 
 msgid "Just change channels"
-msgstr "Just change channels"
+msgstr ""
 
 msgid "Just zap"
-msgstr "Just zap"
+msgstr ""
 
-#, fuzzy
 msgid "Justiz"
-msgstr "Just zap"
+msgstr ""
 
 msgid "KA-SAT"
 msgstr ""
 
-#, fuzzy
 msgid "KB"
-msgstr "B"
+msgstr ""
 
-#, fuzzy
 msgid "Kampfsport"
-msgstr "team sports"
+msgstr ""
 
 msgid "Katastrophe"
 msgstr ""
@@ -9201,10 +8940,10 @@ msgid "Kazakhstan"
 msgstr ""
 
 msgid "Keep service"
-msgstr "Keep service"
+msgstr ""
 
 msgid "Keeps MovieList open whilst playing audio files."
-msgstr "Keeps MovieList open whilst playing audio files."
+msgstr ""
 
 msgid "Kenya"
 msgstr ""
@@ -9212,26 +8951,28 @@ msgstr ""
 msgid "Kernel"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Kernel:\t\t%s"
-msgstr "Kernel:\t%s"
+msgstr ""
 
 #, python-format
 msgid "Kernel: %s"
-msgstr "Kernel: %s"
+msgstr ""
 
 msgid "Keyboard"
-msgstr "Keyboard"
+msgstr ""
 
-#, fuzzy
 msgid "Keyboard data entry"
-msgstr "Keyboard setup"
+msgstr ""
+
+msgid "Keyboard long"
+msgstr ""
 
 msgid "Keyboard map"
-msgstr "Keyboard map"
+msgstr ""
 
 msgid "Keyboard setup"
-msgstr "Keyboard setup"
+msgstr ""
 
 msgid "Keymap Selection"
 msgstr ""
@@ -9239,9 +8980,8 @@ msgstr ""
 msgid "Keymap changed, you need to restart the GUI"
 msgstr ""
 
-#, fuzzy
 msgid "Kinder"
-msgstr "Sat finder"
+msgstr ""
 
 msgid "Kiribati"
 msgstr ""
@@ -9255,13 +8995,11 @@ msgstr ""
 msgid "Kodi MediaCenter"
 msgstr ""
 
-#, fuzzy
 msgid "Kodi installed:"
-msgstr "Undo install"
+msgstr ""
 
-#, fuzzy
 msgid "Kodi media player"
-msgstr "Exit media player?"
+msgstr ""
 
 msgid "Kodi/extra partition free space:"
 msgstr ""
@@ -9275,9 +9013,8 @@ msgstr ""
 msgid "Korea (Republic of)"
 msgstr ""
 
-#, fuzzy
 msgid "Kraftsport"
-msgstr "water sport"
+msgstr ""
 
 msgid "Krieg"
 msgstr ""
@@ -9297,22 +9034,20 @@ msgstr ""
 msgid "Kurzfilm"
 msgstr ""
 
-#, fuzzy
 msgid "Kuwait"
-msgstr "waiting"
+msgstr ""
 
 msgid "Kyrgyzstan"
 msgstr ""
 
-#, fuzzy
 msgid "LAN"
-msgstr "LNB"
+msgstr ""
 
 msgid "LAN adapter"
-msgstr "LAN adapter"
+msgstr ""
 
 msgid "LAN connection"
-msgstr "LAN connection"
+msgstr ""
 
 msgid "LAN long"
 msgstr ""
@@ -9332,26 +9067,32 @@ msgstr ""
 msgid "LCN rules:"
 msgstr ""
 
+msgid "LEFT  -  back to active screen   |    EXIT  -  close right screen"
+msgstr ""
+
+msgid "LEFT  -  change screen   |   RIGHT  -  active status change   |   EXIT  -  close right screen"
+msgstr ""
+
 msgid "LED Deep Standby"
-msgstr "LED Deep Standby"
+msgstr ""
 
 msgid "LED Normal"
-msgstr "LED Normal"
+msgstr ""
 
 msgid "LED Standby"
-msgstr "LED Standby"
+msgstr ""
 
 msgid "LED brightness during deep standby."
-msgstr "LED brightness during deep standby."
+msgstr ""
 
 msgid "LED brightness during normal operations."
-msgstr "LED brightness during normal operations."
+msgstr ""
 
 msgid "LED brightness during standby."
-msgstr "LED brightness during standby."
+msgstr ""
 
 msgid "LNB"
-msgstr "LNB"
+msgstr ""
 
 msgid "LNB/Switch Bootup time [ms]"
 msgstr ""
@@ -9366,60 +9107,61 @@ msgid "LOF/L"
 msgstr ""
 
 msgid "Label"
-msgstr "Label"
+msgstr ""
 
 msgid "Landestypisch"
 msgstr ""
 
 msgid "Language"
-msgstr "Language"
+msgstr ""
 
 msgid "Language selection"
-msgstr "Language selection"
+msgstr ""
 
 msgid "Lao People's Democratic Republic"
 msgstr ""
 
+#, python-format
+msgid "Last E2 update:\t\t%s"
+msgstr ""
+
 msgid "Last Req."
-msgstr "Last Req."
+msgstr ""
 
 msgid "Last config"
-msgstr "Last config"
+msgstr ""
 
 msgid "Last speed"
-msgstr "Last speed"
+msgstr ""
 
-#, fuzzy, python-format
 msgid "Last update:\t\t%s"
-msgstr "Last update:\t%s"
+msgstr ""
 
 #, python-format
 msgid "Last update:\t%s"
-msgstr "Last update:\t%s"
+msgstr ""
 
 msgid "Last used share: "
-msgstr "Last used share: "
+msgstr ""
 
-#, fuzzy
 msgid "Late Night"
-msgstr "Page right"
+msgstr ""
 
 msgctxt "third event: 'third' event label"
 msgid "Later"
-msgstr "Later"
+msgstr ""
 
 msgid "Latitude"
-msgstr "Latitude"
+msgstr ""
 
-#, fuzzy
 msgid "Latvia"
-msgstr "Latvian"
+msgstr ""
 
 msgid "Latvian"
-msgstr "Latvian"
+msgstr ""
 
 msgid "Leave DVD player?"
-msgstr "Leave DVD player?"
+msgstr ""
 
 msgid "Leave File Commander"
 msgstr ""
@@ -9434,31 +9176,29 @@ msgid "Lebanon"
 msgstr ""
 
 msgid "Left"
-msgstr "Left"
+msgstr ""
 
 msgid "Left from servicename"
-msgstr "Left from servicename"
+msgstr ""
 
-#, fuzzy
 msgid "Left long"
-msgstr "Left"
+msgstr ""
 
-#, fuzzy
 msgid "Leichtathletik"
-msgstr "athletics"
+msgstr ""
 
 msgid "Leisure hobbies"
-msgstr "Leisure hobbies"
+msgstr ""
 
 msgid "Lesotho"
 msgstr ""
 
 #. TRANSLATORS: (aspect ratio policy: black bars on top/bottom) in doubt, keep english term.
 msgid "Letterbox"
-msgstr "Letterbox"
+msgstr ""
 
 msgid "Letterbox zoom"
-msgstr "Letterbox zoom"
+msgstr ""
 
 msgid "Liberia"
 msgstr ""
@@ -9469,81 +9209,78 @@ msgstr ""
 msgid "Liechtenstein"
 msgstr ""
 
-#, fuzzy
 msgid "Lifestyle"
-msgstr "Time scale"
+msgstr ""
 
 msgid "Light Grey"
-msgstr "Light Grey"
+msgstr ""
 
 msgid "Limit character set for recording filenames"
-msgstr "Limit character set for recording filenames"
+msgstr ""
 
 msgid "Limit debug log size (MB)"
-msgstr "Limit debug log size (MB)"
+msgstr ""
 
 msgid "Limit east"
-msgstr "Limit east"
+msgstr ""
 
 msgid "Limit the characters that can be used in recording filenames to (7 bit) ascii. This ensures compatibility with operating systems or file systems with limited character sets."
-msgstr "Limit the characters that can be used in recording filenames to (7 bit) ascii. This ensures compatibility with operating systems or file systems with limited character sets."
+msgstr ""
 
 msgid "Limit west"
-msgstr "Limit west"
+msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "Limits cancelled"
 msgstr "Limits cancelled"
 
 msgid "Limits enabled"
-msgstr "Limits enabled"
+msgstr ""
 
 msgid "Limits off"
-msgstr "Limits off"
+msgstr ""
 
 msgid "Limits on"
-msgstr "Limits on"
+msgstr ""
 
 msgid "Link Quality:"
-msgstr "Link Quality:"
+msgstr ""
 
 msgid "Link quality:"
-msgstr "Link quality:"
+msgstr ""
 
-#, fuzzy
 msgid "Link target:"
-msgstr "Link Quality:"
+msgstr ""
 
 msgid "Link:"
-msgstr "Link:"
+msgstr ""
 
 msgid "Linked titles with a DVD menu"
-msgstr "Linked titles with a DVD menu"
+msgstr ""
 
-#, fuzzy
 msgid "Links:"
-msgstr "Link:"
+msgstr ""
 
 msgid "List EPG functions..."
-msgstr "List EPG functions..."
+msgstr ""
 
 msgid "List available networks"
-msgstr "List available networks"
+msgstr ""
 
 msgid "List mode"
 msgstr ""
 
-#, fuzzy
 msgid "List of Storage Devices"
-msgstr "List of storage devices"
+msgstr ""
 
 msgid "List of storage devices"
-msgstr "List of storage devices"
+msgstr ""
 
 #, python-format
 msgid "List version %d, found %d channel"
 msgid_plural "List version %d, found %d channels"
-msgstr[0] "List version %d, found %d channel"
-msgstr[1] "List version %d, found %d channels"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "List/Fav"
 msgstr ""
@@ -9552,38 +9289,34 @@ msgid "List/Fav long"
 msgstr ""
 
 msgid "Listen to the radio..."
-msgstr "Listen to the radio..."
+msgstr ""
 
 msgid "Lists reloaded!"
 msgstr ""
 
-#, fuzzy
 msgid "Literatur"
-msgstr "literature"
+msgstr ""
 
-#, fuzzy
 msgid "Literaturverfilmung"
-msgstr "literature"
+msgstr ""
 
-#, fuzzy
 msgid "Lithuania"
-msgstr "Lithuanian"
+msgstr ""
 
 msgid "Lithuanian"
-msgstr "Lithuanian"
+msgstr ""
 
 msgid "Live"
 msgstr ""
 
 msgid "Load"
-msgstr "Load"
+msgstr ""
 
-#, fuzzy
 msgid "Load Default Settings"
-msgstr "Default settings"
+msgstr ""
 
 msgid "Load EPG"
-msgstr "Load EPG"
+msgstr ""
 
 msgid "Load playlist"
 msgstr "load playlist"
@@ -9591,48 +9324,44 @@ msgstr "load playlist"
 msgid "Load unlinked userbouquets"
 msgstr ""
 
-#, fuzzy
 msgid "Load/Save/Delete"
-msgstr "Load/Save"
+msgstr ""
 
 msgid "Local box"
-msgstr "Local box"
+msgstr ""
 
 msgid "Local network"
-msgstr "Local network"
+msgstr ""
 
-#, fuzzy
 msgid "Locale"
-msgstr "Local box"
+msgstr ""
 
 msgid "Location"
-msgstr "Location"
+msgstr ""
 
-#, fuzzy
 msgid "Location list"
-msgstr "Location"
+msgstr ""
 
 msgid "Lock ratio"
-msgstr "Lock ratio"
+msgstr ""
 
 msgid "Lock:"
 msgstr ""
 
-#, fuzzy
 msgid "Log"
-msgstr "Logs"
+msgstr ""
 
 msgid "Log Manager"
-msgstr "Log Manager"
+msgstr ""
 
 msgid "Log python stack trace on spinner ?"
 msgstr ""
 
 msgid "Log results to harddisk"
-msgstr "Log results to hard disk"
+msgstr ""
 
 msgid "LogManager"
-msgstr "LogManager"
+msgstr ""
 
 msgid "Login"
 msgstr ""
@@ -9644,31 +9373,31 @@ msgid "Login to IceTV server"
 msgstr ""
 
 msgid "Logs location"
-msgstr "Logs location"
+msgstr ""
 
 msgid "Logs older then the set no of days will be deleted."
 msgstr ""
 
 msgid "Logs settings"
-msgstr "Logs settings"
+msgstr ""
 
 msgid "Long << / >>"
-msgstr "Long << / >>"
+msgstr ""
 
 msgid "Long Left/Right"
-msgstr "Long Left/Right"
+msgstr ""
 
 msgid "Long filenames"
-msgstr "Long filenames"
+msgstr ""
 
 msgid "Long key press"
-msgstr "Long key press"
+msgstr ""
 
 msgid "Long press emulation with button"
 msgstr ""
 
 msgid "Longitude"
-msgstr "Longitude"
+msgstr ""
 
 msgid "Loop through to"
 msgstr ""
@@ -9685,43 +9414,38 @@ msgstr ""
 msgid "Lower limit in kilobits per seconds [kbit/s]"
 msgstr ""
 
-#, fuzzy
 msgid "Lowest Mode"
-msgstr "Test mode"
+msgstr ""
 
-#, fuzzy
 msgid "Lowest Video output mode"
-msgstr "Video output"
+msgstr ""
 
-#, fuzzy
 msgid "Luxembourg"
-msgstr "Luxembourgish"
+msgstr ""
 
 msgid "Luxembourgish"
-msgstr "Luxembourgish"
+msgstr ""
 
-#, fuzzy
 msgid "MAC"
-msgstr "MAC:"
+msgstr ""
 
 msgid "MAC-address"
-msgstr "MAC-address"
+msgstr ""
 
 msgid "MAC-address settings"
-msgstr "MAC-address settings"
+msgstr ""
 
 msgid "MAC:"
-msgstr "MAC:"
+msgstr ""
 
 msgid "MB"
-msgstr "MB"
+msgstr ""
 
 msgid "MIRACLEBOX_TWINPLUS"
 msgstr ""
 
-#, fuzzy
 msgid "MMA"
-msgstr "MAC:"
+msgstr ""
 
 msgid "MORE"
 msgstr ""
@@ -9741,18 +9465,17 @@ msgstr ""
 msgid "Madagascar"
 msgstr ""
 
-#, fuzzy
 msgid "Magazin"
-msgstr "news magazine"
+msgstr ""
 
 msgid "Main menu"
-msgstr "Main menu"
+msgstr ""
 
 msgid "Mainmenu"
-msgstr "Mainmenu"
+msgstr ""
 
 msgid "Maintain old EPG data for"
-msgstr "Maintain old EPG data for"
+msgstr ""
 
 msgid "Make File Commander accessible from the Extensions menu."
 msgstr ""
@@ -9761,13 +9484,13 @@ msgid "Make File Commander accessible from the main menu."
 msgstr ""
 
 msgid "Make this mark an 'in' point"
-msgstr "Make this mark an 'in' point"
+msgstr ""
 
 msgid "Make this mark an 'out' point"
-msgstr "Make this mark an 'out' point"
+msgstr ""
 
 msgid "Make this mark just a mark"
-msgstr "Make this mark just a mark"
+msgstr ""
 
 msgid "Malawi"
 msgstr ""
@@ -9785,14 +9508,14 @@ msgid "Malta"
 msgstr ""
 
 msgid "Manage extensions"
-msgstr "Manage extensions"
+msgstr ""
 
 msgid "Manage network mounts"
 msgstr ""
 
 #, python-format
 msgid "Manage your %s %s's software"
-msgstr "Manage your %s %s's software"
+msgstr ""
 
 msgid "Manage your online update files"
 msgstr ""
@@ -9804,35 +9527,34 @@ msgid "Manual"
 msgstr ""
 
 msgid "Manual Scan"
-msgstr "Manual Scan"
+msgstr ""
 
-#, fuzzy
 msgid "Manual Service Searching"
-msgstr "Service searching"
+msgstr ""
 
 msgid "Manual configuration"
-msgstr "Manual configuration"
+msgstr ""
 
 msgid "Manual scan"
-msgstr "Manual scan"
+msgstr ""
 
 msgid "Manual scan for services"
 msgstr ""
 
 msgid "Manual transponder"
-msgstr "Manual transponder"
+msgstr ""
 
 msgid "Manufacturer"
-msgstr "Manufacturer"
+msgstr ""
 
 msgid "MaraM9"
 msgstr ""
 
 msgid "Margin after recording (minutes)"
-msgstr "Margin after recording (minutes)"
+msgstr ""
 
 msgid "Margin before recording (minutes)"
-msgstr "Margin before recording (minutes)"
+msgstr ""
 
 msgid "Mark service as dedicated 3D service"
 msgstr ""
@@ -9843,9 +9565,8 @@ msgstr ""
 msgid "Mark/Portal/Playlist long"
 msgstr ""
 
-#, fuzzy
 msgid "Marshall Islands"
-msgstr "show all cards"
+msgstr ""
 
 msgid "Martinique"
 msgstr ""
@@ -9856,28 +9577,26 @@ msgstr ""
 msgid "Mature Audience 15+"
 msgstr ""
 
-#, fuzzy
 msgid "Mauritania"
-msgstr "Lithuanian"
+msgstr ""
 
-#, fuzzy
 msgid "Mauritius"
-msgstr "Favourites"
+msgstr ""
 
 msgid "Max memory positions"
 msgstr ""
 
 msgid "Max. bitrate: "
-msgstr "Max. bitrate: "
+msgstr ""
 
 msgid "Maxdown +"
-msgstr "Maxdown +"
+msgstr ""
 
 msgid "Maxdown -"
-msgstr "Maxdown -"
+msgstr ""
 
 msgid "Maxdown: "
-msgstr "Maxdown: "
+msgstr ""
 
 #, python-format
 msgid "Maximum minutes to jump %d !"
@@ -9886,9 +9605,8 @@ msgstr ""
 msgid "Maximum no of days:"
 msgstr ""
 
-#, fuzzy
 msgid "Maximum number of days in EPG"
-msgstr "Maximum no of days"
+msgstr ""
 
 msgid "Maximum space used (MB):"
 msgstr ""
@@ -9902,9 +9620,8 @@ msgstr ""
 msgid "Media Center"
 msgstr ""
 
-#, fuzzy
 msgid "Media Player"
-msgstr "Media player"
+msgstr ""
 
 msgid "Media Portal"
 msgstr ""
@@ -9913,29 +9630,28 @@ msgid "Media long"
 msgstr ""
 
 msgid "Media playback Remaining/Elapsed as"
-msgstr "Media playback Remaining/Elapsed as"
+msgstr ""
 
 msgid "Media player"
-msgstr "Media player"
+msgstr ""
 
 msgid "Media scanner"
-msgstr "Media scanner"
+msgstr ""
 
 msgid "MediaPlayer"
 msgstr ""
 
-#, fuzzy
 msgid "Medical"
-msgstr "Vertical"
+msgstr ""
 
 msgid "Medien"
 msgstr ""
 
 msgid "Medium is not a writeable DVD!"
-msgstr "Medium is not a writeable DVD!"
+msgstr ""
 
 msgid "Medium is not empty!"
-msgstr "Medium is not empty!"
+msgstr ""
 
 msgid "Medium toolbox"
 msgstr ""
@@ -9944,22 +9660,22 @@ msgid "MemInfo"
 msgstr ""
 
 msgid "Memory"
-msgstr "Memory"
+msgstr ""
 
 msgid "Memory Information"
-msgstr "Memory Information"
+msgstr ""
 
 msgid "Memory index"
-msgstr "Memory index"
+msgstr ""
 
 msgid "Menu"
-msgstr "Menu"
+msgstr ""
 
 msgid "Menu config"
-msgstr "Menu config"
+msgstr ""
 
 msgid "Merging Timeshift files"
-msgstr "Merging Timeshift files"
+msgstr ""
 
 msgid "Merlin EPG Center"
 msgstr ""
@@ -9982,18 +9698,17 @@ msgstr ""
 msgid "Micronesia (Federated States of)"
 msgstr ""
 
-#, fuzzy
 msgid "Mini Series"
-msgstr "Services"
+msgstr ""
 
 msgid "MiniDLNA"
 msgstr ""
 
 msgid "MiniDLNA Log"
-msgstr "MiniDLNA Log"
+msgstr ""
 
 msgid "MiniDLNA Setup"
-msgstr "MiniDLNA Setup"
+msgstr ""
 
 msgid "MiniTV"
 msgstr ""
@@ -10003,16 +9718,19 @@ msgstr ""
 
 #, python-format
 msgid "Minimum age %d years"
-msgstr "Minimum age %d years"
+msgstr ""
 
 msgid "Minimum send interval"
-msgstr "Minimum send interval"
+msgstr ""
 
 msgid "Mins"
-msgstr "Mins"
+msgstr ""
 
 msgid "Mins Secs"
-msgstr "Mins Secs"
+msgstr ""
+
+msgid "Minutes:"
+msgstr ""
 
 msgid "Miscellaneous"
 msgstr ""
@@ -10027,11 +9745,10 @@ msgid ""
 msgstr ""
 
 msgid "Missing "
-msgstr "Missing "
+msgstr ""
 
-#, fuzzy
 msgid "Mode"
-msgstr "Mode"
+msgstr ""
 
 #, python-format
 msgid "Mode %s (%04o)"
@@ -10048,16 +9765,15 @@ msgstr ""
 msgid "Mode 2"
 msgstr ""
 
-#, fuzzy
 msgid "Mode for autorestore"
-msgstr "Software restore"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Model:\t\t%s %s\n"
-msgstr "Model:\t%s %s\n"
+msgstr ""
 
 msgid "Model: "
-msgstr "Model: "
+msgstr ""
 
 #, python-format
 msgid "Model: %s %s\n"
@@ -10067,10 +9783,10 @@ msgid "Modified:"
 msgstr ""
 
 msgid "Modulation"
-msgstr "Modulation"
+msgstr ""
 
 msgid "Modulator"
-msgstr "Modulator"
+msgstr ""
 
 msgid "Module"
 msgstr ""
@@ -10079,16 +9795,16 @@ msgid "Moldova (Republic of)"
 msgstr ""
 
 msgid "Mon"
-msgstr "Mon"
+msgstr ""
 
 msgid "Mon-Fri"
-msgstr "Mon-Fri"
+msgstr ""
 
 msgid "Monaco"
 msgstr ""
 
 msgid "Monday"
-msgstr "Monday"
+msgstr ""
 
 msgid "Mongolia"
 msgstr ""
@@ -10097,7 +9813,7 @@ msgid "Montenegro"
 msgstr ""
 
 msgid "Monthly"
-msgstr "Monthly"
+msgstr ""
 
 msgid "Montserrat"
 msgstr ""
@@ -10106,11 +9822,10 @@ msgid "Morocco"
 msgstr ""
 
 msgid "Mosquito noise reduction"
-msgstr "Mosquito noise reduction"
+msgstr ""
 
-#, fuzzy
 msgid "Motor Sport"
-msgstr "motor sport"
+msgstr ""
 
 msgid "Motor command retries"
 msgstr ""
@@ -10118,12 +9833,11 @@ msgstr ""
 msgid "Motor running timeout"
 msgstr ""
 
-#, fuzzy
 msgid "Motorsport"
-msgstr "motor sport"
+msgstr ""
 
 msgid "Mount"
-msgstr "Mount"
+msgstr ""
 
 #, python-format
 msgid "Mount '%s' has not enough free space to record."
@@ -10151,68 +9865,71 @@ msgid "Mounts Devices"
 msgstr ""
 
 msgid "Mounts Setup"
-msgstr "Mounts Setup"
+msgstr ""
 
 msgid "Move"
-msgstr "Move"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Move %d elements"
-msgstr "Movement"
+msgstr ""
 
-#, fuzzy
 msgid "Move 1 element"
-msgstr "Movement"
+msgstr ""
 
 msgid "Move Left/Right"
-msgstr "Move Left/Right"
+msgstr ""
 
 msgid "Move PIP"
 msgstr ""
 
 msgid "Move PiP to main picture"
-msgstr "Move PiP to main picture"
+msgstr ""
 
 msgid "Move Up/Down"
-msgstr "Move Up/Down"
+msgstr ""
 
-#, fuzzy
 msgid "Move down a line"
-msgstr "Move down a page"
+msgstr ""
 
 msgid "Move down a page"
-msgstr "Move down a page"
+msgstr ""
 
-#, fuzzy
 msgid "Move down list"
-msgstr "Go down the list"
+msgstr ""
 
 msgid "Move east"
-msgstr "Move east"
+msgstr ""
 
-#, fuzzy
 msgid "Move file"
-msgstr "Moving files"
+msgstr ""
 
-#, fuzzy
 msgid "Move file/directory to target directory"
-msgstr "Move to other directory"
+msgstr ""
 
-#, fuzzy
 msgid "Move files/directories to target directory"
-msgstr "Move to other directory"
+msgstr ""
 
-#, fuzzy
 msgid "Move folder"
-msgstr "Select folders"
+msgstr ""
 
-#, fuzzy
 msgid "Move mode off"
-msgstr "[move mode]"
+msgstr ""
 
-#, fuzzy
 msgid "Move mode on"
-msgstr "Movement"
+msgstr ""
+
+msgid "Move the keyboard cursor down"
+msgstr ""
+
+msgid "Move the keyboard cursor left"
+msgstr ""
+
+msgid "Move the keyboard cursor right"
+msgstr ""
+
+msgid "Move the keyboard cursor up"
+msgstr ""
 
 msgid "Move the text buffer cursor left"
 msgstr ""
@@ -10224,6 +9941,18 @@ msgid "Move the text buffer cursor to the first character"
 msgstr ""
 
 msgid "Move the text buffer cursor to the last character"
+msgstr ""
+
+msgid "Move the text cursor left"
+msgstr ""
+
+msgid "Move the text cursor right"
+msgstr ""
+
+msgid "Move the text cursor to the first character"
+msgstr ""
+
+msgid "Move the text cursor to the last character"
 msgstr ""
 
 msgid "Move the virtual keyboard cursor down"
@@ -10239,71 +9968,67 @@ msgid "Move the virtual keyboard cursor up"
 msgstr ""
 
 msgid "Move to home of list"
-msgstr "Move to home of list"
+msgstr ""
 
 msgid "Move to position X"
-msgstr "Move to position X"
+msgstr ""
 
-#, fuzzy
 msgid "Move up a line"
-msgstr "Move up a page"
+msgstr ""
 
 msgid "Move up a page"
-msgstr "Move up a page"
+msgstr ""
 
-#, fuzzy
 msgid "Move up list"
-msgstr "Go up the list"
+msgstr ""
 
 msgid "Move west"
-msgstr "Move west"
+msgstr ""
 
 msgid "Moved to position 0"
-msgstr "Moved to position 0"
+msgstr ""
 
 msgid "Moved to position at index"
-msgstr "Moved to position at index"
+msgstr ""
 
 msgid "Movement"
-msgstr "Movement"
+msgstr ""
 
-#, fuzzy
 msgid "Movie"
-msgstr "Moving"
+msgstr ""
 
 msgid "Movie List"
-msgstr "Movie List"
+msgstr ""
 
 msgid "Movie List Setup"
-msgstr "Movie List Setup"
+msgstr ""
 
 msgid "Movie location"
-msgstr "Movie location"
+msgstr ""
 
 msgid "Movie selection"
-msgstr "Movie selection"
+msgstr ""
 
 msgid "Movie/Drama"
-msgstr "Movie/Drama"
+msgstr ""
 
-#, fuzzy
 msgid "Movieplayer"
-msgstr "Hide player"
+msgstr ""
 
 msgid "Moving"
-msgstr "Moving"
+msgstr ""
 
 msgid "Moving east ..."
-msgstr "Moving east ..."
+msgstr ""
 
 msgid "Moving files"
-msgstr "Moving files"
+msgstr ""
 
 msgid "Moving to position"
-msgstr "Moving to position"
+msgstr ""
 
 msgid "Moving west ..."
-msgstr "Moving west ..."
+msgstr ""
 
 msgid "Mozambique"
 msgstr ""
@@ -10312,19 +10037,23 @@ msgid "Mtd"
 msgstr ""
 
 msgid "Multi EPG"
-msgstr "Multi EPG"
+msgstr ""
 
-#, fuzzy
 msgid "MultiBoot Image Manager"
-msgstr "Image Manager"
+msgstr ""
+
+msgid "MultiBoot Image Selector"
+msgstr ""
+
+msgid "MultiBootSelector Actions"
+msgstr ""
 
 msgid "MultiEPG settings"
-msgstr "Multi EPG settings"
+msgstr ""
 
 msgid "MultiQuickButton"
 msgstr ""
 
-#, python-format
 msgid "Multiboot ERROR! - no %s in boot partition."
 msgstr ""
 
@@ -10335,9 +10064,8 @@ msgstr ""
 msgid "Multiboot Image created on: %s/%s-%s-%s-backup-%s_usb.zip"
 msgstr ""
 
-#, fuzzy
 msgid "Multiboot Manager"
-msgstr "Log Manager"
+msgstr ""
 
 msgid "Multiboot manager - Cannot initialize SDcard when running image on SDcard."
 msgstr ""
@@ -10349,23 +10077,22 @@ msgid "Multiboot manager - The SDcard must be at least 8MB."
 msgstr ""
 
 msgid "Multimedia"
-msgstr "Multimedia"
+msgstr ""
 
 msgid "Multiple service support"
-msgstr "Multiple service support"
+msgstr ""
 
 msgid "Multiplex"
-msgstr "Multiplex"
+msgstr ""
 
 msgid "Multisat"
-msgstr "Multisat"
+msgstr ""
 
 msgid "Multisat all select"
 msgstr ""
 
-#, fuzzy
 msgid "Multistream"
-msgstr "Multisat"
+msgstr ""
 
 msgid "Murder"
 msgstr ""
@@ -10374,11 +10101,10 @@ msgid "Music"
 msgstr ""
 
 msgid "Music/Ballet/Dance"
-msgstr "Music/Ballet/Dance"
+msgstr ""
 
-#, fuzzy
 msgid "Musical"
-msgstr "musical/opera"
+msgstr ""
 
 msgid "Musik"
 msgstr ""
@@ -10386,130 +10112,120 @@ msgstr ""
 msgid "Mute"
 msgstr ""
 
-#, fuzzy
 msgid "My Extension"
-msgstr "Extensions"
+msgstr ""
 
-#, fuzzy
 msgid "My extension"
-msgstr "Only extensions."
+msgstr ""
 
 msgid "Myanmar"
 msgstr ""
 
-#, fuzzy
 msgid "Mystery"
-msgstr "Yesterday"
+msgstr ""
 
 msgid "Märchen"
 msgstr ""
 
 msgid "N/A"
-msgstr "N/A"
+msgstr ""
 
 msgid "NEXT"
 msgstr ""
 
 msgid "NFI image flashing"
-msgstr "NFI image flashing"
+msgstr ""
 
 msgid "NFI image flashing completed. Press Yellow to Reboot!"
-msgstr "NFI image flashing completed. Press Yellow to Reboot!"
+msgstr ""
 
 msgid "NFS"
 msgstr ""
 
 msgid "NFS Setup"
-msgstr "NFS Setup"
+msgstr ""
 
 msgid "NIM"
-msgstr "NIM"
+msgstr ""
 
 msgid "NOW"
 msgstr ""
 
 msgid "NTP"
-msgstr "NTP"
+msgstr ""
 
 msgid "NTP server"
-msgstr "NTP server"
+msgstr ""
 
 msgid "NTSC"
-msgstr "NTSC"
+msgstr ""
 
 msgid "Nachrichten"
 msgstr ""
 
 msgid "Name"
-msgstr "Name"
+msgstr ""
 
-#, fuzzy
 msgid "Name reverse"
-msgstr "Nameserver"
+msgstr ""
 
 msgid "Name:"
-msgstr "Name:"
+msgstr ""
 
 msgid "Nameserver"
-msgstr "Nameserver"
+msgstr ""
 
 #, python-format
 msgid "Nameserver %d"
-msgstr "Nameserver %d"
+msgstr ""
 
 msgid "Nameserver settings"
-msgstr "Nameserver settings"
+msgstr ""
 
 msgid "Nameserver setup"
 msgstr ""
 
 msgid "Namespace"
-msgstr "Namespace"
+msgstr ""
 
 msgid "Namibia"
 msgstr ""
 
-#, fuzzy
 msgid "National"
-msgstr "Location"
+msgstr ""
 
-#, fuzzy
 msgid "Native"
-msgstr "Relative"
+msgstr ""
 
-#, fuzzy
 msgid "Natur"
-msgstr "Saturday"
+msgstr ""
 
-#, fuzzy
 msgid "Nature"
-msgstr "literature"
+msgstr ""
 
 msgid "Nauru"
 msgstr ""
 
-#, fuzzy
 msgid "NcamInfo"
-msgstr "OScam Info"
+msgstr ""
 
 msgid "Nepal"
 msgstr ""
 
-#, fuzzy
 msgid "Netball"
-msgstr "ballet"
+msgstr ""
 
 msgid "Netherlands"
 msgstr ""
 
 msgid "Netmask"
-msgstr "Netmask"
+msgstr ""
 
 msgid "Netmask:"
-msgstr "Netmask:"
+msgstr ""
 
 msgid "Network"
-msgstr "Network"
+msgstr ""
 
 msgid "Network Adapter Selection"
 msgstr ""
@@ -10518,16 +10234,16 @@ msgid "Network Browser"
 msgstr ""
 
 msgid "Network ID"
-msgstr "Network ID"
+msgstr ""
 
 msgid "Network Information"
-msgstr "Network Information"
+msgstr ""
 
 msgid "Network Interface"
 msgstr ""
 
 msgid "Network MAC settings"
-msgstr "Network MAC settings"
+msgstr ""
 
 msgid "Network Neighbourhood"
 msgstr ""
@@ -10536,20 +10252,19 @@ msgid "Network Restart"
 msgstr ""
 
 msgid "Network Servers:"
-msgstr "Network Servers:"
+msgstr ""
 
 msgid "Network Services"
 msgstr ""
 
 msgid "Network Setup"
-msgstr "Network Setup"
+msgstr ""
 
-#, fuzzy
 msgid "Network Speed:"
-msgstr "Network Servers:"
+msgstr ""
 
 msgid "Network Test"
-msgstr "Network Test"
+msgstr ""
 
 msgid "Network Wizard"
 msgstr ""
@@ -10561,31 +10276,31 @@ msgid "Network menu"
 msgstr ""
 
 msgid "Network mounts"
-msgstr "Network mounts"
+msgstr ""
 
 msgid "Network name (SSID)"
-msgstr "Network name (SSID)"
+msgstr ""
 
 msgid "Network scan"
-msgstr "Network scan"
+msgstr ""
 
 msgid "Network setup"
-msgstr "Network setup"
+msgstr ""
 
 msgid "Network test"
-msgstr "Network test"
+msgstr ""
 
 msgid "Network test..."
 msgstr ""
 
 msgid "Network test: "
-msgstr "Network test: "
+msgstr ""
 
 msgid "Network wizard"
-msgstr "Network wizard"
+msgstr ""
 
 msgid "Network:"
-msgstr "Network:"
+msgstr ""
 
 msgid "NetworkWizard"
 msgstr ""
@@ -10599,18 +10314,17 @@ msgstr ""
 msgid "Never decrypt the content while recording. This overrides the individual timer settings globally. If enabled, recordings are stored in crypted presentation and must be decrypted afterwards (sometimes called offline decoding). Default: off."
 msgstr ""
 
-#, fuzzy
 msgid "Never decrypt while recording"
-msgstr "Set the description of the recording."
+msgstr ""
 
 msgid "New"
-msgstr "New"
+msgstr ""
 
 msgid "New Caledonia"
 msgstr ""
 
 msgid "New PIN"
-msgstr "New PIN"
+msgstr ""
 
 msgid "New Packages"
 msgstr ""
@@ -10621,55 +10335,54 @@ msgstr ""
 msgid "New Zealand"
 msgstr ""
 
-#, fuzzy
 msgid "New event info"
-msgstr "Event Info"
+msgstr ""
 
-#, fuzzy
 msgid "New folder"
-msgstr "Select folders"
+msgstr ""
 
-#, fuzzy
 msgid "New password"
-msgstr "Password"
+msgstr ""
 
 msgid "New profile: "
-msgstr "New profile: "
+msgstr ""
 
-#, fuzzy
 msgid "New program info"
-msgstr "show program information..."
+msgstr ""
 
 msgid "New timers location"
-msgstr "New timers location"
+msgstr ""
 
-#, fuzzy
 msgid "New user"
-msgstr "Select folders"
+msgstr ""
 
 msgid "New version:"
-msgstr "New version:"
+msgstr ""
 
 msgid "News"
 msgstr ""
 
-#, fuzzy
 msgid "News/Current Affairs"
-msgstr "News Current Affairs"
+msgstr ""
 
 msgid "Next"
 msgstr ""
 
 msgctxt "now/next: 'next' event label"
 msgid "Next"
-msgstr "Next"
+msgstr ""
+
+msgid "Next bouquet"
+msgstr ""
+
+msgid "Next page"
+msgstr ""
 
 msgid "Next quad PiP channel"
 msgstr ""
 
-#, fuzzy
 msgid "Nextsong"
-msgstr "Next"
+msgstr ""
 
 msgid "Nextsong long"
 msgstr ""
@@ -10687,19 +10400,19 @@ msgid "Niue"
 msgstr ""
 
 msgid "No"
-msgstr "No"
+msgstr ""
 
 msgid "No (supported) DVDROM found!"
-msgstr "No (supported) DVDROM found!"
+msgstr ""
 
 msgid "No Connection"
-msgstr "No Connection"
+msgstr ""
 
 msgid "No Devices Found !!"
 msgstr ""
 
 msgid "No HDD found or HDD not initialized!"
-msgstr "No HDD found or HDD not initialised!"
+msgstr ""
 
 msgid ""
 "No Settings loaded !!\n"
@@ -10707,12 +10420,11 @@ msgid ""
 "Please install first a settinglist"
 msgstr ""
 
-#, fuzzy
 msgid "No TS recorder available"
-msgstr "No free index available"
+msgstr ""
 
 msgid "No Timeshift found to save as recording!"
-msgstr "No Timeshift found to save as recording!"
+msgstr ""
 
 msgid "No active channel found."
 msgstr ""
@@ -10721,17 +10433,16 @@ msgid "No age block"
 msgstr ""
 
 msgid "No backup needed"
-msgstr "No backup needed"
+msgstr ""
 
 msgid "No cable tuner found!"
-msgstr "No cable tuner found!"
+msgstr ""
 
 msgid "No card inserted!"
-msgstr "No card inserted!"
+msgstr ""
 
-#, fuzzy
 msgid "No channel"
-msgstr "Channel"
+msgstr ""
 
 msgid "No clients streaming"
 msgstr ""
@@ -10743,73 +10454,66 @@ msgid ""
 "No data on transponder!\n"
 "(Timeout reading PAT)"
 msgstr ""
-"No data on transponder!\n"
-"(Timeout reading PAT)"
 
 msgid "No delay"
-msgstr "No delay"
+msgstr ""
 
-#, fuzzy
 msgid "No demux available"
-msgstr "No free index available"
+msgstr ""
 
 msgid "No description available."
-msgstr "No description available."
+msgstr ""
 
 msgid "No details for this image file"
-msgstr "No details for this image file"
+msgstr ""
 
 msgid "No displayable files on this medium found!"
-msgstr "No displayable files on this medium found!"
+msgstr ""
 
 msgid "No entry in lcn db. Please do a service scan."
 msgstr ""
 
-#, fuzzy
 msgid "No error"
-msgstr "unknown service"
+msgstr ""
 
 msgid "No event info found, recording indefinitely."
-msgstr "No event info found, recording indefinitely."
+msgstr ""
 
 msgid "No fast winding possible yet.. but you can use the number buttons to skip forward/backward!"
-msgstr "No fast winding possible yet.. but you can use the number buttons to skip forward/backward!"
+msgstr ""
 
-#, fuzzy
 msgid "No files found."
-msgstr "No networks found"
+msgstr ""
 
 msgid "No free index available"
-msgstr "No free index available"
+msgstr ""
 
 msgid "No free tuner!"
-msgstr "No free tuner!"
+msgstr ""
 
 msgid "No hash calculations configured"
 msgstr ""
 
-#, fuzzy
 msgid "No images found"
-msgstr "No networks found"
+msgstr ""
 
-#, fuzzy
 msgid "No matching place names found"
-msgstr "No new plugins found"
+msgstr ""
 
 msgid "No network connection available."
-msgstr "No network connection available."
+msgstr ""
 
 msgid "No networks found"
-msgstr "No networks found"
+msgstr ""
 
 msgid "No of items switch (increase or reduced)"
-msgstr "No of items switch (increase or reduced)"
+msgstr ""
 
 msgid "No packages were upgraded yet. So you can check your network and try again."
 msgstr ""
 
 msgid "No positioner capable frontend found."
-msgstr "No positioner capable frontend found."
+msgstr ""
 
 msgid "No priority"
 msgstr ""
@@ -10818,28 +10522,28 @@ msgid "No satellite, terrestrial or cable tuner is configured. Please check your
 msgstr ""
 
 msgid "No service"
-msgstr "No service"
+msgstr ""
 
 msgid "No services/providers selected"
-msgstr "No services/providers selected"
+msgstr ""
 
 msgid "No standby"
-msgstr "No standby"
+msgstr ""
 
 msgid "No suitable sat tuner found!"
-msgstr "No suitable sat tuner found!"
+msgstr ""
 
 msgid "No tags are set on these movies."
-msgstr "No tags are set on these movies."
+msgstr ""
 
 msgid "No timeout"
-msgstr "No timeout"
+msgstr ""
 
 msgid "No to all"
-msgstr "No to all"
+msgstr ""
 
 msgid "No transparency"
-msgstr "No transparency"
+msgstr ""
 
 msgid "No tuner is available for recording a timer!\n"
 msgstr ""
@@ -10852,20 +10556,18 @@ msgid ""
 msgstr ""
 
 msgid "No tuner is configured for use with a diseqc positioner!"
-msgstr "No tuner is configured for use with a diseqc positioner!"
+msgstr ""
 
 msgid ""
 "No tuner is enabled!\n"
 "Please setup your tuner settings before you start a service scan."
 msgstr ""
-"No tuner is enabled!\n"
-"Please setup your tuner settings before you start a service scan."
 
 msgid "No update required!"
 msgstr ""
 
 msgid "No updates available. Please try again later."
-msgstr "No updates available. Please try again later."
+msgstr ""
 
 msgid "No valid region details were found"
 msgstr ""
@@ -10875,67 +10577,61 @@ msgid "No viewer installed for this file type: %s"
 msgstr ""
 
 msgid "No wireless networks found! Searching..."
-msgstr "No wireless networks found! Searching..."
+msgstr ""
 
 msgid ""
 "No working local network adapter found.\n"
 "Please verify that you have attached a network cable and your network is configured correctly."
 msgstr ""
-"No working local network adapter found.\n"
-"Please verify that you have attached a network cable and your network is configured correctly."
 
 msgid ""
 "No working wireless network adapter found.\n"
 "Please verify that you have attached a compatible WLAN device and your network is configured correctly."
 msgstr ""
-"No working wireless network adapter found.\n"
-"Please verify that you have attached a compatible WLAN device and your network is configured correctly."
 
 msgid ""
 "No working wireless network interface found.\n"
 " Please verify that you have attached a compatible WLAN device or enable your local network interface."
 msgstr ""
-"No working wireless network interface found.\n"
-" Please verify that you have attached a compatible WLAN device or enable your local network interface."
+
+msgid "No, and I will never ask for notification again"
+msgstr ""
 
 msgid "No, but restart from begin"
-msgstr "No, but restart from begin"
+msgstr ""
 
-#, fuzzy
 msgid "No, do not backup a image"
-msgstr "No, do nothing."
+msgstr ""
 
-#, fuzzy
 msgid "No, do not flash an image"
-msgstr "No, do nothing."
+msgstr ""
 
 msgid "No, do nothing."
-msgstr "No, do nothing."
+msgstr ""
 
 msgid "No, just start my %s %s"
-msgstr "No, just start my %s %s"
+msgstr ""
 
 msgid "No, never"
-msgstr "No, never"
+msgstr ""
 
 msgid "No, scan later manually"
-msgstr "No, scan later manually"
+msgstr ""
 
-#, fuzzy
 msgid "No, show always the plugin browser"
-msgstr "Show the plugin browser.."
+msgstr ""
 
 msgid "No, show always the timer list"
 msgstr ""
 
 msgid "NodeID"
-msgstr "NodeID"
+msgstr ""
 
 msgid "NodeID: "
-msgstr "NodeID: "
+msgstr ""
 
 msgid "None"
-msgstr "None"
+msgstr ""
 
 #, python-format
 msgid "None of the hash programs for the hashes %s are available"
@@ -10948,40 +10644,38 @@ msgid "Normal mode"
 msgstr ""
 
 msgid "North"
-msgstr "North"
+msgstr ""
 
 msgid "Northern Mariana Islands"
 msgstr ""
 
-#, fuzzy
 msgid "Norway"
-msgstr "Norwegian"
+msgstr ""
 
 msgid "Norwegian"
-msgstr "Norwegian"
+msgstr ""
 
-#, fuzzy
 msgid "Not Classified"
-msgstr "Not associated"
+msgstr ""
 
 msgid "Not Defined"
 msgstr ""
 
 msgid "Not Flashing"
-msgstr "Not Flashing"
+msgstr ""
 
 msgid "Not Shown"
-msgstr "Not Shown"
+msgstr ""
 
 msgid "Not allowed with folders"
 msgstr ""
 
 msgid "Not associated"
-msgstr "Not associated"
+msgstr ""
 
 #, python-format
 msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
-msgstr "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -10991,48 +10685,42 @@ msgid ""
 "Free Space: %sMB\n"
 "Path: %s"
 msgstr ""
-"Not enough free Disk space!\n"
-"\n"
-"File size: %sMB\n"
-"Free Space: %sMB\n"
-"Path: %s"
 
 msgid "Not mounted"
-msgstr "Not mounted"
+msgstr ""
 
-#, fuzzy
+msgid "Not now, but warn me next time"
+msgstr ""
+
 msgid "Not running"
-msgstr "running..."
+msgstr ""
 
-#, fuzzy
 msgid "Not tested:"
-msgstr "Network test: "
+msgstr ""
 
 msgid "Not-Associated"
-msgstr "Not-Associated"
+msgstr ""
 
 msgid "Note: slot list does not show current image or empty slots."
 msgstr ""
 
 msgid "Nothing"
-msgstr "Nothing"
+msgstr ""
 
 msgid ""
 "Nothing to scan!\n"
 "Please setup your tuner settings before you start a service scan."
 msgstr ""
-"Nothing to scan!\n"
-"Please setup your tuner settings before you start a service scan."
 
 msgid "Nothing to upgrade"
-msgstr "Nothing to upgrade"
+msgstr ""
 
 msgid "Nothing, just leave this menu"
-msgstr "Nothing, just leave this menu"
+msgstr ""
 
 msgctxt "now/next: 'now' event label"
 msgid "Now"
-msgstr "Now"
+msgstr ""
 
 msgid "Now building the Backup Image"
 msgstr ""
@@ -11041,10 +10729,10 @@ msgid "Now save timeshift as movie and continues recording"
 msgstr ""
 
 msgid "Now, use the contrast setting to turn up the brightness of the background as much as possible, but make sure that you can still see the difference between the two brightest levels of shades.If you have done that, press OK."
-msgstr "Now, use the contrast setting to turn up the brightness of the background as much as possible, but make sure that you can still see the difference between the two brightest levels of shades.If you have done that, press OK."
+msgstr ""
 
 msgid "Number"
-msgstr "Number"
+msgstr ""
 
 msgid "Number of digits in channel number"
 msgstr ""
@@ -11053,7 +10741,7 @@ msgid "Number of lines in script messages"
 msgstr ""
 
 msgid "Number of rows"
-msgstr "Number of rows"
+msgstr ""
 
 msgid "Number of rows to display"
 msgstr ""
@@ -11071,23 +10759,26 @@ msgid "ODIN_M7"
 msgstr ""
 
 msgid "OE Changes"
-msgstr "OE Changes"
+msgstr ""
 
 msgid "OE Log"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "OEM Model:\t\t%s\n"
-msgstr "Model:\t%s %s\n"
+msgstr ""
 
 msgid "OK"
-msgstr "OK"
+msgstr ""
+
+msgid "OK - go back to the TV mode  |  EXIT - cancel  |   <  >  -  change usage mode"
+msgstr ""
 
 msgid "OK button (long)"
-msgstr "OK button (long)"
+msgstr ""
 
 msgid "OK button (short)"
-msgstr "OK button (short)"
+msgstr ""
 
 msgid "OK button mode"
 msgstr ""
@@ -11096,16 +10787,16 @@ msgid "OK long"
 msgstr ""
 
 msgid "OK, guide me through the upgrade process"
-msgstr "OK, guide me through the upgrade process"
+msgstr ""
 
 msgid "ONID"
-msgstr "ONID"
+msgstr ""
 
 msgid "OSD"
 msgstr ""
 
 msgid "OSD 3D Setup"
-msgstr "OSD 3D Setup"
+msgstr ""
 
 msgid "OSD Adjustment"
 msgstr ""
@@ -11116,35 +10807,32 @@ msgstr ""
 msgid "OSD Settings"
 msgstr ""
 
-#, fuzzy
 msgid "OSD Setup"
-msgstr "OSD 3D Setup"
+msgstr ""
 
 msgid "OSD name request"
-msgstr "OSD name request"
+msgstr ""
 
-#, fuzzy
 msgid "OSD position setup"
-msgstr "Position setup"
+msgstr ""
 
 msgid "OSD settings"
-msgstr "OSD settings"
+msgstr ""
 
 msgid "OScam Info"
-msgstr "OScam Info"
+msgstr ""
 
-#, fuzzy
 msgid "OScamInfo"
-msgstr "OScam Info"
+msgstr ""
 
 msgid "OVR"
 msgstr ""
 
 msgid "Off"
-msgstr "Off"
+msgstr ""
 
 msgid "Offline decode delay (ms)"
-msgstr "Offline decode delay (ms)"
+msgstr ""
 
 msgid "Ok"
 msgstr ""
@@ -11162,44 +10850,46 @@ msgid "Oman"
 msgstr ""
 
 msgid "On"
-msgstr "On"
+msgstr ""
 
-#, fuzzy
 msgid "On device:"
-msgstr "Input devices"
+msgstr ""
 
 msgid "On end of movie"
-msgstr "On end of movie"
+msgstr ""
 
 msgid "On end of movie (as menu)"
 msgstr ""
 
 msgid "On reaching the end of a file during playback, you can choose the box's behavior."
-msgstr "On reaching the end of a file during playback, you can choose the box's behavior."
+msgstr ""
 
 msgid "On valid ONIDs, ignore frequency sub network part"
 msgstr ""
 
 msgid "Once per day"
-msgstr "Once per day"
+msgstr ""
 
 msgid "One"
-msgstr "One"
+msgstr ""
 
 msgid "One line"
-msgstr "One line"
+msgstr ""
 
 msgid "Online software update"
 msgstr ""
 
 msgid "OnlineVersionCheck"
-msgstr "OnlineVersionCheck"
+msgstr ""
+
+msgid "Only Standard"
+msgstr ""
 
 msgid "Only extensions."
-msgstr "Only extensions."
+msgstr ""
 
 msgid "Only free scan"
-msgstr "Only free scan"
+msgstr ""
 
 msgid "Only move the dish quickly after this hour."
 msgstr ""
@@ -11208,6 +10898,9 @@ msgid "Only move the dish quickly before this hour."
 msgstr ""
 
 msgid "Only on startup"
+msgstr ""
+
+msgid "Only provider"
 msgstr ""
 
 msgid "Only select 'yes' if you are using a multiswich that requires a DiSEqC Port-A command signal. For all other setups select 'no'."
@@ -11237,26 +10930,27 @@ msgstr ""
 msgid "Open bouquetlist..."
 msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "Open favourites list"
-msgstr ""
+msgstr "Open favourites list"
 
 msgid "Open long"
 msgstr ""
 
 msgid "Open satellites list"
-msgstr "Open satellites list"
+msgstr ""
 
 msgid "Open service list"
-msgstr "Open service list"
+msgstr ""
 
 msgid "Open service list and select next channel"
-msgstr "Open service list and select next channel"
+msgstr ""
 
 msgid "Open service list and select next channel for PiP"
 msgstr ""
 
 msgid "Open service list and select previous channel"
-msgstr "Open service list and select previous channel"
+msgstr ""
 
 msgid "Open service list and select previous channel for PiP"
 msgstr ""
@@ -11268,7 +10962,7 @@ msgid "Open the Plugin Browser"
 msgstr ""
 
 msgid "Open the movie list"
-msgstr "Open the movie list"
+msgstr ""
 
 msgid "Open with File Commander"
 msgstr ""
@@ -11280,29 +10974,25 @@ msgid "OpenVPN Setup"
 msgstr ""
 
 msgid "OpenVpn Log"
-msgstr "OpenVpn Log"
+msgstr ""
 
 msgid "OpenVpn Setup"
-msgstr "OpenVpn Setup"
+msgstr ""
 
-#, fuzzy
 msgid "Operating LED status in deep standby mode"
-msgstr "LED brightness during deep standby."
+msgstr ""
 
-#, fuzzy
 msgid "Operating LED status in standby mode"
-msgstr "LED brightness during standby."
+msgstr ""
 
 msgid "Operating LED status while running"
 msgstr ""
 
-#, fuzzy
 msgid "Option"
-msgstr "Encryption"
+msgstr ""
 
-#, fuzzy
 msgid "Option long"
-msgstr "OK button (long)"
+msgstr ""
 
 msgid "Option to disable picons on the Infobar"
 msgstr ""
@@ -11311,19 +11001,19 @@ msgid "Option to enable the Hardware Standby Timer"
 msgstr ""
 
 msgid "Orbital position"
-msgstr "Orbital position"
+msgstr ""
 
 msgid "Ordinary"
 msgstr ""
 
 msgid "Original"
-msgstr "Original"
+msgstr ""
 
 msgid "Oscam Info - Configuration"
-msgstr "Oscam Info - Configuration"
+msgstr ""
 
 msgid "Oscam Info - Main Menu"
-msgstr "Oscam Info - Main Menu"
+msgstr ""
 
 #, python-format
 msgid "Oscam Log ( Oscam-Version: %s )"
@@ -11333,18 +11023,16 @@ msgid "OscamInfo Mainmenu"
 msgstr ""
 
 msgid "Other"
-msgstr "Other"
+msgstr ""
 
 msgid "Outdoor"
 msgstr ""
 
-#, fuzzy
 msgid "Overall progress:"
-msgstr "Small progress"
+msgstr ""
 
-#, fuzzy
 msgid "Overscan Test"
-msgstr "scan state"
+msgstr ""
 
 msgid "Overwrite Bootlogo Files ?"
 msgstr ""
@@ -11368,10 +11056,10 @@ msgid "Overwrite bootlogo files during software upgrade?"
 msgstr ""
 
 msgid "Overwrite configuration files during software upgrade?"
-msgstr "Overwrite configuration files during software upgrade?"
+msgstr ""
 
 msgid "Overwrite configuration files?"
-msgstr "Overwrite configuration files?"
+msgstr ""
 
 msgid "Overwrite driver files during software upgrade?"
 msgstr ""
@@ -11392,10 +11080,10 @@ msgid "Owner:"
 msgstr ""
 
 msgid "PAGE UP/DOWN"
-msgstr "PAGE UP/DOWN"
+msgstr ""
 
 msgid "PAL"
-msgstr "PAL"
+msgstr ""
 
 msgid "PC"
 msgstr ""
@@ -11410,18 +11098,16 @@ msgid "PCM Multichannel"
 msgstr ""
 
 msgid "PCR PID"
-msgstr "PCR PID"
+msgstr ""
 
-#, fuzzy
 msgid "PDC"
-msgstr "DAC"
+msgstr ""
 
-#, fuzzy
 msgid "PID"
-msgstr "PIDs"
+msgstr ""
 
 msgid "PIDs"
-msgstr "PIDs"
+msgstr ""
 
 msgid "PIN code needed"
 msgstr ""
@@ -11436,23 +11122,22 @@ msgid "PIP with OSD"
 msgstr ""
 
 msgid "PLP ID"
-msgstr "PLP ID"
+msgstr ""
 
 msgid "PLS Code"
 msgstr ""
 
-#, fuzzy
 msgid "PLS Mode"
-msgstr "3D Mode"
+msgstr ""
 
 msgid "PMT PID"
-msgstr "PMT PID"
+msgstr ""
 
 msgid "PPanel"
 msgstr ""
 
 msgid "PRIMETIME"
-msgstr "PRIMETIME"
+msgstr ""
 
 msgid "PVR"
 msgstr ""
@@ -11464,49 +11149,43 @@ msgid "Package list"
 msgstr ""
 
 msgid "Package list update"
-msgstr "Package list update"
+msgstr ""
 
 msgid "Packages"
-msgstr "Packages"
+msgstr ""
 
 msgid "Packet management"
-msgstr "Packet management"
+msgstr ""
 
 msgid "Packet manager"
-msgstr "Packet manager"
+msgstr ""
 
 msgid "Page down"
-msgstr "Page down"
+msgstr ""
 
-#, fuzzy
 msgid "Page down list"
-msgstr "Page down"
+msgstr ""
 
 msgid "Page right"
-msgstr "Page right"
+msgstr ""
 
 msgid "Page up"
-msgstr "Page up"
+msgstr ""
 
-#, fuzzy
 msgid "Page up list"
-msgstr "Page up"
+msgstr ""
 
-#, fuzzy
 msgid "PageDown"
-msgstr "Page down"
+msgstr ""
 
-#, fuzzy
 msgid "PageDown long"
-msgstr "Downloading"
+msgstr ""
 
-#, fuzzy
 msgid "PageUp"
-msgstr "Page up"
+msgstr ""
 
-#, fuzzy
 msgid "PageUp long"
-msgstr "Page down"
+msgstr ""
 
 msgid "Pakistan"
 msgstr ""
@@ -11520,7 +11199,7 @@ msgstr ""
 #. TRANSLATORS: (aspect ratio policy: cropped content on left/right) in doubt, keep english term
 #. TRANSLATORS: (aspect ratio policy: Fit width, cut/crop top and bottom (Maintain aspect ratio))
 msgid "Pan&scan"
-msgstr "Pan&scan"
+msgstr ""
 
 msgid "Panama"
 msgstr ""
@@ -11534,31 +11213,29 @@ msgstr ""
 msgid "Papua New Guinea"
 msgstr ""
 
-#, fuzzy
 msgid "Parabel"
-msgstr "Label"
+msgstr ""
 
 msgid "Paraguay"
 msgstr ""
 
-#, fuzzy
 msgid "Parent Directory"
-msgstr "Parent directory"
+msgstr ""
 
 msgid "Parent directory"
-msgstr "Parent directory"
+msgstr ""
 
 msgid "Parental Guidance Recommended"
 msgstr ""
 
 msgid "Parental control"
-msgstr "Parental control"
+msgstr ""
 
 msgid "Parental control services editor"
 msgstr ""
 
 msgid "Parental control setup"
-msgstr "Parental control setup"
+msgstr ""
 
 msgid "Parliament"
 msgstr ""
@@ -11573,63 +11250,58 @@ msgid "Passthrough"
 msgstr ""
 
 msgid "Password"
-msgstr "Password"
+msgstr ""
 
 msgid "Password (httpwd)"
-msgstr "Password (httpwd)"
+msgstr ""
 
-#, fuzzy
 msgid "Password Setup"
-msgstr "Password"
+msgstr ""
 
-#, fuzzy
 msgid "Password changed"
-msgstr "Password (httpwd)"
+msgstr ""
 
 msgid "Password:"
-msgstr "Password:"
+msgstr ""
 
 msgid "Path to save not exist: '/tmp/'"
 msgstr ""
 
 msgid "Pause"
-msgstr "Pause"
+msgstr ""
 
 msgid "Pause movie at end"
-msgstr "Pause movie at end"
+msgstr ""
 
 msgid "Pause playback"
-msgstr "Pause playback"
+msgstr ""
 
 msgid "Pause/Continue playback"
 msgstr ""
 
-#, fuzzy
 msgid "Pausing"
-msgstr "using:"
+msgstr ""
 
 msgid "Peak load (max queued requests per workerthread)"
-msgstr "Peak load (max queued requests per worker thread)"
+msgstr ""
 
 msgid "Percentage"
-msgstr "Percentage"
+msgstr ""
 
 msgid "Percentage left"
-msgstr "Percentage left"
+msgstr ""
 
 msgid "Percentage right"
-msgstr "Percentage right"
+msgstr ""
 
-#, fuzzy
 msgid "Percentage/Progress bar left"
-msgstr "Progress bar left"
+msgstr ""
 
-#, fuzzy
 msgid "Percentage/Progress bar right"
-msgstr "Progress bar right"
+msgstr ""
 
 msgid "Perform a full image backup"
-msgstr "Perform a full image backup"
+msgstr ""
 
 msgid "Perform a image backup before updating."
 msgstr ""
@@ -11638,29 +11310,28 @@ msgid "Perform a setting backup before updating."
 msgstr ""
 
 msgid "Perform a settings backup,"
-msgstr "Perform a settings backup,"
+msgstr ""
 
 msgid "Perform a settings backup, making a backup before updating is strongly advised."
-msgstr "Perform a settings backup, making a backup before updating is strongly advised."
+msgstr ""
 
 msgid "Perform an online update check in the background"
-msgstr "Perform an online update check in the background"
+msgstr ""
 
 msgid "Permanently delete all recordings in the trash can?"
-msgstr "Permanently delete all recordings in the trash can?"
+msgstr "Are you sure you want to permanently delete all recordings in the trash?"
 
 msgid "Permanently remove all deleted items"
-msgstr "Permanently remove all deleted items"
+msgstr ""
 
-#, fuzzy
 msgid "Permissions:"
-msgstr "Version: "
+msgstr ""
 
 msgid "Persian"
-msgstr "Persian"
+msgstr ""
 
 msgid "Personalize your Skin"
-msgstr ""
+msgstr "Personalise your Skin"
 
 msgid "Peru"
 msgstr ""
@@ -11669,9 +11340,18 @@ msgid "Philippines"
 msgstr ""
 
 msgid "PiP"
-msgstr "PiP"
+msgstr ""
 
 msgid "PiP-Zap"
+msgstr ""
+
+msgid "PiP mode"
+msgstr ""
+
+msgid "PiP size and position change"
+msgstr ""
+
+msgid "PiP usage Setup"
 msgstr ""
 
 msgid "PiPSetup"
@@ -11681,100 +11361,101 @@ msgid "PiPZap"
 msgstr ""
 
 msgid "Picon"
-msgstr "Picon"
+msgstr ""
 
 msgid "Picon and Service Name"
-msgstr "Picon and Service Name"
+msgstr ""
 
 msgid "Picon and service name"
 msgstr ""
 
 msgid "Picon width"
-msgstr "Picon width"
+msgstr ""
 
-#, fuzzy
 msgid "Picture in EPG"
-msgstr "Picture in graphics"
+msgstr ""
 
 msgid "Picture in Picture Setup"
 msgstr ""
 
 msgid "Picture in graphics"
-msgstr "Picture in graphics"
+msgstr ""
 
 msgid "Picture player"
-msgstr "Picture player"
+msgstr ""
 
 msgid "PicturePlayer"
 msgstr ""
 
-#, fuzzy
 msgid "Pictures"
-msgstr "Picture player"
+msgstr ""
 
 #. TRANSLATORS: (aspect ratio policy: black bars on left/right) in doubt, keep english term.
 msgid "Pillarbox"
-msgstr "Pillarbox"
+msgstr ""
 
 msgid "Pilot"
-msgstr "Pilot"
+msgstr ""
 
 msgid "Pitcairn"
 msgstr ""
 
+msgid "Pixel Test"
+msgstr ""
+
+msgid "Pixels\n"
+msgstr ""
+
 msgid "Play"
-msgstr "Play"
+msgstr ""
 
 msgid "Play DVD"
-msgstr "Play DVD"
+msgstr ""
 
-#, fuzzy
 msgid "Play DVDs"
-msgstr "Play DVD"
+msgstr ""
 
 msgid "Play audio in background"
-msgstr "Play audio in background"
+msgstr ""
 
 msgid "Play audio-CD..."
-msgstr "Play audio-CD..."
+msgstr ""
 
 msgid "Play back media files"
-msgstr "Play back media files"
+msgstr ""
 
 msgid "Play entry"
-msgstr "Play entry"
+msgstr ""
 
-#, fuzzy
 msgid "Play folder"
-msgstr "Play entry"
+msgstr ""
 
 msgid "Play from next mark or playlist entry"
-msgstr "Play from next mark or playlist entry"
+msgstr ""
 
 msgid "Play from previous mark or playlist entry"
-msgstr "Play from previous mark or playlist entry"
+msgstr ""
 
 msgid "Play music..."
-msgstr "Play Music…"
+msgstr ""
 
 msgid "Play next"
-msgstr "Play next"
+msgstr ""
 
 msgid "Play next (return to movie list)"
-msgstr "Play next (return to movie list)"
+msgstr ""
 
 msgid "Play next (return to previous service)"
-msgstr "Play next (return to previous service)"
+msgstr ""
 
 msgid "Play previous"
-msgstr "Play previous"
+msgstr ""
 
 msgid "Play recorded movies..."
-msgstr "Play recorded movies..."
+msgstr ""
 
-#, fuzzy
 msgid "Play title"
-msgstr "Delay time"
+msgstr ""
 
 msgid "Play/view/edit/install/extract/run file or enter directory"
 msgstr ""
@@ -11789,149 +11470,137 @@ msgid "Playpause"
 msgstr ""
 
 msgid "Please add titles to the compilation."
-msgstr "Please add titles to the compilation."
+msgstr ""
 
 msgid "Please be patient, a backup will now be made,\n"
 msgstr ""
 
 msgid "Please change recording endtime"
-msgstr "Please change recording end time"
+msgstr ""
 
-#, fuzzy
 msgid "Please check the manual of the receiver"
-msgstr "Please enter name of the new directory"
+msgstr ""
 
 msgid "Please check your network settings!"
-msgstr "Please check your network settings!"
+msgstr ""
 
 msgid "Please choose CCcam-Reader"
-msgstr "Please choose CCcam-Reader"
+msgstr ""
 
 msgid "Please choose an extension..."
-msgstr "Please choose an extension..."
+msgstr ""
 
 msgid "Please choose he package..."
 msgstr ""
 
 msgid "Please choose reader"
-msgstr "Please choose reader"
+msgstr ""
 
 msgid ""
 "Please configure or verify your Nameservers by filling out the required values.\n"
 "When you are ready press OK to continue."
 msgstr ""
-"Please configure or verify your Name servers by filling out the required values.\n"
-"When you are ready press OK to continue."
 
 msgid ""
 "Please configure your internet connection by filling out the required values.\n"
 "When you are ready press OK to continue."
 msgstr ""
-"Please configure your internet connection by filling out the required values.\n"
-"When you are ready press OK to continue."
 
 msgid "Please connect your %s %s to the internet"
 msgstr ""
 
 msgid "Please do not change any values unless you know what you are doing!"
-msgstr "Please do not change any values unless you know what you are doing!"
+msgstr ""
 
 msgid "Please enter a name for the new bouquet"
-msgstr "Please enter a name for the new bouquet"
+msgstr ""
 
 msgid "Please enter a name for the new marker"
-msgstr "Please enter a name for the new marker"
+msgstr ""
 
 msgid "Please enter a new filename"
-msgstr "Please enter a new filename"
+msgstr ""
 
 msgid "Please enter filename (empty = use current date)"
-msgstr "Please enter filename (empty = use current date)"
+msgstr ""
 
 msgid "Please enter name of the new directory"
-msgstr "Please enter name of the new directory"
+msgstr ""
 
-#, fuzzy
 msgid "Please enter name of the new symlink"
-msgstr "Please enter name of the new directory"
+msgstr ""
 
 msgid "Please enter new description:"
 msgstr ""
 
 msgid "Please enter new name:"
-msgstr "Please enter new name:"
+msgstr ""
 
-#, fuzzy
 msgid "Please enter password"
-msgstr "Please enter new name:"
+msgstr ""
 
 msgid "Please enter search string for your location"
 msgstr ""
 
 msgid "Please enter the correct pin code"
-msgstr "Please enter the correct pin code"
+msgstr ""
 
-#, fuzzy
 msgid "Please enter the new directory name"
-msgstr "Please enter name of the new directory"
+msgstr ""
 
-#, fuzzy
 msgid "Please enter the new file name"
-msgstr "Please enter a new filename"
+msgstr ""
 
 msgid "Please enter the old PIN code"
-msgstr "Please enter the old PIN code"
+msgstr ""
 
 msgid "Please enter your email address. This is required for us to send you service announcements, account reminders, promotional offers and a welcome email."
 msgstr ""
 
-#, fuzzy
 msgid "Please enter your personal feed URL"
-msgstr "Please enter a new filename"
+msgstr ""
 
 msgid "Please follow the instructions on the TV"
-msgstr "Please follow the instructions on the TV"
+msgstr ""
 
 msgid "Please note that the previously selected media could not be accessed and therefore the default directory is being used instead."
-msgstr "Please note that the previously selected media could not be accessed and therefore the default directory is being used instead."
+msgstr ""
 
 msgid "Please open Picture in Picture first"
 msgstr ""
 
 msgid "Please press OK to continue."
-msgstr "Please press OK to continue."
+msgstr ""
 
-#, fuzzy
 msgid "Please press OK to start Kodi..."
-msgstr "Please press OK to continue."
+msgstr ""
 
-#, fuzzy
 msgid "Please select a backup destination"
-msgstr "Please select medium to use as backup location"
+msgstr ""
 
 msgid "Please select a default EPG type..."
-msgstr "Please select a default EPG type…"
+msgstr ""
 
 msgid "Please select a playlist to delete..."
-msgstr "Please select a playlist to delete..."
+msgstr ""
 
 msgid "Please select a playlist..."
-msgstr "Please select a playlist..."
+msgstr ""
 
 msgid "Please select a resolution..."
 msgstr ""
 
 msgid "Please select a sub service..."
-msgstr "Please select a sub service…"
+msgstr ""
 
 msgid "Please select a subservice to record..."
-msgstr "Please select a subservice to record..."
+msgstr ""
 
 msgid "Please select a subservice..."
-msgstr "Please select a subservice..."
+msgstr ""
 
 msgid "Please select an NFI file and press green key to flash!"
-msgstr "Please select an NFI file and press green key to flash!"
+msgstr ""
 
 msgid "Please select an aspect ratio..."
 msgstr ""
@@ -11940,29 +11609,25 @@ msgid "Please select device to use as swapfile location"
 msgstr ""
 
 msgid "Please select medium to be scanned"
-msgstr "Please select medium to be scanned"
+msgstr ""
 
 msgid "Please select medium to use as backup location"
-msgstr "Please select medium to use as backup location"
+msgstr ""
 
 msgid "Please select tag to filter..."
-msgstr "Please select tag to filter..."
+msgstr ""
 
-#, fuzzy
 msgid "Please select the IceTV service that you wish to use."
-msgstr "Please select the movie path..."
+msgstr ""
 
 msgid "Please select the movie path..."
-msgstr "Please select the movie path..."
+msgstr ""
 
 msgid ""
 "Please select the network interface that you want to use for your internet connection.\n"
 "\n"
 "Please press OK to continue."
 msgstr ""
-"Please select the network interface that you want to use for your internet connection.\n"
-"\n"
-"Please press OK to continue."
 
 msgid "Please select the region that most closely matches your physical location. The region is required to enable us to provide the correct guide information for the channels you can receive."
 msgstr ""
@@ -11972,9 +11637,6 @@ msgid ""
 "\n"
 "Please press OK to continue."
 msgstr ""
-"Please select the wireless network that you want to connect to.\n"
-"\n"
-"Please press OK to continue."
 
 msgid ""
 "Please select what to do after flashing the image:\n"
@@ -11982,7 +11644,7 @@ msgid ""
 msgstr ""
 
 msgid "Please set up tuner A"
-msgstr "Please set up tuner A"
+msgstr ""
 
 msgid ""
 "Please set up tuner A\n"
@@ -11990,7 +11652,7 @@ msgid ""
 msgstr ""
 
 msgid "Please set up tuner B"
-msgstr "Please set up tuner B"
+msgstr ""
 
 msgid ""
 "Please set up tuner B\n"
@@ -11998,7 +11660,7 @@ msgid ""
 msgstr ""
 
 msgid "Please set up tuner C"
-msgstr "Please set up tuner C"
+msgstr ""
 
 msgid ""
 "Please set up tuner C\n"
@@ -12006,7 +11668,7 @@ msgid ""
 msgstr ""
 
 msgid "Please set up tuner D"
-msgstr "Please set up tuner D"
+msgstr ""
 
 msgid ""
 "Please set up tuner D\n"
@@ -12053,9 +11715,8 @@ msgid ""
 "For Hybrid Tuner Models switch Tuner Type with left and right keys"
 msgstr ""
 
-#, fuzzy
 msgid "Please set your time zone"
-msgstr "Setup your timezone."
+msgstr ""
 
 msgid ""
 "Please setup your user interface by adjusting the values till the edges of the red box are touching the edges of your TV.\n"
@@ -12072,81 +11733,72 @@ msgid ""
 "Press Bouquet +/- to resize the window.\n"
 "Press OK to go back to the TV mode or EXIT to cancel the moving."
 msgstr ""
-"Please use direction keys to move the PiP window.\n"
-"Press Bouquet +/- to resize the window.\n"
-"Press OK to go back to the TV mode or EXIT to cancel the moving."
 
 msgid "Please use the UP and DOWN keys to select your language. Afterwards press the OK button."
-msgstr "Please use the UP and DOWN keys to select your language. Afterwards press the OK button."
+msgstr ""
 
-#, fuzzy
 msgid "Please wait"
-msgstr "Please wait..."
+msgstr ""
 
 msgid "Please wait for activation of your network configuration..."
-msgstr "Please wait for activation of your network configuration..."
+msgstr ""
 
 msgid "Please wait while gathering data..."
-msgstr "Please wait while gathering data..."
+msgstr ""
 
 msgid "Please wait while scanning is in progress..."
-msgstr "Please wait while scanning is in progress..."
+msgstr ""
 
-#, fuzzy
 msgid "Please wait while the list downloads..."
-msgstr "Please wait while gathering data..."
+msgstr ""
 
 msgid "Please wait while we check your installed plugins..."
 msgstr ""
 
 msgid "Please wait while we configure your network..."
-msgstr "Please wait while we configure your network..."
+msgstr ""
 
 msgid "Please wait while we prepare your network interfaces..."
-msgstr "Please wait while we prepare your network interfaces..."
+msgstr ""
 
 msgid "Please wait while we test your network..."
-msgstr "Please wait while we test your network..."
+msgstr ""
 
 msgid "Please wait while your network is restarting..."
-msgstr "Please wait while your network is restarting..."
+msgstr ""
 
 msgid "Please wait while your skin setting is restoring..."
 msgstr ""
 
 msgid "Please wait whilst feeds state is checked."
-msgstr "Please wait whilst feeds state is checked."
+msgstr ""
 
-#, fuzzy
 msgid "Please wait, Loading image."
-msgstr "Please wait... Loading list..."
+msgstr ""
 
-#, fuzzy
 msgid "Please wait, restarting cardserver."
-msgstr "Please wait (updating packages)"
+msgstr ""
 
 msgid "Please wait, restarting softcam and cardserver."
 msgstr ""
 
-#, fuzzy
 msgid "Please wait, restarting softcam."
-msgstr "Please wait while gathering data..."
+msgstr ""
 
 msgid "Please wait."
 msgstr ""
 
 msgid "Please wait..."
-msgstr "Please wait..."
+msgstr ""
 
 msgid "Please wait... Loading list..."
-msgstr "Please wait... Loading list..."
+msgstr ""
 
-#, fuzzy
 msgid "Please wait...almost ready! "
-msgstr "Please wait..."
+msgstr ""
 
 msgid "Plugin Browser"
-msgstr "Plugin Browser"
+msgstr ""
 
 msgid "Plugin Filter"
 msgstr ""
@@ -12155,19 +11807,19 @@ msgid "Plugin browser"
 msgstr ""
 
 msgid "Plugin details"
-msgstr "Plugin details"
+msgstr ""
 
 msgid "Plugin manager activity information"
-msgstr "Plugin manager activity information"
+msgstr ""
 
 msgid "Plugin manager help"
-msgstr "Plugin manager help"
+msgstr ""
 
 msgid "Pluginbrowser Settings"
 msgstr ""
 
 msgid "Plugins"
-msgstr "Plugins"
+msgstr ""
 
 msgid "Poker"
 msgstr ""
@@ -12176,65 +11828,67 @@ msgid "Poland"
 msgstr ""
 
 msgid "Polarisation"
-msgstr "Polarisation"
+msgstr ""
 
 msgid "Polarization"
 msgstr "Polarisation"
 
 msgid "Polish"
-msgstr "Polish"
+msgstr ""
 
-#, fuzzy
 msgid "Politik"
-msgstr "Polish"
+msgstr ""
 
 msgid "Popup"
 msgstr ""
 
 msgid "Port"
-msgstr "Port"
+msgstr ""
 
 msgid "Port A"
-msgstr "Port A"
+msgstr ""
 
 msgid "Port B"
-msgstr "Port B"
+msgstr ""
 
 msgid "Port C"
-msgstr "Port C"
+msgstr ""
 
 msgid "Port D"
-msgstr "Port D"
+msgstr ""
 
 msgid "Port:"
-msgstr "Port:"
+msgstr ""
 
-#, fuzzy
 msgid "Porträt"
-msgstr "Port"
+msgstr ""
 
-#, fuzzy
 msgid "Portugal"
-msgstr "Portuguese"
+msgstr ""
 
 msgid "Portuguese"
-msgstr "Portuguese"
+msgstr ""
 
 msgid "Position Setup"
-msgstr "Position Setup"
+msgstr ""
+
+msgid ""
+"Position change:  Use direction keys to move the PiP window\n"
+"Size change:  Channel +/- to resize the window\n"
+"OK  -  save changes  |  EXIT  -  cancel"
+msgstr ""
 
 msgid "Position of finished Timers in Timerlist"
 msgstr ""
 
-#, fuzzy
 msgid "Position of recording icons"
-msgstr "Composition of the recording filenames"
+msgstr ""
 
 msgid "Position stored at index"
-msgstr "Position stored at index"
+msgstr ""
 
 msgid "Positioner"
-msgstr "Positioner"
+msgstr ""
 
 msgid "Positioner (selecting satellites)"
 msgstr ""
@@ -12242,34 +11896,29 @@ msgstr ""
 msgid "Positioner Setup"
 msgstr ""
 
-#, fuzzy
 msgid "Positioner Setup Log"
-msgstr "Positioner setup"
+msgstr ""
 
 msgid "Positioner setup"
-msgstr "Positioner setup"
+msgstr ""
 
 msgid "Power"
 msgstr ""
 
-#, fuzzy
 msgid "Power LED State in Deep-Standby"
-msgstr "LED Deep Standby"
+msgstr ""
 
-#, fuzzy
 msgid "Power LED State in Standby"
-msgstr "LED Deep Standby"
+msgstr ""
 
 msgid "Power LED can be turned on or off here."
 msgstr ""
 
-#, fuzzy
 msgid "Power LED state during deep-standby."
-msgstr "LED brightness during deep standby."
+msgstr ""
 
-#, fuzzy
 msgid "Power LED state during standby."
-msgstr "LED brightness during standby."
+msgstr ""
 
 msgid "Power On Display"
 msgstr ""
@@ -12281,16 +11930,16 @@ msgid "Power management. Consult your receiver's manual for more information."
 msgstr ""
 
 msgid "Power threshold in mA"
-msgstr "Power threshold in mA"
+msgstr ""
 
 msgid "Power threshold. Consult your receiver's manual for more information."
 msgstr ""
 
 msgid "PowerManager entry"
-msgstr "PowerManager entry"
+msgstr ""
 
 msgid "PowerManager log"
-msgstr "PowerManager log"
+msgstr ""
 
 msgid "PowerTimer"
 msgstr ""
@@ -12299,43 +11948,43 @@ msgid "PowerTimer DeepStandby"
 msgstr ""
 
 msgid "PowerTimer List"
-msgstr "PowerTimer List"
+msgstr ""
 
 msgid "PowerTimer Overview"
-msgstr "PowerTimer Overview"
+msgstr ""
 
 msgid "PowerTimer Standby"
 msgstr ""
 
 msgid "PowerTimers"
-msgstr "PowerTimers"
+msgstr ""
 
 msgid "Predefined"
-msgstr "Predefined"
+msgstr ""
 
 msgid "Predefined transponder"
-msgstr "Predefined transponder"
+msgstr ""
 
 msgid "Prefer AC3 track"
-msgstr "Prefer AC3 track"
+msgstr ""
 
 msgid "Prefer AC3+ track"
 msgstr ""
 
 msgid "Prefer audio track stored by service"
-msgstr "Prefer audio track stored by service"
+msgstr ""
 
 msgid "Prefer graphical DVB subtitles"
-msgstr "Prefer graphical DVB subtitles"
+msgstr ""
 
 msgid "Prefer subtitles for hearing impaired"
-msgstr "Prefer subtitles for hearing impaired"
+msgstr ""
 
 msgid "Prefer subtitles stored by service"
-msgstr "Prefer subtitles stored by service"
+msgstr ""
 
 msgid "Preferred tuner"
-msgstr "Preferred tuner"
+msgstr ""
 
 msgid "Preferred tuner for recordings"
 msgstr ""
@@ -12346,59 +11995,60 @@ msgstr ""
 msgid "Preferred tuners, multiple selection allowed"
 msgstr ""
 
-#, fuzzy
 msgid "Preparation time for recording (seconds)"
-msgstr "Margin before recording (minutes)"
+msgstr ""
 
 msgid "Prepare another USB stick for image flashing"
-msgstr "Prepare another USB stick for image flashing"
+msgstr ""
 
 msgid "Preparing... Please wait"
-msgstr "Preparing... Please wait"
+msgstr ""
 
 msgid "Preschool"
+msgstr ""
+
+msgid "Press '0' to toggle PiP current mode"
 msgstr ""
 
 msgid "Press '0' to toggle PiP mode"
 msgstr ""
 
 msgid "Press INFO on your remote control for additional information."
-msgstr "Press INFO on your remote control for additional information."
+msgstr ""
 
 msgid "Press Init to format SDcard."
 msgstr ""
 
 msgid "Press MENU on your remote control for additional options."
-msgstr "Press MENU on your remote control for additional options."
+msgstr ""
 
-#, fuzzy
 msgid "Press MENU to install additional language(s)."
-msgstr "Press MENU on your remote control for additional options."
+msgstr ""
 
 msgid "Press OK on your remote control to continue."
-msgstr "Press OK on your remote control to continue."
+msgstr ""
 
 msgid "Press OK to activate the selected skin."
-msgstr "Press OK to activate the selected skin."
+msgstr ""
 
 msgid "Press OK to activate the settings."
-msgstr "Press OK to activate the settings."
+msgstr ""
 
 msgid "Press OK to edit the settings."
-msgstr "Press OK to edit the settings."
+msgstr ""
 
 #, python-format
 msgid "Press OK to get further details for %s"
-msgstr "Press OK to get further details for %s"
+msgstr ""
 
 msgid "Press OK to scan"
-msgstr "Press OK to scan"
+msgstr ""
 
 msgid "Press OK to select a group of satellites to configure in one block."
 msgstr ""
 
 msgid "Press OK to select a provider."
-msgstr "Press OK to select a provider."
+msgstr ""
 
 msgid "Press OK to select a service."
 msgstr ""
@@ -12407,19 +12057,19 @@ msgid "Press OK to select satellites"
 msgstr ""
 
 msgid "Press OK to select/deselect a CAId."
-msgstr "Press OK to select/deselect a CAId."
+msgstr ""
 
 msgid "Press OK to set the MAC-address."
-msgstr "Press OK to set the MAC-address."
+msgstr ""
 
 msgid "Press OK to start the scan"
-msgstr "Press OK to start the scan"
+msgstr ""
 
 msgid "Press OK to toggle the selection"
 msgstr ""
 
 msgid "Press OK to toggle the selection."
-msgstr "Press OK to toggle the selection."
+msgstr ""
 
 msgid "Press this button to emulate a long press on a button pressed afterwards (this also overrides any other actions assigned to emulation button)."
 msgstr ""
@@ -12434,15 +12084,21 @@ msgid "Prev quad PiP channel"
 msgstr ""
 
 msgid "Preview"
-msgstr "Preview"
+msgstr ""
 
 msgid "Preview menu"
-msgstr "Preview menu"
+msgstr ""
 
 msgid "Preview selected channel"
 msgstr ""
 
 msgid "Previous"
+msgstr ""
+
+msgid "Previous bouquet"
+msgstr ""
+
+msgid "Previous page"
 msgstr ""
 
 msgid "Prevsong"
@@ -12452,40 +12108,38 @@ msgid "Prevsong long"
 msgstr ""
 
 msgid "Primary DNS"
-msgstr "Primary DNS"
+msgstr ""
 
-#, fuzzy
 msgid "Primetime"
-msgstr "Primetime hour"
+msgstr ""
 
 msgid "Primetime hour"
-msgstr "Primetime hour"
+msgstr ""
 
 msgid "Primetime minute"
-msgstr "Primetime minute"
+msgstr ""
 
 msgid "Priority"
-msgstr "Priority"
+msgstr ""
 
 msgid "Probable causes could be"
 msgstr ""
 
 msgid "Process"
-msgstr "Process"
+msgstr ""
 
 #, python-format
 msgid "Processor temperature:\t%s"
 msgstr ""
 
 msgid "Profile"
-msgstr "Profile"
+msgstr ""
 
 msgid "Profile: Local box"
-msgstr "Profile: Local box"
+msgstr ""
 
-#, fuzzy
 msgid "Program"
-msgstr "Progress"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -12530,43 +12184,37 @@ msgid "Programmlisten-Updater from DXAndy"
 msgstr ""
 
 msgid "Progress"
-msgstr "Progress"
+msgstr ""
 
 msgid "Progress bar left"
-msgstr "Progress bar left"
+msgstr ""
 
 msgid "Progress bar right"
-msgstr "Progress bar right"
+msgstr ""
 
-#, fuzzy
 msgid "Progress bar/Percentage left"
-msgstr "Progress bar left"
+msgstr ""
 
-#, fuzzy
 msgid "Progress bar/Percentage right"
-msgstr "Progress bar right"
+msgstr ""
 
-#, fuzzy
 msgid "Progress bar/Remaining minutes left"
-msgstr "Progress bar left"
+msgstr ""
 
-#, fuzzy
 msgid "Progress bar/Remaining minutes right"
-msgstr "Progress bar right"
+msgstr ""
 
-#, fuzzy
 msgid "Progress info font size"
-msgstr "Service info font size"
+msgstr ""
 
-#, fuzzy
 msgid "Progress:"
-msgstr "Progress"
+msgstr ""
 
 msgid "Prominent"
 msgstr ""
 
 msgid "Properties of current title"
-msgstr "Properties of current title"
+msgstr ""
 
 msgid "Protect InfoPanel"
 msgstr ""
@@ -12596,7 +12244,7 @@ msgid "Protect plugin browser"
 msgstr ""
 
 msgid "Protect services"
-msgstr "Protect services"
+msgstr ""
 
 msgid "Protect standby menu"
 msgstr ""
@@ -12608,7 +12256,7 @@ msgid "Protek 4K UHD/HD61"
 msgstr ""
 
 msgid "Protocol"
-msgstr "Protocol"
+msgstr ""
 
 msgid "Prov"
 msgstr ""
@@ -12617,22 +12265,22 @@ msgid "Prov long"
 msgstr ""
 
 msgid "Provider"
-msgstr "Provider"
+msgstr ""
 
 msgid "Provider Name: "
-msgstr "Provider Name: "
+msgstr ""
 
 msgid "Provider: "
-msgstr "Provider: "
+msgstr ""
 
 msgid "Providers"
-msgstr "Providers"
+msgstr ""
 
 msgid "Providers:"
-msgstr "Providers:"
+msgstr ""
 
 msgid "Providers: "
-msgstr "Providers: "
+msgstr ""
 
 msgid "Psychologie"
 msgstr ""
@@ -12644,14 +12292,13 @@ msgid "Puppentrick"
 msgstr ""
 
 msgid "Put TV in standby"
-msgstr "Put TV in standby"
+msgstr ""
 
-#, fuzzy
 msgid "Put your AV Receiver in standby"
-msgstr "Put your %s %s in standby"
+msgstr ""
 
 msgid "Python frontend for /tmp/mmi.socket"
-msgstr "Python frontend for /tmp/mmi.socket"
+msgstr ""
 
 #, python-format
 msgid "Python:\t\t%s"
@@ -12660,26 +12307,23 @@ msgstr ""
 msgid "Qatar"
 msgstr ""
 
-#, fuzzy
 msgid "Quad PiP Channel Selection"
-msgstr "Channel selection"
+msgstr ""
 
 msgid "Quad PiP Screen"
 msgstr ""
 
-#, fuzzy
 msgid "Quad PiP channel "
-msgstr "%d channel found"
+msgstr ""
 
-#, fuzzy
 msgid "Quad PiP is not available."
-msgstr "Update feed not available."
+msgstr ""
 
 msgid "Question"
 msgstr ""
 
 msgid "Quick"
-msgstr "Quick"
+msgstr ""
 
 msgid "Quick Actions"
 msgstr ""
@@ -12691,7 +12335,7 @@ msgid "Quick Menu..."
 msgstr ""
 
 msgid "Quick zap"
-msgstr "Quick zap"
+msgstr ""
 
 msgid "QuickEPG mode"
 msgstr ""
@@ -12706,11 +12350,10 @@ msgid "Quiz"
 msgstr ""
 
 msgid "RAM"
-msgstr "RAM"
+msgstr ""
 
-#, fuzzy
 msgid "REC"
-msgstr "FEC"
+msgstr ""
 
 msgid "REC Symbol"
 msgstr ""
@@ -12722,57 +12365,54 @@ msgid "REC Symbol in use"
 msgstr ""
 
 msgid "RF output"
-msgstr "RF output"
+msgstr ""
 
 msgid "RGB"
-msgstr "RGB"
+msgstr ""
 
 msgid "Radio"
 msgstr ""
 
-#, fuzzy
 msgid "Radio Channel Selection"
-msgstr "Channel selection"
+msgstr ""
 
 msgid "Radio long"
 msgstr ""
 
-#, fuzzy
 msgid "Radsport"
-msgstr "team sports"
+msgstr ""
 
 msgid "Ram"
 msgstr ""
 
 msgid "Random"
-msgstr "Random"
+msgstr ""
 
-#, fuzzy
 msgid "Random password"
-msgstr "Please enter new name:"
+msgstr ""
 
 #, python-format
 msgid "Rating defined by broadcaster - %d"
-msgstr "Rating defined by broadcaster - %d"
+msgstr ""
 
 msgid "Rating undefined"
-msgstr "Rating undefined"
+msgstr ""
 
 msgid "Re-enter new PIN"
 msgstr ""
 
 msgid "Read Userdata from oscam.conf"
-msgstr "Read User data from oscam.conf"
+msgstr ""
 
 msgid "Reader"
-msgstr "Reader"
+msgstr ""
 
 msgid "Reader Statistics"
-msgstr "Reader Statistics"
+msgstr ""
 
 #, python-format
 msgid "Ready to install \"%s\" ?"
-msgstr "Ready to install \"%s\" ?"
+msgstr ""
 
 #, python-format
 msgid "Ready to install %s ?"
@@ -12780,7 +12420,7 @@ msgstr ""
 
 #, python-format
 msgid "Ready to remove \"%s\" ?"
-msgstr "Ready to remove \"%s\" ?"
+msgstr ""
 
 #, python-format
 msgid "Ready to remove %s ?"
@@ -12796,47 +12436,45 @@ msgid "Really WOL now?"
 msgstr ""
 
 msgid "Really close without saving settings?"
-msgstr "Really close without saving settings?"
+msgstr ""
 
 msgid "Really delete done timers?"
-msgstr "Really delete completed timers?"
+msgstr ""
 
-#, fuzzy
 msgid "Really delete this entry?"
-msgstr "Really delete completed timers?"
+msgstr ""
 
 msgid "Really exit the subservices quickzap?"
-msgstr "Really exit the sub-services quick-zap?"
+msgstr ""
 
-#, fuzzy
 msgid "Really reboot into Recovery Mode?"
-msgstr "Really reboot now?"
+msgstr ""
 
 msgid "Really reboot now?"
-msgstr "Really reboot now?"
+msgstr ""
 
 #, python-format
 msgid "Really reflash your %s %s and reboot now?"
-msgstr "Really reflash your %s %s and reboot now?"
+msgstr ""
 
 msgid "Really restart now?"
-msgstr "Really restart now?"
+msgstr ""
 
 msgid "Really shutdown now?"
-msgstr "Really shutdown now?"
+msgstr ""
 
 msgid "Really upgrade the front panel and reboot now?"
 msgstr ""
 
 msgid "Really upgrade the frontprocessor and reboot now?"
-msgstr "Really upgrade the front-processor and reboot now?"
+msgstr ""
 
 #, python-format
 msgid "Really upgrade your %s %s and reboot now?"
-msgstr "Really upgrade your %s %s and reboot now?"
+msgstr ""
 
 msgid "Reboot"
-msgstr "Reboot"
+msgstr ""
 
 msgid "Rebuild"
 msgstr ""
@@ -12850,9 +12488,8 @@ msgstr ""
 msgid "Rec long"
 msgstr ""
 
-#, fuzzy
 msgid "Reception"
-msgstr "Description"
+msgstr ""
 
 msgid "Reception Settings"
 msgstr ""
@@ -12864,23 +12501,23 @@ msgid "Reception settings"
 msgstr ""
 
 msgid "Record"
-msgstr "Record"
+msgstr ""
 
 msgid "Record - same as record button"
 msgstr ""
 
 msgid "Record next"
-msgstr "Record next"
+msgstr ""
 
 msgid "Record now"
-msgstr "Record now"
+msgstr ""
 
 msgid "Record started! Stopping timeshift now ..."
-msgstr "Record started! Stopping timeshift now ..."
+msgstr ""
 
 #, python-format
 msgid "Record time limited due to conflicting timer %s"
-msgstr "Record time limited due to conflicting timer %s"
+msgstr ""
 
 msgid "Record write error (no space on disk?)"
 msgstr ""
@@ -12889,50 +12526,43 @@ msgid "Recordable media toolbox"
 msgstr ""
 
 msgid "Recording"
-msgstr "Recording"
+msgstr ""
 
 msgid "Recording Setup"
 msgstr ""
 
-#, fuzzy
 msgid "Recording aborted"
-msgstr "Recording type"
+msgstr "Recording cancelled"
 
-#, fuzzy
 msgid "Recording failed"
-msgstr "Recording type"
+msgstr ""
 
-#, fuzzy
 msgid "Recording finished"
-msgstr "Recording settings"
+msgstr ""
 
 msgid "Recording in progress"
-msgstr "Recording in progress"
+msgstr ""
 
-#, fuzzy
 msgid "Recording running"
-msgstr "Recording settings"
+msgstr ""
 
 msgid "Recording settings"
-msgstr "Recording settings"
+msgstr ""
 
-#, fuzzy
 msgid "Recording started"
-msgstr "Recording type"
+msgstr ""
 
-#, fuzzy
 msgid "Recording stopped"
-msgstr "Recording type"
+msgstr ""
 
-#, fuzzy
 msgid "Recording tuning failed"
-msgstr "Recording settings"
+msgstr ""
 
 msgid "Recording type"
-msgstr "Recording type"
+msgstr ""
 
 msgid "Recording(s) are in progress or coming up in few seconds!"
-msgstr "Recording(s) are in progress or coming up in few seconds!"
+msgstr ""
 
 msgid ""
 "Recording(s) are in progress or coming up in few seconds!\n"
@@ -12940,7 +12570,7 @@ msgid ""
 msgstr ""
 
 msgid "Recordings"
-msgstr "Recordings"
+msgstr ""
 
 msgid "Recordings & Timeshift"
 msgstr ""
@@ -12955,28 +12585,25 @@ msgid "Recordings abort streaming"
 msgstr ""
 
 msgid "Recordings always have priority"
-msgstr "Recordings always have priority"
+msgstr "Prioritise recordings"
 
-#, fuzzy
 msgid "Records"
-msgstr "Record"
+msgstr ""
 
-#, fuzzy
 msgid "Recovery Mode"
-msgstr "Record"
+msgstr ""
 
 msgid "Red"
-msgstr "Red"
+msgstr ""
 
-#, fuzzy
 msgid "Red button"
-msgstr "Red button..."
+msgstr ""
 
 msgid "Red button..."
-msgstr "Red button..."
+msgstr ""
 
 msgid "Red colored"
-msgstr ""
+msgstr "red colour text"
 
 msgid "Red long"
 msgstr ""
@@ -12985,7 +12612,7 @@ msgid "Reduce the size of the service picons for more line spacing between them.
 msgstr ""
 
 msgid "Reduce time scale"
-msgstr "Reduce time scale"
+msgstr ""
 
 msgid "Reenter PIN"
 msgstr ""
@@ -12996,40 +12623,33 @@ msgid ""
 "Please wait until your %s %s reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Reflash in progress\n"
-"Please wait until your %s %s reboots\n"
-"This may take a few minutes"
 
 msgid "Refresh every (in hours)"
-msgstr "Refresh every (in hours)"
+msgstr ""
 
 msgid "Refresh rate"
-msgstr "Refresh rate"
+msgstr ""
 
-#, fuzzy
 msgid "Refresh rate for 'Lowest Mode'"
-msgstr "Refresh rate selection."
+msgstr ""
 
 msgid "Refresh rate selection."
-msgstr "Refresh rate selection."
+msgstr ""
 
-#, fuzzy
 msgid "Refresh screen"
-msgstr "Refresh rate"
+msgstr ""
 
 msgid "Regard deep standby as standby"
-msgstr "Regard deep standby as standby"
+msgstr ""
 
 msgid "Region"
 msgstr ""
 
-#, fuzzy
 msgid "Regional"
-msgstr "religion"
+msgstr ""
 
-#, fuzzy
 msgid "Regular file"
-msgstr "template file"
+msgstr ""
 
 msgid "Reisen"
 msgstr ""
@@ -13038,7 +12658,7 @@ msgid "Reiten"
 msgstr ""
 
 msgid "Relative"
-msgstr "Relative"
+msgstr ""
 
 msgid "Release Notes"
 msgstr ""
@@ -13046,12 +12666,11 @@ msgstr ""
 msgid "Relevant PIDs Routing"
 msgstr ""
 
-#, fuzzy
 msgid "Religion"
-msgstr "religion"
+msgstr ""
 
 msgid "Reload"
-msgstr "Reload"
+msgstr ""
 
 msgid "Reload Services"
 msgstr ""
@@ -13060,108 +12679,101 @@ msgid "Reload blacklists"
 msgstr ""
 
 msgid "Reloading EPG Cache..."
-msgstr "Reloading EPG Cache..."
+msgstr ""
 
 msgid "Reloading bouquets and services..."
-msgstr "Reloading bouquets and services..."
+msgstr ""
 
 msgid "Remaining"
-msgstr "Remaining"
+msgstr ""
 
 msgid "Remaining & Elapsed"
-msgstr "Remaining & Elapsed"
+msgstr ""
 
-#, fuzzy
 msgid "Remaining minutes left"
-msgstr "Remaining & Elapsed"
+msgstr ""
 
 msgid "Remaining minutes right"
 msgstr ""
 
-#, fuzzy
 msgid "Remaining minutes/Progress bar left"
-msgstr "Progress bar left"
+msgstr ""
 
-#, fuzzy
 msgid "Remaining minutes/Progress bar right"
-msgstr "Progress bar right"
+msgstr ""
 
 msgid "Remember last service in PiP"
 msgstr ""
 
 msgid "Remember service PIN"
-msgstr "Remember service PIN"
+msgstr ""
 
 msgid "Remote Control Code"
 msgstr ""
 
 msgid "Remote box"
-msgstr "Remote box"
+msgstr ""
 
-#, fuzzy
 msgid "Remote control model shown"
-msgstr "Remote control type"
+msgstr ""
 
 msgid "Remote control type"
-msgstr "Remote control type"
+msgstr ""
 
 #, python-format
 msgid "Removal of this slot will not show in %s Gui.  Are you sure you want to delete image slot %s ?"
 msgstr ""
 
 msgid "Remove"
-msgstr "Remove"
+msgstr ""
 
 msgid "Remove Confirmation"
-msgstr "Remove Confirmation"
+msgstr ""
 
 msgid "Remove Plugins"
 msgstr ""
 
-#, fuzzy
 msgid "Remove Quad Channel Entry"
-msgstr "Remove a nameserver entry"
+msgstr ""
 
 msgid "Remove Service"
-msgstr "Remove Service"
+msgstr ""
 
 msgid "Remove a mark"
-msgstr "Remove a mark"
+msgstr ""
 
 msgid "Remove a nameserver entry"
-msgstr "Remove a nameserver entry"
+msgstr ""
 
-#, fuzzy
 msgid "Remove all cuts and marks"
-msgstr "Remove a mark"
+msgstr ""
 
 msgid "Remove bookmark"
-msgstr "Remove bookmark"
+msgstr ""
 
 msgid "Remove completed timers after (days)"
-msgstr "Remove completed timers after (days)"
+msgstr ""
 
-#, fuzzy
 msgid "Remove confirmation"
-msgstr "Remove Confirmation"
+msgstr ""
 
 msgid "Remove current folder from bookmarks"
 msgstr ""
 
 msgid "Remove currently selected title"
-msgstr "Remove currently selected title"
+msgstr ""
 
 msgid "Remove finished."
-msgstr "Remove finished."
+msgstr ""
 
 msgid "Remove hide VBI line for this service"
 msgstr ""
 
 msgid "Remove items from trash can after (days)"
-msgstr "Remove items from trash can after (days)"
+msgstr "Remove items from trash after X days"
 
 msgid "Remove plugins"
-msgstr "Remove plugins"
+msgstr ""
 
 msgid "Remove selected folder from bookmarks"
 msgstr ""
@@ -13170,53 +12782,51 @@ msgid "Remove texts for the hearing impaired from external subtitles (instrument
 msgstr ""
 
 msgid "Remove timer"
-msgstr "Remove timer"
+msgstr ""
 
 msgid "Remove title"
-msgstr "Remove title"
+msgstr ""
 
 msgid "Removing"
-msgstr "Removing"
+msgstr ""
 
 msgid "Removing Service"
-msgstr "Removing Service"
+msgstr ""
 
 #, python-format
 msgid "Removing directory %s failed. (Maybe not empty.)"
-msgstr "Removing directory %s failed. (Maybe not empty.)"
+msgstr ""
 
 msgid "Removing partition table"
-msgstr "Removing partition table"
+msgstr ""
 
 msgid "Rename"
-msgstr "Rename"
+msgstr ""
 
 msgid "Rename failed!"
-msgstr "Rename failed!"
+msgstr ""
 
-#, fuzzy
 msgid "Rename file/directory"
-msgstr "Create directory"
+msgstr ""
 
 msgid "Rename name and description for new events"
 msgstr ""
 
 msgid "Rename to:"
-msgstr "Rename to:"
+msgstr ""
 
 #, python-format
 msgid "Renamed %s!"
-msgstr "Renamed %s!"
+msgstr ""
 
-#, fuzzy
 msgid "Renovation"
-msgstr "Resolution"
+msgstr ""
 
 msgid "Repeat"
-msgstr "Repeat"
+msgstr ""
 
 msgid "Repeat Display Message"
-msgstr "Repeat Display Message"
+msgstr ""
 
 msgid "Repeat the sent standby and wakeup commands"
 msgstr ""
@@ -13225,66 +12835,64 @@ msgid "Repeat the standby commands?"
 msgstr ""
 
 msgid "Repeat type"
-msgstr "Repeat type"
-
-msgid "Repeating event currently recording... What do you want to do?"
-msgstr "Repeating event currently recording... What do you want to do?"
-
-msgid "Repeats"
-msgstr "Repeats"
-
-msgid "Replace `- ` in dialogs with colored text per speaker (like teletext subtitles for the hearing impaired)"
 msgstr ""
 
-#, fuzzy
+msgid "Repeating event currently recording... What do you want to do?"
+msgstr ""
+
+msgid "Repeats"
+msgstr ""
+
+msgid "Replace `- ` in dialogs with colored text per speaker (like teletext subtitles for the hearing impaired)"
+msgstr "Replace '- ' in dialogue with coloured text per speaker (like teletext subtitles for the hearing impaired)."
+
 msgid "Reportage"
-msgstr "Percentage"
+msgstr ""
 
 msgid "Require authentication for http streams"
 msgstr ""
 
 msgid "Required medium type:"
-msgstr "Required medium type:"
+msgstr ""
 
 msgid "Rereading partition table"
-msgstr "Rereading partition table"
+msgstr ""
 
 msgid "Reserved"
-msgstr "Reserved"
+msgstr ""
 
 msgid "Reserved for future use"
 msgstr ""
 
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 msgid "Reset and renumerate title names"
-msgstr "Reset and enumerate title names"
+msgstr ""
 
 msgid "Reset persistent PIN code"
 msgstr ""
 
 msgid "Reset playback position"
-msgstr "Reset playback position"
+msgstr ""
 
 msgid "Reset video enhancement settings to system defaults?"
-msgstr "Reset video enhancement settings to system defaults?"
+msgstr ""
 
 msgid "Reset video enhancement settings to your last configuration?"
-msgstr "Reset video enhancement settings to your last configuration?"
+msgstr ""
 
-#, fuzzy
 msgid "Reshare"
-msgstr "Reshare:"
+msgstr ""
 
 msgid "Reshare:"
-msgstr "Reshare:"
+msgstr ""
 
 msgid "Resolution"
-msgstr "Resolution"
+msgstr ""
 
 msgid "Restart"
-msgstr "Restart"
+msgstr ""
 
 #, python-format
 msgid "Restart %s %s."
@@ -13294,13 +12902,13 @@ msgid "Restart Enigma2 to apply the changes?"
 msgstr ""
 
 msgid "Restart GUI"
-msgstr "Restart GUI"
+msgstr ""
 
 msgid "Restart GUI after x crashes"
 msgstr ""
 
 msgid "Restart GUI now?"
-msgstr "Restart GUI now?"
+msgstr ""
 
 msgid "Restart Gui"
 msgstr ""
@@ -13311,23 +12919,20 @@ msgstr ""
 msgid "Restart Network Adapter"
 msgstr ""
 
-#, fuzzy
 msgid "Restart both"
-msgstr "Restart test"
+msgstr ""
 
-#, fuzzy
 msgid "Restart cardserver"
-msgstr "get the cards' server"
+msgstr ""
 
 msgid "Restart enigma"
-msgstr "Restart enigma"
+msgstr ""
 
-#, fuzzy
 msgid "Restart necessary, restart GUI now?"
-msgstr "Really restart now?"
+msgstr ""
 
 msgid "Restart network"
-msgstr "Restart network"
+msgstr ""
 
 msgid "Restart network and remount connections"
 msgstr ""
@@ -13335,18 +12940,17 @@ msgstr ""
 msgid "Restart network to with current setup"
 msgstr ""
 
-#, fuzzy
 msgid "Restart softcam"
-msgstr "Restart test"
+msgstr ""
 
 msgid "Restart test"
-msgstr "Restart test"
+msgstr ""
 
 msgid "Restart your network connection and interfaces.\n"
-msgstr "Restart your network connection and interfaces.\n"
+msgstr ""
 
 msgid "Restore"
-msgstr "Restore"
+msgstr ""
 
 msgid "Restore MetrixHD Settings"
 msgstr ""
@@ -13358,22 +12962,22 @@ msgid "Restore Settings"
 msgstr ""
 
 msgid "Restore backups"
-msgstr "Restore backups"
+msgstr ""
 
 msgid "Restore is running..."
-msgstr "Restore is running..."
+msgstr ""
 
 msgid "Restore settings from a backup"
 msgstr ""
 
 msgid "Restore system settings"
-msgstr "Restore system settings"
+msgstr ""
 
 msgid "Restore your settings back from a backup. After restore the box will restart to activated the new settings"
 msgstr ""
 
 msgid "Restoring..."
-msgstr "Restoring..."
+msgstr ""
 
 msgid "Restrict the active time range"
 msgstr ""
@@ -13382,34 +12986,32 @@ msgid "Restricted 18+"
 msgstr ""
 
 msgid "Resume from last position"
-msgstr "Resume from last position"
+msgstr ""
 
 #, python-format
 msgid "Resume position at %s"
-msgstr "Resume position at %s"
+msgstr ""
 
 msgid "Resuming playback"
-msgstr "Resuming playback"
+msgstr ""
 
-#, fuzzy
 msgid "Retrieving image list - Please wait..."
-msgstr "Getting plugin information. Please wait..."
+msgstr ""
 
-#, fuzzy
 msgid "Retrieving image slots - Please wait..."
-msgstr "Searching for available updates. Please wait..."
+msgstr ""
 
 msgid "Return to movie list"
-msgstr "Return to movie list"
+msgstr ""
 
 msgid "Return to previous service"
-msgstr "Return to previous service"
+msgstr ""
 
 msgid "Reunion"
 msgstr ""
 
 msgid "Reverse bouquet buttons"
-msgstr "Reverse bouquet buttons"
+msgstr ""
 
 msgid "Reverse left file sorting"
 msgstr ""
@@ -13427,54 +13029,49 @@ msgid "Rewind"
 msgstr ""
 
 msgid "Rewind speeds"
-msgstr "Rewind speeds"
+msgstr ""
 
 msgid "Rewrap subtitles"
 msgstr ""
 
 msgid "Right"
-msgstr "Right"
+msgstr ""
 
 msgid "Right from servicename"
-msgstr "Right from servicename"
+msgstr ""
 
-#, fuzzy
 msgid "Right long"
-msgstr "Right"
+msgstr ""
 
 msgid "Roll-off"
-msgstr "Roll-off"
+msgstr ""
 
-#, fuzzy
 msgid "Romance"
-msgstr "romance"
+msgstr ""
 
-#, fuzzy
 msgid "Romania"
-msgstr "Romanian"
+msgstr ""
 
 msgid "Romanian"
-msgstr "Romanian"
+msgstr ""
 
-#, fuzzy
 msgid "Romantik"
-msgstr "Romanian"
+msgstr ""
 
 msgid "Root"
 msgstr ""
 
 msgid "Root directory"
-msgstr "Root directory"
+msgstr ""
 
 msgid "Rotor step position:"
-msgstr "Rotor step position:"
+msgstr ""
 
 msgid "Rotor turning speed"
-msgstr "Rotor turning speed"
+msgstr ""
 
-#, fuzzy
 msgid "Routing request"
-msgstr "Source request"
+msgstr ""
 
 msgid "Rowing"
 msgstr ""
@@ -13496,14 +13093,13 @@ msgid "Run Confirmation"
 msgstr ""
 
 msgid "Run how often ?"
-msgstr "Run how often ?"
+msgstr ""
 
 msgid "Run script"
 msgstr ""
 
-#, fuzzy
 msgid "Run script in background"
-msgstr "Play audio in background"
+msgstr ""
 
 msgid "Run script with optional parameter"
 msgstr ""
@@ -13512,13 +13108,13 @@ msgid "Run script with optional parameter in background"
 msgstr ""
 
 msgid "Running"
-msgstr "Running"
+msgstr ""
 
 msgid "Running Myrestore script, Please wait ..."
 msgstr ""
 
 msgid "Russian"
-msgstr "Russian"
+msgstr ""
 
 msgid "Russian Federation"
 msgstr ""
@@ -13527,13 +13123,13 @@ msgid "Rwanda"
 msgstr ""
 
 msgid "S-Video"
-msgstr "S-Video"
+msgstr ""
 
 msgid "SABnzbd"
 msgstr ""
 
 msgid "SABnzbd Setup"
-msgstr "SABnzbd Setup"
+msgstr ""
 
 msgid "SAT"
 msgstr ""
@@ -13553,8 +13149,9 @@ msgstr ""
 msgid "SD"
 msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "SDcard is not initialised for multiboot - Exit and use MultiBoot Image Manager to initialise"
-msgstr ""
+msgstr "SDcard is not initialised for multi-boot - Exit and use Multi-Boot Image Manager to initialise"
 
 msgid "SDcard switch ERROR! - H9 root files not transferred to SD card"
 msgstr ""
@@ -13566,33 +13163,31 @@ msgid "SDcard switch ERROR! - already on mmc"
 msgstr ""
 
 msgid "SID"
-msgstr "SID"
+msgstr ""
 
 msgid "SINGLE LAYER DVD"
-msgstr "SINGLE LAYER DVD"
+msgstr ""
 
 msgid "SNR:"
 msgstr ""
 
 msgid "SPDIF"
-msgstr "SPDIF"
+msgstr ""
 
 msgid "SSID:"
-msgstr "SSID:"
+msgstr ""
 
 msgid "STARTUP_"
 msgstr ""
 
-#, fuzzy
 msgid "STB Display"
-msgstr "Display"
+msgstr ""
 
 msgid "Saga"
 msgstr ""
 
-#, fuzzy
 msgid "Sailing"
-msgstr "Dialling:"
+msgstr ""
 
 msgid "Saint Barthelemy"
 msgstr ""
@@ -13619,7 +13214,7 @@ msgid "Samba"
 msgstr ""
 
 msgid "Samba Log"
-msgstr "Samba Log"
+msgstr ""
 
 msgid "Samba Setup"
 msgstr ""
@@ -13631,7 +13226,7 @@ msgid "Same behavior as current animation"
 msgstr ""
 
 msgid "Same resolution as skin"
-msgstr "Same resolution as skin"
+msgstr ""
 
 msgid "Samoa"
 msgstr ""
@@ -13643,83 +13238,79 @@ msgid "Sao Tome and Principe"
 msgstr ""
 
 msgid "Sat"
-msgstr "Sat"
+msgstr ""
 
 msgid "Sat Finder"
 msgstr ""
 
 msgid "Satellite"
-msgstr "Satellite"
+msgstr ""
 
-#, fuzzy
 msgid "Satellite configuration mode"
-msgstr "Configuration mode"
+msgstr ""
 
 msgid "Satellite dish setup"
-msgstr "Satellite dish setup"
+msgstr ""
 
 msgid "Satellite equipment"
-msgstr "Satellite equipment"
+msgstr ""
 
 msgid "Satellite equipment setup"
-msgstr "Satellite equipment setup"
+msgstr ""
 
 msgid "Satellite longitude:"
-msgstr "Satellite longitude:"
+msgstr ""
 
 msgid "Satellites"
-msgstr "Satellites"
+msgstr ""
 
 msgid "Satfinder"
-msgstr "Sat finder"
+msgstr ""
 
 msgid "Satire"
 msgstr ""
 
 msgid "Sats"
-msgstr "Sats"
+msgstr ""
 
 msgid "Saturation"
-msgstr "Saturation"
+msgstr ""
 
 msgid "Saturday"
-msgstr "Saturday"
+msgstr ""
 
 msgid "Saudi Arabia"
 msgstr ""
 
 msgid "Save"
-msgstr "Save"
+msgstr ""
 
-#, fuzzy
 msgid "Save / Enter text and exit"
-msgstr "save last directory on exit"
+msgstr ""
 
 msgid "Save EPG"
-msgstr "Save EPG"
+msgstr ""
 
 msgid "Save EPG data"
 msgstr ""
 
 msgid "Save and record"
-msgstr "Save and record"
+msgstr ""
 
 msgid "Save and stop"
-msgstr "Save and stop"
+msgstr ""
 
 msgid "Save every (in hours)"
-msgstr "Save every (in hours)"
+msgstr ""
 
-#, fuzzy
 msgid "Save left folder on exit"
-msgstr "save last directory on exit"
+msgstr ""
 
 msgid "Save playlist"
-msgstr "Save playlist"
+msgstr ""
 
-#, fuzzy
 msgid "Save right folder on exit"
-msgstr "save last directory on exit"
+msgstr ""
 
 msgid "Save settings and EPG data"
 msgstr ""
@@ -13737,84 +13328,84 @@ msgid "Save the right folder list location on exit."
 msgstr ""
 
 msgid "Save timeshift as movie and continue recording"
-msgstr "Save timeshift as movie and continue recording"
+msgstr ""
 
 msgid "Save timeshift as movie and stop recording"
-msgstr "Save timeshift as movie and stop recording"
+msgstr ""
 
 msgid "Saving EPG Cache..."
-msgstr "Saving EPG Cache..."
+msgstr ""
 
 msgid "Saving Timeshift files"
-msgstr "Saving Timeshift files"
+msgstr ""
 
 msgid "Saving timeshift as movie now. This might take a while!"
-msgstr "Saving timeshift as movie now. This might take a while!"
+msgstr ""
 
 msgid "Scaler sharpness"
-msgstr "Scaler sharpness"
+msgstr ""
 
 msgid "Scaler vertical dejagging"
 msgstr ""
 
 msgid "Scaling mode"
-msgstr "Scaling mode"
+msgstr ""
 
 msgid "Scan"
-msgstr "Scan"
+msgstr ""
 
 msgid "Scan "
-msgstr "Scan "
+msgstr ""
 
 #, python-format
 msgid "Scan %s"
-msgstr "Scan %s"
+msgstr ""
 
 #. TRANSLATORS: option name, indicating which type of (DVB-C) band should be scanned. The name of the band is printed in '%s'. E.g.: 'Scan EU MID band'
 #, python-format
 msgid "Scan %s band"
-msgstr "Scan %s band"
+msgstr ""
 
 msgid "Scan additional SR"
-msgstr "Scan additional SR"
+msgstr ""
 
 msgid "Scan files..."
-msgstr "Scan files..."
+msgstr ""
 
 msgid "Scan for local extensions and install them"
 msgstr ""
 
 msgid "Scan wireless networks"
-msgstr "Scan wireless networks"
+msgstr ""
 
 msgid "Scan your network for wireless access points and connect to them using your selected wireless device.\n"
-msgstr "Scan your network for wireless access points and connect to them using your selected wireless device.\n"
+msgstr ""
 
 #, python-format
 msgid "Scanning %s..."
-msgstr "Scanning %s..."
+msgstr ""
 
 #. TRANSLATORS: The stb is performing a channel scan, progress percentage is printed in '%d' (and '%%' will show a single '%' symbol)
 #, python-format
 msgid "Scanning - %d%% completed"
 msgid_plural "Scanning - %d%% completed"
-msgstr[0] "Scanning - %d%% completed"
-msgstr[1] "Scanning - %d%% completed"
+msgstr[0] ""
+msgstr[1] ""
 
 #, python-format
 msgid "Scanning completed, %d channel found"
 msgid_plural "Scanning completed, %d channels found"
-msgstr[0] "Scanning completed, %d channel found"
-msgstr[1] "Scanning completed, %d channels found"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Scanning failed!"
-msgstr "Scanning failed!"
+msgstr ""
 
 msgid "Scanning..."
-msgstr "Scanning..."
+msgstr ""
 
 msgid "Scans default lamedbs sorted by satellite with a connected dish positioner"
-msgstr "Scans default lamedbs sorted by satellite with a connected dish positioner"
+msgstr ""
 
 msgid "Sci-Fi"
 msgstr ""
@@ -13825,9 +13416,8 @@ msgstr ""
 msgid "Science & Tech"
 msgstr ""
 
-#, fuzzy
 msgid "Science-Fiction"
-msgstr "Movie selection"
+msgstr ""
 
 msgid "Screenshot of LCD in /tmp"
 msgstr ""
@@ -13840,7 +13430,7 @@ msgid "ScriptRunner"
 msgstr ""
 
 msgid "Scrolling Speed"
-msgstr "Scrolling Speed"
+msgstr ""
 
 msgid "Scrolling delay (software renderer)"
 msgstr ""
@@ -13849,10 +13439,10 @@ msgid "Scrolling speed (software renderer)"
 msgstr ""
 
 msgid "Search"
-msgstr "Search"
+msgstr ""
 
 msgid "Search IMDb for information about current event."
-msgstr "Search IMDb for information about current event."
+msgstr ""
 
 msgid "Search Sats"
 msgstr ""
@@ -13861,23 +13451,22 @@ msgid "Search Sats, check signal and lock"
 msgstr ""
 
 msgid "Search east"
-msgstr "Search east"
+msgstr ""
 
 msgid "Search for network shares"
 msgstr ""
 
 msgid "Search for similar events"
-msgstr "Search for similar events"
+msgstr ""
 
 msgid "Search the epg for current event."
-msgstr "Search the epg for current event."
+msgstr ""
 
-#, fuzzy
 msgid "Search weather location ID"
-msgstr "Select location"
+msgstr ""
 
 msgid "Search west"
-msgstr "Search west"
+msgstr ""
 
 msgid "Search/WEB"
 msgstr ""
@@ -13886,19 +13475,19 @@ msgid "Search/WEB long"
 msgstr ""
 
 msgid "Searching"
-msgstr "Searching"
+msgstr ""
 
 msgid "Searching east ..."
-msgstr "Searching east ..."
+msgstr ""
 
 msgid "Searching for available updates. Please wait..."
-msgstr "Searching for available updates. Please wait..."
+msgstr ""
 
 msgid "Searching for new installed or removed packages. Please wait..."
-msgstr "Searching for new installed or removed packages. Please wait..."
+msgstr ""
 
 msgid "Searching west ..."
-msgstr "Searching west ..."
+msgstr ""
 
 msgid "Second cable of motorized LNB"
 msgstr ""
@@ -13907,39 +13496,37 @@ msgid "SecondInfoBar"
 msgstr ""
 
 msgid "Secondary DNS"
-msgstr "Secondary DNS"
+msgstr ""
 
-#, fuzzy
 msgid "Secondinfobar:"
-msgstr "Show second infobar"
+msgstr ""
 
 msgid "Seek"
-msgstr "Seek"
+msgstr ""
 
 msgid "Seek backward"
-msgstr "Seek backward"
+msgstr ""
 
 msgid "Seek backward (enter time)"
-msgstr "Seek backward (enter time)"
+msgstr ""
 
 msgid "Seek forward"
-msgstr "Seek forward"
+msgstr ""
 
 msgid "Seek forward (enter time)"
-msgstr "Seek forward (enter time)"
+msgstr ""
 
-#, fuzzy
 msgid "Seekbar"
-msgstr "Seek"
+msgstr ""
 
 msgid "Seekbar activation"
-msgstr "Seekbar activation"
+msgstr ""
 
 msgid "Seekbar sensibility"
-msgstr "Seekbar sensibility"
+msgstr ""
 
 msgid "Select"
-msgstr "Select"
+msgstr ""
 
 msgid "Select '1.0' for standard committed switches, '1.1' for uncommitted switches, and '1.2' for systems using a positioner."
 msgstr ""
@@ -13981,11 +13568,10 @@ msgid "Select (source list) or enter directory (target list)"
 msgstr ""
 
 msgid "Select CAId"
-msgstr "Select CAId"
+msgstr ""
 
-#, fuzzy
 msgid "Select Card Server"
-msgstr "Select refresh rate"
+msgstr ""
 
 msgid "Select Enigma2 Skin"
 msgstr ""
@@ -13996,9 +13582,8 @@ msgstr ""
 msgid "Select HDD"
 msgstr ""
 
-#, fuzzy
 msgid "Select LCD Skin"
-msgstr "Select CAId"
+msgstr ""
 
 msgid "Select Lan/Wlan"
 msgstr ""
@@ -14015,9 +13600,8 @@ msgstr ""
 msgid "Select Red-key action long"
 msgstr ""
 
-#, fuzzy
 msgid "Select Softcam"
-msgstr "Select location"
+msgstr ""
 
 msgid "Select Software Update"
 msgstr ""
@@ -14028,9 +13612,8 @@ msgstr ""
 msgid "Select Yellow Key Action long"
 msgstr ""
 
-#, fuzzy
 msgid "Select Your Skin"
-msgstr "Select CAId"
+msgstr ""
 
 msgid "Select a bouquet"
 msgstr ""
@@ -14041,9 +13624,8 @@ msgstr ""
 msgid "Select a network adapter"
 msgstr ""
 
-#, fuzzy
 msgid "Select a path"
-msgstr "Select the movie path"
+msgstr ""
 
 msgid "Select a script to run:"
 msgstr ""
@@ -14052,15 +13634,14 @@ msgid "Select a tuner"
 msgstr ""
 
 msgid "Select a wireless network"
-msgstr "Select a wireless network"
+msgstr ""
 
-#, fuzzy
 msgid "Select action"
-msgstr "Select location"
+msgstr ""
 
 #, python-format
 msgid "Select action for timer %s:"
-msgstr "Select action for timer %s:"
+msgstr ""
 
 msgid "Select additional backup files"
 msgstr ""
@@ -14069,32 +13650,31 @@ msgid "Select additional files to backup"
 msgstr ""
 
 msgid "Select an image to be downloaded"
-msgstr "Select an image to be downloaded"
+msgstr ""
 
 msgid "Select audio track"
-msgstr "Select audio track"
+msgstr ""
 
 msgid "Select backup location"
-msgstr "Select backup location"
+msgstr ""
 
-#, fuzzy
 msgid "Select channel audio"
-msgstr "Select channel to record from"
+msgstr ""
 
 msgid "Select channel to record from"
-msgstr "Select channel to record from"
+msgstr ""
 
 msgid "Select copy destination for:"
-msgstr "Select copy destination for:"
+msgstr ""
 
 msgid "Select default EPG type..."
-msgstr "Select default EPG type…"
+msgstr ""
 
 msgid "Select desired image from feed list"
-msgstr "Select desired image from feed list"
+msgstr ""
 
 msgid "Select destination for:"
-msgstr "Select destination for:"
+msgstr ""
 
 msgid "Select excluded backup files"
 msgstr ""
@@ -14103,10 +13683,10 @@ msgid "Select files to exclude from backup"
 msgstr ""
 
 msgid "Select files/folders to backup"
-msgstr "Select files/folders to backup"
+msgstr ""
 
 msgid "Select folders"
-msgstr "Select folders"
+msgstr ""
 
 msgid "Select how quickly the dish should move between satellites."
 msgstr ""
@@ -14115,7 +13695,7 @@ msgid "Select how the satellite dish is set up. i.e. fixed dish, single LNB, DiS
 msgstr ""
 
 msgid "Select how to activate the Quick EPG mode:"
-msgstr "Select how to activate the Quick EPG mode:"
+msgstr ""
 
 msgid "Select how your box will upgrade."
 msgstr ""
@@ -14124,46 +13704,46 @@ msgid "Select if timeshift must continue when set to record."
 msgstr ""
 
 msgid "Select if you want the Subservice mode to be activated."
-msgstr "Select if you want the Subservice mode to be activated."
+msgstr ""
 
 msgid "Select input device"
-msgstr "Select input device"
+msgstr ""
 
 msgid "Select input device."
-msgstr "Select input device."
+msgstr ""
 
 msgid "Select interface"
-msgstr "Select interface"
+msgstr ""
 
 msgid "Select location"
-msgstr "Select location"
+msgstr ""
 
 msgid "Select movie"
-msgstr "Select movie"
+msgstr ""
 
 msgid "Select of the number"
 msgstr ""
 
 msgid "Select provider to add..."
-msgstr "Select provider to add..."
+msgstr ""
 
 msgid "Select refresh rate"
-msgstr "Select refresh rate"
+msgstr ""
 
 msgid "Select satellites"
 msgstr ""
 
 msgid "Select seekbar to be activated by arrow L/R (long) or << >> (long)."
-msgstr "Select seekbar to be activated by arrow L/R (long) or << >> (long)."
+msgstr ""
 
 msgid "Select service to add..."
-msgstr "Select service to add..."
+msgstr ""
 
 msgid "Select sort method:"
 msgstr ""
 
 msgid "Select target folder"
-msgstr "Select target folder"
+msgstr ""
 
 msgid "Select the Swap File Size:"
 msgstr ""
@@ -14186,10 +13766,19 @@ msgstr ""
 msgid "Select the User Band frequency to be assigned to this tuner. This is the frequency the SCR switch uses to pass the requested transponder to the tuner."
 msgstr ""
 
+msgid "Select the character or action under the keyboard cursor"
+msgstr ""
+
 msgid "Select the character or action under the virtual keyboard cursor"
 msgstr ""
 
 msgid "Select the desired function and click on \"OK\" to assign it. Use \"CH+/-\" to toggle between the lists. Select an assigned function and click on \"OK\" to de-assign it. Use \"Next/Previous\" to change the order of the assigned functions."
+msgstr ""
+
+msgid "Select the highlighted image and reboot"
+msgstr ""
+
+msgid "Select the locale from a menu"
 msgstr ""
 
 msgid "Select the manufacturer of your SCR device. If the manufacturer is not listed, set 'SCR' to 'user defined' and enter the device parameters manually according to its spec sheet."
@@ -14202,7 +13791,7 @@ msgid "Select the model number of your Unicable device. If the model number is n
 msgstr ""
 
 msgid "Select the movie path"
-msgstr "Select the movie path"
+msgstr ""
 
 msgid "Select the protocol used by your SCR device. Choices are 'SCR Unicable' (Unicable), or 'SCR JESS' (JESS, also known as Unicable II)."
 msgstr ""
@@ -14225,11 +13814,18 @@ msgstr ""
 msgid "Select the satellite your dish receives from. If you are unsure select 'automatic' and the receiver will attempt to determine this for you."
 msgstr ""
 
+msgid "Select the shifted character set"
+msgstr ""
+
+msgid "Select the shifted character set for the next character only"
+msgstr ""
+
 msgid "Select the sleep timer action."
 msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "Select the tuner that controls the motorised dish."
-msgstr ""
+msgstr "Select which tuner should be used to control the motorised dish."
 
 msgid "Select the tuner that this loopthrough depends on."
 msgstr ""
@@ -14253,16 +13849,16 @@ msgid "Select the virtual keyboard shifted character set for the next character 
 msgstr ""
 
 msgid "Select upgrade source"
-msgstr "Select upgrade source"
+msgstr ""
 
 msgid "Select upgrade source to edit."
-msgstr "Select upgrade source to edit."
+msgstr ""
 
 msgid "Select video input with up/down buttons"
-msgstr "Select video input with up/down buttons"
+msgstr ""
 
 msgid "Select video mode"
-msgstr "Select video mode"
+msgstr ""
 
 msgid "Select what should be done when the %s %s was boot-up, normal playing or goto standby."
 msgstr ""
@@ -14301,11 +13897,10 @@ msgid "Select what you want the YELLOW-Long button to activate:"
 msgstr ""
 
 msgid "Select wireless network"
-msgstr "Select wireless network"
+msgstr ""
 
-#, fuzzy
 msgid "Select your ATSC provider."
-msgstr "Select provider to add..."
+msgstr ""
 
 msgid "Select your Language for Audio/Subtitles"
 msgstr ""
@@ -14317,14 +13912,14 @@ msgid "Select your provider and region. If not present in this list you will nee
 msgstr ""
 
 msgid "Select your provider, and press OK to start the scan"
-msgstr "Select your provider, and press OK to start the scan"
+msgstr ""
 
 msgid "Select your region. If not available change 'Country' to 'all' and select one of the default alternatives."
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Selected Image:\t\t%s"
-msgstr "Deleted %s!"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -14343,12 +13938,12 @@ msgid ""
 "Do you want to delete this settinglist?"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Selected settingslist: %s\n"
 "\n"
 "Do you want to restore this settinglist?"
-msgstr "Do you want to restore your settings?"
+msgstr ""
 
 msgid "Selecting satellites 1 (USALS)"
 msgstr ""
@@ -14356,152 +13951,140 @@ msgstr ""
 msgid "Selecting satellites 2 (USALS)"
 msgstr ""
 
-#, fuzzy
 msgid "Selecting this option allows you to configure a group of satellites in one block."
-msgstr "This option allows you to choose from the two channel lists that are available."
+msgstr ""
 
 msgid "Send"
-msgstr "Send"
+msgstr ""
 
 msgid "Send Confirmation"
-msgstr "Send Confirmation"
+msgstr ""
 
 msgid "Send DiSEqC"
-msgstr "Send DiSEqC"
+msgstr ""
 
 msgid "Send DiSEqC only on satellite change"
-msgstr "Send DiSEqC only on satellite change"
+msgstr ""
 
 msgid "Senegal"
 msgstr ""
 
 msgid "Seperate titles with a main menu"
-msgstr "Separate titles with a main menu"
+msgstr ""
 
 msgid "Sequence repeat"
-msgstr "Sequence repeat"
+msgstr ""
 
-#, fuzzy
 msgid "Serbia"
-msgstr "Serbian"
+msgstr ""
 
 msgid "Serbian"
-msgstr "Serbian"
+msgstr ""
 
 msgid "Serial No"
-msgstr "Serial No"
+msgstr ""
 
 msgid "Serie"
 msgstr ""
 
 msgid "Serv.Name"
-msgstr "Serv.Name"
+msgstr ""
 
 #, python-format
 msgid "Server Info ( Oscam-Version: %s )"
 msgstr ""
 
-#, fuzzy
 msgid "Server down"
-msgstr "Server:"
+msgstr ""
 
 msgid "Server:"
-msgstr "Server:"
+msgstr ""
 
 msgid "Servers"
-msgstr "Servers"
+msgstr ""
 
 msgid "Servers:"
-msgstr "Servers:"
+msgstr ""
 
 msgid "Service"
-msgstr "Service"
+msgstr ""
 
 msgid "Service Information"
-msgstr "Service Information"
+msgstr ""
 
 msgid "Service Name"
-msgstr "Service Name"
+msgstr ""
 
-#, fuzzy
 msgid "Service Number and Service Name"
-msgstr "Picon and Service Name"
+msgstr ""
 
-#, fuzzy
 msgid "Service Number, Picon and Service Name"
-msgstr "Picon and Service Name"
+msgstr ""
 
 msgid "Service Title mode"
-msgstr "Service Title mode"
+msgstr ""
 
-#, fuzzy
+#. TRANSLATORS: override en_US
 msgid "Service cant been added to the favourites."
-msgstr "Service has been added to the favourites."
+msgstr "Channel can't be added to favourites."
 
 msgid "Service font size"
-msgstr "Service font size"
+msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "Service has been added to the favourites."
-msgstr "Service has been added to the favourites."
+msgstr "Channel has been added to favourites."
 
 msgid "Service has been added to the selected bouquet."
-msgstr "Service has been added to the selected bouquet."
+msgstr ""
 
 msgid "Service info"
 msgstr ""
 
 msgid "Service info font size"
-msgstr "Service info font size"
+msgstr ""
 
 msgid ""
 "Service invalid!\n"
 "(Timeout reading PMT)"
 msgstr ""
-"Service invalid!\n"
-"(Timeout reading PMT)"
 
 msgid "Service name"
 msgstr ""
 
 msgid "Service name font size"
-msgstr "Service name font size"
+msgstr ""
 
 msgid ""
 "Service not found!\n"
 "(SID not found in PAT)"
 msgstr ""
-"Service not found!\n"
-"(SID not found in PAT)"
 
 msgid "Service number font size"
-msgstr "Service number font size"
+msgstr ""
 
-#, fuzzy
 msgid "Service off-air"
-msgstr "Service Name"
+msgstr ""
 
-#, fuzzy
 msgid "Service picons aspect ratio"
-msgstr "Service Information"
+msgstr ""
 
 msgid "Service picons downsize"
 msgstr ""
 
 msgid "Service reference"
-msgstr "Service reference"
+msgstr ""
 
 msgid "Service scan"
-msgstr "Service scan"
+msgstr ""
 
 msgid ""
 "Service unavailable!\n"
 "Check tuner configuration!"
 msgstr ""
-"Service unavailable!\n"
-"Check tuner configuration!"
 
 msgid "Service width"
-msgstr "Service width"
+msgstr ""
 
 msgid "ServiceName"
 msgstr ""
@@ -14513,14 +14096,13 @@ msgid "Serviceinfo"
 msgstr ""
 
 msgid "Services"
-msgstr "Services"
+msgstr ""
 
 msgid "Services may be grouped in bouquets. When enabled, you can use more than one bouquet."
-msgstr "Services may be grouped in bouquets. When enabled, you can use more than one bouquet."
+msgstr ""
 
-#, fuzzy
 msgid "Set Basetime"
-msgstr "Base time"
+msgstr ""
 
 msgid "Set CI assignment for detection of available services."
 msgstr ""
@@ -14529,11 +14111,10 @@ msgid "Set Framerate for MiniTV"
 msgstr ""
 
 msgid "Set System"
-msgstr "Set System"
+msgstr ""
 
-#, fuzzy
 msgid "Set action for 'Info' key"
-msgstr "Select action for timer %s:"
+msgstr ""
 
 msgid "Set archive mode (644)"
 msgstr ""
@@ -14542,25 +14123,25 @@ msgid "Set default"
 msgstr ""
 
 msgid "Set end time"
-msgstr "Set end time"
+msgstr ""
 
 msgid "Set executable mode (755)"
 msgstr ""
 
 msgid "Set fixed"
-msgstr "Set fixed"
+msgstr ""
 
 msgid "Set for 'stout' and 'sterr' the number of lines in script info or script error messages."
 msgstr ""
 
 msgid "Set fps for external subtitles"
-msgstr "Set fps for external subtitles"
+msgstr ""
 
 msgid "Set interface as the default Interface"
 msgstr ""
 
 msgid "Set limits"
-msgstr "Set limits"
+msgstr ""
 
 msgid "Set pin code persistent"
 msgstr ""
@@ -14573,51 +14154,49 @@ msgstr ""
 
 #, python-format
 msgid "Set the MAC-address of your %s %s.\n"
-msgstr "Set the MAC-address of your %s %s.\n"
+msgstr ""
 
-#, fuzzy
 msgid "Set the aspect ratio of the service picons."
-msgstr "Set the description of the recording."
+msgstr ""
 
 msgid "Set the channel for this timer."
-msgstr "Set the channel for this timer."
+msgstr ""
 
 msgid "Set the date the timer must start."
-msgstr "Set the date the timer must start."
+msgstr ""
 
 msgid "Set the default location for your autorecord-files. Press 'OK' to add new locations, select left/right to select an existing location."
 msgstr ""
 
 msgid "Set the default location for your instant recordings. Press 'OK' to add new locations, select left/right to select an existing location."
-msgstr "Set the default location for your instant recordings. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr ""
 
 msgid "Set the default location for your recordings. Press 'OK' to add new locations, select left/right to select an existing location."
-msgstr "Set the default location for your recordings. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr ""
 
 msgid "Set the default location for your timers. Press 'OK' to add new locations, select left/right to select an existing location."
-msgstr "Set the default location for your timers. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr ""
 
 msgid "Set the default location for your timeshift-files. Press 'OK' to add new locations, select left/right to select an existing location."
-msgstr "Set the default location for your timeshift-files. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr ""
 
 msgid "Set the default sorting method."
-msgstr "Set the default sorting method."
+msgstr ""
 
 msgid "Set the delay time between repeated loops, this is used by software renderer in some skins."
 msgstr ""
 
 msgid "Set the description of the recording."
-msgstr "Set the description of the recording."
+msgstr ""
 
 msgid "Set the jump-size of the seekbar."
-msgstr "Set the jump-size of the seekbar."
+msgstr ""
 
 msgid "Set the name the recording will get."
-msgstr "Set the name the recording will get."
+msgstr ""
 
-#, fuzzy
 msgid "Set the position of the recording icons"
-msgstr "Set the description of the recording."
+msgstr ""
 
 msgid "Set the screen type you get on pressing 'OK' when the info bar shows to 2nd infobar Lite or event info."
 msgstr ""
@@ -14626,16 +14205,16 @@ msgid "Set the scrolling speed of text on the front display, this is used by sof
 msgstr ""
 
 msgid "Set the scrolling speed of text on the front display."
-msgstr "Set the scrolling speed of text on the front display."
+msgstr ""
 
 msgid "Set the time before checking video source for resolution information."
-msgstr "Set the time before checking video source for resolution information."
+msgstr ""
 
 msgid "Set the time the timer must start."
-msgstr "Set the time the timer must start."
+msgstr ""
 
 msgid "Set the time the timer must stop."
-msgstr "Set the time the timer must stop."
+msgstr ""
 
 msgid "Set the time to hide the infobar."
 msgstr ""
@@ -14647,7 +14226,7 @@ msgid "Set the time to wait for execute the default action in shutdown, standby 
 msgstr ""
 
 msgid "Set the type of the progress indication in the channel selection screen."
-msgstr "Set the type of the progress indication in the channel selection screen."
+msgstr ""
 
 msgid "Set time window to 1 hour"
 msgstr ""
@@ -14668,39 +14247,41 @@ msgid "Set time window to 6 hours"
 msgstr ""
 
 msgid "Set to the desired primetime (hour)."
-msgstr "Set to the desired primetime (hour)."
+msgstr ""
 
 msgid "Set to the desired primetime (minutes."
 msgstr ""
 
 msgid "Set to what you want the button to do."
-msgstr "Set to what you want the button to do."
+msgstr ""
 
 msgid "Set to yes for debugging the root cause of a spinner."
 msgstr ""
 
 msgid "Set voltage and 22KHz"
-msgstr "Set voltage and 22KHz"
+msgstr ""
 
 msgid "Sets the root folder of movie list, to remove the '..' from benign shown in that folder."
-msgstr "Sets the root folder of movie list, to remove the '..' from benign shown in that folder."
+msgstr ""
 
-#, fuzzy
 msgid "Setting Restored "
-msgstr "Settings"
+msgstr ""
+
+msgid "Setting by user"
+msgstr ""
 
 msgid "Settings"
-msgstr "Settings"
+msgstr ""
 
 msgid "Settings..."
-msgstr "Settings..."
+msgstr ""
 
 msgid "Setup"
-msgstr "Setup"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Setup - %s"
-msgstr "Setup"
+msgstr ""
 
 msgid "Setup AFP"
 msgstr ""
@@ -14756,9 +14337,8 @@ msgstr ""
 msgid "Setup Plugin filter. Here you can select which Plugins are showed in the PluginBrowser"
 msgstr ""
 
-#, fuzzy
 msgid "Setup Plugins"
-msgstr "Plugins"
+msgstr ""
 
 msgid "Setup SABnzbd"
 msgstr ""
@@ -14785,19 +14365,19 @@ msgid "Setup each tuner for your satellite system"
 msgstr ""
 
 msgid "Setup how to control the channel changing."
-msgstr "Setup how to control the channel changing."
+msgstr ""
 
 msgid "Setup interface"
 msgstr ""
 
 msgid "Setup menu"
-msgstr "Setup menu"
+msgstr ""
 
 msgid "Setup mode"
-msgstr "Setup mode"
+msgstr ""
 
 msgid "Setup network time synchronization interval."
-msgstr "Setup network time synchronisation interval."
+msgstr ""
 
 msgid "Setup network. Here you can setup DHCP, IP, DNS"
 msgstr ""
@@ -14866,7 +14446,7 @@ msgid "Setup your network mounts"
 msgstr ""
 
 msgid "Setup your positioner"
-msgstr "Setup your positioner"
+msgstr ""
 
 msgid "Setup your positioner for your satellite system"
 msgstr ""
@@ -14878,29 +14458,29 @@ msgid "Setup your remote buttons"
 msgstr ""
 
 msgid "Setup your satellite equipment"
-msgstr "Setup your satellite equipment"
+msgstr ""
 
 msgid "Setup your timezone."
-msgstr "Setup your timezone."
+msgstr ""
 
 msgid "Seychelles"
 msgstr ""
 
 #, python-format
 msgid "Shall the USB stick wizard proceed and program the image file %s into flash memory?"
-msgstr "Should the USB stick wizard proceed and program the image file %s into flash memory?"
+msgstr ""
 
 msgid "Share Folder's"
-msgstr "Share Folders"
+msgstr ""
 
 msgid "Share View"
-msgstr "Share View"
+msgstr ""
 
 msgid "Shares"
-msgstr "Shares"
+msgstr ""
 
 msgid "Sharpness"
-msgstr "Sharpness"
+msgstr ""
 
 msgid "Shellscript"
 msgstr ""
@@ -14908,27 +14488,23 @@ msgstr ""
 msgid "Shift"
 msgstr ""
 
-#, fuzzy
 msgid "Shopping"
-msgstr "zapped"
+msgstr ""
 
-#, fuzzy
 msgid "Short Film"
-msgstr "Short filenames"
+msgstr ""
 
 msgid "Short filenames"
-msgstr "Short filenames"
+msgstr ""
 
-#, fuzzy
 msgid "Short filenames with time"
-msgstr "Short filenames"
+msgstr ""
 
 msgid "Should the crash counter be reset to prevent a restart?"
 msgstr ""
 
-#, fuzzy
 msgid "Show"
-msgstr "Show Log"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -14937,28 +14513,25 @@ msgid ""
 msgstr ""
 
 msgid "Show /tmp/ecm.info"
-msgstr "Show /tmp/ecm.info"
+msgstr ""
 
 msgid "Show 1080p 24fps as"
-msgstr "Show 1080p 24fps as"
+msgstr ""
 
 msgid "Show 1080p 25fps as"
-msgstr "Show 1080p 25fps as"
+msgstr ""
 
 msgid "Show 1080p 30fps as"
-msgstr "Show 1080p 30fps as"
+msgstr ""
 
-#, fuzzy
 msgid "Show 2160p 24fps as"
-msgstr "Show 720p 24fps as"
+msgstr ""
 
-#, fuzzy
 msgid "Show 2160p 25fps as"
-msgstr "Show 1080p 25fps as"
+msgstr ""
 
-#, fuzzy
 msgid "Show 2160p 30fps as"
-msgstr "Show 1080p 30fps as"
+msgstr ""
 
 msgid "Show 24p up to 720p / higher than 720p as"
 msgstr ""
@@ -14982,13 +14555,13 @@ msgid "Show 480/576p 24fps as"
 msgstr ""
 
 msgid "Show 720p 24fps as"
-msgstr "Show 720p 24fps as"
+msgstr ""
 
 msgid "Show Audioselection"
 msgstr ""
 
 msgid "Show AutoTimer List"
-msgstr "Show AutoTimer List"
+msgstr ""
 
 msgid "Show Box Portal..."
 msgstr ""
@@ -15000,7 +14573,7 @@ msgid "Show CI messages"
 msgstr ""
 
 msgid "Show Clients"
-msgstr "Show Clients"
+msgstr ""
 
 msgid "Show CoolChannelGuide"
 msgstr ""
@@ -15018,19 +14591,19 @@ msgid "Show CoolTVGuide"
 msgstr ""
 
 msgid "Show Display Icons"
-msgstr "Show Display Icons"
+msgstr ""
 
 msgid "Show E2 Log"
-msgstr "Show E2 Log"
+msgstr ""
 
 msgid "Show EIT now/next in infobar"
-msgstr "Show EIT now/next in infobar"
+msgstr ""
 
 msgid "Show EPG"
 msgstr ""
 
 msgid "Show EPG for current channel..."
-msgstr "Show EPG for current channel..."
+msgstr ""
 
 msgid "Show Eventview"
 msgstr ""
@@ -15050,33 +14623,29 @@ msgstr ""
 msgid "Show HDMI-Output Res"
 msgstr ""
 
-#, fuzzy
 msgid "Show HDMIRecord setup..."
-msgstr "Show RFmod setup..."
+msgstr ""
 
 msgid "Show Infobar"
 msgstr ""
 
-#, fuzzy
 msgid "Show Information..."
-msgstr "show program information..."
+msgstr ""
 
-#, fuzzy
 msgid "Show Live in MiniTV"
-msgstr "Show info line"
+msgstr ""
 
 msgid "Show Log"
-msgstr "Show Log"
+msgstr ""
 
 msgid "Show Log Manager in extensions list ?"
-msgstr "Show Log Manager in extensions list ? ?"
+msgstr ""
 
-#, fuzzy
 msgid "Show Main Menu as"
-msgstr "Show tag menu"
+msgstr ""
 
 msgid "Show Media playback Remaining/Elapsed as"
-msgstr "Show Media playback Remaining/Elapsed as"
+msgstr ""
 
 msgid "Show Merlin EPG Center"
 msgstr ""
@@ -15087,15 +14656,14 @@ msgstr ""
 msgid "Show Movies"
 msgstr ""
 
-#, fuzzy
 msgid "Show Movies List"
-msgstr "Show Timer List"
+msgstr ""
 
 msgid "Show Multi EPG"
 msgstr ""
 
 msgid "Show OE Log"
-msgstr "Show OE Log"
+msgstr ""
 
 msgid "Show OScam in extensions ?"
 msgstr ""
@@ -15103,9 +14671,8 @@ msgstr ""
 msgid "Show PIP"
 msgstr ""
 
-#, fuzzy
 msgid "Show PIP in MiniTV"
-msgstr "Show info line"
+msgstr ""
 
 msgid "Show PIP in the Front Display"
 msgstr ""
@@ -15114,10 +14681,10 @@ msgid "Show PVR status in MoviePlayer infobar"
 msgstr ""
 
 msgid "Show RFmod setup..."
-msgstr "Show RFmod setup..."
+msgstr ""
 
 msgid "Show Readers/Proxies"
-msgstr "Show Readers/Proxies"
+msgstr ""
 
 msgid "Show Record Movies"
 msgstr ""
@@ -15126,7 +14693,7 @@ msgid "Show Restart Network in Extensions list *"
 msgstr ""
 
 msgid "Show SD as"
-msgstr "Show SD as"
+msgstr ""
 
 msgid "Show Script completed message"
 msgstr ""
@@ -15138,36 +14705,34 @@ msgid "Show Task's completed message"
 msgstr ""
 
 msgid "Show Time Remaining/Elapsed"
-msgstr "Show Time Remaining/Elapsed"
+msgstr ""
 
 msgid "Show Timer List"
-msgstr "Show Timer List"
+msgstr ""
 
 msgid "Show Transponder Remaining/Elapsed as"
-msgstr "Show Transponder Remaining/Elapsed as"
+msgstr ""
 
 msgid "Show True/False as graphical switch"
 msgstr ""
 
 msgid "Show VCR scart on main menu"
-msgstr "Show VCR scart on main menu"
+msgstr ""
 
-#, fuzzy
 msgid "Show Vertical EPG"
-msgstr "Vertical"
+msgstr ""
 
 msgid "Show WLAN status"
-msgstr "Show WLAN status"
+msgstr ""
 
-#, fuzzy
 msgid "Show additional slider value"
-msgstr "Show animation while busy"
+msgstr ""
 
 msgid "Show advanced settings"
 msgstr ""
 
 msgid "Show animation while busy"
-msgstr "Show animation while busy"
+msgstr ""
 
 msgid "Show as Picture (press any key to close)"
 msgstr ""
@@ -15180,23 +14745,22 @@ msgid "Show background in Radio Mode"
 msgstr ""
 
 msgid "Show background when tuned to a radio channel."
-msgstr "Show background when tuned to a radio channel."
+msgstr ""
 
 msgid "Show bouquet on launch"
-msgstr "Show bouquet on launch"
+msgstr ""
 
 msgid "Show bouquet selection menu"
 msgstr ""
 
 msgid "Show channel number in infobar"
-msgstr "Show channel number in infobar"
+msgstr ""
 
 msgid "Show channel numbers in channel selection"
-msgstr "Show channel numbers in channel selection"
+msgstr ""
 
-#, fuzzy
 msgid "Show channel selection"
-msgstr "Channel selection"
+msgstr ""
 
 msgid "Show chapter positions for supported video files. (gstreamer version must be greather than 1)"
 msgstr ""
@@ -15223,52 +14787,49 @@ msgid "Show crypto icons"
 msgstr ""
 
 msgid "Show crypto info in infobar"
-msgstr "Show crypto info in infobar"
+msgstr ""
 
 msgid "Show default backup files"
 msgstr ""
 
 msgid "Show detailed event info"
-msgstr "Show detailed event info"
+msgstr ""
 
-#, fuzzy
 msgid "Show detailed event info (setup in menu)"
-msgstr "Show detailed event info"
+msgstr ""
 
-#, fuzzy
 msgid "Show directories first"
-msgstr "Show Timer List"
+msgstr ""
 
 msgid "Show directories on first or last in list.(must restart File Commander)"
 msgstr ""
 
 msgid "Show encryption info in the infobar (when supported by the skin)."
-msgstr "Show encryption info in the infobar (when supported by the skin)."
+msgstr ""
 
 msgid "Show epg"
-msgstr "Show epg"
+msgstr ""
 
 msgid "Show event details"
-msgstr "Show event details"
+msgstr ""
 
-#, fuzzy
 msgid "Show event genre information"
-msgstr "Software manager information"
+msgstr ""
 
 msgid "Show event-progress in channel selection"
-msgstr "Show event-progress in channel selection"
+msgstr ""
 
 msgid "Show eventinfo plugins"
 msgstr ""
 
 msgid "Show extended description"
-msgstr "Show extended description"
+msgstr ""
 
 msgid "Show extension selection"
 msgstr ""
 
 msgid "Show extensions..."
-msgstr "Show extensions..."
+msgstr ""
 
 msgid "Show favourites list"
 msgstr ""
@@ -15283,68 +14844,61 @@ msgid "Show help"
 msgstr ""
 
 msgid "Show icon for new/unseen items"
-msgstr "Show icon for new/unseen items"
+msgstr ""
 
-#, fuzzy
 msgid "Show image information"
-msgstr "Software manager information"
+msgstr ""
 
-#, fuzzy
 msgid "Show in Standby"
-msgstr "Auto Standby"
+msgstr ""
 
 msgid "Show in extensions list ?"
-msgstr "Show in extensions list ?"
+msgstr ""
 
 msgid "Show info"
-msgstr "Show info"
+msgstr ""
 
 msgid "Show info line"
-msgstr "Show info line"
+msgstr ""
 
 msgid "Show infobar lite *"
 msgstr ""
 
 msgid "Show infobar on channel change"
-msgstr "Show infobar on channel change"
+msgstr ""
 
 msgid "Show infobar on event change"
-msgstr "Show infobar on event change"
+msgstr ""
 
 msgid "Show infobar on skip forward/backward"
-msgstr "Show infobar on skip forward/backward"
+msgstr ""
 
-#, fuzzy
 msgid "Show infobar permanently while paused"
-msgstr "Show infobar on event change"
+msgstr ""
 
 msgid "Show infobar picons"
 msgstr ""
 
 msgid "Show job tasks in extensions"
-msgstr "Show job tasks in extensions"
+msgstr ""
 
 msgid "Show live tv when movie stopped"
-msgstr "Show live TV when movie is stopped"
+msgstr ""
 
-#, fuzzy
 msgid "Show log"
-msgstr "Show Log"
+msgstr ""
 
-#, fuzzy
 msgid "Show marked events"
-msgstr "Show detailed event info"
+msgstr ""
 
-#, fuzzy
 msgid "Show marked events in all rows."
-msgstr "Show detailed event info"
+msgstr ""
 
 msgid "Show menu"
-msgstr "Show menu"
+msgstr ""
 
-#, fuzzy
 msgid "Show menu numbers"
-msgstr "Show menu"
+msgstr ""
 
 msgid "Show message if File Commander is not running and all Task's are completed."
 msgstr ""
@@ -15353,10 +14907,10 @@ msgid "Show message if a background script ends successfully. Has 'stout', then 
 msgstr ""
 
 msgid "Show message when recording starts"
-msgstr "Show message when recording starts"
+msgstr ""
 
 msgid "Show movie lengths in movielist"
-msgstr "Show movie lengths in movielist"
+msgstr ""
 
 msgid "Show movies"
 msgstr ""
@@ -15365,7 +14919,7 @@ msgid "Show multi channel EPG"
 msgstr ""
 
 msgid "Show network mounts ..."
-msgstr "Show network mounts ..."
+msgstr ""
 
 msgid "Show next picture"
 msgstr ""
@@ -15374,11 +14928,10 @@ msgid "Show on Display"
 msgstr ""
 
 msgid "Show or hide the extended description, (skin dependent)."
-msgstr "Show or hide the extended description, (skin dependant)."
+msgstr ""
 
-#, fuzzy
 msgid "Show parting lines"
-msgstr "Show info line"
+msgstr ""
 
 msgid "Show parting lines between events."
 msgstr ""
@@ -15387,15 +14940,13 @@ msgid "Show picon background colour"
 msgstr ""
 
 msgid "Show positioner movement"
-msgstr "Show positioner movement"
+msgstr ""
 
-#, fuzzy
 msgid "Show preview of current mode (*)."
-msgstr "Properties of current title"
+msgstr ""
 
-#, fuzzy
 msgid "Show previous picture"
-msgstr "Switch to previous channel"
+msgstr ""
 
 msgid "Show quickmenu..."
 msgstr ""
@@ -15410,7 +14961,7 @@ msgid "Show satellites list"
 msgstr ""
 
 msgid "Show screensaver"
-msgstr "Show screensaver"
+msgstr ""
 
 msgid "Show service list"
 msgstr ""
@@ -15419,7 +14970,7 @@ msgid "Show service name and event description among each other instead of side 
 msgstr ""
 
 msgid "Show service type icons"
-msgstr "Show service type icons"
+msgstr ""
 
 msgid "Show servicelist or movies"
 msgstr ""
@@ -15428,26 +14979,25 @@ msgid "Show setup..."
 msgstr ""
 
 msgid "Show shutdown menu"
-msgstr "Show shutdown menu"
+msgstr ""
 
 msgid "Show single epg for current channel"
-msgstr "Show single epg for current channel"
+msgstr ""
 
-#, fuzzy
 msgid "Show single epg for current channel (setup in menu)"
-msgstr "Show single epg for current channel"
+msgstr ""
 
 msgid "Show single service EPG"
 msgstr ""
 
 msgid "Show source packages"
-msgstr "Show source packages"
+msgstr ""
 
 msgid "Show spinning logo when system is busy."
 msgstr ""
 
 msgid "Show status icons in movielist"
-msgstr "Show status icons in movielist"
+msgstr ""
 
 msgid "Show status messages when switch to live TV"
 msgstr ""
@@ -15455,69 +15005,65 @@ msgstr ""
 msgid "Show subservice selection"
 msgstr ""
 
-#, fuzzy
 msgid "Show subtitle quick menu"
-msgstr "Subtitle Quickmenu"
+msgstr ""
 
 msgid "Show subtitle selection"
 msgstr ""
 
-#, fuzzy
 msgid "Show task list"
-msgstr "Show Games show"
+msgstr ""
 
 msgid "Show the DreamPlex player..."
 msgstr ""
 
-#, fuzzy
 msgid "Show the Power Timer..."
-msgstr "Show the TV player..."
+msgstr ""
 
 msgid "Show the Sleep Timer..."
 msgstr ""
 
-#, fuzzy
 msgid "Show the information on current event."
-msgstr "Search IMDb for information about current event."
+msgstr ""
 
 msgid "Show the list of AutoTimers."
-msgstr "Show the list of AutoTimers."
+msgstr ""
 
 msgid "Show the list of timers."
-msgstr "Show the list of timers."
+msgstr ""
 
 msgid "Show the media center..."
 msgstr ""
 
 msgid "Show the media player..."
-msgstr "Show the media player..."
+msgstr ""
 
 msgid "Show the plugin browser.."
-msgstr "Show the plugin browser.."
+msgstr ""
 
 msgid "Show the plugins..."
 msgstr ""
 
 msgid "Show the radio player..."
-msgstr "Show the radio player..."
+msgstr ""
 
 msgid "Show the tv player..."
-msgstr "Show the TV player..."
+msgstr ""
 
 msgid "Show time elapsed as positive"
-msgstr "Show time elapsed as positive"
+msgstr ""
 
 msgid "Show time in 24 hour clock format."
 msgstr ""
 
 msgid "Show time remaining/elapsed"
-msgstr "Show time remaining/elapsed"
+msgstr ""
 
 msgid "Show translation packages"
-msgstr "Show translation packages"
+msgstr ""
 
 msgid "Show transponder remaining/elapsed as"
-msgstr "Show transponder remaining/elapsed as"
+msgstr ""
 
 msgid "Show two lines per entry"
 msgstr ""
@@ -15525,9 +15071,8 @@ msgstr ""
 msgid "Show unknown Videoresolution as next higher or as highest screen resolution."
 msgstr ""
 
-#, fuzzy
 msgid "Show unknown extension as text"
-msgstr "Show in extensions list ?"
+msgstr ""
 
 msgid "Show unknown file extensions with 'Addon File-Viewer'."
 msgstr ""
@@ -15535,19 +15080,17 @@ msgstr ""
 msgid "Show unknown video format as"
 msgstr ""
 
-#, fuzzy
 msgid "Show vertical Program Guide"
-msgstr "Electronic Program Guide"
+msgstr ""
 
 msgid "Show warning before restart"
 msgstr ""
 
 msgid "Show warning when timeshift is stopped"
-msgstr "Show warning when timeshift is stopped"
+msgstr ""
 
-#, fuzzy
 msgid "Show/Games show"
-msgstr "Show Games show"
+msgstr ""
 
 msgid "Show/Hide focus bar"
 msgstr ""
@@ -15565,25 +15108,28 @@ msgid "Shows live tv or informations on LCD."
 msgstr ""
 
 msgid "Shows the icons when new/unseen, else will not show an icon."
-msgstr "Shows the icons when new/unseen, else will not show an icon."
+msgstr ""
 
 msgid "Shows the state of your wireless LAN connection.\n"
-msgstr "Shows the state of your wireless LAN connection.\n"
+msgstr ""
 
 msgid "Shows the watched status of the movie."
-msgstr "Shows the watched status of the movie."
+msgstr ""
 
 msgid "Shuffle playlist"
-msgstr "Shuffle playlist"
+msgstr ""
 
 msgid "Shutdown"
-msgstr "Shutdown"
+msgstr ""
 
 msgid "Side by Side"
-msgstr "Side by Side"
+msgstr ""
 
 msgid "Side by side"
-msgstr "Side by side"
+msgstr ""
+
+msgid "Side by side mode"
+msgstr ""
 
 msgid "Sierra Leone"
 msgstr ""
@@ -15592,67 +15138,64 @@ msgid "Signal Finder"
 msgstr ""
 
 msgid "Signal OK, proceeding"
-msgstr "Signal OK, proceeding"
+msgstr ""
 
 msgid "Signal Strength:"
-msgstr "Signal Strength:"
+msgstr ""
 
 msgid "Signal quality"
-msgstr "Signal quality"
+msgstr ""
 
 msgid "Signal strength:"
-msgstr "Signal strength:"
+msgstr ""
 
 msgid "Signal: "
-msgstr "Signal: "
+msgstr ""
 
 msgid "Similar"
-msgstr "Similar"
+msgstr ""
 
 msgid "Similar broadcasts:"
-msgstr "Similar broadcasts:"
+msgstr ""
 
 msgid "Simple"
-msgstr "Simple"
+msgstr ""
 
 msgid "Simple fade"
 msgstr ""
 
 msgid "Simple titleset (compatibility for legacy players)"
-msgstr "Simple titleset (compatibility for legacy players)"
+msgstr ""
 
-#, fuzzy
 msgid "Simple umounter mass storage device."
-msgstr "List of storage devices"
+msgstr ""
 
 msgid "Simple zoom"
 msgstr ""
 
-#, fuzzy
 msgid "SimpleUmount"
-msgstr "Simple"
+msgstr ""
 
 msgid "Simplified Chinese"
 msgstr ""
 
-#, fuzzy
 msgid "Singapore"
-msgstr "Single"
+msgstr ""
 
 msgid "Single"
-msgstr "Single"
+msgstr ""
 
 msgid "Single EPG"
-msgstr "Single EPG"
+msgstr ""
 
 msgid "Single satellite"
-msgstr "Single satellite"
+msgstr ""
 
 msgid "Single step (GOP)"
-msgstr "Single step (GOP)"
+msgstr ""
 
 msgid "SingleEPG settings"
-msgstr "SingleEPG settings"
+msgstr ""
 
 msgid "Sint Maarten (Dutch part)"
 msgstr ""
@@ -15661,25 +15204,22 @@ msgid "Sitcom"
 msgstr ""
 
 msgid "Site latitude"
-msgstr "Site latitude"
+msgstr ""
 
 msgid "Site longitude"
-msgstr "Site longitude"
+msgstr ""
 
-#, fuzzy
 msgid "Size"
-msgstr "Size: "
+msgstr ""
 
-#, fuzzy
 msgid "Size reverse"
-msgstr "Servers"
+msgstr ""
 
-#, fuzzy
 msgid "Size:"
-msgstr "Size: "
+msgstr ""
 
 msgid "Size: "
-msgstr "Size: "
+msgstr ""
 
 msgid "Skin"
 msgstr ""
@@ -15688,39 +15228,41 @@ msgid "Skin Selector"
 msgstr ""
 
 msgid "Skin Setting"
-msgstr "Skin Setting"
+msgstr ""
 
 msgid "Skin Setup"
 msgstr ""
 
 msgid "Skin setup"
-msgstr "Skin setup"
+msgstr ""
+
+#, python-format
+msgid "Skin:\t\t%s"
+msgstr ""
 
 msgid "SkinSelector"
 msgstr ""
 
 msgid "Skins"
-msgstr "Skins"
+msgstr ""
 
-#, fuzzy
 msgid "Skinselector"
-msgstr "Movie selection"
+msgstr ""
 
 msgid "Skip back"
 msgstr ""
 
 msgid "Skip empty services"
-msgstr "Skip empty services"
+msgstr ""
 
 msgid "Skip forward"
 msgstr ""
 
 msgid "Skip internet connection check (disables automatic package installation)"
-msgstr "Skip internet connection check (disables automatic package installation)"
+msgstr ""
 
-#, fuzzy
 msgid "Skip selection"
-msgstr "Movie selection"
+msgstr ""
 
 msgid "Slapstick"
 msgstr ""
@@ -15732,11 +15274,10 @@ msgid "Sleep Timer"
 msgstr ""
 
 msgid "Sleep delay"
-msgstr "Sleep delay"
+msgstr ""
 
-#, fuzzy
 msgid "Sleep long"
-msgstr "Sleep delay"
+msgstr ""
 
 msgid "SleepTimer"
 msgstr ""
@@ -15751,43 +15292,49 @@ msgid "Slide left to right"
 msgstr ""
 
 msgid "Slide picture in loop"
-msgstr "Slide picture in loop"
+msgstr ""
 
 msgid "Slide right to left"
 msgstr ""
 
 msgid "Slide show interval (sec.)"
-msgstr "Slide show interval (sec.)"
+msgstr ""
 
 msgid "Slide top to bottom"
 msgstr ""
 
 #, python-format
 msgid "Slot %d"
-msgstr "Slot %d"
+msgstr ""
+
+#, python-format
+msgid "Slot %s: %s - Mode %d%s"
+msgstr ""
+
+#, python-format
+msgid "Slot %s: %s%s"
+msgstr ""
 
 msgid "Slovak"
-msgstr "Slovak"
+msgstr ""
 
-#, fuzzy
 msgid "Slovakia"
-msgstr "Slovak"
+msgstr ""
 
-#, fuzzy
 msgid "Slovenia"
-msgstr "Slovenian"
+msgstr ""
 
 msgid "Slovenian"
-msgstr "Slovenian"
+msgstr ""
 
 msgid "Slow"
-msgstr "Slow"
+msgstr ""
 
 msgid "Slow motion speeds"
-msgstr "Slow motion speeds"
+msgstr ""
 
 msgid "Small progress"
-msgstr "Small progress"
+msgstr ""
 
 msgid "Smartcard PIN"
 msgstr ""
@@ -15811,14 +15358,13 @@ msgid "Soccer"
 msgstr ""
 
 msgid "Social/Political/Economics"
-msgstr "Social/Political/Economics"
+msgstr ""
 
 msgid "Society & Culture"
 msgstr ""
 
-#, fuzzy
 msgid "Socket"
-msgstr "locked"
+msgstr ""
 
 msgid "Softcam"
 msgstr ""
@@ -15827,11 +15373,10 @@ msgid "Softcam Setup"
 msgstr ""
 
 msgid "Softcam settings"
-msgstr "Softcam settings"
+msgstr ""
 
-#, fuzzy
 msgid "Softcam setup"
-msgstr "Softcam settings"
+msgstr ""
 
 msgid "Softcam-Panel"
 msgstr ""
@@ -15839,16 +15384,14 @@ msgstr ""
 msgid "Softcam-Panel..."
 msgstr ""
 
-#, fuzzy
 msgid "Softcam-Setup"
-msgstr "Softcam settings"
+msgstr ""
 
-#, fuzzy
 msgid "SoftcamSetup"
-msgstr "Softcam settings"
+msgstr ""
 
 msgid "Software"
-msgstr "Software"
+msgstr ""
 
 msgid "Software Manager"
 msgstr ""
@@ -15860,22 +15403,22 @@ msgid "Software Panel"
 msgstr ""
 
 msgid "Software Update"
-msgstr "Software Update"
+msgstr ""
 
 msgid "Software management"
-msgstr "Software management"
+msgstr ""
 
 msgid "Software manager setup"
-msgstr "Software manager setup"
+msgstr ""
 
 msgid "Software restore"
-msgstr "Software restore"
+msgstr ""
 
 msgid "Software update"
-msgstr "Software update"
+msgstr ""
 
 msgid "Softwaremanager information"
-msgstr "Software manager information"
+msgstr ""
 
 msgid "Softwaremanager..."
 msgstr ""
@@ -15895,29 +15438,28 @@ msgid ""
 msgstr ""
 
 msgid "Some plugins are not available:\n"
-msgstr "Some plugins are not available:\n"
+msgstr ""
 
 msgid "Sorry CIHelper Config is Missing"
 msgstr ""
 
 msgid "Sorry Inadyn Config is Missing"
-msgstr "Sorry Inadyn Config is Missing"
+msgstr ""
 
 msgid "Sorry MediaScanner is not installed!"
 msgstr ""
 
 msgid "Sorry MiniDLNA Config is Missing"
-msgstr "Sorry MiniDLNA Config is Missing"
+msgstr ""
 
 msgid "Sorry feeds are down for maintenance"
-msgstr "Sorry feeds are down for maintenance"
+msgstr ""
 
 msgid "Sorry feeds are down for maintenance, please try again later."
-msgstr "Sorry feeds are down for maintenance, please try again later."
+msgstr ""
 
-#, fuzzy
 msgid "Sorry feeds are down for maintenance, please try again later. If this issue persists please check www.opena.tv"
-msgstr "Sorry feeds are down for maintenance, please try again later."
+msgstr ""
 
 msgid "Sorry no backups found!"
 msgstr ""
@@ -15926,7 +15468,7 @@ msgid "Sorry only possible to record 2 channels at once"
 msgstr ""
 
 msgid "Sorry uShare Config is Missing"
-msgstr "Sorry uShare Config is Missing"
+msgstr ""
 
 msgid ""
 "Sorry your Backup destination does not exist\n"
@@ -15936,13 +15478,13 @@ msgstr ""
 
 #, python-format
 msgid "Sorry, %s has not been installed!"
-msgstr "Sorry, %s has not been installed!"
+msgstr ""
 
 msgid "Sorry, no backups found!"
-msgstr "Sorry, no backups found!"
+msgstr ""
 
 msgid "Sorry, no details available!"
-msgstr "Sorry, no details available!"
+msgstr ""
 
 msgid "Sorry, no physical devices that supports SWAP attached. Can't create Swapfile on network or fat32 filesystems"
 msgstr ""
@@ -15954,14 +15496,12 @@ msgid ""
 "Sorry, your backup destination is not writeable.\n"
 "Please select a different one."
 msgstr ""
-"Sorry, your backup destination is not writeable.\n"
-"Please select a different one."
 
 msgid "Sort"
-msgstr "Sort"
+msgstr ""
 
 msgid "Sort EPG List"
-msgstr "Sort EPG List"
+msgstr ""
 
 msgid "Sort Extensions list alphabetically"
 msgstr ""
@@ -15973,7 +15513,7 @@ msgid "Sort by default"
 msgstr ""
 
 msgid "Sort list by"
-msgstr "Sort list by"
+msgstr ""
 
 msgid "Sort list to default and exit?"
 msgstr ""
@@ -15984,9 +15524,8 @@ msgstr ""
 msgid "Sort order for menu entries"
 msgstr ""
 
-#, fuzzy
 msgid "Sort plug-in browser entries"
-msgstr "Sort plug-in browser alphabetically"
+msgstr ""
 
 msgid "Sort setting screen's alphabetically"
 msgstr ""
@@ -15998,16 +15537,16 @@ msgid "Sorting right files by name, date or size"
 msgstr ""
 
 msgid "Sound"
-msgstr "Sound"
+msgstr ""
 
 msgid "Sound carrier"
-msgstr "Sound carrier"
+msgstr ""
 
 msgid "Source request"
-msgstr "Source request"
+msgstr ""
 
 msgid "South"
-msgstr "South"
+msgstr ""
 
 msgid "South Africa"
 msgstr ""
@@ -16015,30 +15554,26 @@ msgstr ""
 msgid "South Georgia and the South Sandwich Islands"
 msgstr ""
 
-#, fuzzy
 msgid "South Sudan"
-msgstr "South"
+msgstr ""
 
 msgid "Space used:"
-msgstr "Space used:"
+msgstr ""
 
 msgid "Spain"
 msgstr ""
 
 msgid "Spanish"
-msgstr "Spanish"
+msgstr ""
 
-#, fuzzy
 msgid "Special"
-msgstr "Serial No"
+msgstr ""
 
-#, fuzzy
 msgid "Special 1"
-msgstr "Serial No"
+msgstr ""
 
-#, fuzzy
 msgid "Special 2"
-msgstr "Serial No"
+msgstr ""
 
 msgid "Special Features"
 msgstr ""
@@ -16050,17 +15585,16 @@ msgid "Spielfilm"
 msgstr ""
 
 msgid "Split preview mode"
-msgstr "Split preview mode"
+msgstr ""
 
 msgid "Splitscreen"
 msgstr ""
 
-#, fuzzy
 msgid "Sport"
-msgstr "Sports"
+msgstr ""
 
 msgid "Sports"
-msgstr "Sports"
+msgstr ""
 
 msgid "Sprache"
 msgstr ""
@@ -16069,64 +15603,64 @@ msgid "Sri Lanka"
 msgstr ""
 
 msgid "Standard"
-msgstr "Standard"
+msgstr ""
 
 msgid "Standard (always)"
+msgstr ""
+
+msgid "Standard and Ads filtering mode"
 msgstr ""
 
 msgid "Standard list"
 msgstr ""
 
-#, fuzzy
 msgid "Standard menu"
-msgstr "Standard"
+msgstr ""
 
 msgid "Standby"
-msgstr "Standby"
+msgstr ""
 
 msgid "Standby / Restart"
-msgstr "Standby / Restart"
+msgstr ""
 
 msgid "Standby / restart"
-msgstr "Standby / restart"
+msgstr ""
 
 msgid "Standby without TV shutdown"
 msgstr ""
 
 msgid "Start"
-msgstr "Start"
+msgstr ""
 
-#, fuzzy
 msgid "Start Kodi"
-msgstr "Start time"
+msgstr ""
 
 msgid "Start from the beginning"
-msgstr "Start from the beginning"
+msgstr ""
 
 msgid "Start instant recording"
 msgstr ""
 
-#, fuzzy
 msgid "Start mode"
-msgstr "Start time"
+msgstr ""
 
 msgid "Start offline decode"
-msgstr "Start offline decode"
+msgstr ""
 
 msgid "Start recording?"
-msgstr "Start recording?"
+msgstr ""
 
 msgid "Start teletext"
 msgstr ""
 
 msgid "Start test"
-msgstr "Start test"
+msgstr ""
 
 msgid "Start time"
-msgstr "Start time"
+msgstr ""
 
 msgid "Start timeshift"
-msgstr "Start timeshift"
+msgstr ""
 
 msgid "Start/stop slide show"
 msgstr ""
@@ -16144,14 +15678,13 @@ msgid "Starting Softcam"
 msgstr ""
 
 msgid "Starting on"
-msgstr "Starting on"
+msgstr ""
 
-#, fuzzy
 msgid "Starts in a few seconds"
-msgstr "Start offline decode"
+msgstr ""
 
 msgid "Status"
-msgstr "Status"
+msgstr ""
 
 msgid "Status of the display during operation"
 msgstr ""
@@ -16166,68 +15699,67 @@ msgid "Status:"
 msgstr ""
 
 msgid "Step east"
-msgstr "Step east"
+msgstr ""
 
 msgid "Step west"
-msgstr "Step west"
+msgstr ""
 
 msgid "Stepped east"
-msgstr "Stepped east"
+msgstr ""
 
 msgid "Stepped west"
-msgstr "Stepped west"
+msgstr ""
 
 msgid "Stop"
-msgstr "Stop"
+msgstr ""
 
 msgid "Stop PiP"
-msgstr "Stop PiP"
+msgstr ""
 
-#, fuzzy
 msgid "Stop Streams"
-msgstr "Stop test"
+msgstr ""
 
 msgid "Stop current event and disable coming events"
-msgstr "Stop current event and disable coming events"
+msgstr ""
 
 msgid "Stop current event but not coming events"
-msgstr "Stop current event but not coming events"
+msgstr ""
 
 msgid "Stop entry"
-msgstr "Stop entry"
+msgstr ""
 
 msgid "Stop playing this movie?"
-msgstr "Stop playing this movie?"
+msgstr ""
 
 msgid "Stop previous broadcasted service on return to movielist."
 msgstr ""
 
 msgid "Stop recording"
-msgstr "Stop recording"
+msgstr ""
 
 msgid "Stop recording and delete"
-msgstr "Stop recording and delete"
+msgstr ""
 
 msgid "Stop recording now"
-msgstr "Stop recording now"
+msgstr ""
 
 msgid "Stop service on return to movie list"
 msgstr ""
 
 msgid "Stop test"
-msgstr "Stop test"
+msgstr ""
 
 msgid "Stop testing plane after # failed transponders"
-msgstr "Stop testing plane after # failed transponders"
+msgstr ""
 
 msgid "Stop testing plane after # successful transponders"
-msgstr "Stop testing plane after # successful transponders"
+msgstr ""
 
 msgid "Stop timer recording"
-msgstr "Stop timer recording"
+msgstr ""
 
 msgid "Stop timeshift"
-msgstr "Stop timeshift"
+msgstr ""
 
 msgid "Stop timeshift and save timeshift buffer as movie"
 msgstr ""
@@ -16236,34 +15768,34 @@ msgid "Stop timeshift and save timeshift buffer as movie and start recording of 
 msgstr ""
 
 msgid "Stop timeshift while recording?"
-msgstr "Stop timeshift while recording?"
+msgstr ""
 
 msgid "Stop's timeshift being used if a recording is in progress. (advisable for usb sticks)"
 msgstr ""
 
 msgid "Stopped"
-msgstr "Stopped"
+msgstr ""
 
 msgid "Stopping Softcam"
 msgstr ""
 
 msgid "Storage devices"
-msgstr "Storage devices"
+msgstr ""
 
 msgid "Store at index"
-msgstr "Store at index"
+msgstr ""
 
 msgid "Store position"
-msgstr "Store position"
+msgstr ""
 
 msgid "Stored position"
-msgstr "Stored position"
+msgstr ""
 
 msgid "Stream"
-msgstr "Stream"
+msgstr ""
 
 msgid "Stream request"
-msgstr "Stream request"
+msgstr ""
 
 msgid "Stream-tv"
 msgstr ""
@@ -16271,13 +15803,11 @@ msgstr ""
 msgid "Streaming"
 msgstr ""
 
-#, fuzzy
 msgid "Streaming clients info"
-msgstr "CCcam Client Info"
+msgstr ""
 
-#, fuzzy
 msgid "Streaming recording ended"
-msgstr "Change recording (endtime)"
+msgstr ""
 
 #. TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (force aspect))
 msgid "Stretch full"
@@ -16293,13 +15823,13 @@ msgid "Stretch nonlinear"
 msgstr ""
 
 msgid "Strict DLNA"
-msgstr "Strict DLNA"
+msgstr ""
 
 msgid "Stripes"
 msgstr ""
 
 msgid "Strongest position"
-msgstr "Strongest position"
+msgstr ""
 
 msgid "Stumm"
 msgstr ""
@@ -16307,71 +15837,68 @@ msgstr ""
 msgid "Style:"
 msgstr ""
 
-#, fuzzy
 msgid "Subservice list..."
-msgstr "Subservices"
+msgstr ""
 
-#, fuzzy
 msgid "Subservice mode (green Button)"
-msgstr "Subservice mode"
+msgstr ""
 
 msgid "Subservices"
-msgstr "Subservices"
+msgstr ""
 
 msgid "Subtitle"
 msgstr ""
 
 msgid "Subtitle Quickmenu"
-msgstr "Subtitle Quickmenu"
+msgstr ""
 
 msgid "Subtitle alignment"
-msgstr "Subtitle alignment"
+msgstr ""
 
-#, fuzzy
 msgid "Subtitle black transparency"
-msgstr "DVB subtitle black transparency"
+msgstr ""
 
 msgid "Subtitle border width"
-msgstr "Subtitle border width"
+msgstr ""
 
 msgid "Subtitle delay when timing is bad"
-msgstr "Subtitle delay when timing is bad"
+msgstr ""
 
 msgid "Subtitle delay when timing lacks"
-msgstr "Subtitle delay when timing lacks"
+msgstr ""
 
 msgid "Subtitle font size"
-msgstr "Subtitle font size"
+msgstr ""
 
 msgid "Subtitle language selection 1"
-msgstr "Subtitle language selection 1"
+msgstr ""
 
 msgid "Subtitle language selection 2"
-msgstr "Subtitle language selection 2"
+msgstr ""
 
 msgid "Subtitle language selection 3"
-msgstr "Subtitle language selection 3"
+msgstr ""
 
 msgid "Subtitle language selection 4"
-msgstr "Subtitle language selection 4"
+msgstr ""
 
 msgid "Subtitle long"
 msgstr ""
 
 msgid "Subtitle position"
-msgstr "Subtitle position"
+msgstr ""
 
 msgid "Subtitle selection"
-msgstr "Subtitle selection"
+msgstr ""
 
 msgid "Subtitle selection..."
-msgstr "Subtitle selection..."
+msgstr ""
 
 msgid "Subtitle settings"
-msgstr "Subtitle settings"
+msgstr ""
 
 msgid "Subtitles"
-msgstr "Subtitles"
+msgstr ""
 
 msgid "Subtitles Settings"
 msgstr ""
@@ -16383,17 +15910,16 @@ msgid "Sudan"
 msgstr ""
 
 msgid "Sun"
-msgstr "Sun"
+msgstr ""
 
 msgid "Sunday"
-msgstr "Sunday"
+msgstr ""
 
 msgid "Support at"
-msgstr "Support at"
+msgstr ""
 
-#, fuzzy
 msgid "Suriname"
-msgstr "rename"
+msgstr ""
 
 msgid "Svalbard and Jan Mayen"
 msgstr ""
@@ -16414,13 +15940,13 @@ msgid "Swap PIP"
 msgstr ""
 
 msgid "Swap PiP and main picture"
-msgstr "Swap PiP and main picture"
+msgstr ""
 
 msgid "Swap Place:"
 msgstr ""
 
 msgid "Swap SNR in '%' with SNR in 'db'"
-msgstr "Swap SNR in '%' with SNR in 'db'"
+msgstr ""
 
 msgid "Swap Size:"
 msgstr ""
@@ -16428,8 +15954,11 @@ msgstr ""
 msgid "Swap buttons right/left with channel plus/minus or the channel button changed always the side."
 msgstr ""
 
+msgid "Swap screen"
+msgstr ""
+
 msgid "Swap services"
-msgstr "Swap services"
+msgstr ""
 
 msgid "SwapManager"
 msgstr ""
@@ -16443,12 +15972,11 @@ msgstr ""
 msgid "Swaziland"
 msgstr ""
 
-#, fuzzy
 msgid "Sweden"
-msgstr "Swedish"
+msgstr ""
 
 msgid "Swedish"
-msgstr "Swedish"
+msgstr ""
 
 msgid "Swimming"
 msgstr ""
@@ -16460,26 +15988,25 @@ msgid "Switch Mode to enable HDR Modes or PIP Functions"
 msgstr ""
 
 msgid "Switch TV to correct input"
-msgstr "Switch TV to correct input"
+msgstr ""
 
 msgid "Switch between Audio-, Subtitlepage"
 msgstr ""
 
 msgid "Switch between filelist/playlist"
-msgstr "Switch between filelist/playlist"
+msgstr ""
 
 msgid "Switch between normal mode and list mode"
 msgstr ""
 
 msgid "Switch config"
-msgstr "Switch config"
+msgstr ""
 
 msgid "Switch next channel"
-msgstr "Switch next channel"
+msgstr ""
 
-#, fuzzy
 msgid "Switch off the TV to correct input"
-msgstr "Switch TV to correct input"
+msgstr ""
 
 msgid "Switch to HDMI in mode"
 msgstr ""
@@ -16494,31 +16021,31 @@ msgid "Switch to TV mode"
 msgstr ""
 
 msgid "Switch to filelist"
-msgstr "Switch to filelist"
+msgstr ""
 
 msgid "Switch to next channel in history"
-msgstr "Switch to next channel in history"
+msgstr ""
 
 msgid "Switch to next sub service"
-msgstr "Switch to next sub service"
+msgstr ""
 
 msgid "Switch to playlist"
-msgstr "Switch to playlist"
+msgstr ""
 
 msgid "Switch to previous channel"
-msgstr "Switch to previous channel"
+msgstr ""
 
 msgid "Switch to previous channel in history"
-msgstr "Switch to previous channel in history"
+msgstr ""
 
 msgid "Switch to previous sub service"
-msgstr "Switch to previous sub service"
+msgstr ""
 
 msgid "Switch to radio mode"
 msgstr ""
 
 msgid "Switchable tuner types:"
-msgstr "Switchable tuner types:"
+msgstr ""
 
 msgid "Switching to live TV - timeshift is still active!"
 msgstr ""
@@ -16527,7 +16054,7 @@ msgid "Switzerland"
 msgstr ""
 
 msgid "Symbol rate"
-msgstr "Symbol rate"
+msgstr ""
 
 msgid "Symbolic link"
 msgstr ""
@@ -16536,29 +16063,28 @@ msgid "Symlink to "
 msgstr ""
 
 msgid "Sync NTP every (minutes)"
-msgstr "Sync NTP every (minutes)"
+msgstr ""
 
 msgid "Sync failure moving back to origin !"
-msgstr "Sync failure moving back to origin !"
+msgstr ""
 
 msgid "Sync time using"
-msgstr "Sync time using"
+msgstr ""
 
 msgid "Synchronize systemtime using transponder or internet."
-msgstr ""
+msgstr "Choose either transponder information or an internet time server to synchronise your receiver's time."
 
 msgid "Syrian Arab Republic"
 msgstr ""
 
 msgid "System"
-msgstr "System"
+msgstr ""
 
 msgid "System Info"
 msgstr ""
 
-#, fuzzy
 msgid "System Message Check"
-msgstr "Filesystem Check"
+msgstr ""
 
 msgid "System Setup"
 msgstr ""
@@ -16571,7 +16097,7 @@ msgid "System temperature:\t%s"
 msgstr ""
 
 msgid "System: "
-msgstr "System: "
+msgstr ""
 
 msgid "SystemInfo"
 msgstr ""
@@ -16579,50 +16105,51 @@ msgstr ""
 msgid "Systeminfo"
 msgstr ""
 
-#, fuzzy
 msgid "T2MI PID"
-msgstr "PMT PID"
+msgstr ""
 
 msgid "T2MI PLP"
 msgstr ""
 
-#, fuzzy
 msgid "T2MI PLP ID"
-msgstr "PLP ID"
+msgstr ""
 
 msgid "T2MI RAW Mode"
 msgstr ""
 
 msgid "TB"
-msgstr "TB"
+msgstr ""
+
+msgid "TEXT"
+msgstr ""
 
 #. TRANSLATORS: Add here whatever should be shown in the "translator" about screen, up to 6 lines (use \n for newline)
 msgid "TRANSLATOR_INFO"
-msgstr "TRANSLATOR_INFO"
+msgstr ""
 
 msgid "TS file is too large for ISO9660 level 1!"
-msgstr "TS file is too large for ISO9660 level 1!"
+msgstr ""
 
 msgid "TSID"
-msgstr "TSID"
+msgstr ""
 
 msgid "TV"
 msgstr ""
 
 msgid "TV button mode"
-msgstr "TV button mode"
+msgstr ""
 
 msgid "TV physical address report"
-msgstr "TV physical address report"
+msgstr ""
 
 msgid "TXT PID"
-msgstr "TXT PID"
+msgstr ""
 
 msgid "Table of content for collection"
 msgstr ""
 
 msgid "Tags"
-msgstr "Tags"
+msgstr ""
 
 msgid "Taiwan"
 msgstr ""
@@ -16633,9 +16160,8 @@ msgstr ""
 msgid "Talk"
 msgstr ""
 
-#, fuzzy
 msgid "Talk Show"
-msgstr "talk show"
+msgstr ""
 
 msgid "Tanz"
 msgstr ""
@@ -16643,9 +16169,8 @@ msgstr ""
 msgid "Tanzania, United Republic of"
 msgstr ""
 
-#, fuzzy
 msgid "Task list"
-msgstr "blacklist"
+msgstr ""
 
 msgid "Technik"
 msgstr ""
@@ -16662,13 +16187,11 @@ msgstr ""
 msgid "Teletext EndY (upper border)"
 msgstr ""
 
-#, fuzzy
 msgid "Teletext StartX (left border)"
-msgstr "Teletext subtitle colour"
+msgstr ""
 
-#, fuzzy
 msgid "Teletext StartY (lower border)"
-msgstr "Teletext subtitle colour"
+msgstr ""
 
 msgid "Teletext TTFBold (0=normal, 1=bold)"
 msgstr ""
@@ -16704,36 +16227,35 @@ msgid "Telnet"
 msgstr ""
 
 msgid "Telnet Interface"
-msgstr "Telnet Interface"
+msgstr ""
 
 msgid "Telnet Port"
-msgstr "Telnet Port"
+msgstr ""
 
 msgid "Telnet Setup"
-msgstr "Telnet Setup"
+msgstr ""
 
-#, fuzzy
 msgid "Tennis"
-msgstr "Finnish"
+msgstr ""
 
 msgid "Terrestrial"
-msgstr "Terrestrial"
+msgstr ""
 
 msgid "Terrestrial bouquet:"
 msgstr ""
 
 msgid "Test DiSEqC settings"
-msgstr "Test DiSEqC settings"
+msgstr ""
 
 msgid "Test mode"
-msgstr "Test mode"
+msgstr ""
 
 #, python-format
 msgid "Test the network configuration of your %s %s.\n"
-msgstr "Test the network configuration of your %s %s.\n"
+msgstr ""
 
 msgid "Test type"
-msgstr "Test type"
+msgstr ""
 
 msgid "Testscreens"
 msgstr ""
@@ -16742,51 +16264,42 @@ msgid "Testscreens that are helpfull to fine-tune your display"
 msgstr ""
 
 msgid "Text"
-msgstr "Text"
+msgstr ""
 
 msgid "Text color"
 msgstr "Text colour"
 
 msgid "Thai"
-msgstr "Thai"
+msgstr ""
 
-#, fuzzy
 msgid "Thailand"
-msgstr "Thai"
+msgstr ""
 
 msgid ""
 "Thank you for using the wizard.\n"
 "Please press OK to continue."
 msgstr ""
-"Thank you for using the wizard.\n"
-"Please press OK to continue."
 
 msgid ""
 "Thank you for using the wizard. Your %s %s is now ready to use.\n"
 "Please press OK to start using your %s %s."
 msgstr ""
-"Thank you for using the wizard. Your %s %s is now ready to use.\n"
-"Please press OK to start using your %s %s."
 
 msgid "The %s %s reads the stored EPG data every (hours)."
-msgstr "The %s %s reads the stored EPG data every (hours)."
+msgstr ""
 
 msgid "The %s %s stores the EPG data every (hours)."
-msgstr "The %s %s stores the EPG data every (hours)."
+msgstr ""
 
 msgid ""
 "The AutoTimer plugin is not installed!\n"
 "Please install it."
 msgstr ""
-"The AutoTimer plugin is not installed!\n"
-"Please install it."
 
 msgid ""
 "The Cool TV Guide plugin is not installed!\n"
 "Please install it."
 msgstr ""
-"The Cool TV Guide plugin is not installed!\n"
-"Please install it."
 
 msgid "The DVD standard doesn't support H.264 (HDTV) video streams."
 msgstr ""
@@ -16800,22 +16313,16 @@ msgid ""
 "The EPGSearch plugin is not installed!\n"
 "Please install it."
 msgstr ""
-"The EPGSearch plugin is not installed!\n"
-"Please install it."
 
 msgid ""
 "The Filesystem on your Timeshift-Device does not support hardlinks.\n"
 "Make sure it is formatted in EXT2, EXT3 or EXT4!"
 msgstr ""
-"The Filesystem on your Timeshift-Device does not support hardlinks.\n"
-"Make sure it is formatted in EXT2, EXT3 or EXT4!"
 
 msgid ""
 "The IMDb plugin is not installed!\n"
 "Please install it."
 msgstr ""
-"The IMDb plugin is not installed!\n"
-"Please install it."
 
 #, python-format
 msgid ""
@@ -16839,8 +16346,6 @@ msgid ""
 "The MediaPlayer plugin is not installed!\n"
 "Please install it."
 msgstr ""
-"The MediaPlayer plugin is not installed!\n"
-"Please install it."
 
 msgid ""
 "The MediaPortal plugin is not installed!\n"
@@ -16853,15 +16358,14 @@ msgid ""
 msgstr ""
 
 msgid "The PIN code has been changed successfully."
-msgstr "The PIN code has been changed successfully."
+msgstr ""
 
 msgid "The PIN code has been saved successfully."
 msgstr ""
 
 msgid "The PIN codes you entered are different."
-msgstr "The PIN codes you entered are different."
+msgstr ""
 
-#, fuzzy
 msgid ""
 "The SimpleUmount plugin is not installed!\n"
 "Please install it."
@@ -16876,17 +16380,14 @@ msgid ""
 "The USB stick was prepared to be bootable.\n"
 "Now you can download an NFI image file!"
 msgstr ""
-"The USB stick was prepared to be bootable.\n"
-"Now you can download an NFI image file!"
 
 msgid ""
 "The VideoMode plugin is not installed!\n"
 "Please install it."
 msgstr ""
 
-#, fuzzy
 msgid "The aspect ratio of the recording."
-msgstr "Set the description of the recording."
+msgstr ""
 
 msgid "The authors are NOT RESPONSIBLE"
 msgstr ""
@@ -16897,7 +16398,7 @@ msgid ""
 msgstr ""
 
 msgid "The backup failed. Please choose a different backup location."
-msgstr "The backup failed. Please choose a different backup location."
+msgstr ""
 
 msgid "The bitrate of the video encoder. Larger value improves quality and increases file size."
 msgstr ""
@@ -16908,7 +16409,7 @@ msgid ""
 msgstr ""
 
 msgid "The current update may be unstable"
-msgstr "The current update may be unstable"
+msgstr ""
 
 msgid ""
 "The default backup selection cannot be changed.\n"
@@ -16932,8 +16433,6 @@ msgid ""
 "The directory %s is not writable.\n"
 "Make sure you select a writable directory instead."
 msgstr ""
-"The directory %s is not writable.\n"
-"Make sure you select a writable directory instead."
 
 #, python-format
 msgid ""
@@ -16943,14 +16442,9 @@ msgid ""
 "\n"
 "Do you want to write the USB flasher to this stick?"
 msgstr ""
-"The following device was found:\n"
-"\n"
-"%s\n"
-"\n"
-"Do you want to write the USB flasher to this stick?"
 
 msgid "The following files were found..."
-msgstr "The following files were found..."
+msgstr ""
 
 msgid "The frame rate of the recording. Ideally, this will match the frame rate of the source or be an integer multiple. If in doubt, set to 60, which should work with most sources."
 msgstr ""
@@ -16971,31 +16465,29 @@ msgid "The installation of the default settings is finished. You can now continu
 msgstr ""
 
 msgid "The loopthrough setting is wrong."
-msgstr "The loopthrough setting is wrong."
+msgstr ""
 
 msgid "The md5sum validation failed, the file may be corrupted!"
-msgstr "The md5sum validation failed, the file may be corrupted!"
+msgstr ""
 
 msgid ""
 "The network wizard extension is not installed!\n"
 "Please install it."
 msgstr ""
-"The network wizard extension is not installed!\n"
-"Please install it."
 
 msgid "The password can not be blank."
 msgstr ""
 
 #, python-format
 msgid "The path %s already exists."
-msgstr "The path %s already exists."
+msgstr ""
 
 msgid "The pin code you entered is wrong."
-msgstr "The pin code you entered is wrong."
+msgstr ""
 
 #, python-format
 msgid "The results have been written to %s."
-msgstr "The results have been written to %s."
+msgstr ""
 
 msgid "The saved PIN was cleared."
 msgstr ""
@@ -17016,8 +16508,6 @@ msgid ""
 "The software management extension is not installed!\n"
 "Please install it."
 msgstr ""
-"The software management extension is not installed!\n"
-"Please install it."
 
 msgid "The status of the current update could not be checked because http://www.opena.tv could not be reached for some reason"
 msgstr ""
@@ -17026,10 +16516,10 @@ msgid "The time is multiplied by the current repeat counter."
 msgstr ""
 
 msgid "The timer file (pm_timers.xml) is corrupt and could not be loaded."
-msgstr "The timer file (pm_timers.xml) is corrupt and could not be loaded."
+msgstr ""
 
 msgid "The timer file (timers.xml) is corrupt and could not be loaded."
-msgstr "The timer file (timers.xml) is corrupt and could not be loaded."
+msgstr ""
 
 msgid ""
 "The unicable connection setting is wrong.\n"
@@ -17038,15 +16528,13 @@ msgstr ""
 
 #, python-format
 msgid "The user interface of your %s %s is restarting"
-msgstr "The user interface of your %s %s is restarting"
+msgstr ""
 
 #, python-format
 msgid ""
 "The user interface of your %s %s is restarting\n"
 "due to an error in mytest.py"
 msgstr ""
-"The user interface of your %s %s is restarting\n"
-"due to an error in mytest.py"
 
 msgid "The width of the picture. The input will be scaled to match this value."
 msgstr ""
@@ -17055,42 +16543,37 @@ msgid ""
 "The wireless LAN plugin is not installed!\n"
 "Please install it and choose what you want to do next."
 msgstr ""
-"The wireless LAN plugin is not installed!\n"
-"Please install it and choose what you want to do next."
 
 msgid ""
 "The wireless LAN plugin is not installed!\n"
 "Please install it."
 msgstr ""
-"The wireless LAN plugin is not installed!\n"
-"Please install it."
 
 msgid "The wizard can backup your current settings. Do you want to do a backup now?"
-msgstr "The wizard can backup your current settings. Do you want to do a backup now?"
+msgstr ""
 
 #, python-format
 msgid "The wizard found a configuration backup. Do you want to restore your old settings from %s?"
-msgstr "The wizard found a configuration backup. Do you want to restore your old settings from %s?"
+msgstr ""
 
 msgid "The wizard is finished now."
-msgstr "The wizard is finished now."
+msgstr ""
 
-#, fuzzy
 msgid "Theater"
-msgstr "Later"
+msgstr "Theatre"
 
 msgid "There are at least "
-msgstr "There are at least "
+msgstr ""
 
 #, python-format
 msgid "There are at least %s updates available."
-msgstr "There are at least %s updates available."
+msgstr ""
 
 msgid "There are currently no outstanding actions."
-msgstr "There are currently no outstanding actions."
+msgstr ""
 
 msgid "There are no updates available."
-msgstr "There are no updates available."
+msgstr ""
 
 #, python-format
 msgid ""
@@ -17105,14 +16588,12 @@ msgid ""
 msgstr ""
 
 msgid "There is no signal to lock on !"
-msgstr "There is no signal to lock on !"
+msgstr ""
 
 msgid ""
 "There might not be enough space on the selected partition..\n"
 "Do you really want to continue?"
 msgstr ""
-"There might not be enough space on the selected partition.\n"
-"Do you really want to continue?"
 
 msgid "There was an error downloading current region details"
 msgstr ""
@@ -17128,20 +16609,19 @@ msgstr ""
 
 #, python-format
 msgid "This %s %s cannot decode %s streams!"
-msgstr "This %s %s cannot decode %s streams!"
+msgstr ""
 
 msgid "This DVD RW medium is already formatted - reformatting will erase all content on the disc."
-msgstr "This DVD RW medium is already formatted - reformatting will erase all content on the disc."
+msgstr ""
 
 msgid "This Device is already mounted as HDD."
 msgstr ""
 
-#, fuzzy
 msgid "This Option allows you to switch Audio to BT Speakers."
-msgstr "This option allows you to boost the blue tones in the picture."
+msgstr ""
 
 msgid "This allows you change the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size"
-msgstr "This allows you change the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size"
+msgstr ""
 
 msgid "This allows you change the number of rows shown."
 msgstr ""
@@ -17158,9 +16638,8 @@ msgstr ""
 msgid "This allows you to show kernel modules in downloads"
 msgstr ""
 
-#, fuzzy
 msgid "This allows you to show languages in downloads"
-msgstr "This allows you to change the number of rows shown."
+msgstr ""
 
 msgid "This allows you to show lcd skins in downloads"
 msgstr ""
@@ -17180,9 +16659,8 @@ msgstr ""
 msgid "This allows you to show settings modules in downloads"
 msgstr ""
 
-#, fuzzy
 msgid "This allows you to show skin modules in downloads"
-msgstr "This option allows you to disable sorting of the plugin browser."
+msgstr ""
 
 msgid "This allows you to show softcams modules in downloads"
 msgstr ""
@@ -17196,6 +16674,9 @@ msgstr ""
 msgid "This allows you to show weblinks modules in downloads"
 msgstr ""
 
+msgid "This feature is currently unavailable!"
+msgstr ""
+
 #, python-format
 msgid "This field allows you to search an additional symbol rate up to %s."
 msgstr ""
@@ -17206,56 +16687,55 @@ msgstr ""
 msgid "This is the order in which DiSEqC commands are sent to the aerial system. The order must correspond exactly with the order the physical devices are arranged along the signal cable (starting from the receiver end)."
 msgstr ""
 
-#, fuzzy
 msgid "This line is not editable!"
-msgstr "This plugin is not installed."
+msgstr ""
 
 msgid "This option allows to reduce the block-noise in the picture. Obviously this is at the cost of the picture's sharpness."
-msgstr "This option allows to reduce the block-noise in the picture. Obviously this is at the cost of the picture's sharpness."
+msgstr ""
 
 msgid "This option allows to set the level of dynamic contrast of the picture."
-msgstr "This option allows to set the level of dynamic contrast of the picture."
+msgstr ""
 
-#, fuzzy
 msgid "This option allows you can config the Colordepth for UHD"
-msgstr "This option allows you to boost the blue tones in the picture."
+msgstr "This option lets you set the colour depth (also known as as bit depth) for UHD"
 
-#, fuzzy
 msgid "This option allows you can config the Colorimetry for HDR"
-msgstr "This option allows you to disable sorting of the menus"
+msgstr "This option lets you set the colourimetry for HDR.This relates to how colour is perceived."
 
 msgid "This option allows you can config the Colorspace from Auto to RGB"
 msgstr ""
+"Choose between Auto and RGB colour spaces.\n"
+"This determines how color signals are sent to your TV."
 
-#, fuzzy
 msgid "This option allows you can enable or disable the 10 Bit Color Mode"
-msgstr "This option allows you to disable sorting of the menus"
+msgstr "Choose whether to enable or disable 10-bit colour mode"
 
-#, fuzzy
 msgid "This option allows you can enable or disable the 12 Bit Color Mode"
-msgstr "This option allows you to disable sorting of the menus"
+msgstr "Choose whether to enable or disable 12-bit colour mode"
 
-#, fuzzy
 msgid "This option allows you can force the HDR Modes for UHD"
-msgstr "This option lets you choose the 3D mode"
+msgstr ""
+"This option allows you to force HDR mode for UHD\n"
+"High Dynamic Range; HDR pictures on supported television sets will have brighter highlights, more impact and a wider range of color detail."
 
-#, fuzzy
 msgid "This option allows you can force the HDR10 Modes for UHD"
-msgstr "This option lets you choose the 3D mode"
+msgstr ""
+"This option allows you to force HDR10 mode for UHD\n"
+"High Dynamic Range for streaming; HDR10 is similar to Dolby Vision.HDR pictures on supported television sets will have brighter highlights, more impact and a wider range of color detail."
 
-#, fuzzy
 msgid "This option allows you can force the HLG Modes for UHD"
-msgstr "This option lets you choose the 3D mode"
+msgstr ""
+"This option allows you to force HLG mode for UHDHybrid Log Gamma; HLG is a type of High Dynamic Range (HDR) for broadcast cable, satellite and live TV.\n"
+"HDR pictures on supported television sets have brighter highlights, more impact and a wider range of color detail."
 
 msgid "This option allows you choose how to display elapsed time  as + or -"
 msgstr ""
 
 msgid "This option allows you choose how to display remaining time, or elapsed time, or both."
-msgstr "This option allows you choose how to display remaining time, or elapsed time, or both."
+msgstr ""
 
-#, fuzzy
 msgid "This option allows you choose how to display the Time or nothing in Standby"
-msgstr "This option allows you choose how to display elapsed time as + or -"
+msgstr ""
 
 msgid "This option allows you choose how to display the remaining/elapsed time for Media playback."
 msgstr ""
@@ -17266,8 +16746,9 @@ msgstr ""
 msgid "This option allows you choose how to display the remaining/elapsed time for media playback."
 msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "This option allows you choose the background colour of transparent picons."
-msgstr ""
+msgstr "Choose which colour to show behind channel picons with transparent backgrounds."
 
 msgid "This option allows you enable smoothing filter to control the dithering process."
 msgstr ""
@@ -17276,7 +16757,7 @@ msgid "This option allows you enable the vertical scaler dejagging."
 msgstr ""
 
 msgid "This option allows you set the layout view (Text or Graphics)."
-msgstr "This option allows you set the layout view (Text or Graphics)."
+msgstr ""
 
 msgid "This option allows you to Power Off the display."
 msgstr ""
@@ -17285,56 +16766,52 @@ msgid "This option allows you to always use e.g. 1080p50 for TV/.ts, and 1080p24
 msgstr ""
 
 msgid "This option allows you to boost the blue tones in the picture."
-msgstr "This option allows you to boost the blue tones in the picture."
+msgstr ""
 
 msgid "This option allows you to boost the green tones in the picture."
-msgstr "This option allows you to boost the green tones in the picture."
+msgstr ""
 
 msgid "This option allows you to bypass HDMI EDID check"
-msgstr "This option allows you to bypass HDMI EDID check"
+msgstr ""
 
 msgid "This option allows you to change the virtuell loadspeaker position."
 msgstr ""
 
 msgid "This option allows you to choose from the two channel lists that are available."
-msgstr "This option allows you to choose from the two channel lists that are available."
+msgstr ""
 
 msgid "This option allows you to choose how to display 1080p 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 24Hz on your TV. (As not all TV's support these resolutions.)"
+msgstr ""
 
 msgid "This option allows you to choose how to display 1080p 25Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 25Hz on your TV. (As not all TV's support these resolutions.)"
+msgstr ""
 
 msgid "This option allows you to choose how to display 1080p 30Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 30Hz on your TV. (As not all TV's support these resolutions.)"
+msgstr ""
 
-#, fuzzy
 msgid "This option allows you to choose how to display 2160p 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 720p 24Hz on your TV. (As not all TV's support these resolutions.)"
+msgstr ""
 
-#, fuzzy
 msgid "This option allows you to choose how to display 2160p 25Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 25Hz on your TV. (As not all TV's support these resolutions.)"
+msgstr ""
 
-#, fuzzy
 msgid "This option allows you to choose how to display 2160p 30Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 1080p 30Hz on your TV. (As not all TV's support these resolutions.)"
+msgstr ""
 
 msgid "This option allows you to choose how to display 720p 24Hz on your TV. (as not all TV's support these resolutions)"
-msgstr "This option allows you to choose how to display 720p 24Hz on your TV. (As not all TV's support these resolutions.)"
+msgstr ""
 
 msgid "This option allows you to choose how to display SD progressive 24Hz on your TV. (as not all TV's support these resolutions)"
 msgstr ""
 
 msgid "This option allows you to choose how to display standard definition video on your TV."
-msgstr "This option allows you to choose how to display standard definition video on your TV."
+msgstr ""
 
 msgid "This option allows you to choose what the first button press jumps to in channel list screen, (so pressing '2' jumps to 'A' or '2' first), when 'Quick Actions' preset actions are performed. "
 msgstr ""
 
-#, fuzzy
 msgid "This option allows you to choose whether or not to display genre information for the event."
-msgstr "This option allows you to choose how to display the remaining/elapsed time for live TV."
+msgstr ""
 
 msgid "This option allows you to disable show Restart Network in Extensions list."
 msgstr ""
@@ -17346,97 +16823,91 @@ msgid "This option allows you to disable sorting of the option in setting screen
 msgstr ""
 
 msgid "This option allows you to enable 3D Surround Sound."
-msgstr "This option allows you to enable 3D Surround Sound."
+msgstr ""
 
-#, fuzzy
 msgid "This option allows you to hide and sorting of the menus"
-msgstr "This option allows you to disable sorting of the menus"
+msgstr ""
 
-#, fuzzy
 msgid "This option allows you to hide and sorting of the plugin browser."
-msgstr "This option allows you to disable sorting of the plugin browser."
+msgstr ""
 
-#, fuzzy
 msgid "This option allows you to show menu number quick links."
-msgstr "This option allows you to boost the green tones in the picture."
+msgstr ""
 
 msgid "This option allows you to the SNR as a percentage (not all receivers support this)."
 msgstr ""
 
-#, fuzzy
 msgid "This option allows you to use all HDMI Modes"
-msgstr "This option allows you to bypass HDMI EDID check"
+msgstr ""
 
 msgid "This option allows you to view the old and new settings side by side."
-msgstr "This option allows you to view the old and new settings side by side."
+msgstr ""
 
-#, fuzzy
 msgid "This option configures the general audio delay for BT Speakers."
-msgstr "This option configures the general audio delay of stereo sound tracks."
+msgstr ""
 
 msgid "This option configures the general audio delay of Dolby Digital sound tracks."
-msgstr "This option configures the general audio delay of Dolby Digital sound tracks."
+msgstr ""
 
 msgid "This option configures the general audio delay of stereo sound tracks."
-msgstr "This option configures the general audio delay of stereo sound tracks."
+msgstr ""
 
-#, fuzzy
 msgid "This option configures the picture sharpness."
-msgstr "This option sets the picture brightness."
+msgstr ""
 
 msgid "This option configures the screen resolution in PC output mode."
-msgstr "This option configures the screen resolution in PC output mode."
+msgstr ""
 
 msgid "This option configures the video output mode (or resolution)."
-msgstr "This option configures the video output mode (or resolution)."
+msgstr ""
 
 msgid "This option configures you can set Auto Volume Level."
 msgstr ""
 
 msgid "This option lets you adjust the 3D depth"
-msgstr "This option lets you adjust the 3D depth"
+msgstr ""
 
 msgid "This option lets you adjust the transparency of the user interface"
-msgstr "This option lets you adjust the transparency of the user interface"
+msgstr ""
 
 msgid "This option lets you choose the 3D mode"
-msgstr "This option lets you choose the 3D mode"
+msgstr ""
 
 msgid "This option lets you show the option in the extension screen"
-msgstr "This option lets you show the option in the extension screen"
+msgstr ""
 
 msgid "This option moves the PVR status from the separate window into the MoviePlayer infobar."
 msgstr ""
 
 msgid "This option set the level of suppression of mosquito noise (Mosquito Noise is random aliasing as a result of strong compression). Obviously this goes at the cost of picture details."
-msgstr "This option set the level of suppression of mosquito noise (Mosquito Noise is random aliasing as a result of strong compression). Obviously this goes at the cost of picture details."
+msgstr ""
 
 msgid "This option sets  the picture contrast."
-msgstr "This option sets  the picture contrast."
+msgstr ""
 
 msgid "This option sets the picture brightness."
-msgstr "This option sets the picture brightness."
+msgstr ""
 
 msgid "This option sets the picture color space."
-msgstr "This option sets the picture colour space."
+msgstr "This option lets you set the picture colour space."
 
 msgid "This option sets the picture flesh tones."
-msgstr "This option sets the picture flesh tones."
+msgstr ""
 
 msgid "This option sets the picture hue."
-msgstr "This option sets the picture hue."
+msgstr ""
 
 msgid "This option sets the picture saturation."
-msgstr "This option sets the picture saturation."
+msgstr ""
 
 msgid "This option sets the scaler sharpness, used when stretching picture from 4:3 to 16:9."
-msgstr "This option sets the scaler sharpness, used when scretching picture from 4:3 to 16:9."
+msgstr ""
 
 msgid "This option sets the surpression of false digital contours, that are the result of a limited number of discrete values."
-msgstr "This option sets the suppression of false digital contours, that are the result of a limited number of discrete values."
+msgstr ""
 
 msgid "This option sets up the picture sharpness, used when the picture is being upscaled."
-msgstr "This option sets up the picture sharpness, used when the picture is being upscaled."
+msgstr ""
 
 #, python-format
 msgid ""
@@ -17445,22 +16916,18 @@ msgid ""
 "In the next step, an NFI image file can be downloaded from the update server and saved on the USB stick.\n"
 "If you already have a prepared bootable USB stick, please insert it now. Otherwise plug in a USB stick with a minimum size of 64 MB!"
 msgstr ""
-"This plugin creates a USB stick which can be used to update the firmware of your %s %s without the need for a network or WLAN connection.\n"
-"First, a USB stick needs to be prepared so that it becomes bootable.\n"
-"In the next step, an NFI image file can be downloaded from the update server and saved on the USB stick.\n"
-"If you already have a prepared bootable USB stick, please insert it now. Otherwise plug in a USB stick with a minimum size of 64 MB!"
 
 msgid "This plugin is installed."
-msgstr "This plugin is installed."
+msgstr ""
 
 msgid "This plugin is not installed."
-msgstr "This plugin is not installed."
+msgstr ""
 
 msgid "This plugin will be installed."
-msgstr "This plugin will be installed."
+msgstr ""
 
 msgid "This plugin will be removed."
-msgstr "This plugin will be removed."
+msgstr ""
 
 msgid "This setting allows the tuner configuration to be a duplication of how another tuner is already configured."
 msgstr ""
@@ -17477,10 +16944,6 @@ msgid ""
 "- please check your DHCP, cabling and adapter setup\n"
 "- if you configured your nameservers manually please verify your entries in the \"Nameserver\" configuration"
 msgstr ""
-"This test checks for configured nameservers.\n"
-"If you get a \"unconfirmed\" message:\n"
-"- please check your DHCP, cabling and adapter setup\n"
-"- if you configured your nameservers manually please verify your entries in the \"Nameserver\" configuration"
 
 msgid ""
 "This test checks whether a network cable is connected to your LAN adapter.\n"
@@ -17488,10 +16951,6 @@ msgid ""
 "- verify that a network cable is attached\n"
 "- verify that the cable is not broken"
 msgstr ""
-"This test checks whether a network cable is connected to your LAN adapter.\n"
-"If you get a \"disconnected\" message:\n"
-"- verify that a network cable is attached\n"
-"- verify that the cable is not broken"
 
 msgid ""
 "This test checks whether a valid IP address is found for your LAN adapter.\n"
@@ -17499,10 +16958,6 @@ msgid ""
 "- no valid IP address was found\n"
 "- please check your DHCP, cabling and adapter setup"
 msgstr ""
-"This test checks whether a valid IP address is found for your LAN adapter.\n"
-"If you get a \"unconfirmed\" message:\n"
-"- no valid IP address was found\n"
-"- please check your DHCP, cabling and adapter setup"
 
 msgid ""
 "This test checks whether your LAN adapter is set up for automatic IP address configuration with DHCP.\n"
@@ -17512,58 +16967,53 @@ msgid ""
 "If you get an \"enabled\" message:\n"
 "-verify that you have a configured and working DHCP server in your network."
 msgstr ""
-"This test checks whether your LAN adapter is set up for automatic IP address configuration with DHCP.\n"
-"If you get a \"disabled\" message:\n"
-" - then your LAN adapter is configured for manual IP setup\n"
-"- verify thay you have entered correct IP informations in the adapter setup dialog.\n"
-"If you get an \"enabled\" message:\n"
-"-verify that you have a configured and working DHCP server in your network."
 
 msgid "This test detects your configured LAN adapter."
-msgstr "This test detects your configured LAN adapter."
+msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid ""
 "This will (re-)calculate all positions of your rotor and may remove previously memorised positions and fine-tuning!\n"
 "Are you sure?"
 msgstr ""
-"This will (re-)calculate all positions of your rotor and may remove previously memorised positions and fine-tuning!\n"
+"This will (re-)calculate all rotator positions and may remove previously memorised positions and fine-tuning!\n"
 "Are you sure?"
 
 msgid "This will go fast forward/backward with time frames of x secs"
 msgstr ""
 
 msgid "Three"
-msgstr "Three"
+msgstr ""
 
 msgid "Threshold"
-msgstr "Threshold"
+msgstr ""
 
 msgid "Thriller"
 msgstr ""
 
 msgid "Thu"
-msgstr "Thu"
+msgstr ""
 
 msgid "Thumbnails"
-msgstr "Thumbnails"
+msgstr ""
 
 msgid "Thursday"
-msgstr "Thursday"
+msgstr ""
 
 msgid "TiVo support"
-msgstr "TiVo support"
+msgstr ""
 
 msgid "Tiere"
 msgstr ""
 
 msgid "Time"
-msgstr "Time"
+msgstr ""
 
 msgid "Time Update in Minutes"
-msgstr "Time Update in Minutes"
+msgstr ""
 
 msgid "Time Update in Minutes:"
-msgstr "Time Update in Minutes:"
+msgstr ""
 
 msgid "Time between slides in image viewer slideshow."
 msgstr ""
@@ -17574,20 +17024,17 @@ msgstr ""
 msgid "Time delay of the shutdown messages"
 msgstr ""
 
-#, fuzzy
 msgid "Time delay until standby or deep standby"
-msgstr "Regard deep standby as standby"
+msgstr ""
 
-#, fuzzy
 msgid "Time for Slideshow"
-msgstr "Timer overview"
+msgstr ""
 
 msgid "Time for next LCD scrolling"
 msgstr ""
 
-#, fuzzy
 msgid "Time history"
-msgstr "Timer List"
+msgstr ""
 
 msgid "Time jump avoid zero step size"
 msgstr ""
@@ -17604,9 +17051,8 @@ msgstr ""
 msgid "Time jump: Use normal fast forward for speeds"
 msgstr ""
 
-#, fuzzy
 msgid "Time long"
-msgstr "Timer log"
+msgstr ""
 
 msgid "Time range:"
 msgstr ""
@@ -17616,36 +17062,34 @@ msgid "Time required for this process: %s"
 msgstr ""
 
 msgid "Time scale"
-msgstr "Time scale"
+msgstr ""
 
 msgid "Time settings"
-msgstr "Time settings"
+msgstr ""
 
-#, fuzzy
 msgid "Time style"
-msgstr "Time scale"
+msgstr ""
 
 msgid "Time to execute command or script"
-msgstr "Time to execute command or script"
+msgstr ""
 
 msgid "Time window for detection of the wakeup by a timer [mins]"
 msgstr ""
 
-#, fuzzy
 msgid "Time zone settings"
-msgstr "Time settings"
+msgstr ""
 
 msgid "Timeline 24 Hour"
 msgstr ""
 
 msgid "Timeline font size"
-msgstr "Timeline font size"
+msgstr ""
 
 msgid "Timer"
 msgstr ""
 
 msgid "Timer List"
-msgstr "Timer List"
+msgstr ""
 
 msgid "Timer action"
 msgstr ""
@@ -17657,7 +17101,7 @@ msgid "Timer editor"
 msgstr ""
 
 msgid "Timer entry"
-msgstr "Timer entry"
+msgstr ""
 
 #, python-format
 msgid "Timer is activated: +%d min"
@@ -17667,48 +17111,44 @@ msgid "Timer is not activated"
 msgstr ""
 
 msgid "Timer log"
-msgstr "Timer log"
+msgstr ""
 
 msgid ""
 "Timer overlap in pm_timers.xml detected!\n"
 "Please recheck it!"
 msgstr ""
-"Timer overlap in pm_timers.xml detected!\n"
-"Please recheck it!"
 
 msgid ""
 "Timer overlap in timers.xml detected!\n"
 "Please recheck it!"
 msgstr ""
-"Timer overlap in timers.xml detected!\n"
-"Please recheck it!"
 
 msgid "Timer overview"
-msgstr "Timer overview"
+msgstr ""
 
 msgid "Timer record location"
-msgstr "Timer record location"
+msgstr ""
 
 msgid "Timer recording location"
-msgstr "Timer recording location"
+msgstr ""
 
 msgid "Timer sanity error"
-msgstr "Timer sanity error"
+msgstr ""
 
 msgid "Timer selection"
-msgstr "Timer selection"
+msgstr ""
 
 msgid "Timer selection..."
-msgstr "Timer selection..."
+msgstr ""
 
 msgid "Timer type"
-msgstr "Timer type"
+msgstr ""
 
 msgid "Timers"
-msgstr "Timers"
+msgstr ""
 
 msgid "Timeshift"
-msgstr "Timeshift"
+msgstr ""
 
 msgid "Timeshift buffer delete after zap?"
 msgstr ""
@@ -17729,50 +17169,49 @@ msgid "Timeshift last events limit [number of events]"
 msgstr ""
 
 msgid "Timeshift location"
-msgstr "Timeshift location"
+msgstr ""
 
 msgid "Timeshift not possible!"
-msgstr "Timeshift not possible!"
+msgstr ""
 
 msgid "Timeshift save failed!"
-msgstr "Timeshift save failed!"
+msgstr ""
 
 msgid "Timeshift save recording (Select event)"
-msgstr "Timeshift save recording (select event)"
+msgstr ""
 
 msgid "Timeshift save recording (stop after current event)"
-msgstr "Timeshift save recording (stop after current event)"
+msgstr ""
 
 msgid "Timeshift saved to your harddisk!"
-msgstr "Timeshift saved to your hard disk!"
+msgstr ""
 
 msgid "Timeshift settings"
-msgstr "Timeshift settings"
+msgstr ""
 
 msgid "Timeshift will get saved at end of event!"
-msgstr "Timeshift will get saved at end of event!"
+msgstr ""
 
 msgid "Timeshift-save action on zap"
-msgstr "Timeshift-save action on zap"
+msgstr ""
 
 msgid "Timezone"
-msgstr "Timezone"
+msgstr ""
 
 msgid "Timor-Leste"
 msgstr ""
 
 msgid "Title"
-msgstr "Title"
+msgstr ""
 
 msgid "Title properties"
-msgstr "Title properties"
+msgstr ""
 
 msgid "Titleset mode"
-msgstr "Title set mode"
+msgstr ""
 
-#, fuzzy
 msgid "To restore the image:"
-msgstr "Yes, restore the settings now"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -17781,13 +17220,9 @@ msgid ""
 "2) Turn mains back on and hold the DOWN button on the front panel pressed for 10 seconds.\n"
 "3) Wait for bootup and follow instructions of the wizard."
 msgstr ""
-"To update your %s %s firmware, please follow these steps:\n"
-"1) Turn off your box with the rear power switch and make sure the bootable USB stick is plugged in.\n"
-"2) Turn mains back on and hold the DOWN button on the front panel pressed for 10 seconds.\n"
-"3) Wait for bootup and follow instructions of the wizard."
 
 msgid "Today"
-msgstr "Today"
+msgstr ""
 
 msgid "Toggels between tv and radio..."
 msgstr ""
@@ -17808,19 +17243,19 @@ msgid "Toggle PIPzap"
 msgstr ""
 
 msgid "Toggle Picture In Graphics"
-msgstr "Toggle Picture In Graphics"
+msgstr ""
 
 msgid "Toggle Pillarbox <> Pan&Scan"
 msgstr ""
 
 msgid "Toggle a cut mark at the current position"
-msgstr "Toggle a cut mark at the current position"
+msgstr ""
 
 msgid "Toggle aspect ratio..."
-msgstr "Toggle aspect ratio..."
+msgstr ""
 
 msgid "Toggle between bouquet/epg lists"
-msgstr "Toggle between bouquet/epg lists"
+msgstr ""
 
 msgid "Toggle new text inserts before or overwrites existing text"
 msgstr ""
@@ -17832,16 +17267,16 @@ msgid "Tokelau"
 msgstr ""
 
 msgid "Tone amplitude"
-msgstr "Tone amplitude"
+msgstr ""
 
 msgid "Tone mode"
-msgstr "Tone mode"
+msgstr ""
 
 msgid "Toneburst"
-msgstr "Toneburst"
+msgstr ""
 
 msgid "Toneburst A/B"
-msgstr "Toneburst A/B"
+msgstr ""
 
 msgid "Tonga"
 msgstr ""
@@ -17850,35 +17285,35 @@ msgid "Top"
 msgstr ""
 
 msgid "Top and Bottom"
-msgstr "Top and Bottom"
+msgstr ""
 
 msgid "Total"
-msgstr "Total"
+msgstr ""
 
 msgid "Total Memory:"
-msgstr "Total Memory:"
+msgstr ""
 
 msgid "Total Swap:"
-msgstr "Total Swap:"
+msgstr ""
 
 msgid "Total cards:"
-msgstr "Total cards:"
+msgstr ""
 
 #, python-format
 msgid "Total clients streaming: %d ( %s )"
 msgstr ""
 
 msgid "Total handled client ecm's"
-msgstr "Total handled client ecm's"
+msgstr ""
 
 msgid "Total handled client emm's"
-msgstr "Total handled client emm's"
+msgstr ""
 
 msgid "Total:"
-msgstr "Total:"
+msgstr ""
 
 msgid "Track"
-msgstr "Track"
+msgstr ""
 
 msgid "Traditional Chinese"
 msgstr ""
@@ -17886,9 +17321,8 @@ msgstr ""
 msgid "Tragödie"
 msgstr ""
 
-#, fuzzy
 msgid "Transcode"
-msgstr "Transponder"
+msgstr ""
 
 msgid "Transcoding: "
 msgstr ""
@@ -17897,36 +17331,34 @@ msgid "Translation"
 msgstr ""
 
 msgid "Translation Information"
-msgstr "Translation Information"
+msgstr ""
 
 msgid "Translations"
-msgstr "Translations"
+msgstr ""
 
 msgid "Transmission mode"
-msgstr "Transmission mode"
+msgstr ""
 
 msgid "Transparent"
-msgstr "Transparent"
+msgstr ""
 
 msgid "Transponder"
-msgstr "Transponder"
+msgstr ""
 
-#, fuzzy
 msgid "Transponder Time"
-msgstr "Transponder"
+msgstr ""
 
 msgid "Transponder type"
-msgstr "Transponder type"
+msgstr ""
 
-#, fuzzy
 msgid "Transport Stream Type"
-msgstr "Transponder type"
+msgstr ""
 
 msgid "Trashcan"
-msgstr "Trashcan"
+msgstr "Trash"
 
 msgid "Trashcan:"
-msgstr "Trashcan:"
+msgstr "Trash:"
 
 msgid "Travel"
 msgstr ""
@@ -17935,7 +17367,7 @@ msgid "Tried to disable PIP, suddenly found no InfoBar.instance.\n"
 msgstr ""
 
 msgid "Tries left:"
-msgstr "Tries left:"
+msgstr ""
 
 msgid "Trinidad and Tobago"
 msgstr ""
@@ -17953,7 +17385,7 @@ msgid "TrueType font (full-HD)"
 msgstr ""
 
 msgid "Try to find used transponders in cable network.. please wait..."
-msgstr "Try to find used transponders in cable network.. please wait..."
+msgstr ""
 
 msgid "Try to find used transponders in terrestrial network.. please wait..."
 msgstr ""
@@ -17968,38 +17400,37 @@ msgid "Try to slow down the send interval if not all commands are executed."
 msgstr ""
 
 msgid "Trying to download a new packetlist. Please wait..."
-msgstr "Trying to download a new packet list. Please wait..."
+msgstr ""
 
 msgid "Trying to download a new updatelist. Please wait..."
 msgstr ""
 
 msgid "Tue"
-msgstr "Tue"
+msgstr ""
 
 msgid "Tuesday"
-msgstr "Tuesday"
+msgstr ""
 
 msgid "Tune"
-msgstr "Tune"
+msgstr ""
 
 msgid "Tune and focus"
-msgstr "Tune and focus"
+msgstr ""
 
 msgid "Tune failed!"
-msgstr "Tune failed!"
+msgstr ""
 
-#, fuzzy
 msgid "Tuned for recording"
-msgstr "Stop recording"
+msgstr ""
 
 msgid "Tuner"
-msgstr "Tuner"
+msgstr ""
 
 msgid "Tuner "
 msgstr ""
 
 msgid "Tuner :"
-msgstr "Tuner :"
+msgstr ""
 
 msgid "Tuner Configuration"
 msgstr ""
@@ -18008,47 +17439,41 @@ msgid "Tuner Setup"
 msgstr ""
 
 msgid "Tuner configuration"
-msgstr "Tuner configuration"
+msgstr ""
 
 msgid "Tuner is not supported"
 msgstr ""
 
 msgid "Tuner settings"
-msgstr "Tuner settings"
+msgstr ""
 
 msgid "Tuner slot"
-msgstr "Tuner slot"
+msgstr ""
 
 msgid "Tuner status"
-msgstr "Tuner status"
+msgstr ""
 
-#, fuzzy
 msgid "Tuner status FAILED"
-msgstr "Tuner status"
+msgstr ""
 
-#, fuzzy
 msgid "Tuner status IDLE"
-msgstr "Tuner status"
+msgstr ""
 
-#, fuzzy
 msgid "Tuner status LOCKED"
-msgstr "Tuner status"
+msgstr ""
 
-#, fuzzy
 msgid "Tuner status LOSTLOCK"
-msgstr "Tuner status"
+msgstr ""
 
-#, fuzzy
 msgid "Tuner status TUNING"
-msgstr "Tuner status"
+msgstr ""
 
-#, fuzzy
 msgid "Tuner status UNKNOWN"
-msgstr "Tuner status"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Tuner type %s"
-msgstr "Tuner type"
+msgstr ""
 
 msgid "Tuning algorithm"
 msgstr ""
@@ -18062,16 +17487,14 @@ msgid ""
 "Slow: One reboot after flash, one reboot after restore in GUI"
 msgstr ""
 
-#, fuzzy
 msgid "Turkey"
-msgstr "Turkish"
+msgstr ""
 
 msgid "Turkish"
-msgstr "Turkish"
+msgstr ""
 
-#, fuzzy
 msgid "Turkmenistan"
-msgstr "Turkish"
+msgstr ""
 
 msgid "Turks and Caicos Islands"
 msgstr ""
@@ -18098,27 +17521,28 @@ msgid "Tuvalu"
 msgstr ""
 
 msgid "Two"
-msgstr "Two"
+msgstr ""
 
 msgid "Two lines"
-msgstr "Two lines"
+msgstr ""
 
 msgid "Type"
-msgstr "Type"
+msgstr ""
 
 msgid "Type of scan"
-msgstr "Type of scan"
+msgstr ""
 
-#, fuzzy
 msgid "Type:"
-msgstr "Type: "
+msgstr ""
 
 msgid "Type: "
-msgstr "Type: "
+msgstr ""
 
-#, fuzzy
+msgid "UHD Test"
+msgstr ""
+
 msgid "UI 3D setup"
-msgstr "3D setup"
+msgstr ""
 
 msgid "UP80  (keymap.u80)"
 msgstr ""
@@ -18130,19 +17554,20 @@ msgid "URL of fallback remote receiver"
 msgstr ""
 
 msgid "USALS"
-msgstr "USALS"
-
-msgid "USALS automatically moves a motorised dish to the correct satellite based on the coordinates entered by the user. Without USALS each satellite will need to be setup and saved individually."
 msgstr ""
 
+#. TRANSLATORS: override en_US
+msgid "USALS automatically moves a motorised dish to the correct satellite based on the coordinates entered by the user. Without USALS each satellite will need to be setup and saved individually."
+msgstr "USALS automatically moves a motorised dish to the correct satellite based on the co-ordinates entered by the user. Without USALS, each satellite will need to be set up and saved individually."
+
 msgid "USALS calibration"
-msgstr "USALS calibration"
+msgstr ""
 
 msgid "USB Stick"
 msgstr ""
 
 msgid "USB stick wizard"
-msgstr "USB stick wizard"
+msgstr ""
 
 msgid "USB switch ERROR! - already on USB"
 msgstr ""
@@ -18162,9 +17587,8 @@ msgstr ""
 msgid "Umweltbewusstsein"
 msgstr ""
 
-#, fuzzy
 msgid "Unable to change password"
-msgstr "Please enter new name:"
+msgstr ""
 
 msgid "Unable to create the required directories on the media (e.g. USB stick or Harddisk) - Please verify media and try again!"
 msgstr ""
@@ -18173,23 +17597,22 @@ msgid "Unattended upgrade without GUI"
 msgstr ""
 
 msgid "Unattended upgrade without GUI and reboot system"
-msgstr "Unattended upgrade without GUI and reboot system"
+msgstr ""
 
-#, fuzzy
 msgid "Undefined"
-msgstr "User defined"
+msgstr ""
 
 msgid "Undetermined"
-msgstr "Undetermined"
+msgstr ""
 
 msgid "Undo install"
-msgstr "Undo install"
+msgstr ""
 
 msgid "Undo uninstall"
-msgstr "Undo uninstall"
+msgstr ""
 
 msgid "Unencrypted"
-msgstr "Unencrypted"
+msgstr ""
 
 msgid "UnhandledKey"
 msgstr ""
@@ -18197,21 +17620,20 @@ msgstr ""
 msgid "Unhide parental control services"
 msgstr ""
 
-#, fuzzy
 msgid "Unicable "
-msgstr "Unicable"
+msgstr ""
 
 msgid "Unicable / JESS"
 msgstr ""
 
 msgid "Unicable LNB"
-msgstr "Unicable LNB"
+msgstr ""
 
 msgid "Unicable Matrix"
-msgstr "Unicable Matrix"
+msgstr ""
 
 msgid "Uninstall"
-msgstr "Uninstall"
+msgstr ""
 
 #, python-format
 msgid "Uninstall '%s' package and disable '%s'"
@@ -18233,56 +17655,51 @@ msgid "United States of America"
 msgstr ""
 
 msgid "Universal LNB"
-msgstr "Universal LNB"
+msgstr ""
 
 msgid "Unknown"
-msgstr "Unknown"
+msgstr ""
 
 msgid ""
 "Unknown Error creating Skin.\n"
 "Please check after reboot MyMetrixLite-Plugin and apply your settings."
 msgstr ""
 
-#, fuzzy
 msgid "Unknown error code"
-msgstr "unknown service"
+msgstr ""
 
 #, python-format
 msgid "Unknown group: %d"
 msgstr ""
 
-#, fuzzy
 msgid "Unknown recording event"
-msgstr "Stop recording now"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Unknown user: %d"
-msgstr "unknown service"
+msgstr ""
 
-#, fuzzy
 msgid "Unless set to 'disabled' you get a preview of channels inside the EPG list."
-msgstr "If set to 'yes' you can preview channels in the EPG list."
+msgstr ""
 
 msgid "Unmark service as dedicated 3D service"
 msgstr ""
 
 msgid "Unmount"
-msgstr "Unmount"
+msgstr ""
 
 #, python-format
 msgid "Unpack to %s"
 msgstr ""
 
-#, fuzzy
 msgid "Unpack to current folder"
-msgstr "Jump to current time"
+msgstr ""
 
 msgid "Unsupported"
-msgstr "Unsupported"
+msgstr ""
 
-#, fuzzy
 msgid "Unterhaltung"
-msgstr "Internal"
+msgstr ""
 
 msgid "Unused 0x22"
 msgstr ""
@@ -18320,11 +17737,12 @@ msgstr ""
 msgid "Up/Down button mode"
 msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "Up/Down buttons also for 'all up/down'?"
-msgstr ""
+msgstr "Synchronise column scrolling"
 
 msgid "Update"
-msgstr "Update"
+msgstr ""
 
 msgid "Update Cache"
 msgstr ""
@@ -18333,13 +17751,13 @@ msgid "Update at your own risk"
 msgstr ""
 
 msgid "Update channel list only"
-msgstr "Update channel list only"
+msgstr ""
 
 #, python-format
 msgid "Update completed, %d package was installed."
 msgid_plural "Update completed, %d packages were installed."
-msgstr[0] "Update completed, %d package was installed."
-msgstr[1] "Update completed, %d packages were installed."
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Update delay for Events in List"
 msgstr ""
@@ -18347,20 +17765,18 @@ msgstr ""
 msgid "Update delay for Events in List. Scrolling in List is faster with higher delay, especially on big Lists !"
 msgstr ""
 
-#, fuzzy
 msgid "Update failed!"
-msgstr "Write failed!"
+msgstr ""
 
 #, python-format
 msgid "Update failed. Your %s %s does not have a working internet connection."
-msgstr "Update failed. Your %s %s does not have a working internet connection."
+msgstr ""
 
-#, fuzzy
 msgid "Update finished!"
-msgstr "Upgrade finished."
+msgstr ""
 
 msgid "Update interval (in seconds)"
-msgstr "Update interval (in seconds)"
+msgstr ""
 
 msgid "Update is reported as faulty !!"
 msgstr ""
@@ -18377,18 +17793,16 @@ msgid "Update/Backup/Restore your box"
 msgstr ""
 
 msgid "Updatefeed not available."
-msgstr "Update feed not available."
+msgstr ""
 
 msgid "Updates Available:"
 msgstr ""
 
-#, fuzzy
 msgid "Updating cache"
-msgstr "please wait..."
+msgstr ""
 
-#, fuzzy
 msgid "Updating cache, please wait..."
-msgstr "please wait..."
+msgstr ""
 
 msgid "Updating mount locations."
 msgstr ""
@@ -18400,10 +17814,10 @@ msgid "Upgrade (Backup, Flash & Restore All)"
 msgstr ""
 
 msgid "Upgrade and reboot system"
-msgstr "Upgrade and reboot system"
+msgstr ""
 
 msgid "Upgrade finished."
-msgstr "Upgrade finished."
+msgstr ""
 
 #, python-format
 msgid ""
@@ -18411,24 +17825,21 @@ msgid ""
 "Please wait until your %s %s reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Upgrade in progress\n"
-"Please wait until your %s %s reboots\n"
-"This may take a few minutes"
 
 msgid "Upgrade with GUI"
 msgstr ""
 
 msgid "Upgrading"
-msgstr "Upgrading"
+msgstr ""
 
 msgid "Uphops +"
-msgstr "Uphops +"
+msgstr ""
 
 msgid "Uphops -"
-msgstr "Uphops -"
+msgstr ""
 
 msgid "Uphops: "
-msgstr "Uphops: "
+msgstr ""
 
 msgid "Upper USB"
 msgstr ""
@@ -18437,7 +17848,7 @@ msgid "Upper case"
 msgstr ""
 
 msgid "Uptime"
-msgstr "Uptime"
+msgstr ""
 
 msgid "Uruguay"
 msgstr ""
@@ -18449,19 +17860,19 @@ msgid "Usage Setup"
 msgstr ""
 
 msgid "Use"
-msgstr "Use"
+msgstr ""
 
 msgid "Use DHCP"
-msgstr "Use DHCP"
+msgstr ""
 
 msgid "Use Deinterlacing for 1080i Videosignal?"
 msgstr ""
 
 msgid "Use EIT EPG information when it is available."
-msgstr "Use EIT EPG information when it is available."
+msgstr ""
 
 msgid "Use FreeSat EPG information when it is available."
-msgstr "Use FreeSat EPG information when it is available."
+msgstr ""
 
 msgid "Use HDMI-preemphasis"
 msgstr ""
@@ -18473,35 +17884,34 @@ msgid "Use Keymap"
 msgstr ""
 
 msgid "Use MHW EPG information when it is available."
-msgstr "Use MHW EPG information when it is available."
+msgstr ""
 
 msgid "Use Manual dns-nameserver"
 msgstr ""
 
 msgid "Use Netmed EPG information when it is available."
-msgstr "Use Netmed EPG information when it is available."
+msgstr ""
 
 msgid "Use OnlineFlash in SoftwareManager"
 msgstr ""
 
-#, fuzzy
 msgid "Use OpenTV EPG information when it is available."
-msgstr "Use EIT EPG information when it is available."
+msgstr ""
 
 msgid "Use TV remote control"
-msgstr "Use TV remote control"
+msgstr ""
 
 msgid "Use USALS for this sat"
-msgstr "Use USALS for this sat"
+msgstr ""
 
 msgid "Use ViaSat EPG information when it is available."
-msgstr "Use ViaSat EPG information when it is available."
+msgstr ""
 
 msgid "Use Virgin EPG information when it is available."
 msgstr ""
 
 msgid "Use a gateway"
-msgstr "Use a gateway"
+msgstr ""
 
 msgid "Use as HDD"
 msgstr ""
@@ -18519,49 +17929,49 @@ msgid "Use extended List"
 msgstr ""
 
 msgid "Use fastscan channel names"
-msgstr "Use fastscan channel names"
+msgstr ""
 
 msgid "Use fastscan channel numbering"
-msgstr "Use fastscan channel numbering"
+msgstr ""
 
 msgid "Use for load only x days in EPG"
 msgstr ""
 
 msgid "Use frequency or channel"
-msgstr "Use frequency or channel"
+msgstr ""
 
 msgid "Use individual settings for each directory"
-msgstr "Use individual settings for each directory"
+msgstr ""
 
 msgid "Use interface"
-msgstr "Use interface"
+msgstr ""
 
 msgid "Use official channel numbering"
-msgstr "Use official channel numbering"
+msgstr ""
 
 msgid "Use only for Wake on WLan (WoW)"
 msgstr ""
 
 msgid "Use original DVB subtitle position"
-msgstr "Use original DVB subtitle position"
+msgstr ""
 
 msgid "Use original teletext position"
-msgstr "Use original teletext position"
+msgstr ""
 
 msgid "Use power measurement"
-msgstr "Use power measurement"
+msgstr ""
 
 msgid "Use slim screen"
-msgstr "Use slim screen"
+msgstr ""
 
 msgid "Use the Left/Right buttons on your remote to adjust the size of the user interface. Left button decreases the size, Right increases the size."
-msgstr "Use the Left/Right buttons on your remote to adjust the size of the user interface. Left button decreases the size, Right increases the size."
+msgstr ""
 
 msgid "Use the Left/Right buttons on your remote to move the user interface left/right"
 msgstr ""
 
 msgid "Use the Left/Right buttons on your remote to move the user interface up/down"
-msgstr "Use the Left/Right buttons on your remote to move the user interface up/down"
+msgstr ""
 
 msgid "Use the Networkwizard to configure your Network. The wizard will help you to setup your network"
 msgstr ""
@@ -18570,10 +17980,10 @@ msgid "Use the Softcam Panel to control your Cam. This let you start/stop/select
 msgstr ""
 
 msgid "Use the alternative or the conventional radio mode."
-msgstr "Use the alternative or the conventional radio mode."
+msgstr ""
 
 msgid "Use the alternative screen"
-msgstr "Use the alternative screen"
+msgstr ""
 
 msgid "Use the cursor keys to select an installed image and then Erase button."
 msgstr ""
@@ -18588,56 +17998,56 @@ msgid "Use the extended List"
 msgstr ""
 
 msgid "Use the network wizard to configure selected network adapter"
-msgstr "Use the network wizard to configure selected network adapter"
+msgstr ""
 
 msgid "Use the network wizard to configure your Network\n"
-msgstr "Use the network wizard to configure your Network\n"
+msgstr ""
 
 msgid "Use the up/down keys on your remote control to select an option. After that, press OK."
-msgstr "Use the up/down keys on your remote control to select an option. After that, press OK."
+msgstr ""
 
 msgid "Use the wizard to set up basic features"
-msgstr "Use the wizard to set up basic features"
+msgstr ""
 
 msgid "Use these input device settings?"
-msgstr "Use these input device settings?"
+msgstr ""
 
 msgid "Use these settings?"
-msgstr "Use these settings?"
+msgstr ""
 
 msgid "Use this video enhancement settings?"
-msgstr "Use this video enhancement settings?"
+msgstr ""
 
 msgid "Use time jumps for fast forward/backward"
 msgstr ""
 
 msgid "Use timeshift seekbar while timeshifting?"
-msgstr "Use timeshift seekbar while timeshifting?"
+msgstr ""
 
 msgid "Use trash can in movielist"
-msgstr "Use trash can in movielist"
+msgstr "Use trash in movie list"
 
 msgid "Use workaround for wakeup from deep-standby?"
 msgstr ""
 
 msgid "Used service scan type"
-msgstr "Used service scan type"
+msgstr ""
 
 msgid "Used:"
-msgstr "Used:"
+msgstr ""
 
 msgid "User  (keymap.usr)"
 msgstr ""
 
 msgid "User - bouquets"
-msgstr "User - bouquets"
+msgstr ""
 
 msgid "User defined"
-msgstr "User defined"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "User defined 0x%02x"
-msgstr "User defined"
+msgstr ""
 
 msgid "User defined delay when you press another button to zap to the channel."
 msgstr ""
@@ -18646,54 +18056,54 @@ msgid "User defined delay when you press the first button to zap to the channel.
 msgstr ""
 
 msgid "User defined transponder"
-msgstr "User defined transponder"
+msgstr ""
 
 msgid "User interface settings"
 msgstr ""
 
 msgid "User interface visibility"
-msgstr "User interface visibility"
+msgstr ""
 
 msgid "Userlogo:"
 msgstr ""
 
 msgid "Username"
-msgstr "Username"
+msgstr ""
 
 msgid "Username (httpuser)"
-msgstr "Username (httpuser)"
+msgstr ""
 
 msgid "Username:"
-msgstr "Username:"
+msgstr ""
 
 #, python-format
 msgid "Using LNB %d"
-msgstr "Using LNB %d"
+msgstr ""
 
 msgid "Using fixed address"
-msgstr "Using fixed address"
+msgstr ""
 
 msgid "Using old profile: "
-msgstr "Using old profile: "
+msgstr ""
 
 #, python-format
 msgid "Using tuner %s"
-msgstr "Using tuner %s"
+msgstr ""
 
 msgid "Usually when the subtitle language is the same as the audio language, the subtitles will not be used. Enable this option to allow these subtitles to be used."
-msgstr "Usually when the subtitle language is the same as the audio language, the subtitles will not be used. Enable this option to allow these subtitles to be used."
+msgstr ""
 
 msgid "Uzbekistan"
 msgstr ""
 
 msgid "VCR scart"
-msgstr "VCR scart"
+msgstr ""
 
 msgid "VLAN connection"
 msgstr ""
 
 msgid "VMGM (intro trailer)"
-msgstr "VMGM (intro trailer)"
+msgstr ""
 
 msgid "VOD"
 msgstr ""
@@ -18707,17 +18117,14 @@ msgstr ""
 msgid "VU+"
 msgstr ""
 
-#, fuzzy
 msgid "Vanuatu"
-msgstr "manual"
+msgstr ""
 
-#, fuzzy
 msgid "Variety"
-msgstr "variety show"
+msgstr ""
 
-#, fuzzy
 msgid "Various"
-msgstr "Play previous"
+msgstr ""
 
 msgid "Venezuela (Bolivarian Republic of)"
 msgstr ""
@@ -18725,49 +18132,48 @@ msgstr ""
 msgid "Verkehr"
 msgstr ""
 
-#, fuzzy
 msgid "Verschiedenes"
-msgstr "Version: "
+msgstr ""
 
-#, fuzzy
 msgid "Version"
-msgstr "Version: "
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Version %s %s"
-msgstr "Version: %s"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
+msgid "Version / Build:\t\t%s  (%s)"
+msgstr ""
+
+#, python-format
 msgid "Version:\t\t%s"
-msgstr "Version:\t%s"
+msgstr ""
 
 msgid "Version: "
-msgstr "Version: "
+msgstr ""
 
 #, python-format
 msgid "Version: %s"
-msgstr "Version: %s"
+msgstr ""
 
 msgid "Vertical"
-msgstr "Vertical"
+msgstr ""
 
-#, fuzzy
 msgid "Vertical EPG"
-msgstr "Vertical"
+msgstr ""
 
 msgid "Vertical alignement for the event-progress."
 msgstr ""
 
-#, fuzzy
 msgid "Vertical alignement for the service number."
-msgstr "Configure the width allocated to the service name."
+msgstr ""
 
 msgid "Vertical turning speed"
-msgstr "Vertical turning speed"
+msgstr ""
 
-#, fuzzy
 msgid "VerticalEPG settings"
-msgstr "GraphicalEPG settings"
+msgstr ""
 
 msgid "Very short filenames"
 msgstr ""
@@ -18776,13 +18182,13 @@ msgid "Very very short filenames - Warning"
 msgstr ""
 
 msgid "ViX EPG"
-msgstr "ViX EPG"
+msgstr ""
 
 msgid "Video"
 msgstr ""
 
 msgid "Video PID"
-msgstr "Video PID"
+msgstr ""
 
 msgid "Video Settings"
 msgstr ""
@@ -18795,13 +18201,13 @@ msgstr ""
 
 #, python-format
 msgid "Video content: %ix%i%s %iHz"
-msgstr "Video content: %ix%i%s %iHz"
+msgstr ""
 
 msgid "Video enhancement preview"
-msgstr "Video enhancement preview"
+msgstr ""
 
 msgid "Video enhancement setup"
-msgstr "Video enhancement setup"
+msgstr ""
 
 msgid ""
 "Video input selection\n"
@@ -18810,70 +18216,57 @@ msgid ""
 "\n"
 "The next input port will be automatically probed in 10 seconds."
 msgstr ""
-"Video input selection\n"
-"\n"
-"Please press OK if you can see this page on your TV (or select a different input port).\n"
-"\n"
-"The next input port will be automatically probed in 10 seconds."
 
 msgid "Video mode selection."
-msgstr "Video mode selection."
+msgstr ""
 
 #, python-format
 msgid "Video mode: %s"
-msgstr "Video mode: %s"
+msgstr ""
 
 #, python-format
 msgid "Video mode: %s not available"
 msgstr ""
 
-#, fuzzy
 msgid "Video mode: 1080p"
-msgstr "Video mode: %s"
+msgstr ""
 
 msgid "Video mode: 1080p also not available"
 msgstr ""
 
-#, fuzzy
 msgid "Video mode: 2160p"
-msgstr "Video mode: %s"
+msgstr ""
 
 msgid "Video mode: 2160p also not available"
 msgstr ""
 
 msgid "Video output"
-msgstr "Video output"
+msgstr ""
 
-#, fuzzy
 msgid "Video output mode"
-msgstr "Video output"
+msgstr ""
 
-#, fuzzy
 msgid "Video output mode for FHD"
-msgstr "Video output"
+msgstr ""
 
-#, fuzzy
 msgid "Video output mode for HD"
-msgstr "Video output"
+msgstr ""
 
-#, fuzzy
 msgid "Video output mode for SD"
-msgstr "Video output"
+msgstr ""
 
-#, fuzzy
 msgid "Video output mode for UHD"
-msgstr "Video output"
+msgstr ""
 
 msgid "Video settings"
 msgstr ""
 
-#, fuzzy
 msgid "Video: "
-msgstr "Video PID"
+msgstr ""
 
 #, python-format
 msgid "Video: %s fps"
-msgstr "Video: %s fps"
+msgstr ""
 
 msgid "VideoEnhancement"
 msgstr ""
@@ -18884,87 +18277,83 @@ msgstr ""
 msgid "VideoEnhancementPreview"
 msgstr ""
 
-#, fuzzy
 msgid "VideoFinetune"
-msgstr "Fine tune"
+msgstr ""
 
 msgid "VideoWizard"
 msgstr ""
 
-#, fuzzy
 msgid "Videoclip"
-msgstr "Video size"
+msgstr ""
 
 msgid "Videocodec"
-msgstr "Video codec"
+msgstr ""
 
 msgid "Videoformat"
-msgstr "Video format"
+msgstr ""
 
 msgid "Videomode"
 msgstr ""
 
-#, fuzzy
 msgid "Videosetup"
-msgstr "Video setup"
+msgstr ""
 
 msgid "Videosize"
-msgstr "Video size"
+msgstr ""
 
-#, fuzzy
 msgid "Viet Nam"
-msgstr "Service Name"
+msgstr ""
 
 msgid "View"
-msgstr "View"
+msgstr ""
 
 msgid "View Rass interactive..."
-msgstr "View Rass interactive..."
+msgstr ""
 
 msgid "View details"
-msgstr "View details"
+msgstr ""
 
 msgid "View list of available "
-msgstr "View list of available "
+msgstr ""
 
 msgid "View list of available CommonInterface extensions"
-msgstr "View list of available CommonInterface extensions"
+msgstr ""
 
 msgid "View list of available EPG extensions."
-msgstr "View list of available EPG extensions."
+msgstr ""
 
 msgid "View list of available Satellite equipment extensions."
-msgstr "View list of available Satellite equipment extensions."
+msgstr ""
 
 msgid "View list of available communication extensions."
-msgstr "View list of available communication extensions."
+msgstr ""
 
 msgid "View list of available default settings"
-msgstr "View list of available default settings"
+msgstr ""
 
 msgid "View list of available display and userinterface extensions."
-msgstr "View list of available display and userinterface extensions."
+msgstr ""
 
 msgid "View list of available multimedia extensions."
-msgstr "View list of available multimedia extensions."
+msgstr ""
 
 msgid "View list of available networking extensions"
-msgstr "View list of available networking extensions"
+msgstr ""
 
 msgid "View list of available recording extensions"
-msgstr "View list of available recording extensions"
+msgstr ""
 
 msgid "View list of available skins"
-msgstr "View list of available skins"
+msgstr ""
 
 msgid "View list of available software extensions"
-msgstr "View list of available software extensions"
+msgstr ""
 
 msgid "View list of available system extensions"
-msgstr "View list of available system extensions"
+msgstr ""
 
 msgid "View mode"
-msgstr "View mode"
+msgstr ""
 
 msgid "View or edit file (if size < 1MB)"
 msgstr ""
@@ -18974,16 +18363,16 @@ msgid "View or edit this %s script"
 msgstr ""
 
 msgid "View photos..."
-msgstr "View photos…"
+msgstr ""
 
 msgid "View teletext..."
-msgstr "View teletext..."
+msgstr ""
 
 msgid "View the changes"
-msgstr "View the changes"
+msgstr ""
 
 msgid "View video CD..."
-msgstr "View video CD..."
+msgstr ""
 
 msgid "Violence"
 msgstr ""
@@ -19007,7 +18396,7 @@ msgid "Vol"
 msgstr ""
 
 msgid "Voltage mode"
-msgstr "Voltage mode"
+msgstr ""
 
 msgid "Volume"
 msgstr ""
@@ -19028,38 +18417,37 @@ msgid "Vorschau"
 msgstr ""
 
 msgid "W"
-msgstr "W"
+msgstr ""
 
 msgid "WARNING!"
 msgstr ""
 
 msgid "WEP"
-msgstr "WEP"
+msgstr ""
 
 msgid "WLAN connection"
-msgstr "WLAN connection"
+msgstr ""
 
 msgid "WMA Pro"
 msgstr ""
 
-#, fuzzy
 msgid "WMA Pro downmix"
-msgstr "AAC downmix"
+msgstr ""
 
 msgid "WOL Standby"
 msgstr ""
 
 msgid "WPA"
-msgstr "WPA"
+msgstr ""
 
 msgid "WPA or WPA2"
-msgstr "WPA or WPA2"
+msgstr ""
 
 msgid "WPA2"
-msgstr "WPA2"
+msgstr ""
 
 msgid "WSS on 4:3"
-msgstr "WSS on 4:3"
+msgstr ""
 
 msgid "WWIO 4K"
 msgstr ""
@@ -19077,7 +18465,7 @@ msgid "Wait please while creating swapfile..."
 msgstr ""
 
 msgid "Wait please while scanning for devices..."
-msgstr "Wait please while scanning for devices..."
+msgstr ""
 
 #, python-format
 msgid "Wait please while scanning your %s %s devices..."
@@ -19087,32 +18475,31 @@ msgid "Wait please while scanning..."
 msgstr ""
 
 msgid "Waiting"
-msgstr "Waiting"
+msgstr ""
 
 msgid "Waiting for mount"
-msgstr "Waiting for mount"
+msgstr ""
 
 msgid "Waiting for partition"
-msgstr "Waiting for partition"
+msgstr ""
 
 msgid "Wake Up"
-msgstr "Wake Up"
+msgstr ""
 
 msgid "Wake Up To Standby"
-msgstr "Wake Up To Standby"
+msgstr ""
 
 msgid "Wakeup"
-msgstr "Wakeup"
+msgstr ""
 
 msgid "Wakeup TV from standby"
-msgstr "Wakeup TV from standby"
+msgstr ""
 
 msgid "Wakeup time before a timer begins [mins]"
 msgstr ""
 
-#, fuzzy
 msgid "Wakeup your AV Receiver from standby"
-msgstr "Wakeup your %s %s from standby"
+msgstr ""
 
 msgid "Wallis and Futuna"
 msgstr ""
@@ -19127,17 +18514,16 @@ msgid "Warning: This is the last crash before an automatic restart is performed.
 msgstr ""
 
 msgid "Warning: no LNB; using factory defaults."
-msgstr "Warning: no LNB; using factory defaults."
+msgstr ""
 
-#, fuzzy
 msgid "Wassersport"
-msgstr "water sport"
+msgstr ""
 
 msgid "Watch movies..."
-msgstr "Watch movies..."
+msgstr ""
 
 msgid "Watch recordings..."
-msgstr "Watch recordings..."
+msgstr ""
 
 #, python-format
 msgid ""
@@ -19147,34 +18533,32 @@ msgid ""
 "Component: enigma2"
 msgstr ""
 
-#, fuzzy
 msgid "Weather"
-msgstr "Other"
+msgstr ""
 
 msgid "Web Interface"
-msgstr "Web Interface"
+msgstr ""
 
 msgid "Web browser base visibility"
 msgstr ""
 
 msgid "Wed"
-msgstr "Wed"
+msgstr ""
 
 msgid "Wednesday"
-msgstr "Wednesday"
+msgstr ""
 
 msgid "Weekday"
-msgstr "Weekday"
+msgstr ""
 
-#, fuzzy
 msgid "Weekend"
-msgstr "Weekday"
+msgstr ""
 
 msgid "Weekly"
-msgstr "Weekly"
+msgstr ""
 
 msgid "Weighted position"
-msgstr "Weighted position"
+msgstr ""
 
 msgid "Welcome to IceTV"
 msgstr ""
@@ -19194,14 +18578,9 @@ msgid ""
 "\n"
 "Then seek to the end, press OK, select 'end cut'. That's it."
 msgstr ""
-"Welcome to the cutlist editor.\n"
-"\n"
-"Seek to the start of the stuff you want to cut away. Press OK, select 'start cut'.\n"
-"\n"
-"Then seek to the end, press OK, select 'end cut'. That's it."
 
 msgid "Welcome to the image upgrade wizard. The wizard will assist you in upgrading the firmware of your %s %s by providing a backup facility for your current settings and a short explanation of how to upgrade your firmware."
-msgstr "Welcome to the image upgrade wizard. The wizard will assist you in upgrading the firmware of your %s %s by providing a backup facility for your current settings and a short explanation of how to upgrade your firmware."
+msgstr ""
 
 msgid ""
 "Welcome.\n"
@@ -19210,11 +18589,6 @@ msgid ""
 "\n"
 "Press OK to start configuring your network"
 msgstr ""
-"Welcome.\n"
-"\n"
-"If you want to connect your %s %s to the Internet, this wizard will guide you through the basic network setup of your %s %s.\n"
-"\n"
-"Press OK to start configuring your network"
 
 msgid ""
 "Welcome.\n"
@@ -19222,10 +18596,6 @@ msgid ""
 "This start wizard will guide you through the basic setup of your %s %s.\n"
 "Press the OK button on your remote control to move to the next step."
 msgstr ""
-"Welcome.\n"
-"\n"
-"This start wizard will guide you through the basic setup of your %s %s.\n"
-"Press the OK button on your remote control to move to the next step."
 
 msgid "Welcome..."
 msgstr ""
@@ -19234,14 +18604,13 @@ msgid "Werbung"
 msgstr ""
 
 msgid "West"
-msgstr "West"
+msgstr ""
 
 msgid "West limit set"
-msgstr "West limit set"
+msgstr ""
 
-#, fuzzy
 msgid "Western"
-msgstr "West"
+msgstr ""
 
 msgid "Western Sahara"
 msgstr ""
@@ -19249,25 +18618,23 @@ msgstr ""
 msgid "Wettbewerb"
 msgstr ""
 
-#, fuzzy
 msgid "Wetter"
-msgstr "better"
+msgstr ""
 
 msgid "What Day of month ?"
 msgstr ""
 
 msgid "What Day of week ?"
-msgstr "What Day of week ?"
+msgstr ""
 
 msgid "What action is required on completion of the timer? 'Auto' lets the box return to the state it had when the timer started. 'Do nothing', 'Go to standby' and 'Go to deep standby' do exactly that."
-msgstr "What action is required on completion of the timer? 'Auto' lets the box return to the state it had when the timer started. 'Do nothing', 'Go to standby' and 'Go to deep standby' do exactly that."
+msgstr ""
 
-#, fuzzy
 msgid "What do you want to play?\n"
-msgstr "What do you want to scan?"
+msgstr ""
 
 msgid "What do you want to scan?"
-msgstr "What do you want to scan?"
+msgstr ""
 
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
 msgstr ""
@@ -19276,22 +18643,22 @@ msgid "When enabled the PiP can be closed by the exit button."
 msgstr ""
 
 msgid "When enabled the online checker will also check for experimental versions"
-msgstr "When enabled the online checker will also check for experimental versions"
+msgstr ""
 
 msgid "When enabled, AIT data will be included in http streams. This allows a client receiver to use HbbTV."
-msgstr "When enabled, AIT data will be included in http streams. This allows a client receiver to use HbbTV."
+msgstr ""
 
 msgid "When enabled, EIT data will be included in http streams. This allows a client receiver to show EPG."
-msgstr "When enabled, EIT data will be included in http streams. This allows a client receiver to show EPG."
+msgstr ""
 
 msgid "When enabled, Enigma2 will load unlinked bouquets. This means that bouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
 msgstr ""
 
 msgid "When enabled, a popup message will be shown when a movie has finished and the next one will start."
-msgstr "When enabled, a popup message will be shown when a movie has finished and the next one will start."
+msgstr ""
 
 msgid "When enabled, a popup message will be shown when a recording starts."
-msgstr "When enabled, a popup message will be shown when a recording starts."
+msgstr ""
 
 msgid "When enabled, a recording is allowed to abort picture-in-picture mode, when there are no free tuners."
 msgstr ""
@@ -19306,7 +18673,7 @@ msgid "When enabled, a recording is allowed to interrupt live tv, when there are
 msgstr ""
 
 msgid "When enabled, a warning will be displayed and the user will get an option to stop or to continue the timeshift."
-msgstr "When enabled, a warning will be displayed and the user will get an option to stop or to continue the timeshift."
+msgstr ""
 
 msgid "When enabled, always descramble receiving http streams. This takes up more resources (descrambling demuxers), only enable if necessary. Individual streams are always descrambled if 0x100 is added to the service type, regardless of this setting."
 msgstr ""
@@ -19318,61 +18685,61 @@ msgid "When enabled, channel numbering will start at '1' for each bouquet."
 msgstr ""
 
 msgid "When enabled, content with an aspect ratio of 4:3 will be stretched to fit the screen."
-msgstr "When enabled, content with an aspect ratio of 4:3 will be stretched to fit the screen."
+msgstr ""
 
 msgid "When enabled, continue to the next bouquet when the last channel of the current bouquet is reached while changing channels."
 msgstr ""
 
 msgid "When enabled, deleted recordings are moved to the trash can, instead of being deleted immediately."
-msgstr "When enabled, deleted recordings are moved to the trash can, instead of being permanently deleted."
+msgstr "Choose whether deleted recordings should be moved to the trash instead of being deleted immediately."
 
 msgid "When enabled, external subtitles will be always turned on for playback movie."
 msgstr ""
 
 msgid "When enabled, graphical DVB subtitles are preferred over teletext subtitles, when both types are available."
-msgstr "When enabled, graphical DVB subtitles are preferred over teletext subtitles, when both types are available."
+msgstr ""
 
 msgid "When enabled, graphical DVB subtitles will be displayed at their original position."
-msgstr "When enabled, graphical DVB subtitles will be displayed at their original position."
+msgstr ""
 
 msgid "When enabled, graphical DVB subtitles will be displayed in yellow, instead of the original color."
-msgstr "When enabled, graphical DVB subtitles will be displayed in yellow, instead of the original colour."
+msgstr "When enabled, DVB subtitles will be displayed in yellow instead of their original colour."
 
 msgid "When enabled, it is possible to leave the movieplayer with exit."
 msgstr ""
 
 msgid "When enabled, measure power consumption to detect when the rotor stops turning (when supported by the tuner)."
-msgstr "When enabled, measure power consumption to detect when the rotor stops turning (when supported by the tuner)."
+msgstr ""
 
 msgid "When enabled, network trash cans are probed for cleaning."
-msgstr "When enabled, network trash cans are probed for cleaning."
+msgstr "Choose whether the network trash should be checked for cleaning."
 
 msgid "When enabled, number markers will be hidden."
 msgstr ""
 
 msgid "When enabled, pressing '0' will zap you to the first channel in your first bouquet and delete your zap-history."
-msgstr "When enabled, pressing '0' will zap you to the first channel in your first bouquet and delete your zap-history."
+msgstr ""
 
 msgid "When enabled, reformat subtitles to match the width of the screen."
 msgstr ""
 
 msgid "When enabled, show channel numbers in the channel selection screen."
-msgstr "When enabled, show channel numbers in the channel selection screen."
+msgstr ""
 
 msgid "When enabled, show status or error messages."
 msgstr ""
 
 msgid "When enabled, subtitles for the hearing impaired can be used."
-msgstr "When enabled, subtitles for the hearing impaired can be used."
+msgstr ""
 
 msgid "When enabled, subtitles for the hearing impaired will be preferred over normal subtitles, when both types are available."
-msgstr "When enabled, subtitles for the hearing impaired will be preferred over normal subtitles, when both types are available."
+msgstr ""
 
 msgid "When enabled, teletext pages will be cached, allowing faster access."
-msgstr "When enabled, teletext pages will be cached, allowing faster access."
+msgstr ""
 
 msgid "When enabled, teletext subtitles will be displayed at their original position."
-msgstr "When enabled, teletext subtitles will be displayed at their original position."
+msgstr ""
 
 msgid "When enabled, the VCR scart option will be shown on the main menu"
 msgstr ""
@@ -19381,13 +18748,13 @@ msgid "When enabled, the length of each recording will be shown in the movielist
 msgstr ""
 
 msgid "When enabled, the receiver will automatically use the audio track which you selected before."
-msgstr "When enabled, the receiver will automatically use the audio track which you selected before."
+msgstr ""
 
 msgid "When enabled, the receiver will automatically use the subtitles which you selected before."
-msgstr "When enabled, the receiver will automatically use the subtitles which you selected before."
+msgstr ""
 
 msgid "When enabled, the receiver will select an AC3 track (when available)."
-msgstr "When enabled, the receiver will select an AC3 track (when available)."
+msgstr ""
 
 msgid "When enabled, the receiver will select an AC3+ track (when available)."
 msgstr ""
@@ -19396,28 +18763,28 @@ msgid "When enabled, timeshift starts automatically in background after specifie
 msgstr ""
 
 msgid "When enabled, use DHCP for the IP configuration."
-msgstr "When enabled, use DHCP for the IP configuration."
+msgstr ""
 
 msgid "When enabled, your receiver will detect activity on the VCR SCART input."
-msgstr "When enabled, your receiver will detect activity on the VCR SCART input."
+msgstr ""
 
 msgid "When nonzero, a recording will start earlier than the starting time indicated by the EPG."
-msgstr "When nonzero, a recording will start earlier than the starting time indicated by the EPG."
+msgstr ""
 
 msgid "When nonzero, a recording will stop later than the ending time indicated by the EPG."
-msgstr "When nonzero, a recording will stop later than the ending time indicated by the EPG."
+msgstr ""
 
 msgid "When set each folder will show the previous state used, when off the default values will be shown."
-msgstr "When set each folder will show the previous state used, when off the default values will be shown."
+msgstr ""
 
 msgid "When set the PIG will return to live after a movie has stopped playing."
-msgstr "When set the PIG will return to live after a movie has stopped playing."
+msgstr ""
 
 msgid "When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture."
-msgstr "When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture."
+msgstr ""
 
 msgid "When the content has an aspect ratio of 4:3, choose whether to scale/stretch the picture."
-msgstr "When the content has an aspect ratio of 4:3, choose whether to scale/stretch the picture."
+msgstr ""
 
 msgid "When tuned to a service the system will normally scan the transponder for any changes and save them. Only set to 'yes' if you're absolutely sure what you're doing."
 msgstr ""
@@ -19430,62 +18797,54 @@ msgid ""
 "\n"
 "Really do a factory reset?"
 msgstr ""
-"When you do a factory reset, you will lose ALL your configuration data\n"
-"(including bouquets, services, satellite data ...)\n"
-"After completion of factory reset, your %s %s will restart automatically!\n"
-"\n"
-"Really do a factory reset?"
 
 msgid "Where do you want to backup your settings?"
-msgstr "Where do you want to backup your settings?"
+msgstr ""
 
 msgid "Where should the recording be saved?"
-msgstr "Where should the recording be saved?"
+msgstr ""
 
 msgid "Where to save temporary timeshift recordings?"
-msgstr "Where to save temporary timeshift recordings?"
+msgstr ""
 
 msgid "Which event do you want to save permanently?"
-msgstr "Which event do you want to save permanently?"
+msgstr ""
 
 msgid "Which remote control gets shown. Only influences graphical representation."
 msgstr ""
 
-#, fuzzy
 msgid "While available"
-msgstr "unavailable"
+msgstr ""
 
 msgid "White"
-msgstr "White"
+msgstr ""
 
 msgid "Width"
-msgstr "Width"
+msgstr ""
 
-#, fuzzy
 msgid "Winter Sports"
-msgstr "winter sport"
+msgstr ""
 
-#, fuzzy
 msgid "Wintersport"
-msgstr "winter sport"
+msgstr ""
 
 msgid "Wireless LAN"
-msgstr "Wireless LAN"
+msgstr ""
 
 msgid "Wireless network"
-msgstr "Wireless network"
+msgstr ""
 
 msgid "Wireless network configuration..."
-msgstr "Wireless network configuration…"
+msgstr ""
 
 msgid "Wireless network connection setup"
-msgstr "Wireless network connection setup"
+msgstr ""
 
 msgid "Wireless network connection setup."
-msgstr "Wireless network connection setup."
+msgstr ""
 
 msgid "Wireless network state"
-msgstr "Wireless network state"
+msgstr ""
 
 msgid "Wirtschaft"
 msgstr ""
@@ -19496,18 +18855,17 @@ msgstr ""
 msgid "With T2MI RAW mode disabled (default) we can use single T2MI PLP de-encapsulation. With T2MI RAW mode enabled we can use astra-sm to analyze T2MI"
 msgstr ""
 
-#, fuzzy
 msgid "With errors:"
-msgstr "with %d error"
+msgstr ""
 
 msgid "With popup"
-msgstr "With popup"
+msgstr ""
 
 msgid "With this option set to 'yes' the channel lists will always show you the bouquet screen first. If set to 'no' the current bouquet will be opened."
 msgstr ""
 
 msgid "With this option you can hide Job Tasks from the extension screen (short blue button press)."
-msgstr "With this option you can hide Job Tasks from the extension screen (short blue button press)."
+msgstr ""
 
 msgid "With this option you can switch off the display during operation."
 msgstr ""
@@ -19519,13 +18877,13 @@ msgid "With this option you can switch off the display in Standby Mode."
 msgstr ""
 
 msgid "With this option you can switch the LED color or deactivate the LED."
-msgstr ""
+msgstr "With this option you can change the LED colour or deactivate it."
 
 msgid "With this setting, you can probably improve the signal quality or eliminate problems that can occur with longer HDMI cables."
 msgstr ""
 
 msgid "Without popup"
-msgstr "Without popup"
+msgstr ""
 
 msgid "Workaround for old tuner driver"
 msgstr ""
@@ -19534,26 +18892,21 @@ msgstr ""
 msgid "Would you save the entered PIN %s persistent?"
 msgstr ""
 
-#, fuzzy
 msgid "Wrestling"
-msgstr "Installing"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Write error at start of recording. %s\n"
 "%s"
 msgstr ""
-"Write error while recording. Disk full?\n"
-"%s"
 
-#, fuzzy, python-format
+#, python-format
 msgid "Write error while recording. %s"
 msgstr ""
-"Write error while recording. Disk full?\n"
-"%s"
 
 msgid "Write failed!"
-msgstr "Write failed!"
+msgstr ""
 
 msgid "Www"
 msgstr ""
@@ -19562,7 +18915,7 @@ msgid "Www long"
 msgstr ""
 
 msgid "XBox 360 support"
-msgstr "XBox 360 support"
+msgstr ""
 
 msgid "XP1000"
 msgstr ""
@@ -19583,58 +18936,58 @@ msgid "YCbCr444"
 msgstr ""
 
 msgid "YPbPr"
-msgstr "YPbPr"
+msgstr ""
 
 msgid "Year"
-msgstr "Year"
+msgstr ""
 
 msgid "Yellow"
 msgstr ""
 
 msgid "Yellow DVB subtitles"
-msgstr "Yellow DVB subtitles"
+msgstr ""
 
-#, fuzzy
 msgid "Yellow button"
-msgstr "Red button..."
+msgstr ""
 
 msgid "Yellow long"
 msgstr ""
 
-#, fuzzy
 msgid "Yemen"
-msgstr "Movement"
+msgstr ""
 
 msgid "Yes"
-msgstr "Yes"
+msgstr ""
 
 msgid "Yes to all"
-msgstr "Yes to all"
+msgstr ""
+
+msgid "Yes, I'm setting it up now"
+msgstr ""
 
 msgid "Yes, always"
-msgstr "Yes, always"
+msgstr ""
 
 msgid "Yes, and delete this movie"
-msgstr "Yes, and delete this movie"
+msgstr ""
 
 msgid "Yes, backup my settings!"
-msgstr "Yes, backup my settings!"
+msgstr ""
 
 msgid "Yes, but don't save timeshift as movie"
-msgstr "Yes, but don't save timeshift as movie"
+msgstr ""
 
-#, fuzzy
 msgid "Yes, but if not available show the plugin browser"
-msgstr "This option allows you to disable sorting of the plugin browser."
+msgstr ""
 
 msgid "Yes, but if not available show the timer list"
 msgstr ""
 
 msgid "Yes, but save timeshift as movie and continue recording"
-msgstr "Yes, but save timeshift as movie and continue recording"
+msgstr ""
 
 msgid "Yes, but save timeshift as movie and stop recording"
-msgstr "Yes, but save timeshift as movie and stop recording"
+msgstr ""
 
 msgid "Yes, delete from Timerlist"
 msgstr ""
@@ -19646,25 +18999,25 @@ msgid "Yes, delete this movie and return to movie list"
 msgstr ""
 
 msgid "Yes, do a manual scan now"
-msgstr "Yes, do a manual scan now"
+msgstr ""
 
 msgid "Yes, do an automatic scan now"
-msgstr "Yes, do an automatic scan now"
+msgstr ""
 
 msgid "Yes, do another manual scan now"
-msgstr "Yes, do another manual scan now"
+msgstr ""
 
 msgid "Yes, restore the settings now"
-msgstr "Yes, restore the settings now"
+msgstr ""
 
 msgid "Yes, returning to movie list"
-msgstr "Yes, returning to movie list"
+msgstr ""
 
 msgid "Yes, shut down now."
-msgstr "Yes, shut down now."
+msgstr ""
 
 msgid "Yesterday"
-msgstr "Yesterday"
+msgstr ""
 
 #, python-format
 msgid ""
@@ -19672,9 +19025,6 @@ msgid ""
 "would you like to remove\n"
 "\"%s\"?"
 msgstr ""
-"You already have a bootlogo installed,\n"
-"would you like to remove\n"
-"\"%s\"?"
 
 #, python-format
 msgid ""
@@ -19682,9 +19032,6 @@ msgid ""
 "would you like to remove\n"
 "\"%s\"?"
 msgstr ""
-"You already have a channel list installed,\n"
-"would you like to remove\n"
-"\"%s\"?"
 
 msgid "You can Display MiniTV with or without OSD Menu"
 msgstr ""
@@ -19693,25 +19040,25 @@ msgid "You can Display PIP with or without OSD Menu"
 msgstr ""
 
 msgid "You can cancel the installation."
-msgstr "You can cancel the installation."
+msgstr ""
 
 msgid "You can cancel the removal."
-msgstr "You can cancel the removal."
+msgstr ""
 
 msgid "You can continue watching TV etc. while this is running."
-msgstr "You can continue watching TV etc. while this is running."
+msgstr ""
 
 msgid "You can have the list sorted by time or alphanumerical."
-msgstr "You can have the list sorted by time or alphanumerical."
+msgstr ""
 
 msgid "You can install this plugin."
-msgstr "You can install this plugin."
+msgstr ""
 
 msgid "You can only burn Dreambox recordings!"
 msgstr ""
 
 msgid "You can remove this plugin."
-msgstr "You can remove this plugin."
+msgstr ""
 
 msgid "You can skip this function and turn off the TV when you wake the receiver from standby and immediately switch back to standby."
 msgstr ""
@@ -19729,22 +19076,22 @@ msgid "You can't usefully run '%s' on a directory."
 msgstr ""
 
 msgid "You cannot delete this!"
-msgstr "You cannot delete this!"
+msgstr ""
 
 msgid "You didn't select a channel to record from."
-msgstr "You didn't select a channel to record from."
+msgstr ""
 
 msgid "You have already sent this log, are you sure you want to resend this log:\n"
-msgstr "You have already sent this log, are you sure you want to resend this log:\n"
+msgstr ""
 
 msgid "You have chosen to backup your settings. Please press OK to start the backup now."
-msgstr "You have chosen to backup your settings. Please press OK to start the backup now."
+msgstr ""
 
 msgid "You have chosen to create a new .NFI flasher bootable USB stick. This will repartition the USB stick and therefore all data on it will be erased."
-msgstr "You have chosen to create a new .NFI flasher bootable USB stick. This will repartition the USB stick and therefore all data on it will be erased."
+msgstr ""
 
 msgid "You have chosen to restore your settings. Enigma2 will restart after restore. Please press OK to start the restore now."
-msgstr "You have chosen to restore your settings. Enigma2 will restart after restore. Please press OK to start the restore now."
+msgstr ""
 
 msgid "You have chosen to save the current timeshift"
 msgstr ""
@@ -19753,8 +19100,6 @@ msgid ""
 "You have chosen to save the current timeshift event, but the event has not yet finished\n"
 "What do you want to do ?"
 msgstr ""
-"You have chosen to save the current timeshift event, but the event has not yet finished\n"
-"What do you want to do?"
 
 msgid "You have no script to run."
 msgstr ""
@@ -19763,21 +19108,19 @@ msgid ""
 "You have not setup your user info in the setup screen\n"
 "Press MENU, and enter your info, then try again"
 msgstr ""
-"You have not setup your user info in the setup screen\n"
-"Press MENU, and enter your info, then try again"
 
 msgid "You have selected no logs to delete."
-msgstr "You have not selected any logs to delete."
+msgstr ""
 
 msgid "You have selected no logs to send."
-msgstr "You have not selected any logs to send."
+msgstr ""
 
 msgid "You have to create a Swap File before to activate the autostart."
 msgstr ""
 
 #, python-format
 msgid "You have to wait %s!"
-msgstr "You have to wait %s!"
+msgstr ""
 
 msgid "You must set a root password in order to be able to use network services, such as FTP, telnet or ssh."
 msgstr ""
@@ -19794,13 +19137,13 @@ msgid "You seem to be in timeshft, the service will briefly stop as timeshfit st
 msgstr ""
 
 msgid "You seem to be in timeshift!"
-msgstr "You seem to be in timeshift!"
+msgstr ""
 
 msgid "You seem to be in timeshift, Do you want to leave timeshift ?"
-msgstr "You seem to be in timeshift, Do you want to leave timeshift ?"
+msgstr ""
 
 msgid "You system does not support ext4"
-msgstr "You system does not support ext4"
+msgstr ""
 
 msgid "Your %s %s does not have an internet connection"
 msgstr ""
@@ -19818,7 +19161,7 @@ msgstr ""
 
 #, python-format
 msgid "Your %s %s is not connected to the internet, please check your network settings and try again."
-msgstr "Your %s %s is not connected to the internet, please check your network settings and try again."
+msgstr ""
 
 #, python-format
 msgid ""
@@ -19827,10 +19170,6 @@ msgid ""
 "Your internet connection is working now.\n"
 "\n"
 msgstr ""
-"Your %s %s is now ready to be used.\n"
-"\n"
-"Your internet connection is working now.\n"
-"\n"
 
 msgid ""
 "Your %s %s is now ready to use.\n"
@@ -19839,26 +19178,21 @@ msgid ""
 "\n"
 "Please press OK to continue."
 msgstr ""
-"Your %s %s is now ready to use.\n"
-"\n"
-"Your internet connection is working now.\n"
-"\n"
-"Please press OK to continue."
 
 #, python-format
 msgid "Your %s %s is rebooting"
-msgstr "Your %s %s is rebooting"
+msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "Your %s %s is rebooting into Recovery Mode"
-msgstr "Your %s %s is rebooting"
+msgstr ""
 
 #, python-format
 msgid "Your %s %s is shutting down"
-msgstr "Your %s %s is shutting down"
+msgstr ""
 
 msgid "Your %s %s is shutting down. Please wait..."
-msgstr "Your %s %s is shutting down. Please wait..."
+msgstr ""
 
 #, python-format
 msgid "Your %s %s isn't connected to the internet properly. Please check it and try again."
@@ -19866,7 +19200,7 @@ msgstr ""
 
 #, python-format
 msgid "Your %s %s might be unusable now. Please consult the manual for further assistance before rebooting your %s %s."
-msgstr "Your %s %s might be unusable now. Please consult the manual for further assistance before rebooting your %s %s."
+msgstr ""
 
 #, python-format
 msgid ""
@@ -19895,17 +19229,12 @@ msgid ""
 "\n"
 "Do you want to install now ?"
 msgstr ""
-"Your %s %s will be restarted after the installation of service.\n"
-"\n"
-"Do you want to install now ?"
 
 #, python-format
 msgid ""
 "Your %s %s will be restarted after the removal of service\n"
 "Do you want to remove now ?"
 msgstr ""
-"Your %s %s will be restarted after the removal of service\n"
-"Do you want to remove now ?"
 
 msgid "Your Hardware can detect ci mode self or work only in legacy mode."
 msgstr ""
@@ -19915,24 +19244,22 @@ msgid "Your Receiver has a Software problem detected. Since the last reboot it h
 msgstr ""
 
 msgid "Your STB will restart after pressing OK on your remote control."
-msgstr "Your STB will restart after pressing OK on your remote control."
+msgstr ""
 
 msgid "Your backup succeeded. We will now continue to explain the further upgrade process."
-msgstr "Your backup succeeded. We will now continue to explain the further upgrade process."
+msgstr ""
 
 msgid "Your collection exceeds the size of a single layer medium, you will need a blank dual layer DVD!"
-msgstr "Your collection exceeds the size of a single layer medium, you will need a blank dual layer DVD!"
+msgstr ""
 
 #, python-format
 msgid ""
 "Your config file is not well-formed:\n"
 "%s"
 msgstr ""
-"Your config file is not well-formed:\n"
-"%s"
 
 msgid "Your current collection will get lost!"
-msgstr "Your current collection will get lost!"
+msgstr ""
 
 msgid "Your email address is used to login to IceTV services."
 msgstr ""
@@ -19949,8 +19276,6 @@ msgid ""
 "Your frontprocessor firmware must be upgraded.\n"
 "Press OK to start upgrade."
 msgstr ""
-"Your front-processor firmware must be upgraded.\n"
-"Press OK to start upgrade."
 
 #, python-format
 msgid ""
@@ -19958,9 +19283,6 @@ msgid ""
 "Please wait until your %s %s reboots\n"
 "This may take a few minutes"
 msgstr ""
-"Your frontprocessor will be upgraded\n"
-"Please wait until your %s %s reboots\n"
-"This may take a few minutes"
 
 #, python-format
 msgid ""
@@ -19981,17 +19303,15 @@ msgid ""
 "Your internet connection is not working!\n"
 "Please choose what you want to do next."
 msgstr ""
-"Your internet connection is not working!\n"
-"Please choose what you want to do next."
 
 msgid "Your network configuration has been activated."
-msgstr "Your network configuration has been activated."
+msgstr ""
 
 msgid "Your password must have at least 5 characters."
 msgstr ""
 
 msgid "Your receiver can use SCPC optimized search range. Consult your receiver's manual for more information."
-msgstr ""
+msgstr "Your receiver can use SCPC optimised search range. Consult your receiver's documentation for more information."
 
 msgid "Your receiver can use tone amplitude. Consult your receiver's manual for more information."
 msgstr ""
@@ -20002,14 +19322,9 @@ msgid ""
 "\n"
 "Please choose what you want to do next."
 msgstr ""
-"Your wireless LAN internet connection could not be started!\n"
-"Have you attached your USB WLAN Stick?\n"
-"\n"
-"Please choose what you want to do next."
 
-#, fuzzy
 msgid "Youth"
-msgstr "South"
+msgstr ""
 
 msgid "Youtube TV"
 msgstr ""
@@ -20023,60 +19338,56 @@ msgstr ""
 msgid "ZOOM long"
 msgstr ""
 
-#, fuzzy
 msgid "ZPicon"
-msgstr "Picon"
+msgstr ""
 
-#, fuzzy
 msgid "ZZPicon"
-msgstr "Picon"
+msgstr ""
 
 msgid "Zambia"
 msgstr ""
 
 msgid "Zap"
-msgstr "Zap"
+msgstr ""
 
 msgid "Zap + Exit"
-msgstr "Zap + Exit"
+msgstr ""
 
 msgid "Zap back to previously tuned service?"
-msgstr "Zap back to previously tuned service?"
+msgstr ""
 
 msgid "Zap back to service before positioner setup?"
-msgstr "Zap back to service before positioner setup?"
+msgstr ""
 
 msgid "Zap back to service before tuner setup?"
-msgstr "Zap back to service before tuner setup?"
+msgstr ""
 
 msgid "Zap down"
 msgstr ""
 
 msgid "Zap focus to Picture in Picture"
-msgstr "Zap focus to Picture in Picture"
+msgstr ""
 
 msgid "Zap focus to main screen"
-msgstr "Zap focus to main screen"
+msgstr ""
 
-#, fuzzy
 msgid "Zap focused channel on full screen"
-msgstr "Zap focus to main screen"
+msgstr ""
 
 msgid "Zap mode"
-msgstr "Zap mode"
+msgstr ""
 
-#, fuzzy
 msgid "Zap next"
-msgstr "Play next"
+msgstr ""
 
 msgid "Zap to"
 msgstr ""
 
 msgid "Zap to channel (setup in menu)"
-msgstr "Zap to channel (setup in menu)"
+msgstr ""
 
 msgid "Zap to channel and close (setup in menu)"
-msgstr "Zap to channel and close (setup in menu)"
+msgstr ""
 
 msgid "Zap to selected channel"
 msgstr ""
@@ -20087,9 +19398,8 @@ msgstr ""
 msgid "Zap up"
 msgstr ""
 
-#, fuzzy
 msgid "Zap+Record next"
-msgstr "Record next"
+msgstr ""
 
 msgid "Zeichentrick"
 msgstr ""
@@ -20116,10 +19426,10 @@ msgid "Zirkus"
 msgstr ""
 
 msgid "Zoom In/Out TV..."
-msgstr "Zoom In/Out TV..."
+msgstr ""
 
 msgid "Zoom Off..."
-msgstr "Zoom Off..."
+msgstr ""
 
 msgid "Zoom from left"
 msgstr ""
@@ -20134,43 +19444,44 @@ msgid "[Image Info]\n"
 msgstr ""
 
 msgid "[TimeShift] Restarting Timeshift!"
-msgstr "[TimeShift] Restarting Timeshift!"
+msgstr ""
 
 msgid "[Timeshift] Merging records failed!"
-msgstr "[Timeshift] Merging records failed!"
+msgstr ""
 
 msgid "[alternative edit]"
-msgstr "[alternative edit]"
+msgstr ""
 
 msgid "[bouquet edit]"
-msgstr "[bouquet edit]"
+msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "[favourite edit]"
-msgstr "[favourite edit]"
+msgstr "[editing favourite]"
 
 msgid "[move mode]"
-msgstr "[move mode]"
+msgstr ""
 
 msgid "a gui to assign services/providers to common interface modules"
-msgstr "a gui to assign services/providers to common interface modules"
+msgstr ""
 
 msgid "a gui to assign services/providers/caids to common interface modules"
-msgstr "a gui to assign services/providers/caids to common interface modules"
+msgstr ""
 
 msgid "abort alternatives edit"
-msgstr "abort alternatives edit"
+msgstr ""
 
 msgid "abort bouquet edit"
-msgstr "abort bouquet edit"
+msgstr ""
 
 msgid "abort favourites edit"
-msgstr "abort favourites edit"
+msgstr ""
 
 msgid "about to start"
-msgstr "about to start"
+msgstr ""
 
 msgid "activate network adapter configuration"
-msgstr "activate network adapter configuration"
+msgstr ""
 
 msgid "activatePiP"
 msgstr ""
@@ -20182,74 +19493,71 @@ msgid "add Service"
 msgstr ""
 
 msgid "add alternatives"
-msgstr "add alternatives"
+msgstr ""
 
 msgid "add bookmark"
-msgstr "add bookmark"
+msgstr ""
 
 msgid "add bouquet"
-msgstr "add bouquet"
+msgstr ""
 
 msgid "add bouquet to parental protection"
 msgstr ""
 
 msgid "add marker"
-msgstr "add marker"
+msgstr ""
 
 msgid "add service to bouquet"
-msgstr "add service to bouquet"
+msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "add service to favourites"
 msgstr "add service to favourites"
 
 msgid "add to parental protection"
-msgstr "add to parental protection"
+msgstr ""
 
 msgid "address:"
-msgstr "address:"
+msgstr ""
 
 msgid "adult movie/drama"
-msgstr "adult movie/drama"
+msgstr ""
 
 msgid "advanced"
-msgstr "advanced"
+msgstr ""
 
 msgid "adventure/western/war"
-msgstr "adventure/western/war"
+msgstr ""
 
 msgid "advertisement/shopping"
-msgstr "advertisement/shopping"
+msgstr ""
 
-#, fuzzy
 msgid "all events down"
-msgstr "special events"
+msgstr ""
 
-#, fuzzy
 msgid "all events up"
-msgstr "special events"
+msgstr ""
 
-#, fuzzy
 msgid "all up/down"
-msgstr "Page down"
+msgstr ""
 
 msgid "alpha then oldest"
 msgstr ""
 
 msgid "alphabetic"
-msgstr "alphabetic"
+msgstr ""
 
 msgid "alphabetic reverse"
-msgstr "alphabetic reverse"
+msgstr ""
 
-#, fuzzy
 msgid "alphabetical"
-msgstr "alphabetic"
+msgstr ""
 
 msgid "alpharev then newest"
 msgstr ""
 
 msgid "alternative"
-msgstr "alternative"
+msgstr ""
 
 msgid "am"
 msgstr ""
@@ -20268,30 +19576,29 @@ msgid ""
 "following backup:\n"
 msgstr ""
 
-#, fuzzy
 msgid "arts/culture (general)"
-msgstr "arts/culture (without music, general)"
+msgstr ""
 
 msgid "arts/culture (without music, general)"
-msgstr "arts/culture (without music, general)"
+msgstr ""
 
 msgid "arts/culture magazine"
-msgstr "arts/culture magazine"
+msgstr ""
 
 msgid "as plugin in extended bar"
-msgstr "as plugin in extended bar"
+msgstr ""
 
 msgid "ask user"
 msgstr ""
 
 msgid "at beginning"
-msgstr "at beginning"
+msgstr ""
 
 msgid "at end"
-msgstr "at end"
+msgstr ""
 
 msgid "athletics"
-msgstr "athletics"
+msgstr ""
 
 #, python-format
 msgid "audio track (%s) format"
@@ -20302,28 +19609,28 @@ msgid "audio track (%s) language"
 msgstr ""
 
 msgid "audio tracks"
-msgstr "audio tracks"
+msgstr ""
 
 msgid "auto"
-msgstr "auto"
+msgstr ""
 
 msgid "auto deepstandby"
-msgstr "auto deepstandby"
+msgstr ""
 
 msgid "auto standby"
-msgstr "auto standby"
+msgstr ""
 
 msgid "automatic"
-msgstr "automatic"
+msgstr ""
 
 msgid "back"
-msgstr "back"
+msgstr ""
 
 msgid "background image"
-msgstr "background image"
+msgstr ""
 
 msgid "ballet"
-msgstr "ballet"
+msgstr ""
 
 #, python-format
 msgid "bc%d"
@@ -20333,54 +19640,53 @@ msgid "because of the used filesystem the back-up\n"
 msgstr ""
 
 msgid "better"
-msgstr "better"
+msgstr ""
 
 msgid "black"
-msgstr "black"
+msgstr ""
 
 msgid "black & white"
-msgstr "black & white"
+msgstr ""
 
 msgid "blacklist"
-msgstr "blacklist"
+msgstr ""
 
 msgid "blue"
-msgstr "blue"
+msgstr ""
 
-#, fuzzy
 msgid "bottom"
-msgstr "Top and bottom"
+msgstr ""
 
 msgid "broadcasting/press"
-msgstr "broadcasting/press"
+msgstr ""
 
 #, python-format
 msgid "burn audio track (%s)"
 msgstr ""
 
 msgid "by date"
-msgstr "by date"
+msgstr ""
 
 msgid "caid:"
-msgstr "caid:"
+msgstr ""
 
 msgid "card"
-msgstr "card"
+msgstr ""
 
 msgid "card reader"
-msgstr "card reader"
+msgstr ""
 
 msgid "cartoon/puppets"
-msgstr "cartoon/puppets"
+msgstr ""
 
 msgid "center"
 msgstr "centre"
 
 msgid "centered"
-msgstr ""
+msgstr "centred"
 
 msgid "centered, wrapped"
-msgstr ""
+msgstr "centred, wrapped"
 
 msgid "change"
 msgstr ""
@@ -20392,45 +19698,43 @@ msgid "change Volume up"
 msgstr ""
 
 msgid "chapters"
-msgstr "chapters"
+msgstr ""
 
 msgid "children's/youth program (general)"
-msgstr "children's's/youth program (general)"
+msgstr ""
 
-#, fuzzy
 msgid "childrens (general)"
-msgstr "children's's/youth program (general)"
+msgstr ""
 
 msgid "circular left"
-msgstr "circular left"
+msgstr ""
 
 msgid "circular right"
-msgstr "circular right"
+msgstr ""
 
 msgid "clip overscan / letterbox borders"
 msgstr ""
 
 msgid "close share view"
-msgstr "close share view"
+msgstr ""
 
 msgid "comedy"
-msgstr "comedy"
+msgstr ""
 
-#, fuzzy
 msgid "comedy (general)"
-msgstr "movie/drama (general)"
+msgstr ""
 
 msgid "config menu"
 msgstr ""
 
 msgid "confirmed"
-msgstr "confirmed"
+msgstr ""
 
 msgid "connected"
-msgstr "connected"
+msgstr ""
 
 msgid "continue"
-msgstr "continue"
+msgstr ""
 
 msgid "controlled by HDMI"
 msgstr ""
@@ -20445,44 +19749,41 @@ msgid "convert to multi-channel PCM"
 msgstr ""
 
 msgid "cooking"
-msgstr "cooking"
+msgstr ""
 
 msgid "copy"
-msgstr "copy"
+msgstr ""
 
-#, fuzzy
 msgid "copy file"
-msgstr "Copying files"
+msgstr ""
 
-#, fuzzy
 msgid "copy folder"
-msgstr "Select folders"
+msgstr ""
 
 msgid "copy to bouquets"
-msgstr "copy to bouquets"
+msgstr ""
 
 msgid "create directory"
-msgstr "create directory"
+msgstr ""
 
 msgid "create symlink ..."
 msgstr ""
 
-#, fuzzy
 msgid "current affairs (general)"
-msgstr "news/current affairs (general)"
+msgstr ""
 
 #, python-format
 msgid "currently installed image: %s"
-msgstr "currently installed image: %s"
+msgstr ""
 
 msgid "daily"
-msgstr "daily"
+msgstr ""
 
 msgid "day"
-msgstr "day"
+msgstr ""
 
 msgid "decrease uphop by 1"
-msgstr "decrease uphop by 1"
+msgstr ""
 
 msgid "default"
 msgstr ""
@@ -20491,57 +19792,55 @@ msgid "default Astra (13e-19e)"
 msgstr ""
 
 msgid "delete"
-msgstr "delete"
+msgstr ""
 
 msgid "delete cut"
-msgstr "delete cut"
+msgstr ""
 
 msgid "descramble and record ecm"
-msgstr "descramble and record ecm"
+msgstr ""
 
 msgid "detective/thriller"
-msgstr "detective/thriller"
+msgstr ""
 
 msgid "disable"
-msgstr "disable"
+msgstr ""
 
 msgid "disable move mode"
-msgstr "disable move mode"
+msgstr ""
 
 msgid "disabled"
-msgstr "disabled"
+msgstr ""
 
 msgid "disconnected"
-msgstr "disconnected"
+msgstr ""
 
 msgid "discussion/interview/debate"
-msgstr "discussion/interview/debate"
+msgstr ""
 
 msgid "display"
 msgstr ""
 
 msgid "do nothing"
-msgstr "do nothing"
+msgstr ""
 
 msgid "documentary"
-msgstr "documentary"
+msgstr ""
 
-#, fuzzy
 msgid "documentary (general)"
-msgstr "documentary"
+msgstr ""
 
 msgid "dolby"
 msgstr ""
 
 msgid "don't descramble, record ecm"
-msgstr "don't descramble, record ecm"
+msgstr ""
 
 msgid "done!"
-msgstr "done!"
+msgstr ""
 
-#, fuzzy
 msgid "drama (general)"
-msgstr "movie/drama (general)"
+msgstr ""
 
 msgid "drivers"
 msgstr ""
@@ -20549,63 +19848,66 @@ msgstr ""
 msgid "eMMC"
 msgstr ""
 
+#, python-format
+msgid "eMMC slot %s"
+msgstr ""
+
 msgid "eSATA"
 msgstr ""
 
 msgid "east"
-msgstr "east"
+msgstr ""
 
 msgid "ecm time:"
-msgstr "ecm time:"
+msgstr ""
 
 msgid "ecm.info"
-msgstr "ecm.info"
+msgstr ""
 
 msgid "economics/social advisory"
-msgstr "economics/social advisory"
+msgstr ""
 
 msgid "edit alternatives"
-msgstr "edit alternatives"
+msgstr ""
 
-#, fuzzy
 msgid "education/information (general)"
-msgstr "education/science/factual topics (general)"
+msgstr ""
 
 msgid "education/science/factual topics (general)"
-msgstr "education/science/factual topics (general)"
+msgstr ""
 
 msgid "empty"
-msgstr "empty"
+msgstr ""
 
 msgid "enable"
-msgstr "enable"
+msgstr ""
 
 msgid "enable PIP no HDR"
 msgstr ""
 
 msgid "enable bouquet edit"
-msgstr "enable bouquet edit"
+msgstr ""
 
 msgid "enable favourite edit"
-msgstr "enable favourite edit"
+msgstr ""
 
 msgid "enable move mode"
-msgstr "enable move mode"
+msgstr ""
 
 msgid "enabled"
-msgstr "enabled"
+msgstr ""
 
 msgid "end alternatives edit"
-msgstr "end alternatives edit"
+msgstr ""
 
 msgid "end bouquet edit"
-msgstr "end bouquet edit"
+msgstr ""
 
 msgid "end cut here"
-msgstr "end cut here"
+msgstr ""
 
 msgid "end favourites edit"
-msgstr "end favourites edit"
+msgstr ""
 
 msgid "end zapping"
 msgstr ""
@@ -20614,23 +19916,22 @@ msgid "enigma2 and network"
 msgstr ""
 
 msgid "enter number to jump to channel."
-msgstr "enter number to jump to channel."
+msgstr ""
 
 msgid "entertainment (10-16 year old)"
-msgstr "entertainment (10-16 year old)"
+msgstr ""
 
 msgid "entertainment (6-14 year old)"
-msgstr "entertainment (6-14 year old)"
+msgstr ""
 
-#, fuzzy
 msgid "entertainment (general)"
-msgstr "entertainment (6-14 year old)"
+msgstr ""
 
 msgid "equal to"
-msgstr "equal to"
+msgstr ""
 
 msgid "equestrian"
-msgstr "equestrian"
+msgstr ""
 
 msgid "error starting scanning"
 msgstr ""
@@ -20660,25 +19961,25 @@ msgid "execute cuts (requires MovieCut plugin)"
 msgstr ""
 
 msgid "exit DVD player or return to file browser"
-msgstr "exit DVD player or return to file browser"
+msgstr ""
 
 msgid "exit mounts setup menu"
-msgstr "exit mounts setup menu"
+msgstr ""
 
 msgid "exit network adapter configuration"
-msgstr "exit network adapter configuration"
+msgstr ""
 
 msgid "exit networkadapter setup menu"
-msgstr "exit network adapter setup menu"
+msgstr ""
 
 msgid "experimental film/video"
-msgstr "experimental film/video"
+msgstr ""
 
 msgid "extensions"
 msgstr ""
 
 msgid "extensions."
-msgstr "extensions."
+msgstr ""
 
 msgid "externally loopthrough to"
 msgstr ""
@@ -20690,53 +19991,52 @@ msgid "extrawide"
 msgstr ""
 
 msgid "failed"
-msgstr "failed"
+msgstr ""
 
 msgid "false"
-msgstr "false"
+msgstr ""
 
 msgid "fashion"
-msgstr "fashion"
+msgstr ""
 
 msgid "fast"
-msgstr "fast"
+msgstr ""
 
 msgid "feed status"
 msgstr ""
 
-#, fuzzy
 msgid "file can not displayed - file not found"
-msgstr "file oscam.conf could not be found"
+msgstr ""
 
 msgid "fileformats (BMP, PNG, JPG, GIF)"
-msgstr "fileformats (BMP, PNG, JPG, GIF)"
+msgstr ""
 
 msgid "filename"
-msgstr "filename"
+msgstr ""
 
 msgid "film/cinema"
-msgstr "film/cinema"
+msgstr ""
 
 msgid "find currently played service"
 msgstr ""
 
 msgid "fine arts"
-msgstr "fine arts"
+msgstr ""
 
 msgid "fitness & health"
-msgstr "fitness & health"
+msgstr ""
 
 msgid "flat alphabetic"
-msgstr "flat alphabetic"
+msgstr ""
 
 msgid "flat alphabetic reverse"
-msgstr "flat alphabetic reverse"
+msgstr ""
 
 msgid "folk/traditional music"
-msgstr "folk/traditional music"
+msgstr ""
 
 msgid "football/soccer"
-msgstr "football/soccer"
+msgstr ""
 
 msgid "for DATA LOSS OR DAMAGE !!!"
 msgstr ""
@@ -20744,25 +20044,23 @@ msgstr ""
 msgid "force AC3plus"
 msgstr ""
 
-#, fuzzy
 msgid "force disabled"
-msgstr "disabled"
+msgstr ""
 
-#, fuzzy
 msgid "force enabled"
-msgstr "enabled"
+msgstr ""
 
 msgid "foreign countries/expeditions"
-msgstr "foreign countries/expeditions"
+msgstr ""
 
 msgid "forward to the next chapter"
-msgstr "forward to the next chapter"
+msgstr ""
 
 msgid "free"
-msgstr "free"
+msgstr ""
 
 msgid "free diskspace"
-msgstr "disk space"
+msgstr ""
 
 msgid "from"
 msgstr ""
@@ -20771,40 +20069,37 @@ msgid "from dir"
 msgstr ""
 
 msgid "full"
-msgstr "full"
+msgstr ""
 
 msgid "further education"
-msgstr "further education"
+msgstr ""
 
 msgid "game show/quiz/contest"
-msgstr "game show/quiz/contest"
+msgstr ""
 
 msgid "gardening"
-msgstr "gardening"
+msgstr ""
 
 msgid "get the cards' server"
-msgstr "get the cards' server"
+msgstr ""
 
 msgid "go to deep standby"
-msgstr "go to deep standby"
+msgstr ""
 
 msgid "go to standby"
-msgstr "go to standby"
+msgstr ""
 
-#, fuzzy
 msgid "goto current channel and now"
-msgstr "Goto next channel"
+msgstr ""
 
 msgid "goto deep-standby"
 msgstr ""
 
-#, fuzzy
 msgid "goto first channel"
-msgstr "Goto next channel"
+msgstr ""
 
-#, fuzzy
 msgid "goto last channel"
-msgstr "Goto next channel"
+msgstr ""
 
 msgid "goto now"
 msgstr ""
@@ -20813,10 +20108,10 @@ msgid "goto standby"
 msgstr ""
 
 msgid "grab this frame as bitmap"
-msgstr "grab this frame as bitmap"
+msgstr ""
 
 msgid "green"
-msgstr "green"
+msgstr ""
 
 msgid "h:mm"
 msgstr ""
@@ -20837,14 +20132,13 @@ msgid "h:mmam/pm"
 msgstr ""
 
 msgid "handicraft"
-msgstr "handicraft"
+msgstr ""
 
 msgid "handled"
-msgstr "handled"
+msgstr ""
 
-#, fuzzy
 msgid "has been CHANGED! Do you want to save it?"
-msgstr "Which event do you want to save permanently?"
+msgstr ""
 
 msgid ""
 "has been sent to the SVN team team.\n"
@@ -20855,7 +20149,7 @@ msgid "hdr10"
 msgstr ""
 
 msgid "height"
-msgstr "height"
+msgstr ""
 
 msgid "help..."
 msgstr ""
@@ -20884,47 +20178,45 @@ msgstr ""
 msgid "hide"
 msgstr ""
 
-#, fuzzy
 msgid "highest Resolution"
-msgstr "Resolution"
+msgstr ""
 
 msgid "hlg"
 msgstr ""
 
 msgid "hops:"
-msgstr "hops:"
+msgstr ""
 
 msgid "horizontal"
-msgstr "horizontal"
+msgstr ""
 
 msgid "if set to 'no', only an debug message is written to the Debug log "
 msgstr ""
 
 msgid "increase uphop by 1"
-msgstr "increase uphop by 1"
+msgstr ""
 
 msgid "information/education/school program"
-msgstr "information/education/school program"
+msgstr ""
 
-#, fuzzy
 msgid "infotainment (general)"
-msgstr "sports (general)"
+msgstr ""
 
 msgid "init module"
-msgstr "init module"
+msgstr ""
 
 msgid "init modules"
-msgstr "init modules"
+msgstr ""
 
 msgid "insert mark here"
-msgstr "insert mark here"
+msgstr ""
 
 msgid "install/unpack ipk Files"
 msgstr ""
 
-#, fuzzy, python-format
+#, python-format
 msgid "internal flash:  %s %s "
-msgstr "Internal flash"
+msgstr ""
 
 #, python-format
 msgid "internal flash: %s %s as USB Recovery"
@@ -20934,30 +20226,28 @@ msgid "internally loopthrough to"
 msgstr ""
 
 msgid "invalid type"
-msgstr "invalid type"
+msgstr ""
 
 msgid "is strongly advised."
-msgstr "is strongly advised."
+msgstr ""
 
 msgid "jazz"
-msgstr "jazz"
+msgstr ""
 
 msgid "jump back to the previous title"
-msgstr "jump back to the previous title"
+msgstr ""
 
 msgid "jump forward to the next title"
-msgstr "jump forward to the next title"
+msgstr ""
 
 msgid "jump to chapter by number"
 msgstr ""
 
-#, fuzzy
 msgid "jump to next page or all up (setup in menu)"
-msgstr "Zap to channel (setup in menu)"
+msgstr ""
 
-#, fuzzy
 msgid "jump to previous page or all down (setup in menu)"
-msgstr "Zap to channel (setup in menu)"
+msgstr ""
 
 msgid "just abort, no message"
 msgstr ""
@@ -20972,188 +20262,178 @@ msgid "kernel modules"
 msgstr ""
 
 msgid "languages"
-msgstr "languages"
+msgstr ""
 
 msgid "leave movie player..."
-msgstr "leave movie player..."
+msgstr ""
 
 msgid "left"
-msgstr "left"
+msgstr ""
 
 msgid "left, wrapped"
 msgstr ""
 
 msgid "leisure hobbies (general)"
-msgstr "leisure hobbies (general)"
+msgstr ""
 
 msgid "length"
-msgstr "length"
+msgstr ""
 
 msgid "limit ..., aborting !"
-msgstr "limit ..., aborting !"
+msgstr ""
 
 msgid "literature"
-msgstr "literature"
+msgstr ""
 
 msgid "live broadcast"
-msgstr "live broadcast"
+msgstr ""
 
 msgid "locked"
-msgstr "locked"
+msgstr ""
 
 msgid "long"
 msgstr ""
 
 msgid "loopthrough to"
-msgstr "loopthrough to"
+msgstr ""
 
 msgid "m2k"
 msgstr ""
 
 msgid "magazines/reports/documentary"
-msgstr "magazines/reports/documentary"
+msgstr ""
 
 msgid "making a backup before updating"
-msgstr "making a backup before updating"
+msgstr ""
 
 msgid "manage local Files"
 msgstr ""
 
 msgid "manual"
-msgstr "manual"
+msgstr ""
 
 msgid "martial sports"
-msgstr "martial sports"
+msgstr ""
 
 msgid "medicine/physiology/psychology"
-msgstr "medicine/physiology/psychology"
+msgstr ""
 
 msgid "menu"
-msgstr "menu"
+msgstr ""
 
 msgid "middle"
 msgstr ""
 
-#, fuzzy
 msgid "min"
-msgstr "mins"
+msgstr ""
 
 msgid "mins"
-msgstr "mins"
+msgstr ""
 
 msgid "minute"
-msgstr "minute"
+msgstr ""
 
 msgid "minutes"
-msgstr "minutes"
+msgstr ""
 
 msgid "month"
-msgstr "month"
+msgstr ""
 
 msgid "motor sport"
-msgstr "motor sport"
+msgstr ""
 
 msgid "motoring"
-msgstr "motoring"
+msgstr ""
 
 msgid "move"
-msgstr "move"
+msgstr ""
 
 msgid "move down to last entry"
-msgstr "move down to last entry"
+msgstr ""
 
 msgid "move down to next entry"
-msgstr "move down to next entry"
+msgstr ""
 
-#, fuzzy
 msgid "move file"
-msgstr "Remove title"
+msgstr ""
 
-#, fuzzy
 msgid "move folder"
-msgstr "[move mode]"
+msgstr ""
 
 msgid "move up to first entry"
-msgstr "move up to first entry"
+msgstr ""
 
 msgid "move up to previous entry"
-msgstr "move up to previous entry"
+msgstr ""
 
-#, fuzzy
 msgid "movie (general)"
-msgstr "movie/drama (general)"
+msgstr ""
 
 msgid "movie/drama (general)"
-msgstr "movie/drama (general)"
+msgstr ""
 
 msgid "ms"
-msgstr "ms"
+msgstr ""
 
-#, fuzzy
 msgid "multi"
-msgstr "multinorm"
+msgstr ""
 
 msgid "multinorm"
-msgstr "multinorm"
+msgstr ""
 
-#, fuzzy
 msgid "music (general)"
-msgstr "sports (general)"
+msgstr ""
 
 msgid "music/ballet/dance (general)"
-msgstr "music/ballet/dance (general)"
+msgstr ""
 
 msgid "musical/opera"
-msgstr "musical/opera"
+msgstr ""
 
-#, fuzzy
 msgid "n/A"
-msgstr "N/A"
+msgstr ""
 
 msgid "n/a"
 msgstr ""
 
 msgid "nature/animals/environment"
-msgstr "nature/animals/environment"
+msgstr ""
 
 msgid "never"
-msgstr "never"
+msgstr ""
 
 msgid "never abort"
 msgstr ""
 
 msgid "new media"
-msgstr "new media"
+msgstr ""
 
-#, fuzzy
 msgid "news (general)"
-msgstr "sports (general)"
+msgstr ""
 
 msgid "news magazine"
-msgstr "news magazine"
+msgstr ""
 
 msgid "news/current affairs (general)"
-msgstr "news/current affairs (general)"
+msgstr ""
 
 msgid "news/weather report"
-msgstr "news/weather report"
+msgstr ""
 
-#, fuzzy
 msgid "next channel page"
-msgstr "Goto next channel"
+msgstr ""
 
-#, fuzzy
 msgid "next higher Resolution"
-msgstr "Resolution"
+msgstr ""
 
 msgid "no"
-msgstr "no"
+msgstr ""
 
 msgid "no CAId selected"
-msgstr "no CAId selected"
+msgstr ""
 
 msgid "no CI slots found"
-msgstr "no CI slots found"
+msgstr ""
 
 msgid "no channel list"
 msgstr ""
@@ -21162,82 +20442,80 @@ msgid "no delay"
 msgstr ""
 
 msgid "no module found"
-msgstr "no module found"
+msgstr ""
 
+#. TRANSLATORS: override en_US
 msgid "no or unknown card inserted"
-msgstr "no or unknown card inserted"
+msgstr "no card or unrecognised card inserted"
 
 msgid "no resource manager"
 msgstr ""
 
 msgid "no storage devices found"
-msgstr "no storage devices found"
+msgstr ""
 
 msgid "none"
-msgstr "none"
+msgstr ""
 
 msgid "normal"
-msgstr "normal"
+msgstr ""
 
-#, fuzzy
 msgid "not"
-msgstr "no"
+msgstr ""
 
 msgid "not activated"
 msgstr ""
 
 msgid "not configured"
-msgstr "not configured"
+msgstr ""
 
 msgid "not locked"
-msgstr "not locked"
+msgstr ""
 
 msgid "not supported"
-msgstr "not supported"
+msgstr ""
 
-#, fuzzy
 msgid "not tested"
-msgstr "not used"
+msgstr ""
 
 msgid "not used"
-msgstr "not used"
+msgstr ""
 
 msgid "not_tested"
 msgstr ""
 
 msgid "nothing connected"
-msgstr "nothing connected"
+msgstr ""
 
 msgid "of a DUAL layer medium used."
-msgstr "of a DUAL layer medium used."
+msgstr ""
 
 msgid "of a SINGLE layer medium used."
-msgstr "of a SINGLE layer medium used."
+msgstr ""
 
 msgid "off"
-msgstr "off"
+msgstr ""
 
 msgid "off or wpa2 on"
 msgstr ""
 
 msgid "offset is"
-msgstr "offset is"
+msgstr ""
 
 msgid "on"
-msgstr "on"
+msgstr ""
 
 msgid "on READ ONLY medium."
-msgstr "on READ ONLY medium."
+msgstr ""
 
-#, fuzzy
 msgid "on how to restore the image"
-msgstr "Do you want to remove the package:\n"
+msgstr ""
 
 msgid "once"
-msgstr "once"
+msgstr ""
 
 msgid "only HD"
-msgstr "only HD"
+msgstr ""
 
 msgid "only in Standby"
 msgstr ""
@@ -21246,53 +20524,52 @@ msgid "openATV"
 msgstr ""
 
 msgid "original"
-msgstr "original"
+msgstr ""
 
 msgid "original language"
-msgstr "original language"
+msgstr ""
 
 msgid "oscam webif disabled"
 msgstr ""
 
 msgid "packages selected."
-msgstr "packages selected."
+msgstr ""
 
 msgid "page left"
-msgstr "page left"
+msgstr ""
 
 msgid "pass"
-msgstr "pass"
+msgstr ""
 
 msgid "performing arts"
-msgstr "performing arts"
+msgstr ""
 
 msgid "picons"
 msgstr ""
 
 msgid "pid:"
-msgstr "pid:"
+msgstr ""
 
-#, fuzzy
 msgid "play Files"
-msgstr "Copying files"
+msgstr ""
 
 msgid "play as picture in picture"
-msgstr "play as picture in picture"
+msgstr ""
 
 msgid "play in mainwindow"
-msgstr "play in main window"
+msgstr ""
 
 msgid "play/show Files"
 msgstr ""
 
 msgid "please press OK when ready"
-msgstr "please press OK when ready"
+msgstr ""
 
 msgid "please wait, loading picture..."
-msgstr "please wait, loading picture..."
+msgstr ""
 
 msgid "please wait..."
-msgstr "please wait..."
+msgstr ""
 
 msgid "pli"
 msgstr ""
@@ -21301,26 +20578,28 @@ msgid "pm"
 msgstr ""
 
 msgid "popular culture/traditional arts"
-msgstr "popular culture/traditional arts"
+msgstr ""
 
 msgid "pre-school children's program"
-msgstr "pre-school children's program"
+msgstr ""
 
 msgid "press the menu button to set a general AC3/Dolby offset"
 msgstr ""
 
-#, fuzzy
 msgid "previous channel page"
-msgstr "Goto previous channel"
+msgstr ""
+
+msgid "previous/next Bouquet"
+msgstr ""
 
 msgid "previous/next Page"
 msgstr ""
 
 msgid "provid:"
-msgstr "provid:"
+msgstr ""
 
 msgid "provider:"
-msgstr "provider:"
+msgstr ""
 
 msgid "purge deleted userbouquets"
 msgstr ""
@@ -21338,48 +20617,47 @@ msgid "real recordings or streaming"
 msgstr ""
 
 msgid "reboot system"
-msgstr "reboot system"
+msgstr ""
 
 msgid "record"
-msgstr "record"
+msgstr ""
 
 #, python-format
 msgid "record time changed, start prepare is now: %s"
 msgstr ""
 
 msgid "recording..."
-msgstr "recording..."
+msgstr ""
 
 msgid "red"
-msgstr "red"
+msgstr ""
 
-#, fuzzy
 msgid "reliable"
-msgstr "enable"
+msgstr ""
 
 msgid "reliable, retune"
 msgstr ""
 
 msgid "religion"
-msgstr "religion"
+msgstr ""
 
 msgid "remarkable people"
-msgstr "remarkable people"
+msgstr ""
 
 msgid "remove after this position"
-msgstr "remove after this position"
+msgstr ""
 
 msgid "remove all alternatives"
-msgstr "remove all alternatives"
+msgstr ""
 
 msgid "remove all new found flags"
-msgstr "remove all new found flags"
+msgstr ""
 
 msgid "remove before this position"
-msgstr "remove before this position"
+msgstr ""
 
 msgid "remove bookmark"
-msgstr "remove bookmark"
+msgstr ""
 
 msgid "remove bouquet from parental protection"
 msgstr ""
@@ -21388,40 +20666,40 @@ msgid "remove cable services"
 msgstr ""
 
 msgid "remove directory"
-msgstr "remove directory"
+msgstr ""
 
 msgid "remove entry"
-msgstr "remove entry"
+msgstr ""
 
 msgid "remove from parental protection"
-msgstr "remove from parental protection"
+msgstr ""
 
 msgid "remove new found flag"
-msgstr "remove new found flag"
+msgstr ""
 
 msgid "remove selected satellite"
-msgstr "remove selected satellite"
+msgstr ""
 
 msgid "remove terrestrial services"
 msgstr ""
 
 msgid "remove this mark"
-msgstr "remove this mark"
+msgstr ""
 
 msgid "rename"
-msgstr "rename"
+msgstr ""
 
 msgid "rename entry"
-msgstr "rename entry"
+msgstr ""
 
 msgid "repeat playlist"
-msgstr "repeat playlist"
+msgstr ""
 
 msgid "repeated"
-msgstr "repeated"
+msgstr ""
 
 msgid "restart GUI"
-msgstr "restart GUI"
+msgstr ""
 
 msgid "restore deleted userbouquets"
 msgstr ""
@@ -21430,28 +20708,28 @@ msgid "restoring satellites.xml not possible!"
 msgstr ""
 
 msgid "reverse by date"
-msgstr "reverse by date"
+msgstr ""
 
 msgid "rewind to the previous chapter"
-msgstr "rewind to the previous chapter"
+msgstr ""
 
 msgid "rgb"
 msgstr ""
 
 msgid "right"
-msgstr "right"
+msgstr ""
 
 msgid "right, wrapped"
 msgstr ""
 
 msgid "rock/pop"
-msgstr "rock/pop"
+msgstr ""
 
 msgid "romance"
-msgstr "romance"
+msgstr ""
 
 msgid "running..."
-msgstr "running..."
+msgstr ""
 
 msgid ""
 "satellites.xml not found or corrupted!\n"
@@ -21464,20 +20742,19 @@ msgid "save"
 msgstr ""
 
 msgid "save last directory on exit"
-msgstr "save last directory on exit"
+msgstr ""
 
 msgid "save playlist on exit"
-msgstr "save playlist on exit"
+msgstr ""
 
-#, fuzzy
 msgid "scan new"
-msgstr "scan state"
+msgstr ""
 
 msgid "scan state"
-msgstr "scan state"
+msgstr ""
 
 msgid "science fiction/fantasy/horror"
-msgstr "science fiction/fantasy/horror"
+msgstr ""
 
 msgid "script 'sterr':"
 msgstr ""
@@ -21495,138 +20772,136 @@ msgid "second cable of motorized LNB"
 msgstr "second cable of motorised LNB"
 
 msgid "seconds"
-msgstr "seconds"
+msgstr ""
 
 msgid "security"
 msgstr ""
 
 msgid "select"
-msgstr "select"
+msgstr ""
 
 msgid "select CAId's"
-msgstr "select CAId's"
+msgstr ""
 
 msgid "select channels to add a offset to the Volume"
 msgstr ""
 
 msgid "select menu entry"
-msgstr "select menu entry"
+msgstr ""
 
 msgid "serious music/classic music"
-msgstr "serious music/classic music"
+msgstr ""
 
 msgid "serious/classical/religious/historical movie/drama"
-msgstr "serious/classical/religious/historical movie/drama"
+msgstr ""
 
 msgid "service PIN"
-msgstr "service PIN"
+msgstr ""
 
 msgid "set as startup service"
-msgstr "set as startup service"
+msgstr ""
 
 msgid "settings"
 msgstr ""
 
 msgid "share:"
-msgstr "share:"
+msgstr ""
 
 msgid "shell"
 msgstr ""
 
-#, fuzzy
 msgid "show"
-msgstr "talk show"
+msgstr ""
 
 msgid "show DVD main menu"
-msgstr "show DVD main menu"
+msgstr ""
 
 msgid "show EPG..."
-msgstr "show EPG…"
+msgstr ""
 
 msgid "show all cards"
-msgstr "show all cards"
+msgstr ""
 
 msgid "show all tags"
-msgstr "show all tags"
+msgstr ""
 
 msgid "show alternatives"
-msgstr "show alternatives"
+msgstr ""
 
 msgid "show cards with uphop 0"
-msgstr "show cards with uphop 0"
+msgstr ""
 
 msgid "show cards with uphop 1"
-msgstr "show cards with uphop 1"
+msgstr ""
 
 msgid "show cards with uphop 2"
-msgstr "show cards with uphop 2"
+msgstr ""
 
 msgid "show cards with uphop 3"
-msgstr "show cards with uphop 3"
+msgstr ""
 
 msgid "show cards with uphop 4"
-msgstr "show cards with uphop 4"
+msgstr ""
 
 msgid "show cards with uphop 5"
-msgstr "show cards with uphop 5"
+msgstr ""
 
 msgid "show cards with uphop 6"
-msgstr "show cards with uphop 6"
+msgstr ""
 
 msgid "show cards with uphop 7"
-msgstr "show cards with uphop 7"
+msgstr ""
 
 msgid "show cards with uphop 8"
-msgstr "show cards with uphop 8"
+msgstr ""
 
 msgid "show cards with uphop 9"
-msgstr "show cards with uphop 9"
+msgstr ""
 
 msgid "show event details"
-msgstr "show event details"
+msgstr ""
 
 msgid "show mediaplayer on mainmenu"
-msgstr "show media player on main menu"
+msgstr ""
 
-#, fuzzy
 msgid "show picons in quickzap"
-msgstr "show picons in service list"
+msgstr ""
 
 msgid "show picons in service list"
-msgstr "show picons in service list"
+msgstr ""
 
 msgid "show program information..."
-msgstr "show program information..."
+msgstr ""
 
 msgid "show transponder info"
-msgstr "show transponder info"
+msgstr ""
 
 msgid "show/game show (general)"
-msgstr "show/game show (general)"
+msgstr ""
 
 msgid "shuffle"
-msgstr "shuffle"
+msgstr ""
 
 msgid "shut down"
-msgstr "shut down"
+msgstr ""
 
 msgid "simple"
-msgstr "simple"
+msgstr ""
 
 msgid "skin"
 msgstr ""
 
 msgid "skip backward"
-msgstr "skip backward"
+msgstr ""
 
 msgid "skip backward (enter time)"
-msgstr "skip backward (enter time)"
+msgstr ""
 
 msgid "skip forward"
-msgstr "skip forward"
+msgstr ""
 
 msgid "skip forward (enter time)"
-msgstr "skip forward (enter time)"
+msgstr ""
 
 #, python-format
 msgid "slot%s - %s"
@@ -21640,98 +20915,90 @@ msgstr ""
 msgid "slot%s - %s (current image)"
 msgstr ""
 
-#, python-format
 msgid "slot%s - %s - %s "
 msgstr ""
 
 #, python-format
+msgid "slot%s - %s as USB Recovery"
+msgstr ""
+
 msgid "slot%s - %s - %s (current image)"
 msgstr ""
 
-#, python-format
 msgid "slot%s - %s - %s as USB Recovery"
 msgstr ""
 
-#, python-format
 msgid "slot%s - %s mode 1"
 msgstr ""
 
-#, python-format
 msgid "slot%s - %s mode 1 (current image)"
 msgstr ""
 
-#, python-format
 msgid "slot%s - %s mode 12"
 msgstr ""
 
-#, python-format
 msgid "slot%s - %s mode 12 (current image)"
 msgstr ""
 
-#, python-format
 msgid "slot%s - %s- %s "
 msgstr ""
 
 msgid "slow"
-msgstr "slow"
+msgstr ""
 
 msgid "soap/melodrama/folkloric"
-msgstr "soap/melodrama/folkloric"
+msgstr ""
 
 msgid "social/political issues/economics (general)"
-msgstr "social/political issues/economics (general)"
+msgstr ""
 
 msgid "social/spiritual science"
-msgstr "social/spiritual science"
+msgstr ""
 
 msgid "softcams"
 msgstr ""
 
 msgid "sorting of playlists"
-msgstr "sorting of playlists"
+msgstr ""
 
-#, fuzzy
 msgid "special (general)"
-msgstr "sports (general)"
+msgstr ""
 
 msgid "special events"
-msgstr "special events"
+msgstr ""
 
-#, fuzzy
 msgid "sport (general)"
-msgstr "sports (general)"
+msgstr ""
 
 msgid "sports (general)"
-msgstr "sports (general)"
+msgstr ""
 
 msgid "sports magazine"
-msgstr "sports magazine"
+msgstr ""
 
 msgid "standard"
-msgstr "standard"
+msgstr ""
 
 msgid "start cut here"
-msgstr "start cut here"
+msgstr ""
 
 msgid "start directory"
-msgstr "start directory"
+msgstr ""
 
-#, fuzzy
 msgid "start recording"
-msgstr "Start recording?"
+msgstr ""
 
 msgid "stepsize"
-msgstr "stepsize"
+msgstr ""
 
 msgid "stereo"
-msgstr "stereo"
+msgstr ""
 
-#, fuzzy
 msgid "stop recording"
-msgstr "Stop recording"
+msgstr ""
 
 msgid "stop using as startup service"
-msgstr "stop using as startup service"
+msgstr ""
 
 msgid "successful"
 msgstr ""
@@ -21743,40 +21010,40 @@ msgid "switch Nand and SDcard"
 msgstr ""
 
 msgid "switch to bookmarks"
-msgstr "switch to bookmarks"
+msgstr ""
 
 msgid "switch to filelist"
-msgstr "switch to filelist"
+msgstr ""
 
 msgid "switch to the next angle"
-msgstr "switch to the next angle"
+msgstr ""
 
 msgid "switch to the next audio track"
-msgstr "switch to the next audio track"
+msgstr ""
 
 msgid "switch to the next subtitle language"
-msgstr "switch to the next subtitle language"
+msgstr ""
 
 msgid "system:"
-msgstr "system:"
+msgstr ""
 
 msgid "systemplugins"
 msgstr ""
 
 msgid "talk show"
-msgstr "talk show"
+msgstr ""
 
 msgid "team sports"
-msgstr "team sports"
+msgstr ""
 
 msgid "technology/natural science"
-msgstr "technology/natural science"
+msgstr ""
 
 msgid "template file"
-msgstr "template file"
+msgstr ""
 
 msgid "tennis/squash"
-msgstr "tennis/squash"
+msgstr ""
 
 msgid "this bouquet is protected by a parental control pin"
 msgstr ""
@@ -21785,32 +21052,31 @@ msgid "this offset will only be used if the channel has not its own volume offse
 msgstr ""
 
 msgid "this recording"
-msgstr "this recording"
+msgstr ""
 
 msgid "this service is protected by a parental control pin"
-msgstr "this service is protected by a parental control pin"
+msgstr ""
 
 msgid "to dir"
 msgstr ""
 
 msgid "toggle time, chapter, audio, subtitle info"
-msgstr "toggle time, chapter, audio, subtitle info"
+msgstr ""
 
 msgid "top"
-msgstr "top"
+msgstr ""
 
 msgid "tourism/travel"
-msgstr "tourism/travel"
+msgstr ""
 
-#, fuzzy
 msgid "traditional (fast)"
-msgstr "folk/traditional music"
+msgstr ""
 
 msgid "traditional (fast), retune"
 msgstr ""
 
 msgid "true"
-msgstr "true"
+msgstr ""
 
 msgid "turbo"
 msgstr ""
@@ -21819,36 +21085,34 @@ msgid "uShare"
 msgstr ""
 
 msgid "uShare Log"
-msgstr "uShare Log"
+msgstr ""
 
 msgid "uShare Name"
-msgstr "uShare Name"
+msgstr ""
 
 msgid "uShare Port"
-msgstr "uShare Port"
+msgstr ""
 
 msgid "uShare Setup"
-msgstr "uShare Setup"
+msgstr ""
 
 msgid "unavailable"
-msgstr "unavailable"
+msgstr ""
 
 msgid "unconfirmed"
-msgstr "unconfirmed"
+msgstr ""
 
-#, fuzzy
 msgid "unknow"
-msgstr "unknown"
+msgstr ""
 
 msgid "unknown"
-msgstr "unknown"
+msgstr ""
 
-#, fuzzy
 msgid "unknown error"
-msgstr "unknown service"
+msgstr ""
 
 msgid "unknown service"
-msgstr "unknown service"
+msgstr ""
 
 msgid "unpack Rar Files"
 msgstr ""
@@ -21866,25 +21130,22 @@ msgid "unpack zip Files"
 msgstr ""
 
 msgid "unpublished"
-msgstr "unpublished"
+msgstr ""
 
-#, fuzzy
 msgid "untestable"
-msgstr "Enable"
+msgstr ""
 
 msgid "until standby/restart"
-msgstr "until standby/restart"
+msgstr ""
 
-#, fuzzy
 msgid "update"
-msgstr "Update"
+msgstr ""
 
 msgid "updates available."
-msgstr "updates available."
+msgstr ""
 
-#, fuzzy
 msgid "upper line"
-msgstr "One line"
+msgstr ""
 
 msgid "use best / controlled by HDMI"
 msgstr ""
@@ -21896,26 +21157,25 @@ msgid "use_hdmi_cacenter"
 msgstr ""
 
 msgid "user defined"
-msgstr "user defined"
+msgstr ""
 
 msgid "user feed url"
 msgstr ""
 
-#, fuzzy
 msgid "userdefined"
-msgstr "user defined"
+msgstr ""
 
 msgid "using:"
-msgstr "using:"
+msgstr ""
 
 msgid "variety show"
-msgstr "variety show"
+msgstr ""
 
 msgid "vertical"
-msgstr "vertical"
+msgstr ""
 
 msgid "view extensions..."
-msgstr "view extensions..."
+msgstr ""
 
 msgid "violet"
 msgstr ""
@@ -21924,49 +21184,46 @@ msgid "vix"
 msgstr ""
 
 msgid "wait for mmi..."
-msgstr "wait for mmi..."
+msgstr ""
 
 msgid "waiting"
-msgstr "waiting"
+msgstr ""
 
 msgid "wakeup"
-msgstr "wakeup"
+msgstr ""
 
 msgid "wakeup to standby"
-msgstr "wakeup to standby"
+msgstr ""
 
 msgid "water sport"
-msgstr "water sport"
+msgstr ""
 
 msgid "weblinks"
 msgstr ""
 
 msgid "weekly"
-msgstr "weekly"
+msgstr ""
 
 msgid "west"
-msgstr "west"
+msgstr ""
 
 msgid "when asking question about this log"
-msgstr "when asking question about this log"
+msgstr ""
 
 msgid ""
 "when asking question about this log\n"
 "\n"
 "A copy has been sent to yourself."
 msgstr ""
-"when asking question about this log\n"
-"\n"
-"A copy has been sent to yourself."
 
 msgid "white"
-msgstr "white"
+msgstr ""
 
 msgid "wide"
 msgstr ""
 
 msgid "width"
-msgstr "width"
+msgstr ""
 
 msgid "will take about 1-15 minutes for this system\n"
 msgstr ""
@@ -21975,69 +21232,65 @@ msgid "will take about 30 minutes for this system\n"
 msgstr ""
 
 msgid "winter sport"
-msgstr "winter sport"
+msgstr ""
 
 msgid "wireless network interface"
-msgstr "wireless network interface"
+msgstr ""
 
 #, python-format
 msgid "with %d error"
 msgid_plural "with %d errors"
-msgstr[0] "with %d error"
-msgstr[1] "with %d errors"
+msgstr[0] ""
+msgstr[1] ""
 
-#, fuzzy
 msgid "with errors"
-msgstr "with %d error"
+msgstr ""
 
 msgid "with exit button"
-msgstr "with exit button"
+msgstr ""
 
 msgid "with left/right buttons"
-msgstr "with left/right buttons"
+msgstr ""
 
 msgid "with long OK press"
-msgstr "with long OK press"
+msgstr ""
 
-#, fuzzy
 msgid "with_errors"
-msgstr "with %d error"
+msgstr ""
 
-#, fuzzy
 msgid "without"
-msgstr "Without popup"
+msgstr ""
 
 msgid "without Query"
 msgstr ""
 
 msgid "working"
-msgstr "working"
+msgstr ""
 
 msgid "yellow"
-msgstr "yellow"
+msgstr ""
 
 msgid "yes"
-msgstr "yes"
+msgstr ""
 
 msgid "yes (keep feeds)"
-msgstr "yes (keep feeds)"
+msgstr ""
 
 #, python-format
 msgid "your %s %s might be unusable now. Please consult the manual for further assistance before rebooting your %s %s."
 msgstr ""
 
 msgid "zap"
-msgstr "zap"
+msgstr ""
 
 msgid "zap and record"
-msgstr "zap and record"
+msgstr ""
 
 msgid "zapped"
-msgstr "zapped"
+msgstr ""
 
-#, fuzzy
 msgid "zapping"
-msgstr "zapped"
+msgstr ""
 
 #~ msgid "%d job is running in the background!"
 #~ msgid_plural "%d jobs are running in the background!"


### PR DESCRIPTION
This change:
- uses plain (or at least more plain) English,
  transitioning technical terms to more everyday, user-friendly wording
- fixes typos and grammatical issues
- keeps Americanizations within en_US (en.po), and Intl English in en_GB
- makes capiltalisation, hyphenation, abbreviations and acronyms
  more consistent across menus, option lables and descriptions
- makes terms more consistent (eg. key -> button; rotor/motor -> dish rotator)
- makes option descriptions more consistent
  ('If set to yes'..., 'This option lets you...', 'Configure...' etc.)
- adds a couple of enhanced descriptions (eg. technical terms)
- removed all 'Fuzzy' entries from en_GB and several from en_US (en.po)

Yet to be done includes:
- date formatting

Not part of this work:
- changes to enigma2.pot translation entry template file
- changes to source code

This is very likely still incomplete!
There are some known '# needs improvement' entries