### PR TITLE
[MovieList] fix buildBeginTimeSortKey(()

### DIFF
--- a/lib/python/Components/MovieList.py
+++ b/lib/python/Components/MovieList.py
@@ -796,7 +796,7 @@ class MovieList(GUIComponent):
 	def buildBeginTimeSortKey(self, x):
 		ref = x[0]
 		if ref.flags & eServiceReference.mustDescent:
-			return (0, x[1] and x[1].getName(ref).lower() or "")
+			return 0, "", x[1] and -os.stat(ref.getPath()).st_mtime or 0
 		return 1, "", -x[2]
 
 	def buildGroupwiseSortkey(self, x):


### PR DESCRIPTION
1) buildBeginTimeSortKey() is supposed to sort by time not name.
2) add missing empty string in the return value. The tuple is supposed to have a length of 3, not 2, so it matches the tuple produced by buildAlphaNumericSortKey(), otherwise there will be crashes when using buildGroupwiseSortkey().