### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -2051,7 +2051,7 @@ msgid ""
 "A finished powertimer wants to reboot your %s %s.\n"
 "Do that now?"
 msgstr ""
-"Ein PowerTimer will Ihren Receiver neu starten.\n"
+"Ein PowerTimer will Ihre Box neu starten.\n"
 "Ihre %s %s jetzt neu starten?"
 
 # /usr/lib/enigma2/python/PowerTimer.py
@@ -2068,7 +2068,7 @@ msgid ""
 "A finished powertimer wants to set your\n"
 "%s %s to standby. Do that now?"
 msgstr ""
-"Ein PowerTimer will Ihren Receiver in den Standby schalten.\n"
+"Ein PowerTimer will Ihre Box in den Standby schalten.\n"
 "Ihre %s %s jetzt in den Standby schalten?"
 
 # /usr/lib/enigma2/python/PowerTimer.py
@@ -2077,7 +2077,7 @@ msgid ""
 "A finished powertimer wants to shutdown your %s %s.\n"
 "Do that now?"
 msgstr ""
-"Ein PowerTimer will Ihren Receiver ausschalten.\n"
+"Ein PowerTimer will Ihre Box ausschalten.\n"
 "Ihre %s %s jetzt ausschalten?"
 
 #, python-format
@@ -2735,7 +2735,7 @@ msgid ""
 "An attempt is made to capture the current TV status. If this is not possible due to incorrect or missing status messages, it may cause the receiver to respond unexpectedly.\n"
 "On the other hand, tries to respond better to different operating conditions."
 msgstr ""
-"Es wird versucht den aktuellen TV Betriebszustand zu erfassen. Ist dies aufgrund falscher oder fehlender Statusmeldungen nicht möglich, kann der Receiver unerwartet reagieren.\n"
+"Es wird versucht den aktuellen TV Betriebszustand zu erfassen. Ist dies aufgrund falscher oder fehlender Statusmeldungen nicht möglich, kann Ihre Box unerwartet reagieren.\n"
 "Andererseits wird versucht auf verschiedene Betriebszustände besser zu reagieren."
 
 msgid "An empty filename is illegal."
@@ -2870,15 +2870,15 @@ msgstr ""
 "\n"
 "Backup: %s\n"
 "\n"
-"Nach der Wiederherstellung wird Ihr Receiver neu gestartet!"
+"Nach der Wiederherstellung wird Ihre Box neu gestartet!"
 
 msgid ""
 "Are you sure you want to restore the backup?\n"
 "Your receiver will restart after the backup has been restored!"
 msgstr ""
-"Sind Sie sicher, dass die Einstellungen Ihres Receivers wiederhergestellt werden sollen?\n"
+"Sind Sie sicher, dass die Einstellungen Ihrer Box wiederhergestellt werden sollen?\n"
 "\n"
-"Nach der Wiederherstellung wird Ihr Receiver neu gestartet!"
+"Nach der Wiederherstellung wird Ihre Box neu gestartet!"
 
 # InfoPanel restore settings
 #, python-format
@@ -2888,15 +2888,15 @@ msgid ""
 msgstr ""
 "Sind Sie sicher, dass die Einstellungen Ihrer %s %s wiederhergestellt werden sollen?\n"
 "\n"
-"Ihr Receiver wird neu gestartet, nachdem die Einstellungen wiederhergestellt wurden."
+"Ihre Box wird neu gestartet, nachdem die Einstellungen wiederhergestellt wurden."
 
 msgid ""
 "Are you sure you want to restore your STB backup?\n"
 "STB will restart after the restore"
 msgstr ""
-"Sind Sie sicher, dass die Einstellungen Ihres Receivers wiederhergestellt werden sollen?\n"
+"Sind Sie sicher, dass die Einstellungen Ihrer Box wiederhergestellt werden sollen?\n"
 "\n"
-"Ihr Receiver wird neu gestartet, nachdem die Einstellungen wiederhergestellt wurden."
+"Ihre Box wird neu gestartet, nachdem die Einstellungen wiederhergestellt wurden."
 
 msgid "Are you sure you want to save the EPG Cache to:\n"
 msgstr "Die EPG-Daten hier speichern:\n"
