### PR TITLE
6.4 dev

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -120,8 +120,8 @@
 		<!-- Also uses NavigationActions -->
 		<!-- Also uses NumberActions -->
 		<!-- Also uses TextEditActions -->
-		<key id="KEY_RED" mapto="cancel" flags="m" />
-		<key id="KEY_GREEN" mapto="save" flags="m" />
+		<key id="KEY_RED" mapto="cancel" flags="b" /><!-- Use break to allow legacy code using make to override this assignment. -->
+		<key id="KEY_GREEN" mapto="save" flags="b" /><!-- Use break to allow legacy code using make to override this assignment. -->
 		<key id="KEY_EXIT" mapto="cancel" flags="b" />
 		<key id="KEY_EXIT" mapto="close" flags="l" />
 		<key id="KEY_OK" mapto="select" flags="m" />
@@ -132,8 +132,8 @@
 		<key id="KEY_PVR" mapto="menu" flags="m" />
 		<key id="KEY_VIDEO" mapto="menu" flags="m" />
 		<!-- Keyboard specific buttons -->
-		<key id="KEY_F1" mapto="cancel" flags="m" />
-		<key id="KEY_F2" mapto="save" flags="m" />
+		<key id="KEY_F5" mapto="cancel" flags="m" />
+		<key id="KEY_F6" mapto="save" flags="m" />
 		<key id="KEY_ESC" mapto="cancel" flags="b" />
 		<key id="KEY_ESC" mapto="close" flags="l" />
 		<key id="KEY_ENTER" mapto="select" flags="m" />

--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -557,7 +557,7 @@ int eDVBRecordFileThread::AsyncIO::poll()
 	if (r < 0)
 	{
 		aio.aio_buf = NULL;
-		eWarning("[eDVBRecordFileThread] poll: aio_return returned failure: %d %m", r);
+		eWarning("[eDVBRecordFileThread] poll: aio_return returned failure: %m");
 		return -1;
 	}
 	return 0;

--- a/lib/dvb/demux.h
+++ b/lib/dvb/demux.h
@@ -118,7 +118,7 @@ protected:
 		unsigned char* buffer;
 		AsyncIO()
 		{
-			memset(&aio, 0, sizeof(struct aiocb));
+			memset(&aio, 0, sizeof(aiocb));
 			buffer = NULL;
 		}
 		int wait();

