### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -5726,7 +5726,6 @@ msgstr "Wählen Sie einen Ort zur Speicherung der EPG-Daten, wenn die %s %s ausg
 msgid "Choose the name of the file that holds the EPG data when the %s %s is shut down. This can be handy to differentiate between several boxes."
 msgstr ""
 "Wählen Sie den Dateinamen für die EPG-Daten, wenn die %s %s ausgeschaltet wird. Das kann nützlich sein, wenn mehrere Boxen verwendet werden.\n"
-"\n"
 "Mit der TXT (Videotext) Taste erhalten Sie eine virtuelle Tastatur."
 
 #: setup.xml


### PR DESCRIPTION
Uups, leider ist der Text "Wählen Sie den Dateinamen..." zu weit oben und deshalb
nicht mehr richtig zu lesen, wenn zwischen dem Text und der Info eine Leerzeile ist.
Also: Leerzeile weg...
Gruß - Makumbo