### PR TITLE
[keymap.xml] Correct key assignments

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -120,8 +120,8 @@
 		<!-- Also uses NavigationActions -->
 		<!-- Also uses NumberActions -->
 		<!-- Also uses TextEditActions -->
-		<key id="KEY_RED" mapto="cancel" flags="m" />
-		<key id="KEY_GREEN" mapto="save" flags="m" />
+		<key id="KEY_RED" mapto="cancel" flags="b" /><!-- Use break to allow legacy code using make to override this assignment. -->
+		<key id="KEY_GREEN" mapto="save" flags="b" /><!-- Use break to allow legacy code using make to override this assignment. -->
 		<key id="KEY_EXIT" mapto="cancel" flags="b" />
 		<key id="KEY_EXIT" mapto="close" flags="l" />
 		<key id="KEY_OK" mapto="select" flags="m" />
@@ -132,8 +132,8 @@
 		<key id="KEY_PVR" mapto="menu" flags="m" />
 		<key id="KEY_VIDEO" mapto="menu" flags="m" />
 		<!-- Keyboard specific buttons -->
-		<key id="KEY_F1" mapto="cancel" flags="m" />
-		<key id="KEY_F2" mapto="save" flags="m" />
+		<key id="KEY_F5" mapto="cancel" flags="m" />
+		<key id="KEY_F6" mapto="save" flags="m" />
 		<key id="KEY_ESC" mapto="cancel" flags="b" />
 		<key id="KEY_ESC" mapto="close" flags="l" />
 		<key id="KEY_ENTER" mapto="select" flags="m" />


### PR DESCRIPTION
- Change "ConfigListActions" colour buttons from "m" (Make) to "b" (Break) to allow legacy code using "m" to override these assignments.
- Correct the keyboard function keys to match previous documentation. (RED = F5 -> BLUE = F8)