@@ -3337,7 +3337,7 @@ msgid "Backup your current image"
 msgstr "Backup vom ganzen Image"
 
 msgid "Backup your current image to HDD or USB. This will make a 1:1 copy of your box"
-msgstr "Backup vom ganzen Image auf HDD oder USB. Dies erzeugt eine 1:1-Kopie Ihrer Box"
+msgstr "Backup vom ganzen Image auf HDD oder USB. Dies erzeugt eine 1:1 Kopie Ihrer Box."
 
 msgid "Backup your current settings"
 msgstr "Einstellungen sichern"
@@ -4288,7 +4288,7 @@ msgid "Choose a label that will identify this device within IceTV services."
 msgstr "Wählen Sie eine Beschriftung, damit IceTV Dienste das Gerät zuordnen können."
 
 msgid "Choose a setting where your receiver wakes up from standby."
-msgstr "Wählen Sie eine Einstellung aus, mit der Ihr Receiver aus dem Standby aufwacht."
+msgstr "Wählen Sie eine Einstellung aus, mit der Ihre Box aus dem Standby aufwacht."
 
 msgid "Choose a tag for easy finding a recording."
 msgstr "Wählen Sie einen Tag aus, um die Aufnahme später leichter wieder zu finden."
@@ -4754,7 +4754,7 @@ msgid "Configure the general audio volume step size (limit 1-10)."
 msgstr "Die generelle Schrittweite (von 1 bis 10) für die Lautstärke einstellen."
 
 msgid "Configure the hard disk drive to go to standby after the specified idle time when the box is in standby."
-msgstr "Einstellen, nach welcher Zeit Ihre Festplatte in den Ruhezustand gehen soll, wenn sich die Box im Standby befindet."
+msgstr "Einstellen, nach welcher Zeit Ihre Festplatte in den Ruhezustand gehen soll, wenn sich Ihre Box im Standby befindet."
 
 msgid "Configure the hard disk drive to go to standby after the specified idle time."
 msgstr "Einstellen, nach wie viel Leerlaufzeit eine Festplatte in den Ruhezustand geht."
@@ -5796,7 +5796,7 @@ msgid "Delete all the text"
 msgstr "Lösche den ganzen Text"
 
 msgid "Delete and uninstall Plugins. This will remove the Plugin from your box"
-msgstr "Entfernen installierter Erweiterungen. Dadurch wird das Plugin von der Box entfernt"
+msgstr "Entfernen installierter Erweiterungen. Dadurch wird das Plugin von Ihrer Box entfernt."
 
 msgid "Delete current line"
 msgstr "Aktuelle Zeile löschen"
@@ -5998,7 +5998,7 @@ msgid "Disable MiniTV"
 msgstr "Entferne MiniTV aus Display"
 
 msgid "Disable Picture in Picture"
-msgstr "Bild im Bild (PiP) deaktivieren"
+msgstr "Bild im Bild deaktivieren"
 
 msgid "Disable background scanning"
 msgstr "Suchlauf im Hintergrund deaktivieren"
@@ -6288,7 +6288,7 @@ msgid "Do you want to update your %s %s ?"
 msgstr "Wollen Sie Ihre %s %s updaten?"
 
 msgid "Do you want to update your box?"
-msgstr "Update der Box durchführen?"
+msgstr "Update Ihrer Box durchführen?"
 
 msgid "Do you want to upgrade the package:\n"
 msgstr "Das Paket aktualisieren:\n"
@@ -6446,7 +6446,7 @@ msgid "ECM avg"
 msgstr "ECM-Durchschnitt"
 
 msgid "ECM data will be included in the stream. This enables a client receiver to decode it."
-msgstr "Bei 'Ja' werden ECM Daten in den Stream eingefügt. Dies ermöglicht einem Klient-Receiver den Stream selbst zu entschlüsseln."
+msgstr "Bei 'Ja' werden ECM Daten in den Stream eingefügt. Dies ermöglicht einer Klient-Box den Stream selbst zu entschlüsseln."
 
 msgid "ECM last"
 msgstr "letzte ECM"
