### PR TITLE
Update EventInfo for audio internet streams

### DIFF
--- a/lib/python/Components/Sources/EventInfo.py
+++ b/lib/python/Components/Sources/EventInfo.py
@@ -4,24 +4,60 @@ from Components.Element import cached
 from enigma import iPlayableService, iServiceInformation, eServiceReference, eEPGCache
 from Components.Sources.Source import Source
 
-# Fake eServiceEvent to fill EPG data for Streams
-class eServiceEvent(object):
-	def __init__(self, info):
-		EventName = info.getInfoString(iServiceInformation.sTagTitle)
-		self.m_EventName = None
-		if EventName:
-			self.m_EventName = EventName
-		self.m_ShortDescription = ""
-		self.m_ExtendedDescriptionation = ""
+# Fake eServiceEvent to fill Event_Now and Event_Next in Infobar for Streams
+#
+# from enigma import eServiceEvent
+class pServiceEvent(object):
+	NOW = 0
+	NEXT = 1
+
+	def __init__(self, info, now_or_next):
+		self.now_or_next = now_or_next
+
+		self.m_EventNameNow = ""
+		self.m_EventNameNext = ""
+		self.m_ShortDescriptionNow = ""
+		self.m_ShortDescriptionNext = ""
+		self.m_ExtendedDescriptionNow = ""
+		self.m_ExtendedDescriptionNext = ""
+		
+		sTagTitle = info.getInfoString(iServiceInformation.sTagTitle)
+		if sTagTitle:
+			sTagTitleList = sTagTitle.split(" - ")
+			element1 = sTagTitleList[0] if len(sTagTitleList) >= 1 else ""
+			element2 = sTagTitleList[1] if len(sTagTitleList) >= 2 else ""
+			element3 = sTagTitleList[2] if len(sTagTitleList) >= 3 else ""
+			if element3 == "":
+				self.m_EventNameNow = element1
+				self.m_EventNameNext = element2
+			if element3 != "":
+				self.m_EventNameNow = element1 + " - " + element2
+				self.m_EventNameNext = element3
+
+		sTagGenre = info.getInfoString(iServiceInformation.sTagGenre)
+		if sTagGenre:
+			element4 = sTagGenre
+			self.m_ShortDescriptionNow = element4
+
+		sTagOrganization = info.getInfoString(iServiceInformation.sTagOrganization)
+		if sTagOrganization:
+			element5 = sTagOrganization
+			self.m_ExtendedDescriptionNow = element5
+
+		sTagLocation = info.getInfoString(iServiceInformation.sTagLocation)
+		if sTagLocation:
+			element6 = sTagLocation
+			self.m_ExtendedDescriptionNow += "\n\n" + element6
+
 
 	def getEventName(self):
-		return self.m_EventName
+		return self.m_EventNameNow if self.now_or_next == self.NOW else self.m_EventNameNext
 	
 	def getShortDescription(self):
-		return self.m_ShortDescription
+		return self.m_ShortDescriptionNow if self.now_or_next == self.NOW else self.m_ShortDescriptionNext
 
 	def getExtendedDescriptionation(self):
-		return self.m_ExtendedDescriptionation
+		return self.m_ExtendedDescriptionNow if self.now_or_next == self.NOW else self.m_ExtendedDescriptionNext
 
 	def getBeginTime(self):
 		return 0
@@ -65,8 +101,8 @@ class EventInfo(PerServiceBase, Source, object):
 			if not ret or ret.getEventName() == "":
 				refstr = info.getInfoString(iServiceInformation.sServiceref)
 				ret = self.epgQuery(eServiceReference(refstr), -1, self.now_or_next and 1 or 0)
-				if self.now_or_next == 0 and not ret and refstr.split(':')[0] in ['4097', '5001', '5002', '5003']: # No EPG Try to get Meta
-					ev = eServiceEvent(info)
+				if not ret and refstr.split(':')[0] in ['4097', '5001', '5002', '5003']: # No EPG Try to get Meta
+					ev = pServiceEvent(info, self.now_or_next)
 					if ev.getEventName:
 						return ev
 		return ret


### PR DESCRIPTION
* Split MP3 Stream titles by "-" and display it for Event_Now / Event_Next
* rename to pServiceEvent (pythonServiceEvent)
* fill short and extended description for Event_Now and Event_Next
* Move element3 to Event_Next if it is not empty and place element1 and element2 on Event_Now. If element3 is empty place element1 on Event_Now and element2 on Event_Next