### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7236,10 +7236,10 @@ msgid "Experimental mode"
 msgstr "Experimenteller Modus"
 
 msgid "Experimental: strict limitation to preferred tuners"
-msgstr "Experimentell: Beschränkung auf bevorzugte Tuner"
+msgstr "Exp.: Beschränkung auf bevorzugte Tuner"
 
 msgid "Experimental: strict limitation to preferred tuners for recordings"
-msgstr "Experimentell: Beschränkung auf bevorzugte Tuner bei Aufnahmen"
+msgstr "Exp.: Beschränkung auf bevorzugte Tuner bei Aufnahmen"
 
 msgid "Expert"
 msgstr "Experte"


### PR DESCRIPTION
"Experimentell:" wieder durch "Exp.:" ersetzt, weil sonst der Menütext zu lang ist.