@@ -6745,7 +6745,7 @@ msgid "Enable digital downmix"
 msgstr "Dolby Digital Downmix aktivieren"
 
 msgid "Enable fallback remote receiver"
-msgstr "Aktiviere Reservereceiver"
+msgstr "Aktiviere Reservebox"
 
 msgid "Enable freesat EPG"
 msgstr "Freesat EPG aktivieren"
@@ -6766,7 +6766,7 @@ msgid "Enable preview"
 msgstr "Aktiviere Vorschau"
 
 msgid "Enable remote enigma2 receiver to be tried to tune into services that cannot be tuned into locally (e.g. tuner is occupied or service type is unavailable on the local tuner. Specify complete URL including http:// and port number (normally ...:8001), e.g. http://second_box:8001."
-msgstr "Mit 'Ja' Reserve-Enigma2-Receiver aktivieren der versucht wird, wenn ein Sender lokal nicht empfangen werden kann (z.B. wenn der Tuner belegt oder der Sender lokal nicht verfügbar ist). Geben Sie die komplette URL inklusive 'http://' und Portnummer (normalerweise 8001) an, also z.B. 'http://zweite_box:8001'."
+msgstr "Mit 'Ja' Reserve-Enigma2-Box aktivieren, die versucht wird, wenn ein Sender lokal nicht empfangen werden kann (z.B. wenn der Tuner belegt oder der Sender lokal nicht verfügbar ist). Geben Sie die komplette URL inklusive 'http://' und Portnummer (normalerweise 8001) an, also z.B. 'http://zweite_box:8001'."
 
 msgid "Enable screenshot of LCD in /tmp"
 msgstr ""
@@ -7404,7 +7404,7 @@ msgid "Falkland Islands (Malvinas)"
 msgstr "Falklandinseln (Malvinen)"
 
 msgid "Fallback remote receiver URL"
-msgstr "Reservereceiver URL"
+msgstr "Reservebox URL"
 
 msgid "False"
 msgstr ""
@@ -7564,7 +7564,11 @@ msgid "Film-Noir"
 msgstr ""
 
 msgid "Filter extension for 'My Extension' setting of 'Filter extension'. Use the extension name without a '.'."
-msgstr "Filtererweiterung für 'meine Erweiterung' Einstellung von 'Filtererweiterung'. Verwenden Sie den Erweiterungsnamen ohne '.' ein."
+msgstr ""
+"Einstellung der 'Filtererweiterung'.\n"
+"Geben Sie den Erweiterungsnamen ohne '.' ein.\n"
+"\n"
+"Mit der TXT (Videotext) Taste erhalten Sie eine virtuelle Tastatur."
 
 msgid "Filter extension, (*) appears in title"
 msgstr "Filtererweiterung (*) erscheint im Titel"
@@ -7639,7 +7643,7 @@ msgid "Flash Online a new image"
 msgstr "Online/Offline flashen"
 
 msgid "Flash on the fly your your Receiver software."
-msgstr "Flashen Sie Ihre Receiver-Software online oder von einer lokalen Quelle."
+msgstr "Flashen Sie Ihre Box-Software online oder von einer lokalen Quelle."
 
 msgid "Flashing"
 msgstr "Blinkendes Icon"
@@ -8583,7 +8587,7 @@ msgid "If enabled, AIT data is included in recordings."
 msgstr "Bei 'Ja' sind in den Aufzeichnungen AIT-Daten enthalten."
 
 msgid "If enabled, using a time window to detect a wakeup from deep standby by a timer. Default setting ist disabled and used a special signal from the receiver. But some devices set a wrong or none signal and the wakeup detection can fails."
-msgstr "Bei 'Ja' kann ein Zeitfenster eingestellt werden, um ein Aufwachen aus dem Deep-Standby durch einen Timer zu erkennen. Standardeinstellung ist 'Nein' und verwendet ein spezielles Signal vom Receiver. Manche Geräte setzen aber ein falsches oder kein Signal und die Erkennung kann fehlschlagen."
+msgstr "Bei 'Ja' kann ein Zeitfenster eingestellt werden, um ein Aufwachen aus dem Deep-Standby durch einen Timer zu erkennen. Standardeinstellung ist 'Nein' und verwendet ein spezielles Signal von der Box. Manche Boxen setzen aber ein falsches oder kein Signal und die Erkennung kann fehlschlagen."
 
 msgid "If logs are using the set maximum space used the eldest will be deleted."
 msgstr "Wenn die Log-Dateien zu viel Speicher belegen werden die ältesten Dateien gelöscht."