--- a/lib/dvb/demux.h
+++ b/lib/dvb/demux.h
@@ -98,7 +98,7 @@ public:
 class eDVBRecordFileThread: public eFilePushThreadRecorder
 {
 public:
-	eDVBRecordFileThread(int packetsize, int bufferCount, int buffersize = -1);
+	eDVBRecordFileThread(int packetsize, int bufferCount, int buffersize = -1, bool sync_mode = false);
 	~eDVBRecordFileThread();
 	void setTimingPID(int pid, iDVBTSRecorder::timing_pid_type pidtype, int streamtype);
 	void startSaveMetaInformation(const std::string &filename);
@@ -129,6 +129,7 @@ protected:
 	eMPEGStreamParserTS m_ts_parser;
 	off_t m_current_offset;
 	int m_fd_dest;
+	bool m_sync_mode;
 	typedef std::vector<AsyncIO> AsyncIOvector;
 	unsigned char* m_allocated_buffer;
 	AsyncIOvector m_aio;
@@ -139,7 +140,7 @@ protected:
 class eDVBRecordStreamThread: public eDVBRecordFileThread
 {
 public:
-	eDVBRecordStreamThread(int packetsize, int buffersize = -1);
+	eDVBRecordStreamThread(int packetsize, int buffersize = -1, bool sync_mode = false);
 
 protected:
 	int writeData(int len);

--- a/lib/dvb/demux.h
+++ b/lib/dvb/demux.h
@@ -98,7 +98,7 @@ public:
 class eDVBRecordFileThread: public eFilePushThreadRecorder
 {
 public:
-	eDVBRecordFileThread(int packetsize, int bufferCount);
+	eDVBRecordFileThread(int packetsize, int bufferCount, int buffersize = -1);
 	~eDVBRecordFileThread();
 	void setTimingPID(int pid, iDVBTSRecorder::timing_pid_type pidtype, int streamtype);
 	void startSaveMetaInformation(const std::string &filename);
@@ -139,7 +139,7 @@ protected:
 class eDVBRecordStreamThread: public eDVBRecordFileThread
 {
 public:
-	eDVBRecordStreamThread(int packetsize);
+	eDVBRecordStreamThread(int packetsize, int buffersize = -1);
 
 protected:
 	int writeData(int len);

--- a/lib/dvb/encoder.cpp
+++ b/lib/dvb/encoder.cpp
@@ -90,9 +90,22 @@ int eEncoder::allocateEncoder(const std::string &serviceref, int &buffersize,
 	int encoder_index;
 	char filename[128];
 	std::string source_file;
+	const char *vcodec_node;
+	const char *acodec_node;
 
 	eDebug("[eEncoder] allocateEncoder serviceref=%s bitrate=%d width=%d height=%d vcodec=%s acodec=%s",
 			serviceref.c_str(), bitrate, width, height, vcodec.c_str(), acodec.c_str());
+
+	if(bcm_encoder)
+	{
+		vcodec_node = "video_codec";
+		acodec_node = "audio_codec";
+	}
+	else
+	{
+		vcodec_node = "vcodec";
+		acodec_node = "acodec";
+	}
 
 	// extract file path from serviceref, this is needed for Broadcom transcoding
 	if(serviceref.compare(0, sizeof(fileref) - 1, std::string(fileref), 0, std::string::npos) == 0)
@@ -121,6 +134,19 @@ int eEncoder::allocateEncoder(const std::string &serviceref, int &buffersize,
 	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/height", encoder_index);
 	CFile::writeInt(filename, height);
 
+	if(bcm_encoder)
+	{
+		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/display_format", encoder_index);
+
+		if(height > 576)
+			CFile::write(filename, "720p");
+		else
+			if(height > 480)
+				CFile::write(filename, "576p");
+			else
+				CFile::write(filename, "480p");
+	}
+
 	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/framerate", encoder_index);
 	CFile::writeInt(filename, framerate);
 
@@ -132,20 +158,20 @@ int eEncoder::allocateEncoder(const std::string &serviceref, int &buffersize,
 
 	if(!vcodec.empty())
 	{
-		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/vcodec_choices", encoder_index);
+		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/%s_choices", encoder_index, vcodec_node);
 		if (CFile::contains_word(filename, vcodec))
 		{
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/vcodec", encoder_index);
+			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/%s", encoder_index, vcodec_node);
 			CFile::write(filename, vcodec.c_str());
 		}
 	}
 
 	if(!acodec.empty())
 	{
-		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/acodec_choices", encoder_index);
+		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/%s_choices", encoder_index, acodec_node);
 		if (CFile::contains_word(filename, acodec))
 		{
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/acodec", encoder_index);
+			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/%s", encoder_index, acodec_node);
 			CFile::write(filename, acodec.c_str());
 		}
 	}

--- a/lib/dvb/encoder.cpp
+++ b/lib/dvb/encoder.cpp
@@ -42,7 +42,7 @@ eEncoder::eEncoder()
 		 * The Broadcom transcoding engine does not transfer the data to the encoder
 		 * itself, so we need to start a thread to do that. Therefore there is no
 		 * use to connect a (valid) decoder device. Even more it won't work because
-		 * we can't open de encoder when more than two (main, PiP) decoders are in
+		 * we can't open the encoder when more than two (main, PiP) decoders are in
 		 * use. The encoder is reported as "busy" then. That's why we use dummy values
 		 * here (4 onwards).
 		 *

--- a/lib/dvb/encoder.cpp
+++ b/lib/dvb/encoder.cpp
@@ -263,12 +263,15 @@ int eEncoder::getUsedEncoderCount()
 
 void eEncoder::navigation_event(int encoder_index, int event)
 {
+	eDebug("[eEncoder] navigation event: %d %d", encoder_index, event);
+
 	if((encoder_index < 0) || (encoder_index >= (int)encoder.size()))
 		return;
 
 	if(event == eDVBServicePMTHandler::eventTuned)
 	{
 		if(encoder[encoder_index].state == encoder_t::state_wait_pmt)
+		eDebug("[eEncoder] navigation event tuned: %d %d", encoder_index, event);
 		{
 			ePtr<iPlayableService> service;
 			ePtr<iTapService> tservice;
@@ -332,14 +335,10 @@ void eEncoder::navigation_event_1(int event)
 
 void eEncoder::encoder_t::thread(void)
 {
-	eDebug("[eEncoder] start encoder thread");
-
 	hasStarted();
 
 	if(ioctl(fd, IOCTL_BROADCOM_START_TRANSCODING, 0))
 		eWarning("[eEncoder] thread encoder failed");
-
-	eDebug("[eEncoder] thread encoder done %d", encoder);
 }
 
 eAutoInitPtr<eEncoder> init_eEncoder(eAutoInitNumbers::service + 1, "Encoders");

--- a/lib/dvb/encoder.cpp
+++ b/lib/dvb/encoder.cpp
@@ -82,8 +82,9 @@ eEncoder::~eEncoder()
 	instance = nullptr;
 }
 
-// FIXME: const
-int eEncoder::allocateEncoder(const std::string &serviceref, const int bitrate, const int width, const int height, const int framerate, const int interlaced, const int aspectratio, int &buffersize, const std::string &vcodec, const std::string &acodec)
+int eEncoder::allocateEncoder(const std::string &serviceref,
+		int bitrate, int width, int height, int framerate, int interlaced, int aspectratio,
+		const std::string &vcodec, const std::string &acodec)
 {
 	int encoder_index;
 	char filename[128];

--- a/lib/dvb/encoder.cpp
+++ b/lib/dvb/encoder.cpp
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/ioctl.h>
 
 #include <lib/base/eerror.h>
 #include <lib/base/init.h>
@@ -12,6 +13,7 @@
 #include <lib/base/cfile.h>
 #include <lib/nav/core.h>
 #include <lib/dvb/encoder.h>
+#include <lib/dvb/pmt.h>
 #include <lib/service/service.h>
 
 DEFINE_REF(eEncoder);
@@ -25,113 +27,319 @@ eEncoder *eEncoder::getInstance()
 
 eEncoder::eEncoder()
 {
-	instance = this;
+	int decoder_index;
 	ePtr<iServiceHandler> service_center;
+	eNavigation *navigation_instance;
+
+	instance = this;
 	eServiceCenter::getInstance(service_center);
-	if (service_center)
+
+	if(service_center)
 	{
-		int index = 0;
-		while (1)
+		bcm_encoder = bool(CFile("/dev/bcm_enc0", "r"));
+
+		/*
+		 * The Broadcom transcoding engine does not transfer the data to the encoder
+		 * itself, so we need to start a thread to do that. Therefore there is no
+		 * use to connect a (valid) decoder device. Even more it won't work because
+		 * we can't open de encoder when more than two (main, PiP) decoders are in
+		 * use. The encoder is reported as "busy" then. That's why we use dummy values
+		 * here (4 onwards).
+		 *
+		 * OTOH the "xtrend" transcoding engine has the video decoder connected to
+		 * the selected encoder internally. So we need to use the right decoder,
+		 * connected to the selected encoder. This is usually 2 -> 0, 3 -> 1.
+		 */
+
+		for(int index = 0; index < 4; index++) // increase this if machines appear with more than 4 encoding engines
 		{
-			int decoderindex;
-			char filename[256];
+			char filename[64];
+
 			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/decoder", index);
-			if (CFile::parseInt(&decoderindex, filename) < 0) break;
-			navigationInstances.push_back(new eNavigation(service_center, decoderindex));
-			encoderUser.push_back(-1);
-			index++;
+
+			if (CFile::parseInt(&decoder_index, filename) < 0)
+				break;
+
+			if(bcm_encoder)
+				decoder_index = index + 4;
+
+			if((navigation_instance = new eNavigation(service_center, decoder_index)) == nullptr)
+				break;
+
+			encoder.push_back(encoder_t(index, decoder_index, navigation_instance));
 		}
 	}
 }
 
 eEncoder::~eEncoder()
 {
-	instance = NULL;
+	for(int encoder_index = 0; encoder_index < (int)encoder.size(); encoder_index++)
+	{
+		encoder[encoder_index].state = encoder_t::state_destroyed;
+		encoder[encoder_index].navigation_instance = nullptr; /* apparently we're not allowed to delete */
+	}
+
+	instance = nullptr;
 }
 
-int eEncoder::allocateEncoder(const std::string &serviceref, const int bitrate, const int width, const int height, const int framerate, const int interlaced, const int aspectratio, const std::string &vcodec, const std::string &acodec)
+// FIXME: const
+int eEncoder::allocateEncoder(const std::string &serviceref, const int bitrate, const int width, const int height, const int framerate, const int interlaced, const int aspectratio, int &buffersize, const std::string &vcodec, const std::string &acodec)
 {
-	unsigned int i;
+	int encoder_index;
 	int encoderfd = -1;
-	for (i = 0; i < encoderUser.size(); i++)
-	{
-		if (encoderUser[i] < 0)
-		{
-			char filename[128];
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/bitrate", i);
-			CFile::writeInt(filename, bitrate);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/width", i);
-			CFile::writeInt(filename, width);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/height", i);
-			CFile::writeInt(filename, height);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/framerate", i);
-			CFile::writeInt(filename, framerate);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/interlaced", i);
-			CFile::writeInt(filename, interlaced);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/aspectratio", i);
-			CFile::writeInt(filename, aspectratio);
-			if (!vcodec.empty())
-			{
-				snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/vcodec_choices", i);
-				if (CFile::contains_word(filename, vcodec))
-				{
-					snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/vcodec", i);
-					CFile::write(filename, vcodec.c_str());
-				}
-			}
-			if (!acodec.empty())
-			{
-				snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/acodec_choices", i);
-				if (CFile::contains_word(filename, acodec))
-				{
-					snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/acodec", i);
-					CFile::write(filename, acodec.c_str());
-				}
-			}
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/apply", i);
-			CFile::writeInt(filename, 1);
-			if (navigationInstances[i]->playService(serviceref) >= 0)
-			{
-				snprintf(filename, sizeof(filename), "/dev/encoder%d", i);
-				encoderfd = open(filename, O_RDONLY);
-				encoderUser[i] = encoderfd;
-			}
+	char filename[128];
+
+	eDebug("[eEncoder] allocateEncoder serviceref=%s bitrate=%d width=%d height=%d vcodec=%s acodec=%s",
+			serviceref.c_str(), bitrate, width, height, vcodec.c_str(), acodec.c_str());
+
+	for(encoder_index = 0; encoder_index < (int)encoder.size(); encoder_index++)
+		if(encoder[encoder_index].state == encoder_t::state_idle)
 			break;
+
+	if(encoder_index >= (int)encoder.size())
+	{
+		eWarning("[eEncoder] no encoders free");
+		return(-1);
+	}
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/bitrate", encoder_index);
+	CFile::writeInt(filename, bitrate);
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/width", encoder_index);
+	CFile::writeInt(filename, width);
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/height", encoder_index);
+	CFile::writeInt(filename, height);
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/framerate", encoder_index);
+	CFile::writeInt(filename, framerate);
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/interlaced", encoder_index);
+	CFile::writeInt(filename, interlaced);
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/aspectratio", encoder_index);
+	CFile::writeInt(filename, aspectratio);
+
+	if(!vcodec.empty())
+	{
+		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/vcodec_choices", encoder_index);
+		if (CFile::contains_word(filename, vcodec))
+		{
+			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/vcodec", encoder_index);
+			CFile::write(filename, vcodec.c_str());
 		}
 	}
-	return encoderfd;
+
+	if(!acodec.empty())
+	{
+		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/acodec_choices", encoder_index);
+		if (CFile::contains_word(filename, acodec))
+		{
+			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/acodec", encoder_index);
+			CFile::write(filename, acodec.c_str());
+		}
+	}
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/apply", encoder_index);
+	CFile::writeInt(filename, 1);
+
+	if(encoder[encoder_index].navigation_instance->playService(serviceref) < 0)
+	{
+		eWarning("[eEncoder] navigation->playservice failed");
+		return(-1);
+	}
+
+	snprintf(filename, sizeof(filename), "/dev/%s%d", bcm_encoder ? "bcm_enc" : "encoder", encoder_index);
+
+	if((encoderfd = open(filename, bcm_encoder ? O_RDWR : O_RDONLY)) < 0)
+	{
+		eWarning("[eEncoder] open encoder failed");
+		return(-1);
+	}
+
+	encoder[encoder_index].fd = encoderfd;
+
+	if(bcm_encoder)
+	{
+		buffersize = 188 * 256; /* broadcom magic value */
+		encoder[encoder_index].state = encoder_t::state_wait_pmt;
+
+		switch(encoder_index)
+		{
+			case(0):
+			{
+				encoder[encoder_index].navigation_instance->connectEvent(sigc::mem_fun(*this, &eEncoder::navigation_event_0), m_nav_event_connection_0);
+				break;
+			}
+
+			case(1):
+			{
+				encoder[encoder_index].navigation_instance->connectEvent(sigc::mem_fun(*this, &eEncoder::navigation_event_1), m_nav_event_connection_1);
+				break;
+			}
+
+			default:
+			{
+				eWarning("[eEncoder] only encoder 0 and encoder 1 implemented");
+				break;
+			}
+		}
+	}
+	else
+	{
+		buffersize = -1;
+		encoder[encoder_index].state = encoder_t::state_running;
+	}
+
+	return(encoderfd);
 }
 
 void eEncoder::freeEncoder(int encoderfd)
 {
-	unsigned int i;
-	for (i = 0; i < encoderUser.size(); i++)
+	int encoder_index;
+	ePtr<iPlayableService> service;
+	ePtr<iTapService> tservice;
+
+	if(encoderfd < 0)
 	{
-		if (encoderUser[i] == encoderfd)
-		{
-			encoderUser[i] = -1;
-			if (navigationInstances[i])
-			{
-				navigationInstances[i]->stopService();
-			}
+		eWarning("[eEncoder] trying to release incorrect encoder %d", encoderfd);
+		return;
+	}
+
+	for(encoder_index = 0; encoder_index < (int)encoder.size(); encoder_index++)
+		if(encoder[encoder_index].fd == encoderfd)
 			break;
+
+	if(encoder_index >= (int)encoder.size())
+	{
+		eWarning("[eEncoder] encoder with fd=%d not found", encoderfd);
+		return;
+	}
+
+	switch(encoder[encoder_index].state)
+	{
+		case(encoder_t::state_idle):
+		case(encoder_t::state_finishing):
+		case(encoder_t::state_destroyed):
+		{
+			eWarning("[eEncoder] trying to release inactive encoder %d fd=%d, state=%d", encoder_index, encoderfd, encoder[encoder_index].state);
+			return;
 		}
 	}
-	if (encoderfd >= 0) ::close(encoderfd);
+
+	encoder[encoder_index].state = encoder_t::state_finishing;
+	encoder[encoder_index].kill();
+
+	encoder[encoder_index].navigation_instance->getCurrentService(service);
+	service->tap(tservice);
+	tservice->stopTapToFD();
+
+	encoder[encoder_index].navigation_instance->stopService();
+
+	close(encoder[encoder_index].fd);
+	encoder[encoder_index].fd = -1;
+	encoder[encoder_index].state = encoder_t::state_idle;
 }
 
 int eEncoder::getUsedEncoderCount()
 {
 	int count = 0;
-	unsigned int i;
-	for (i = 0; i < encoderUser.size(); i++)
+
+	for(int encoder_index = 0; encoder_index < (int)encoder.size(); encoder_index++)
 	{
-		if (encoderUser[i] >= 0)
+		switch(encoder[encoder_index].state)
 		{
-			count++;
+			case(encoder_t::state_running):
+			case(encoder_t::state_wait_pmt):
+			{
+				count++;
+				break;
+			}
 		}
 	}
-	return count;
+
+	return(count);
+}
+
+void eEncoder::navigation_event(int encoder_index, int event)
+{
+	if((encoder_index < 0) || (encoder_index >= (int)encoder.size()))
+		return;
+
+	if(event == eDVBServicePMTHandler::eventTuned)
+	{
+		if(encoder[encoder_index].state == encoder_t::state_wait_pmt)
+		{
+			ePtr<iPlayableService> service;
+			ePtr<iTapService> tservice;
+			ePtr<iServiceInformation> info;
+			std::vector<int> pids;
+
+			encoder[encoder_index].navigation_instance->getCurrentService(service);
+			service->info(info);
+
+			int vpid = info->getInfo(iServiceInformation::sVideoPID);
+			int apid = info->getInfo(iServiceInformation::sAudioPID);
+			int pmtpid = info->getInfo(iServiceInformation::sPMTPID);
+
+			if((vpid > 0) && (apid > 0) && (pmtpid > 0))
+			{
+				eDebug("[eEncoder] info complete: %d, %d, %d", vpid, apid, pmtpid);
+
+				pids.push_back(pmtpid);
+				pids.push_back(vpid);
+				pids.push_back(apid);
+
+				service->tap(tservice);
+
+				if(tservice == nullptr)
+					freeEncoder(encoder[encoder_index].fd);
+
+				tservice->startTapToFD(encoder[encoder_index].fd, pids);
+
+				if(ioctl(encoder[encoder_index].fd, IOCTL_BROADCOM_SET_PMTPID_MIPS, pmtpid) ||
+						ioctl(encoder[encoder_index].fd, IOCTL_BROADCOM_SET_VPID_MIPS, vpid) ||
+						ioctl(encoder[encoder_index].fd, IOCTL_BROADCOM_SET_APID_MIPS, apid))
+				{
+					eDebug("[eEncoder] set ioctl(mips) failed");
+
+					if(ioctl(encoder[encoder_index].fd, IOCTL_BROADCOM_SET_PMTPID_ARM, pmtpid) ||
+							ioctl(encoder[encoder_index].fd, IOCTL_BROADCOM_SET_VPID_ARM, vpid) ||
+							ioctl(encoder[encoder_index].fd, IOCTL_BROADCOM_SET_APID_ARM, apid))
+					{
+						eWarning("[eEncoder] set ioctl(arm) failed too, giving up");
+						freeEncoder(encoder[encoder_index].fd);
+						return;
+					}
+				}
+
+				encoder[encoder_index].state = encoder_t::state_running;
+				encoder[encoder_index].run();
+			}
+		}
+	}
+}
+
+void eEncoder::navigation_event_0(int event)
+{
+	navigation_event(0, event);
+}
+
+void eEncoder::navigation_event_1(int event)
+{
+	navigation_event(1, event);
+}
+
+void eEncoder::encoder_t::thread(void)
+{
+	eDebug("[eEncoder] start encoder thread");
+
+	hasStarted();
+
+	if(ioctl(fd, IOCTL_BROADCOM_START_TRANSCODING, 0))
+		eWarning("[eEncoder] thread encoder failed");
+
+	eDebug("[eEncoder] thread encoder done %d", encoder);
 }
 
 eAutoInitPtr<eEncoder> init_eEncoder(eAutoInitNumbers::service + 1, "Encoders");

--- a/lib/dvb/encoder.h
+++ b/lib/dvb/encoder.h
@@ -71,8 +71,8 @@ class eEncoder
 		eEncoder();
 		~eEncoder();
 
-		//FIXME: const
-		int allocateEncoder(const std::string &serviceref, const int bitrate, const int width, const int height, const int framerate, const int interlaced, const int aspectratio, int &buffersize, const std::string &vcodec = "", const std::string &acodec = "");
+		int allocateEncoder(const std::string &serviceref, int bitrate, int width, int height, int framerate, int interlaced, int aspectratio,
+				const std::string &vcodec = "", const std::string &acodec = "");
 		void freeEncoder(int encoderfd);
 		int getUsedEncoderCount();
 

--- a/lib/dvb/encoder.h
+++ b/lib/dvb/encoder.h
@@ -30,16 +30,16 @@ class eEncoder
 
 				EncoderContext(int encoder_index_in, int decoder_index_in, eNavigation *navigation_instance_in)
 				{
-					encoder = encoder_in;
-					decoder = decoder_in;
-					fd = -1;
+					encoder_index = encoder_index_in;
+					decoder_index = decoder_index_in;
+					encoder_fd = -1;
 					state = state_idle;
 					navigation_instance = navigation_instance_in;
 				}
 
-				int encoder;
-				int decoder;
-				int fd;
+				int encoder_index;
+				int decoder_index;
+				int encoder_fd;
 
 				enum
 				{

--- a/lib/dvb/encoder.h
+++ b/lib/dvb/encoder.h
@@ -4,25 +4,79 @@
 #include <vector>
 
 #include <lib/nav/core.h>
+#include <lib/base/thread.h>
 
 class eEncoder
 {
-	DECLARE_REF(eEncoder);
+	private:
 
-	std::vector<eNavigation *> navigationInstances;
-	std::vector<int> encoderUser;
+		DECLARE_REF(eEncoder);
 
-	static eEncoder *instance;
+		enum
+		{
+			IOCTL_BROADCOM_SET_VPID_MIPS = 1,
+			IOCTL_BROADCOM_SET_VPID_ARM = 11,
+			IOCTL_BROADCOM_SET_APID_MIPS = 2,
+			IOCTL_BROADCOM_SET_APID_ARM = 12,
+			IOCTL_BROADCOM_SET_PMTPID_MIPS = 3,
+			IOCTL_BROADCOM_SET_PMTPID_ARM = 13,
+			IOCTL_BROADCOM_START_TRANSCODING = 100,
+			IOCTL_BROADCOM_STOP_TRANSCODING = 200,
+		};
 
-public:
-	eEncoder();
-	~eEncoder();
+		class encoder_t : public eThread
+		{
+			public:
 
-	int allocateEncoder(const std::string &serviceref, const int bitrate, const int width, const int height, const int framerate, const int interlaced, const int aspectratio, const std::string &vcodec = "", const std::string &acodec = "");
-	void freeEncoder(int encoderfd);
-	int getUsedEncoderCount();
+				encoder_t(int encoder_in, int decoder_in, eNavigation *navigation_instance_in) :
+						encoder(encoder_in),
+						decoder(decoder_in),
+						fd(-1),
+						state(state_idle),
+						navigation_instance(navigation_instance_in)
+				{
+				}
 
-	static eEncoder *getInstance();
+				int encoder;
+				int decoder;
+				int fd;
+
+				enum
+				{
+					state_idle,
+					state_wait_pmt,
+					state_running,
+					state_finishing,
+					state_destroyed,
+				} state;
+
+				eNavigation *navigation_instance;
+
+				void thread(void);
+		};
+
+		std::vector<encoder_t> encoder;
+		bool bcm_encoder;
+		ePtr<eConnection> m_nav_event_connection_0;
+		ePtr<eConnection> m_nav_event_connection_1;
+
+		static eEncoder *instance;
+
+		void navigation_event_0(int);
+		void navigation_event_1(int);
+		void navigation_event(int, int);
+
+	public:
+
+		eEncoder();
+		~eEncoder();
+
+		//FIXME: const
+		int allocateEncoder(const std::string &serviceref, const int bitrate, const int width, const int height, const int framerate, const int interlaced, const int aspectratio, int &buffersize, const std::string &vcodec = "", const std::string &acodec = "");
+		void freeEncoder(int encoderfd);
+		int getUsedEncoderCount();
+
+		static eEncoder *getInstance();
 };
 
 #endif /* __DVB_ENCODER_H_ */

--- a/lib/dvb/encoder.h
+++ b/lib/dvb/encoder.h
@@ -24,17 +24,17 @@ class eEncoder
 			IOCTL_BROADCOM_STOP_TRANSCODING = 200,
 		};
 
-		class encoder_t : public eThread
+		class EncoderContext : public eThread
 		{
 			public:
 
-				encoder_t(int encoder_in, int decoder_in, eNavigation *navigation_instance_in) :
-						encoder(encoder_in),
-						decoder(decoder_in),
-						fd(-1),
-						state(state_idle),
-						navigation_instance(navigation_instance_in)
+				EncoderContext(int encoder_index_in, int decoder_index_in, eNavigation *navigation_instance_in)
 				{
+					encoder = encoder_in;
+					decoder = decoder_in;
+					fd = -1;
+					state = state_idle;
+					navigation_instance = navigation_instance_in;
 				}
 
 				int encoder;
@@ -55,7 +55,7 @@ class eEncoder
 				void thread(void);
 		};
 
-		std::vector<encoder_t> encoder;
+		std::vector<EncoderContext> encoder;
 		bool bcm_encoder;
 		ePtr<eConnection> m_nav_event_connection_0;
 		ePtr<eConnection> m_nav_event_connection_1;

--- a/lib/dvb/encoder.h
+++ b/lib/dvb/encoder.h
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include <lib/nav/core.h>
-#include <lib/base/thread.h>
+#include <lib/dvb/streamserver.h>
 
 class eEncoder
 {
@@ -32,14 +32,18 @@ class eEncoder
 				{
 					encoder_index = encoder_index_in;
 					decoder_index = decoder_index_in;
+					file_fd = -1;
 					encoder_fd = -1;
 					state = state_idle;
 					navigation_instance = navigation_instance_in;
+					stream_thread = nullptr;
 				}
 
 				int encoder_index;
 				int decoder_index;
 				int encoder_fd;
+				int file_fd;
+				eDVBRecordStreamThread *stream_thread;
 
 				enum
 				{
@@ -71,7 +75,7 @@ class eEncoder
 		eEncoder();
 		~eEncoder();
 
-		int allocateEncoder(const std::string &serviceref, int bitrate, int width, int height, int framerate, int interlaced, int aspectratio,
+		int allocateEncoder(const std::string &serviceref, int &buffersize, int bitrate, int width, int height, int framerate, int interlaced, int aspectratio,
 				const std::string &vcodec = "", const std::string &acodec = "");
 		void freeEncoder(int encoderfd);
 		int getUsedEncoderCount();

--- a/lib/dvb/filepush.cpp
+++ b/lib/dvb/filepush.cpp
@@ -611,7 +611,7 @@ void eFilePushThreadRecorder::thread()
 #endif
 		if (w < 0)
 		{
-			eDebug("[eFilePushThreadRecorder] WRITE ERROR, aborting thread: %m");
+			eWarning("[eFilePushThreadRecorder] WRITE ERROR, aborting thread: %m");
 			sendEvent(evtWriteError);
 			break;
 		}

--- a/lib/dvb/filepush.cpp
+++ b/lib/dvb/filepush.cpp
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <poll.h>
 
 #if defined(__sh__) // this allows filesystem tasks to be prioritised
 #include <sys/vfs.h>
@@ -559,6 +560,13 @@ void eFilePushThreadRecorder::thread()
 	/* m_stop must be evaluated after each syscall. */
 	while (!m_stop)
 	{
+		/* this works around the buggy Broadcom encoder that always returns even if there is no data */
+		/* (works like O_NONBLOCK even when not opened as such), prevent idle waiting for the data */
+		/* this won't ever hurt, because it will return immediately when there is data or an error condition */
+
+		struct pollfd pfd = { m_fd_source, POLLIN | POLLRDHUP | POLLERR | POLLHUP | POLLNVAL, 0 };
+		poll(&pfd, 1, 1000);
+
 		ssize_t bytes;
 		if (m_protocol == _PROTO_RTSP_TCP)
 			bytes = read_dmx(m_fd_source, m_buffer, m_buffersize);

--- a/lib/dvb/filepush.cpp
+++ b/lib/dvb/filepush.cpp
@@ -564,8 +564,8 @@ void eFilePushThreadRecorder::thread()
 		/* (works like O_NONBLOCK even when not opened as such), prevent idle waiting for the data */
 		/* this won't ever hurt, because it will return immediately when there is data or an error condition */
 
-		struct pollfd pfd = { m_fd_source, POLLIN | POLLRDHUP | POLLERR | POLLHUP | POLLNVAL, 0 };
-		poll(&pfd, 1, 1000);
+		struct pollfd pfd = { m_fd_source, POLLIN, 0 };
+		poll(&pfd, 1, 100);
 
 		ssize_t bytes;
 		if (m_protocol == _PROTO_RTSP_TCP)

--- a/lib/dvb/streamserver.cpp
+++ b/lib/dvb/streamserver.cpp
@@ -177,8 +177,13 @@ void eStreamClient::notifier(int what)
 				{
 					request = serviceref.substr(pos);
 					serviceref = serviceref.substr(0, pos);
-					pos = request.find("?bitrate=");
-					posdur = request.find("?duration=");
+					/* BC support for ? instead of & as URL argument seperator */
+					while((pos = request.find('?')) != std::string::npos)
+					{
+						request.replace(pos, 1, "&");
+					}
+					pos = request.find("&bitrate=");
+					posdur = request.find("&duration=");
 					eDebug("[eDVBServiceStream] stream ref: %s", serviceref.c_str());
 					if (posdur != std::string::npos)
 					{
@@ -189,7 +194,7 @@ void eStreamClient::notifier(int what)
 							m_useencoder = false;
 						}
 						int timeout = 0;
-						sscanf(request.substr(posdur).c_str(), "?duration=%d", &timeout);
+						sscanf(request.substr(posdur).c_str(), "&duration=%d", &timeout);
 						eDebug("[eDVBServiceStream] duration: %d seconds", timeout);
 						if (timeout)
 						{
@@ -211,34 +216,34 @@ void eStreamClient::notifier(int what)
 						sscanf(request.substr(pos).c_str(), "&bitrate=%d", &bitrate);
 						pos = request.find("&width=");
 						if (pos != std::string::npos)
-							sscanf(request.substr(pos).c_str(), "?width=%d", &width);
-						pos = request.find("?height=");
+							sscanf(request.substr(pos).c_str(), "&width=%d", &width);
+						pos = request.find("&height=");
 						if (pos != std::string::npos)
-							sscanf(request.substr(pos).c_str(), "?height=%d", &height);
-						pos = request.find("?framerate=");
+							sscanf(request.substr(pos).c_str(), "&height=%d", &height);
+						pos = request.find("&framerate=");
 						if (pos != std::string::npos)
-							sscanf(request.substr(pos).c_str(), "?framerate=%d", &framerate);
-						pos = request.find("?interlaced=");
+							sscanf(request.substr(pos).c_str(), "&framerate=%d", &framerate);
+						pos = request.find("&interlaced=");
 						if (pos != std::string::npos)
-							sscanf(request.substr(pos).c_str(), "?interlaced=%d", &interlaced);
-						pos = request.find("?aspectratio=");
+							sscanf(request.substr(pos).c_str(), "&interlaced=%d", &interlaced);
+						pos = request.find("&aspectratio=");
 						if (pos != std::string::npos)
-							sscanf(request.substr(pos).c_str(), "?aspectratio=%d", &aspectratio);
-						pos = request.find("?vcodec=");
+							sscanf(request.substr(pos).c_str(), "&aspectratio=%d", &aspectratio);
+						pos = request.find("&vcodec=");
 						if (pos != std::string::npos)
 						{
 							vcodec = request.substr(pos + 8);
-							pos = vcodec.find('?');
+							pos = vcodec.find('&');
 							if (pos != std::string::npos)
 							{
 								vcodec = vcodec.substr(0, pos);
 							}
 						}
-						pos = request.find("?acodec=");
+						pos = request.find("&acodec=");
 						if (pos != std::string::npos)
 						{
 							acodec = request.substr(pos + 8);
-							pos = acodec.find('?');
+							pos = acodec.find('&');
 							if (pos != std::string::npos)
 							{
 								acodec = acodec.substr(0, pos);

--- a/lib/dvb/streamserver.cpp
+++ b/lib/dvb/streamserver.cpp
@@ -213,9 +213,11 @@ void eStreamClient::notifier(int what)
 						int framerate = 25000;
 						int interlaced = 0;
 						int aspectratio = 0;
+						int buffersize;
 						std::string vcodec, acodec;
-						sscanf(request.substr(pos).c_str(), "?bitrate=%d", &bitrate);
-						pos = request.find("?width=");
+
+						sscanf(request.substr(pos).c_str(), "&bitrate=%d", &bitrate);
+						pos = request.find("&width=");
 						if (pos != std::string::npos)
 							sscanf(request.substr(pos).c_str(), "?width=%d", &width);
 						pos = request.find("?height=");
@@ -252,11 +254,11 @@ void eStreamClient::notifier(int what)
 						}
 						encoderFd = -1;
 						if (eEncoder::getInstance())
-							encoderFd = eEncoder::getInstance()->allocateEncoder(serviceref, bitrate, width, height, framerate, !!interlaced, aspectratio, vcodec, acodec);
+							encoderFd = eEncoder::getInstance()->allocateEncoder(serviceref, bitrate, width, height, framerate, !!interlaced, aspectratio, buffersize, vcodec, acodec);
 						if (encoderFd >= 0)
 						{
 							running = true;
-							streamThread = new eDVBRecordStreamThread(188);
+							streamThread = new eDVBRecordStreamThread(188, buffersize);
 							if (streamThread)
 							{
 								streamThread->setTargetFD(streamFd);

--- a/lib/python/Tools/KeyBindings.py
+++ b/lib/python/Tools/KeyBindings.py
@@ -161,7 +161,6 @@ keyDescriptions = [{  # id=0 - dmm0 remote directory, DM8000.
 	KEYIDS["KEY_F1"]: ("F1",),
 	KEYIDS["KEY_F2"]: ("F2",),
 	KEYIDS["KEY_F3"]: ("F3",),
-	KEYIDS["KEY_F6"]: ("PIP",),
 	KEYIDS["KEY_FASTFORWARD"]: ("FASTFORWARD",),
 	KEYIDS["KEY_FAVORITES"]: ("FAV",),
 	KEYIDS["KEY_FILE"]: ("LIST",),

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -667,6 +667,19 @@ public:
 };
 SWIG_TEMPLATE_TYPEDEF(ePtr<iTimeshiftService>, iTimeshiftServicePtr);
 
+SWIG_IGNORE(iTapService);
+class iTapService: public iObject
+{
+#ifdef SWIG
+	iTapService();
+	~iTapService();
+#endif
+public:
+	virtual bool startTapToFD(int fd, const std::vector<int> &pids, int packetsize = 188)=0;
+	virtual void stopTapToFD()=0;
+};
+SWIG_TEMPLATE_TYPEDEF(ePtr<iTapService>, iTapServicePtr);
+
 	/* not related to eCueSheet */
 
 class iCueSheet_ENUMS
@@ -977,6 +990,7 @@ public:
 	virtual SWIG_VOID(RESULT) subServices(ePtr<iSubserviceList> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) frontendInfo(ePtr<iFrontendInformation> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) timeshift(ePtr<iTimeshiftService> &SWIG_OUTPUT)=0;
+	virtual SWIG_VOID(RESULT) tap(ePtr<iTapService> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) cueSheet(ePtr<iCueSheet> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) subtitle(ePtr<iSubtitleOutput> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) audioDelay(ePtr<iAudioDelay> &SWIG_OUTPUT)=0;

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2684,7 +2684,7 @@ bool eDVBServicePlay::startTapToFD(int fd, const std::vector<int> &pids, int pac
 	if (m_service_handler.getDataDemux(demux))
 		return(false);
 
-	demux->createTSRecorder(m_tap_recorder, packetsize, true);
+	demux->createTSRecorder(m_tap_recorder, packetsize, false);
 
 	if (!m_tap_recorder)
 	{

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1042,6 +1042,7 @@ eDVBServicePlay::eDVBServicePlay(const eServiceReference &ref, eDVBService *serv
 	m_skipmode(0),
 	m_fastforward(0),
 	m_slowmotion(0),
+	m_tap_recorder(0),
 	m_cuesheet_changed(0),
 	m_cutlist_enabled(1),
 	m_subtitle_widget(0),
@@ -1775,6 +1776,12 @@ RESULT eDVBServicePlay::timeshift(ePtr<iTimeshiftService> &ptr)
 		return 0;
 	}
 	return -1;
+}
+
+RESULT eDVBServicePlay::tap(ePtr<iTapService> &ptr)
+{
+	ptr = this;
+	return 0;
 }
 
 RESULT eDVBServicePlay::cueSheet(ePtr<iCueSheet> &ptr)
@@ -2660,6 +2667,46 @@ std::string eDVBServicePlay::getTimeshiftFilename()
 		return m_timeshift_file;
 	else
 		return "";
+}
+
+bool eDVBServicePlay::startTapToFD(int fd, const std::vector<int> &pids, int packetsize)
+{
+	ePtr<iDVBDemux> demux;
+
+	eDebug("[eServiceTap] Start tap");
+
+	if(m_tap_recorder)
+	{
+		eWarning("[eServiceTap] tap already running");
+		return(false);
+	}
+
+	if (m_service_handler.getDataDemux(demux))
+		return(false);
+
+	demux->createTSRecorder(m_tap_recorder, packetsize, true);
+
+	if (!m_tap_recorder)
+	{
+		eWarning("[eServiceTap] tap create recorder failed");
+		return(false);
+	}
+
+	m_tap_recorder->setTargetFD(fd);
+	m_tap_recorder->enableAccessPoints(false);
+
+	for(auto i : pids)
+		m_tap_recorder->addPID(i);
+
+	m_tap_recorder->start();
+
+	return(true);
+}
+
+void eDVBServicePlay::stopTapToFD()
+{
+	m_tap_recorder->stop();
+	m_tap_recorder = 0;
 }
 
 PyObject *eDVBServicePlay::getCutList()

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2686,7 +2686,7 @@ bool eDVBServicePlay::startTapToFD(int fd, const std::vector<int> &pids, int pac
 
 	demux->createTSRecorder(m_tap_recorder, packetsize, false);
 
-	if (!m_tap_recorder)
+	if(m_tap_recorder == nullptr)
 	{
 		eWarning("[eServiceTap] tap create recorder failed");
 		return(false);
@@ -2705,8 +2705,11 @@ bool eDVBServicePlay::startTapToFD(int fd, const std::vector<int> &pids, int pac
 
 void eDVBServicePlay::stopTapToFD()
 {
-	m_tap_recorder->stop();
-	m_tap_recorder = 0;
+	if(m_tap_recorder != nullptr)
+	{
+		m_tap_recorder->stop();
+		m_tap_recorder = nullptr;
+	}
 }
 
 PyObject *eDVBServicePlay::getCutList()

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2673,7 +2673,7 @@ bool eDVBServicePlay::startTapToFD(int fd, const std::vector<int> &pids, int pac
 {
 	ePtr<iDVBDemux> demux;
 
-	eDebug("[eServiceTap] Start tap");
+	eDebug("[eServiceTap] start tap");
 
 	if(m_tap_recorder)
 	{

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -86,7 +86,7 @@ class eDVBServicePlay: public eDVBServiceBase,
 		public iPlayableService, public iPauseableService,
 		public iSeekableService, public sigc::trackable, public iServiceInformation,
 		public iAudioTrackSelection, public iAudioChannelSelection,
-		public iSubserviceList, public iTimeshiftService,
+		public iSubserviceList, public iTimeshiftService, public iTapService,
 		public iCueSheet, public iSubtitleOutput, public iAudioDelay,
 		public iRdsDecoder, public iStreamableService,
 		public iStreamedService
@@ -109,6 +109,7 @@ public:
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr);
 	RESULT subServices(ePtr<iSubserviceList> &ptr);
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr);
+	RESULT tap(ePtr<iTapService> &ptr);
 	RESULT cueSheet(ePtr<iCueSheet> &ptr);
 	RESULT subtitle(ePtr<iSubtitleOutput> &ptr);
 	RESULT audioDelay(ePtr<iAudioDelay> &ptr);
@@ -175,6 +176,10 @@ public:
 	RESULT saveTimeshiftFile();
 	std::string getTimeshiftFilename();
 	void switchToLive();
+
+		// iTapService
+	bool startTapToFD(int fd, const std::vector<int> &pids, int packetsize = 188);
+	void stopTapToFD();
 
 		// iCueSheet
 	PyObject *getCutList();
@@ -255,6 +260,10 @@ protected:
 	int m_skipmode;
 	int m_fastforward;
 	int m_slowmotion;
+
+		/* tap */
+
+	ePtr<iDVBTSRecorder> m_tap_recorder;
 
 		/* cuesheet */
 

--- a/lib/service/servicedvd.h
+++ b/lib/service/servicedvd.h
@@ -68,13 +68,14 @@ public:
 	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr);
-	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
-	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
-	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }
-	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = 0; return -1; }
-	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = 0; return -1; }
-	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = 0; return -1; }
-	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = 0; return -1; }
+	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = nullptr; return -1; }
+	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = nullptr; return -1; }
+	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = nullptr; return -1; }
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
+	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = nullptr; return -1; }
+	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; }
+	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; }
+	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = nullptr; return -1; }
 	RESULT cueSheet(ePtr<iCueSheet> &ptr);
 	void setQpipMode(bool value, bool audio) { }
 

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -254,6 +254,8 @@ RESULT eServiceHDMIRecord::stop()
 
 int eServiceHDMIRecord::doPrepare()
 {
+	int buffersize; /* unused here */
+
 	if (!m_simulate && m_encoder_fd < 0)
 	{
 		if (eEncoder::getInstance())
@@ -264,7 +266,7 @@ int eServiceHDMIRecord::doPrepare()
 			int framerate = eConfigManager::getConfigIntValue("config.hdmirecord.framerate", 50000);
 			int interlaced = eConfigManager::getConfigIntValue("config.hdmirecord.interlaced", 0);
 			int aspectratio = eConfigManager::getConfigIntValue("config.hdmirecord.aspectratio", 0);
-			m_encoder_fd = eEncoder::getInstance()->allocateEncoder(m_ref.toString(), bitrate, width, height, framerate, interlaced, aspectratio);
+			m_encoder_fd = eEncoder::getInstance()->allocateEncoder(m_ref.toString(), bitrate, width, height, framerate, interlaced, aspectratio, buffersize);
 		}
 		if (m_encoder_fd < 0) return -1;
 	}

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -266,7 +266,7 @@ int eServiceHDMIRecord::doPrepare()
 			int framerate = eConfigManager::getConfigIntValue("config.hdmirecord.framerate", 50000);
 			int interlaced = eConfigManager::getConfigIntValue("config.hdmirecord.interlaced", 0);
 			int aspectratio = eConfigManager::getConfigIntValue("config.hdmirecord.aspectratio", 0);
-			m_encoder_fd = eEncoder::getInstance()->allocateEncoder(m_ref.toString(), bitrate, width, height, framerate, interlaced, aspectratio, buffersize);
+			m_encoder_fd = eEncoder::getInstance()->allocateEncoder(m_ref.toString(), buffersize, bitrate, width, height, framerate, interlaced, aspectratio);
 		}
 		if (m_encoder_fd < 0) return -1;
 	}

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -55,10 +55,11 @@ public:
 	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = 0; return -1; }
 	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = 0; return -1; }
 
-	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
-	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
-	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }
-	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = 0; return -1; }
+	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = nullptr; return -1; }
+	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = nullptr; return -1; }
+	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = nullptr; return -1; }
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
+	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = nullptr; return -1; }
 
 	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = 0; return -1; }
 	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = 0; return -1; }

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -150,6 +150,7 @@ public:
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
 	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
 //	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = 0; return -1; }
 
 		// iCueSheet

--- a/lib/service/servicets.h
+++ b/lib/service/servicets.h
@@ -66,12 +66,13 @@ public:
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; };
 	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = 0; return -1; };
 	void setQpipMode(bool value, bool audio) { }
