### PR TITLE
Do not use list as variable in ConfigList

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -18,7 +18,7 @@ class ConfigList(HTMLComponent, GUIComponent, object):
 		height, space = skin.parameters.get("ConfigListSlider", (17, 0))
 		self.l.setSlider(height, space)
 		self.timer = eTimer()
-		self.list = list
+		self.configList = list
 		self.onSelectionChanged = [ ]
 		self.current = None
 		self.session = session
@@ -111,7 +111,7 @@ class ConfigList(HTMLComponent, GUIComponent, object):
 
 	def isChanged(self):
 		is_changed = False
-		for x in self.list:
+		for x in self.configList:
 			is_changed |= x[1].isChanged()
 
 		return is_changed


### PR DESCRIPTION
This fix error on ConfigList init.

For example in plugin YouTube init I get error:
    ConfigListScreen.__init__(self, searchList, session)
  File "/usr/lib/enigma2/python/Components/ConfigList.py", line 176, in __init__
    self["config"] = ConfigList(list, session = session)
  File "/usr/lib/enigma2/python/Components/ConfigList.py", line 21, in __init__
    self.list = _list
  File "/usr/lib/enigma2/python/Components/ConfigList.py", line 102, in setList
    assert len(x) < 2 or isinstance(x[1], ConfigElement), "entry in ConfigList " + str(x[1]) + " must be a ConfigElement"
AssertionError: entry in ConfigList None must be a ConfigElement