@@ -8776,7 +8780,7 @@ msgid "In progress"
 msgstr "In Arbeit"
 
 msgid "In the Standby Record on the LCD Display"
-msgstr "Bei 'Ja' wird das blinkende REC Symbol im Gerätedisplay im Standby aktiviert (nicht alle Receiver unterstützen das)."
+msgstr "Bei 'Ja' wird das blinkende REC Symbol im Gerätedisplay im Standby aktiviert (nicht alle Boxen unterstützen das)."
 
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -11200,7 +11204,7 @@ msgid "On end of movie (as menu)"
 msgstr "Am Ende des Films (als Menü)"
 
 msgid "On reaching the end of a file during playback, you can choose the box's behavior."
-msgstr "Am Ende einer Filmwiedergabe kann das Verhalten der Box bestimmt werden."
+msgstr "Am Ende einer Filmwiedergabe kann das Verhalten Ihrer Box bestimmt werden."
 
 msgid "On valid ONIDs, ignore frequency sub network part"
 msgstr "Bei 'Ja' werden Subnetzwerk Frequenzen bei gültigen ONIDs ignoriert."
@@ -11283,13 +11287,13 @@ msgid "Open service list and select next channel"
 msgstr "Öffne Kanalliste und wähle nächsten Kanal"
 
 msgid "Open service list and select next channel for PiP"
-msgstr "Öffne Kanalliste und wähle nächsten Kanal für Bild im Bild (PiP)"
+msgstr "Öffne Kanalliste und wähle nächsten Kanal für Bild im Bild"
 
 msgid "Open service list and select previous channel"
 msgstr "Öffne Kanalliste und wähle vorherigen Kanal"
 
 msgid "Open service list and select previous channel for PiP"
-msgstr "Öffne Kanalliste und wähle vorherigen Kanal für Bild im Bild (PiP)"
+msgstr "Öffne Kanalliste und wähle vorherigen Kanal für Bild im Bild"
 
 msgid "Open settings/actions menu"
 msgstr "Menü Einstellungen / Aktionen öffnen"
@@ -11823,7 +11827,7 @@ msgstr "Aufnahmeendzeit ändern"
 
 # ImageBackup.py
 msgid "Please check the manual of the receiver"
-msgstr "Schauen Sie bitte in das Handbuch Ihres Receivers,"
+msgstr "Schauen Sie bitte in das Handbuch Ihrer Box,"
 
 msgid "Please check your network settings!"
 msgstr "Netzwerkeinstellungen überprüfen!"
@@ -12327,13 +12331,13 @@ msgid "Power long"
 msgstr "Ausschalttaste lang"
 
 msgid "Power management. Consult your receiver's manual for more information."
-msgstr "Energieverwaltung. Weitere Informationen finden Sie im Handbuch Ihres Receivers."
+msgstr "Energieverwaltung. Weitere Informationen finden Sie im Handbuch Ihrer Box."
 
 msgid "Power threshold in mA"
 msgstr "Schwellwert Stromverbrauch in mA"
 
 msgid "Power threshold. Consult your receiver's manual for more information."
-msgstr "Leistungsschwelle. Weitere Informationen finden Sie im Handbuch Ihres Receivers."
+msgstr "Leistungsschwelle. Weitere Informationen finden Sie im Handbuch Ihrer Box."
 
 msgid "PowerManager entry"
 msgstr "PowerTimer-Eintrag"
@@ -12979,7 +12983,7 @@ msgid ""
 "Entering standby, after recording the box will shutdown."
 msgstr ""
 "Zurzeit ist eine/sind Aufnahmen aktiv oder starten gleich!\n"
-"Der Receiver wird jetzt in den Standby versetzt und am Ende der Aufnahme(n) heruntergefahren."
+"Ihre Box wird jetzt in den Standby versetzt und am Ende der Aufnahme(n) heruntergefahren."
 
 msgid "Recordings"
 msgstr "Aufnahmen"
