### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -23671,7 +23671,7 @@ msgid "A highlight on the remote control image shows which button the help refer
 msgstr "Die Hervorhebung auf dem Fernbedienungsbild zeigt an, auf welche Tasten sich die Hilfe bezieht. Wenn mehr als eine Taste die angegebene Funktion ausführt, werden mehr als eine Markierung angezeigt. Der Text unterhalb der Liste listet die aktiven Tasten auf und gibt an, ob die Funktion ein langes Drücken oder SHIFT der Taste(n) erfordert."
 
 msgid "Configuration options for the HELP screen can be found in 'MENU > Setup > Usage & User Interface > Settings'."
-msgstr "Konfigurationsoptionen für den HILFE-Bildschirm finden Sie unter 'MENÜ > Einstellungen > Bedienung & Oberfläche > OSD'."
+msgstr "Konfigurationsoptionen für den HILFE-Bildschirm finden Sie unter 'MENU > Einstellungen > Bedienung & Oberfläche > OSD'."
 
 msgid "Press EXIT to return to the help screen."
 msgstr "Drücken Sie EXIT, um zum Hilfebildschirm zurückzukehren."


### PR DESCRIPTION
In 'de.po' heißt es immer "MENU" - und auch auf (allen) Fernbedienungen...

Oh, und eventuell gibt es ein Problem mit den An- und Abführungszeichen bei „Deaktiviert“ in Zeile 23701.
Können das alle Boxen so darstellen?
Mein Editor kann es zum Beispiel nicht...

Gruß - Makumbo