### PR TITLE
[ConfigList.py] fix Py3 crash, TypeError: object of type 'zip' has no…

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -288,7 +288,7 @@ class ConfigListScreen:
 		selection = self["config"].getCurrent()
 		if selection and selection[1].enabled and hasattr(selection[1], "description"):
 			self.session.openWithCallback(self.handleKeyFileCallback, ChoiceBox, selection[0],
-				list=zip(selection[1].description, selection[1].choices),
+				list=list(zip(selection[1].description, selection[1].choices)),
 				selection=selection[1].choices.index(selection[1].value),
 				keys=[],
 				text=self.getCurrentDescription())


### PR DESCRIPTION
… len()

[ActionMap] Keymap 'SetupActions' -> Action = 'file'.
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 79, in action
    return ActionMap.action(self, contexts, action)
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 59, in action
    res = self.actions[action]()
  File "/usr/lib/enigma2/python/Components/ConfigList.py", line 290, in keyFile
    self.session.openWithCallback(self.handleKeyFileCallback, ChoiceBox, selection[0],
  File "/usr/lib/enigma2/python/mytest.py", line 350, in openWithCallback
    dlg = self.open(screen, *arguments, **kwargs)
  File "/usr/lib/enigma2/python/mytest.py", line 369, in open
    dlg = self.current_dialog = self.instantiateDialog(screen, *arguments, **kwargs)
  File "/usr/lib/enigma2/python/mytest.py", line 298, in instantiateDialog
    return self.doInstantiateDialog(screen, arguments, kwargs, self.desktop)
  File "/usr/lib/enigma2/python/mytest.py", line 320, in doInstantiateDialog
    dlg = screen(self, *arguments, **kwargs)
  File "/usr/lib/enigma2/python/Screens/ChoiceBox.py", line 79, in __init__
    self.__keys = keys + (len(list) - len(keys)) * [""]
TypeError: object of type 'zip' has no len()
[ePyObject] (PyObject_CallObject(<bound method NumberActionMap.action of <Components.ActionMap.NumberActionMap object at 0xad6e5d00>>,('SetupActions', 'file')) failed)