@@ -13392,7 +13396,7 @@ msgid "Restore system settings"
 msgstr "Systemeinstellungen wiederherstellen"
 
 msgid "Restore your settings back from a backup. After restore the box will restart to activated the new settings"
-msgstr "Wiederherstellen der Settings vom Backup. Nach Wiederherstellung die Box neu starten"
+msgstr "Wiederherstellen der Settings vom Backup. Nach Wiederherstellung wird Ihre Box neu starten, um die Settings zu aktivieren."
 
 msgid "Restoring..."
 msgstr "Wiederherstellen..."
@@ -16996,7 +17000,7 @@ msgid "The default settings are 5 minutes earlier to wakeup from deep standby. I
 msgstr "Die Standardeinstellung ist 5 Minuten früher aus dem Deep-Standby aufzuwachen. Es kann erforderlich sein, dies zu ändern (z.B.: Die tatsächliche Aufwachzeit ist ungenau oder zu spät, warten auf ein Netzlaufwerk etc.)."
 
 msgid "The default settings are wakeup time - 5 minutes and timer begin time + 5 minutes. This setting changed the time window before the wakeup time. So can be detected a wakeup by a timer even at very early starting receivers."
-msgstr "Die Standardeinstellungen sind Aufwachzeit - 5 Minuten und Timerbeginn + 5 Minuten. Diese Einstellung verändert das Zeitfenster vor der Aufwachzeit. So kann das Aufwachen durch einen Timer auch bei sehr früh startenden Receivern erkannt werden."
+msgstr "Die Standardeinstellungen sind Aufwachzeit - 5 Minuten und Timerbeginn + 5 Minuten. Diese Einstellung verändert das Zeitfenster vor der Aufwachzeit. So kann das Aufwachen durch einen Timer auch bei sehr früh startenden Boxen erkannt werden."
 
 #, python-format
 msgid ""
@@ -17440,7 +17444,7 @@ msgid "This option allows you to show the screen menu path history."
 msgstr "Mit dieser Option können Sie den Pfadverlauf des Bildschirmmenüs anzeigen."
 
 msgid "This option allows you to the SNR as a percentage (not all receivers support this)."
-msgstr "Einstellen, ob der Signalwert SNR in 'dB' statt '%' anzeigt werden soll (nicht alle Receiver unterstützen diese Funktion)."
+msgstr "Einstellen, ob der Signalwert SNR in 'dB' statt '%' anzeigt werden soll (nicht alle Boxen unterstützen diese Funktion)."
 
 msgid "This option allows you to use all HDMI Modes"
 msgstr "Bei 'Ja' können Sie alle HDMI-Modi verwenden."
@@ -18212,7 +18216,7 @@ msgstr ""
 
 msgid "URL of fallback remote receiver"
 msgstr ""
-"URL des Reservereceivers.\n"
+"URL der Reservebox.\n"
 "\n"
 "Mit der TXT (Videotext) Taste erhalten Sie eine virtuelle Tastatur."
 
@@ -18455,7 +18459,7 @@ msgid "Update/Backup your firmware, Backup/Restore settings"
 msgstr "Sichern/Wiederherstellen des Images oder der Einstellungen."
 
 msgid "Update/Backup/Restore your box"
-msgstr "Update/Backup/Restore der Box"
+msgstr "Update/Backup/Restore Ihrer Box"
 
 msgid "Updatefeed not available."
 msgstr "Update-Feed nicht verfügbar."
@@ -19225,9 +19229,9 @@ msgid ""
 "Your receiver restarts in 10 seconds!\n"
 "Component: enigma2"
 msgstr ""
-"Es tut uns leid. Ihr Receiver hat ein Software-Problem und muss neu gestartet werden.\n"
+"Es tut uns leid, aber Ihre Box hat ein Software-Problem und muss neu gestartet werden!\n"
 "Bitte senden Sie die Logdatei '%senigma2_crash_xxxxxx.log' an 'https://www.opena.tv'.\n"
-"Ihr Receiver startet in 10 Sekunden neu!\n"
+"Ihre Box startet in 10 Sekunden neu!\n"
 "Komponente: Enigma2"
 
 msgid "Weather"
