### PR TITLE
No truncate SHORT_EVENT_DESCRIPTOR text for UTF8

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -232,8 +232,8 @@ eventData::eventData(const eit_event_struct* e, int size, int _type, int tsidoni
 						*pdescr++ = title_crc;
 					}
 
-					//save text with original encoding
-					if( eventTextLen > 0 ) //only store the data if there is something to store 
+					//save the text with original encoding
+					if( eventTextLen > 0 ) //only store the data if there is something to store
 					{
 						int text_len = 6 + eventTextLen;
 						uint8_t *text_data = new uint8_t[text_len + 2];

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -190,9 +190,7 @@ eventData::eventData(const eit_event_struct* e, int size, int _type, int tsidoni
 
 					//convert our strings to UTF8
 					std::string eventNameUTF8 = convertDVBUTF8((const unsigned char*)&descr[6], eventNameLen, table, tsidonid);
-					std::string textUTF8 = convertDVBUTF8((const unsigned char*)&descr[7 + eventNameLen], eventTextLen, table, tsidonid);
 					unsigned int eventNameUTF8len = eventNameUTF8.length();
-					unsigned int textUTF8len = textUTF8.length();
 
 					//Rebuild the short event descriptor with UTF-8 strings
 
@@ -234,11 +232,10 @@ eventData::eventData(const eit_event_struct* e, int size, int _type, int tsidoni
 						*pdescr++ = title_crc;
 					}
 
-					//save the text
-					if( textUTF8len > 0 ) //only store the data if there is something to store
+					//save text with original encoding
+					if( eventTextLen > 0 ) //only store the data if there is something to store 
 					{
-						textUTF8len = truncateUTF8(textUTF8, 255 - 6);
-						int text_len = 6 + textUTF8len;
+						int text_len = 6 + eventTextLen;
 						uint8_t *text_data = new uint8_t[text_len + 2];
 						text_data[0] = SHORT_EVENT_DESCRIPTOR;
 						text_data[1] = text_len;
@@ -246,9 +243,8 @@ eventData::eventData(const eit_event_struct* e, int size, int _type, int tsidoni
 						text_data[3] = descr[3];
 						text_data[4] = descr[4];
 						text_data[5] = 0;
-						text_data[6] = textUTF8len + 1; //identify text as UTF-8
-						text_data[7] = 0x15; //identify text as UTF-8
-						memcpy(&text_data[8], textUTF8.data(), textUTF8len);
+						text_data[6] = eventTextLen;
+						memcpy(&text_data[7], &descr[7 + eventNameLen], eventTextLen);
 
 						text_len += 2; //add 2 the length to include the 2 bytes in the header
 						uint32_t text_crc = calculate_crc_hash(text_data, text_len);

--- a/lib/service/event.cpp
+++ b/lib/service/event.cpp
@@ -208,9 +208,9 @@ RESULT eServiceEvent::parseFrom(ATSCEvent *evt)
 
 RESULT eServiceEvent::parseFrom(const ExtendedTextTableSection *sct)
 {
-	m_short_description = sct->getMessage(m_language);
-	if (m_short_description.empty()) m_short_description = sct->getMessage(m_language_alternative);
-	if (m_short_description.empty()) m_short_description = sct->getMessage("");
+	m_short_description = convertDVBUTF8(sct->getMessage(m_language));
+	if (m_short_description.empty()) m_short_description = convertDVBUTF8(sct->getMessage(m_language_alternative));
+	if (m_short_description.empty()) m_short_description = convertDVBUTF8(sct->getMessage(""));
 	return 0;
 }
 


### PR DESCRIPTION
This problem is related to the fact that when saving information from SHORT_EVENT_DESCRIPTOR to the epg.dat cache file, it is transcoded to UTF-8. And since the information is initially transmitted in ISO 8859-5 encoding, in which the Cyrillic character is encoded in one byte - the standard field SHORT_EVENT_DESCRIPTOR of 255 - 6 bytes can contain text in 249 characters, in UTF-8 Cyrillic characters are encoded in two bytes and, accordingly, in the field SHORT_EVENT_DESCRIPTOR can fit approximately 125 Cyrillic characters, so that everything that is more than 249 bytes is truncated. In this patch, the text field is saved with the original encoding, and transcoding is performed when the text field is requested.

![Before patch](https://user-images.githubusercontent.com/66304649/88452202-75b47180-ce65-11ea-80ca-ae8bfb7108b7.jpg)
![After patch](https://user-images.githubusercontent.com/66304649/88452204-7a792580-ce65-11ea-8d47-5b3cb92818c2.jpg)
