### PR TITLE
Update implementation of servicemp3's mp3 and aac stream titles

### DIFF
--- a/lib/python/Components/Converter/EventName.py
+++ b/lib/python/Components/Converter/EventName.py
@@ -124,6 +124,7 @@ class EventName(Converter, object):
 		"NameNextOnly": ("type", NAME_NEXT2),
 		"Genre": ("type", GENRE),
 		"GenreList": ("type", GENRELIST),
+		"EventExtraData": ("type", EVENT_EXTRADATA),
 		"Rating": ("type", RATING),
 		"SmallRating": ("type", SRATING),
 		"Pdc": ("type", PDC),
@@ -251,9 +252,8 @@ class EventName(Converter, object):
 		elif self.type == self.ID:
 			return self.trimText(event.getEventId())
 		elif self.type == self.EVENT_EXTRADATA:
-			pass
-			#not include yet
-			#ret = event.getExtraEventData()
+			# This calls lib/python/Components/Sources/EventInfo.py's getExtraEventData 
+			return event.getExtraEventData()
 		elif self.type == self.EPG_SOURCE:
 			pass
 			#not include yet

--- a/lib/python/Components/Sources/EventInfo.py
+++ b/lib/python/Components/Sources/EventInfo.py
@@ -3,6 +3,7 @@ from Components.PerServiceDisplay import PerServiceBase
 from Components.Element import cached
 from enigma import iPlayableService, iServiceInformation, eServiceReference, eEPGCache
 from Components.Sources.Source import Source
+import NavigationInstance
 
 # Fake eServiceEvent to fill Event_Now and Event_Next in Infobar for Streams
 #
@@ -71,8 +72,10 @@ class pServiceEvent(object):
 	def getEventId(self):
 		return 0
 
+	# eServiceEvent::getExtraEventData from lib/service/event.h ruturns std::string
+	# this fake class also return string
 	def getExtraEventData(self):
-		return None
+		return self.m_EventNameNext
 
 	def getBeginTimeString(self):
 		return ""
@@ -113,6 +116,13 @@ class EventInfo(PerServiceBase, Source, object):
 	def gotEvent(self, what):
 		if what == iPlayableService.evEnd:
 			self.changed((self.CHANGED_CLEAR,))
+		elif what == iPlayableService.evUpdatedInfo:
+			nav = NavigationInstance.instance
+			if nav:
+				service = nav.getCurrentlyPlayingServiceReference()
+				servicestring = service.toString()
+				if servicestring.split(':')[0] in ['4097', '5001', '5002', '5003']:
+					self.changed((self.CHANGED_ALL,))
 		else:
 			self.changed((self.CHANGED_ALL,))
 

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -106,7 +106,8 @@ class InfoBar(InfoBarBase, InfoBarShowHide,
 		self.helpList.append((self["actions"], "InfobarActions", [("showRadio", _("Listen to the radio"))]))
 
 		self.__event_tracker = ServiceEventTracker(screen=self, eventmap={
-				enigma.iPlayableService.evUpdatedEventInfo: self.__eventInfoChanged
+				enigma.iPlayableService.evUpdatedEventInfo: self.__eventInfoChanged,
+				enigma.iPlayableService.evUpdatedInfo: self.__infoChanged
 			})
 
 		self.current_begin_time = 0
@@ -156,6 +157,14 @@ class InfoBar(InfoBarBase, InfoBarShowHide,
 			self.current_begin_time = ptr and ptr.getBeginTime() or 0
 			if config.usage.show_infobar_on_event_change.value:
 				if old_begin_time and old_begin_time != self.current_begin_time:
+					self.doShow()
+
+	def __infoChanged(self):
+		if self.execing:
+			if config.usage.show_infobar_on_event_change.value:
+				service = self.session.nav.getCurrentlyPlayingServiceReference()
+				servicestring = service and service.toString()
+				if servicestring.split(':')[0] in ['4097', '5001', '5002', '5003']:
 					self.doShow()
 
 	def __checkServiceStarted(self):


### PR DESCRIPTION
* EventInfo do not refresh downstream elements
This change is to reduce load for normal dvb service reference types
because evUpdatedInfo for dvb is called more often. For example if the
video size has changed which can be the case for old tv series with
4:3 resolution but advertising is broadcast in 16:9.
MP3 and AAC streams advertise their title change via evUpdatedInfo
instead of evUpdatedEventInfo.

* Implement getExtraEventData in Converter and Source
This is implemented in python's fake class and not in servicemp3's
impementation of event.h's c++ interface.
Requested here https://www.opena.tv/skins/57124-radioinfobar-running-text-post483479.html#post483479

* Show infobar if servicemp3's service info changed
This change is to show the infobar if the service info changed and there
could be a new title for ip radio in mp3 or aac streams.
Requested here https://www.opena.tv/skins/57124-radioinfobar-running-text-post483430.html#post483430