### PR TITLE
EventInfo for e1 like radio

### DIFF
--- a/lib/python/Components/Sources/EventInfo.py
+++ b/lib/python/Components/Sources/EventInfo.py
@@ -87,6 +87,7 @@ class EventInfo(PerServiceBase, Source, object):
 			{
 				iPlayableService.evStart: self.gotEvent,
 				iPlayableService.evUpdatedEventInfo: self.gotEvent,
+				iPlayableService.evUpdatedInfo: self.gotEvent,
 				iPlayableService.evEnd: self.gotEvent
 			}, with_event=True)
 		self.now_or_next = now_or_next


### PR DESCRIPTION
Current implementation only get stream title if infobar is shown by
pressing OK.
This change get stream title if it changes in GStreamer because e1 like
radio show the infobar all the time so there would never be a update of
the stream title.

https://www.opena.tv/openatv-7-0-py3-9-openssl-1-1-1-entwicklung/56722-radiotext-stellenweise-fehlerhaft-post482506.html#post482506