### PR TITLE
Revert "[ConfigDirectory] add missing value properties"

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1705,8 +1705,6 @@ class ConfigDirectory(ConfigText):
 			value = ""
 		ConfigText.setValue(self, value)
 
-	value = property(getValue, setValue)
-
 	def onSelect(self, session):
 		self.allmarked = (self.value != "")
 


### PR DESCRIPTION
This reverts commit 1a2e392dfcaef0118889f540e6d2157b4e1a1f38.

Breaks FileCommander and EMC