@@ -19343,7 +19347,7 @@ msgid "What Day of week ?"
 msgstr "An welchem Wochentag?"
 
 msgid "What action is required on completion of the timer? 'Auto' lets the box return to the state it had when the timer started. 'Do nothing', 'Go to standby' and 'Go to deep standby' do exactly that."
-msgstr "Wählen Sie, was nach dem ausgeführten Timer geschehen soll. 'Automatisch' lässt die Box in den Zustand gehen, den sie vor dem Timerstart hatte."
+msgstr "Wählen Sie, was nach dem ausgeführten Timer geschehen soll. 'Automatisch' lässt Ihre Box in den Zustand gehen, den sie vor dem Timerstart hatte."
 
 msgid "What do you want to play?\n"
 msgstr "Was möchten Sie wiedergeben?\n"
@@ -19798,7 +19802,7 @@ msgid "You can remove this plugin."
 msgstr "Sie können diese Erweiterung deinstallieren."
 
 msgid "You can skip this function and turn off the TV when you wake the receiver from standby and immediately switch back to standby."
-msgstr "Sie können diese Funktion überspringen und den TV ausschalten, wenn Sie den Receiver aus dem Standby-Modus aufwecken und sofort wieder in den Standby-Modus wechseln."
+msgstr "Sie können diese Funktion überspringen und den TV ausschalten, wenn Sie Ihre Box aus dem Standby-Modus aufwecken und sofort wieder in den Standby-Modus wechseln."
 
 # Satconfig.py
 #, python-format
@@ -20016,10 +20020,10 @@ msgstr "Hardware erkennt das CI Protokoll selber oder Hardware arbeitet nur im L
 
 #, python-format
 msgid "Your Receiver has a Software problem detected. Since the last reboot it has occurred %d times.\n"
-msgstr "Ihr Receiver hat ein Softwareproblem erkannt. Seit dem letzten Neustart ist es %d Mal aufgetreten.\n"
+msgstr "Ihre Box hat ein Softwareproblem erkannt! Seit dem letzten Neustart ist es %d Mal aufgetreten.\n"
 
 msgid "Your STB will restart after pressing OK on your remote control."
-msgstr "Die Box wird nach dem Drücken von OK auf der Fernbedienung neu starten."
+msgstr "Ihre Box wird nach Drücken von OK auf der Fernbedienung neu starten."
 
 msgid "Your backup succeeded. We will now continue to explain the further upgrade process."
 msgstr "Ihre Sicherung ist geglückt. Die %s %s wird nun den weiteren Aktualisierungs-Prozess erklären."
@@ -20106,10 +20110,10 @@ msgid "Your password must have at least 5 characters."
 msgstr "Ihr Passwort muss aus mindestens 5 Zeichen bestehen."
 
 msgid "Your receiver can use SCPC optimized search range. Consult your receiver's manual for more information."
-msgstr "Ihr Empfänger kann SCPC-optimierten Suchbereich verwenden. Weitere Informationen finden Sie im Handbuch Ihres Receivers."
+msgstr "Ihre Box kann SCPC-optimierten Suchbereich verwenden. Weitere Informationen finden Sie im Handbuch Ihrer Box."
 
 msgid "Your receiver can use tone amplitude. Consult your receiver's manual for more information."
-msgstr "Ihr Receiver kann die Tonamplitude verwenden. Weitere Informationen finden Sie im Handbuch Ihres Receivers."
+msgstr "Ihre Box kann die Tonamplitude verwenden. Weitere Informationen finden Sie im Handbuch Ihrer Box."
 
 msgid ""
 "Your wireless LAN internet connection could not be started!\n"


### PR DESCRIPTION
"**Receiver**" durch "**Box**" ersetzt. Hoffentlich hab ichs nicht versaut...

msgid "Put your AV Receiver in standby"
msgstr "AV Receiver in Standby versetzen"

msgid "Wakeup your AV Receiver from standby"
msgstr "AV Receiver aus dem Standby aufwecken"

Ist mit "**AV Receiver**" auch **die Box**, oder etwa ein externer Receiver, z.B. für Sourround, gemeint?