-	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = 0; return -1; };
-	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = 0; return -1; };
-	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = 0; return -1; };
-	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = 0; return -1; };
-	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = 0; return -1; };
-	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = 0; return -1; };
+	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = nullptr; return -1; };
+	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = nullptr; return -1; };
+	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; };
+	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; };
+	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = nullptr; return -1; };
+	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = nullptr; return -1; };
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
 
 	// iPausableService
 	RESULT pause();

--- a/lib/service/servicewebts.h
+++ b/lib/service/servicewebts.h
@@ -97,12 +97,13 @@ public:
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; };
 	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = 0; return -1; };
 	void setQpipMode(bool value, bool audio) { }
-	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = 0; return -1; };
-	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = 0; return -1; };
-	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = 0; return -1; };
-	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = 0; return -1; };
-	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = 0; return -1; };
-	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = 0; return -1; };
+	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = nullptr; return -1; };
+	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = nullptr; return -1; };
+	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; };
+	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; };
+	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = nullptr; return -1; };
+	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = nullptr; return -1; };
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
 
 	// iPausableService
 	RESULT pause();

--- a/skin.py
+++ b/skin.py
@@ -466,7 +466,7 @@ class AttributeParser:
 				"disable_onhide": 0x01
 			}[value])
 		except KeyError:
