### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -2582,10 +2582,10 @@ msgstr "Verzeichnis zur Playlist hinzufügen"
 
 #
 msgid "Add file to playlist"
-msgstr "Datei zur Wiedergabeliste hinzufügen"
+msgstr "Datei zur Playlist hinzufügen"
 
 msgid "Add files to playlist"
-msgstr "Zur Wiedergabeliste hinzufügen"
+msgstr "Zur Playlist hinzufügen"
 
 msgid "Add plugin to Extensions menu*"
 msgstr "Plugin zum Erweiterungsmenü hinzufügen *"
@@ -18305,7 +18305,7 @@ msgid "Show contents of zip file"
 msgstr "Inhalt der '.zip'-Datei anzeigen"
 
 msgid "Show crash info on screen and write crash log for x times"
-msgstr "Wie oft soll Absturz-Info anzeigt und das Crash-Log erstellt werden?"
+msgstr "Wie oft Absturz-Info anzeigen und Crash-Log erstellen"
 
 msgid "Show crypto icons"
 msgstr "Anzeige der Verschlüsselung"
@@ -20925,7 +20925,7 @@ msgstr "Bei 'Ja' können Sie alle HDMI-Modi verwenden."
 msgid "This option allows you to view the old and new settings side by side."
 msgstr ""
 "Einstellen, ob und wie das Bild mit den alten und neuen Werten nebeneinander "
-"anzeigt werden soll."
+"angezeigt werden soll."
 
 msgid "This option configures the general audio delay for BT Speakers."
 msgstr ""


### PR DESCRIPTION
Playlist statt Wiedergabeliste. Ist an vielen anderen Stellen auch so.

Bei "Wie oft soll die Absturzinfo anzeigt und das Crashlog erstellt werden?"
Das Fragezeichen weg, da es ein Menüpunkt ist, den Text kürzer gemacht und den Schreibfehler behoben.