### PR TITLE
Screen / Skin updates

### DIFF
--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -16,11 +16,12 @@ class Screen(dict):
 	ALLOW_SUSPEND = NO_SUSPEND
 	globalScreen = None
 
-	def __init__(self, session, parent=None):
+	def __init__(self, session, parent=None, mandatoryWidgets=None):
 		dict.__init__(self)
 		self.skinName = self.__class__.__name__
 		self.session = session
 		self.parent = parent
+		self.mandatoryWidgets = mandatoryWidgets
 		self.onClose = []
 		self.onFirstExecBegin = []
 		self.onExecBegin = []

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -282,3 +282,23 @@ class Screen(dict):
 	def removeSummary(self, summary):
 		if summary is not None:
 			self.summaries.remove(summary)
+
+
+class ScreenSummary(Screen):
+	skin = """
+	<screen position="fill" flags="wfNoBorder">
+		<widget source="global.CurrentTime" render="Label" position="0,0" size="e,20" font="Regular;16" halign="center" valign="center">
+			<convert type="ClockToText">WithSeconds</convert>
+		</widget>
+		<widget source="Title" render="Label" position="0,25" size="e,45" font="Regular;18" halign="center" valign="center" />
+	</screen>"""
+
+	def __init__(self, session, parent):
+		Screen.__init__(self, session, parent=parent)
+		self["Title"] = StaticText(parent.getTitle())
+		names = parent.skinName
+		if not isinstance(names, list):
+			names = [names]
+		self.skinName = ["%sSummary" % x for x in names]
+		self.skinName.append("ScreenSummary")
+		self.skin = parent.__dict__.get("skinSummary", self.skin)  # If parent has a "skinSummary" defined, use that as default.

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -144,7 +144,7 @@ class Screen(dict):
 	def getScreenPath(self):
 		return self.screenPath
 
-	def setTitle(self, title):
+	def setTitle(self, title, showPath=True):
 		try:  # This protects against calls to setTitle() before being fully initialised like self.session is accessed *before* being defined.
 			if self.session and len(self.session.dialog_stack) > 1:
 				self.screenPath = " > ".join(ds[0].getTitle() for ds in self.session.dialog_stack[1:])
@@ -156,10 +156,10 @@ class Screen(dict):
 		except AttributeError:
 			pass
 		self.screenTitle = title
-		if config.usage.showScreenPath.value == "large":
+		if showPath and config.usage.showScreenPath.value == "large":
 			screenPath = ""
 			screenTitle = "%s > %s" % (self.screenPath, title) if self.screenPath else title
-		elif config.usage.showScreenPath.value == "small":
+		elif showPath and config.usage.showScreenPath.value == "small":
 			screenPath = "%s >" % self.screenPath if self.screenPath else ""
 			screenTitle = title
 		else:

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -215,30 +215,23 @@ class Screen(dict):
 		self.__callLaterTimer.start(0, True)
 
 	def applySkin(self):
-		z = 0
 		# DEBUG: baseRes = (getDesktop(GUI_SKIN_ID).size().width(), getDesktop(GUI_SKIN_ID).size().height())
 		baseRes = (720, 576)  # FIXME: A skin might have set another resolution, which should be the base res.
-		idx = 0
-		skinTitleIndex = -1
-		title = self.title
+		zPosition = 0
 		for (key, value) in self.skinAttributes:
-			if key == "zPosition":
-				z = int(value)
-			elif key == "title":
-				skinTitleIndex = idx
-				if title:
-					self.skinAttributes[skinTitleIndex] = ("title", title)
-				else:
-					self["Title"].text = value
-					self.summaries.setTitle(value)
-			elif key == "baseResolution":
+			if key == "baseResolution":
 				baseRes = tuple([int(x) for x in value.split(",")])
-			idx += 1
+			elif key == "zPosition":
+				zPosition = int(value)
 		self.scale = ((baseRes[0], baseRes[0]), (baseRes[1], baseRes[1]))
 		if not self.instance:
-			self.instance = eWindow(self.desktop, z)
-		if skinTitleIndex == -1 and title:
-			self.skinAttributes.append(("title", title))
+			self.instance = eWindow(self.desktop, zPosition)
+		if "title" not in self.skinAttributes and self.screenTitle:
+			self.skinAttributes.append(("title", self.screenTitle))
+		else:
+			for attribute in self.skinAttributes:
+				if attribute[0] == "title":
+					self.setTitle(_(attribute[1]))
 		self.skinAttributes.sort(key=lambda a: {"position": 1}.get(a[0], 0))  # We need to make sure that certain attributes come last.
 		applyAllAttributes(self.instance, self.desktop, self.skinAttributes, self.scale)
 		self.createGUIScreen(self.instance, self.desktop)

--- a/skin.py
+++ b/skin.py
@@ -997,7 +997,11 @@ def readSkin(screen, skin, names, desktop):
 	if myScreen is None:  # Otherwise try embedded skin.
 		myScreen = getattr(screen, "parsedSkin", None)
 	if myScreen is None and getattr(screen, "skin", None):  # Try uncompiled embedded skin.
-		skin = screen.skin
+		if isinstance(screen.skin, list):
+			print("[Skin] Resizable embedded skin template found in '%s'." % name)
+			skin = screen.skin[0] % tuple([int(x * getSkinFactor()) for x in screen.skin[1:]])
+		else:
+			skin = screen.skin
 		print("[Skin] Parsing embedded skin '%s'." % name)
 		if isinstance(skin, tuple):
 			for s in skin:

--- a/skin.py
+++ b/skin.py
@@ -466,7 +466,7 @@ class AttributeParser:
 				"disable_onhide": 0x01
 			}[value])
 		except KeyError:
-			print "[Skin] Error: Invalid animationMode '%s'!  Must be one of 'disable', 'off', 'offshow', 'offhide', 'onshow' or 'onhide'." % value
+			print("[Skin] Error: Invalid animationMode '%s'!  Must be one of 'disable', 'off', 'offshow', 'offhide', 'onshow' or 'onhide'." % value)
 
 	def title(self, value):
 		self.guiObject.setTitle(_(value))


### PR DESCRIPTION
These updates bring openATV into sync with developments on the other main images.

[skin.py] Correct a print statement
- Correct a print statement to be ready for Python 3 that was missed in a previous change.

[skin.py] Enable processing of templated screens
- This code allows embedded screens to be a template of a screen scaled to HD resolution together with scaling data to allow that screen to be resized to the current GUI resolution.

[skin.py] Add skin screen validation code
- This option works in conjunction with a change in Screen.py to allow code to check if a screen in the skin is compatible with the code.  If the list of widgets considered mandatory are not present then the current screen will be rejected and the next option will be tested.  It is assumed that if all skin options are rejected that the embedded screen will be acceptable.

[Screen.py] Add facility for mandatory widgets
- This option works in conjunction with a change in Skin.py to allow code to check if a screen in the skin is compatible with the code.  If the list of widgets considered mandatory are not present then the current screen will be rejected and the next option will be tested.  It is assumed that if all skin options are rejected that the embedded screen will be acceptable.

[Screen.py] Add option to suppress screen path
- This option allows coders to suppress the normal screen path processing for a particular screen.  For example, some coders don't want MessageBoxes to have the full screen path.

[Screen.py] Optimise applySkin()
- Optimise the code for applySkin() to remove code that is not needed or unused.
- Ensure that the title text of embedded screens is translated.

[Screen.py] Add new display screen class
- This new class will be the core support from creating a uniform and distinct class for managing front panel displays.