-			print "[Skin] Error: Invalid animationMode '%s'!  Must be one of 'disable', 'off', 'offshow', 'offhide', 'onshow' or 'onhide'." % value
+			print("[Skin] Error: Invalid animationMode '%s'!  Must be one of 'disable', 'off', 'offshow', 'offhide', 'onshow' or 'onhide'." % value)
 
 	def title(self, value):
 		self.guiObject.setTitle(_(value))
@@ -990,14 +990,26 @@ def readSkin(screen, skin, names, desktop):
 	for n in names:  # Try all skins, first existing one has priority.
 		myScreen, path = domScreens.get(n, (None, None))
 		if myScreen is not None:
-			name = n  # Use this name for debug output.
-			break
+			if screen.mandatoryWidgets is None:
+				screen.mandatoryWidgets = []
+			else:
+				widgets = findWidgets(n)
+			if screen.mandatoryWidgets == [] or all(item in widgets for item in screen.mandatoryWidgets):
+				name = n  # Use this name for debug output.
+				break
+			else:
+				print("[Skin] Warning: Skin screen '%s' rejected as it does not offer all the mandatory widgets '%s'!" % (n, ", ".join(screen.mandatoryWidgets)))
+				myScreen = None
 	else:
 		name = "<embedded-in-%s>" % screen.__class__.__name__
 	if myScreen is None:  # Otherwise try embedded skin.
 		myScreen = getattr(screen, "parsedSkin", None)
 	if myScreen is None and getattr(screen, "skin", None):  # Try uncompiled embedded skin.
-		skin = screen.skin
+		if isinstance(screen.skin, list):
+			print("[Skin] Resizable embedded skin template found in '%s'." % name)
+			skin = screen.skin[0] % tuple([int(x * getSkinFactor()) for x in screen.skin[1:]])
+		else:
+			skin = screen.skin
 		print("[Skin] Parsing embedded skin '%s'." % name)
 		if isinstance(skin, tuple):
 			for s in skin:
@@ -1218,6 +1230,31 @@ def readSkin(screen, skin, names, desktop):
 	# things around.
 	screen = None
 	usedComponents = None
+
+# Return a set of all the widgets found in a screen. Panels will be expanded
+# recursively until all referenced widgets are captured. This code only performs
+# a simple scan of the XML and no skin processing is performed.
+#
+def findWidgets(name):
+	widgetSet = set()
+	element, path = domScreens.get(name, (None, None))
+	if element is not None:
+		widgets = element.findall("widget")
+		if widgets is not None:
+			for widget in widgets:
+				name = widget.get("name", None)
+				if name is not None:
+					widgetSet.add(name)
+				source = widget.get("source", None)
+				if source is not None:
+					widgetSet.add(source)
+		panels = element.findall("panel")
+		if panels is not None:
+			for panel in panels:
+				name = panel.get("name", None)
+				if name:
+					widgetSet.update(findWidgets(name))
+	return widgetSet
 
 # Return a scaling factor (float) that can be used to rescale screen displays
 # to suit the current resolution of the screen.  The scales are based on a


### PR DESCRIPTION
Not sure using the good process for this pull request.
Concern 6.3, 6.4, 6.5 branches
File enigma2/lib/python/Screens/InfoBarGenerics.py

Wish: Add channel name in groupedservices screen.  I think the modification has to be made at line 207:
current_show_name = title + " " + str(starttime) + "-" + str(endtime)

So currently we have show name and start/end time of the show, but no channel name. But it will be more readable if the channel name (service) was displayed somewhere, ideas: at the beginning of the subservice line or at the end with ().

For example, currently for the group HD Plus set in /usr/share/enigma2/groupedservices we have a lot of different channels (not declination of just one channel), and without displaying channel name the choice is not easy to do, it's not realy readable.
 
Hope my request is understanding.

Thanks