### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3051,10 +3051,10 @@ msgstr "Jede Aktivität"
 
 msgid "Apply any changes to the active locale/language and exit"
 msgstr ""
-"Änderungen anwenden, um die aktive Sprache zu aktivieren und zu beenden"
+"Änderungen anwenden, um die aktive Sprache zu aktivieren und zu beenden."
 
 msgid "Apply the currently highlighted locale/language and exit"
-msgstr "Die aktuell markierte Sprache anwenden und beenden"
+msgstr "Die aktuell markierte Sprache anwenden und beenden."
 
 msgid "Arabic"
 msgstr "Arabisch"
@@ -6021,7 +6021,7 @@ msgstr "Crashlogs"
 
 # data/setup.xml
 msgid "Crash at skin error for debug reasons ?"
-msgstr "Auch bei Skin-Fehlern abstürzen?"
+msgstr "Auch bei Skin-Fehlern abstürzen"
 
 #
 msgid "Create"
@@ -6715,7 +6715,7 @@ msgid "Delete EPG"
 msgstr "EPG löschen"
 
 msgid "Delete Language"
-msgstr "Sprachen löschen"
+msgstr "Sprache löschen"
 
 msgid "Delete Plugins"
 msgstr "Plugins löschen"
@@ -7515,7 +7515,7 @@ msgid ""
 "ECM data will be included in the stream. This enables a client receiver to "
 "decode it."
 msgstr ""
-"Bei 'Ja' werden ECM-Daten in den Stream eingefügt. Dies ermöglicht einer "
+"Bei 'Ja' werden ECM-Daten in den Stream eingefügt. Dies ermöglicht einem "
 "Client-Receiver den Stream selbst zu entschlüsseln."
 
 msgid "ECM last"
@@ -8778,7 +8778,7 @@ msgid "File appears to be busy.\n"
 msgstr "Datei scheint in Benutzung zu sein.\n"
 
 msgid "File checksums to calculate for button 9"
-msgstr "Für die Berechnung von Datei-Prüfsummen mit der Taste '9'"
+msgstr "Für die Berechnung von Datei-Prüfsummen mit der Taste '9'."
 
 msgid "File checksums/hashes"
 msgstr "Datei Prüfsummen / Hash"
@@ -9672,7 +9672,7 @@ msgstr ""
 "Wählen Sie, welche Dateien bei einem Onlineupdate aktualisiert werden sollen."
 
 msgid "Here you can set what is called when pressing the 'Info' key."
-msgstr "Einstellen, was beim Betätigen der INFO Taste aufgerufen werden soll."
+msgstr "Einstellen, was beim Betätigen der Taste INFO aufgerufen werden soll."
 
 msgid ""
 "Here you can specify additional files that should be added to the backup "
@@ -10016,7 +10016,7 @@ msgid ""
 "of the video contents resolution"
 msgstr ""
 "Wenn die Ausgabeauflösung aktiviert ist, wird Ihr Receiver versuchen, der "
-"Auflösung des Videoinhalts zu entsprechen"
+"Auflösung des Videoinhalts zu entsprechen."
 
 msgid "If enabled the video will always be de-interlaced."
 msgstr "Bei 'Ja' wird das Bild immer deinterlaced."
@@ -10061,7 +10061,7 @@ msgid ""
 msgstr ""
 "Bei 'Nein' wird nur eine Datei als Puffer verwendet. Es wird empfohlen "
 "'Timeshift-Überprüfung auf ältere Dateien (in Minuten)' und 'Timeshift-"
-"Überprüfung auf freien Speicherplatz?' anzupassen."
+"Überprüfung auf freien Speicherplatz' anzupassen."
 
 msgid "If set to 'yes' channels without EPG will not be shown."
 msgstr "Bei 'Ja' werden Sender ohne EPG nicht angezeigt."
@@ -10138,7 +10138,7 @@ msgid ""
 "(no timeout)."
 msgstr ""
 "Bei 'Ja' wird die Infoleiste im pausierten Zustand nicht ausgeblendet "
-"sondern dauerhaft angezeigt."
+"sondern permanent angezeigt."
 
 msgid ""
 "If the 'deep standby workaround' is enabled, it waits until the system time "
@@ -11484,7 +11484,7 @@ msgstr "Logverwaltung"
 
 # data/setup.xml
 msgid "Log python stack trace on spinner ?"
-msgstr "Bei Spinner Python-Stack-Trace loggen?"
+msgstr "Bei Spinner Python-Stack-Trace loggen"
 
 #
 msgid "Log results to harddisk"
@@ -11637,7 +11637,7 @@ msgid "Mainmenu"
 msgstr "Hauptmenü"
 
 msgid "Maintain old EPG data for"
-msgstr "Alte EPG-Daten für x Minuten halten"
+msgstr "Alte EPG-Daten für wie viele Minuten halten"
 
 msgid "Make File Commander accessible from the Extensions menu."
 msgstr "File Commander über das Erweiterungsmenü zugänglich machen."
@@ -11808,13 +11808,13 @@ msgid "Maximum minutes to jump %d !"
 msgstr "Sie können nur maximal %d Minuten springen!"
 
 msgid "Maximum no of days:"
-msgstr "Maximale Anzahl von Tagen:"
+msgstr "Maximale Anzahl von Tagen"
 
 msgid "Maximum number of days in EPG"
 msgstr "Maximale Anzahl von Tagen im EPG"
 
 msgid "Maximum space used (MB):"
-msgstr "Maximale Speicherplatznutzung (MB):"
+msgstr "Maximale Speicherplatznutzung (MB)"
 
 msgid "Mayotte"
 msgstr "Mayotte"
@@ -12953,7 +12953,7 @@ msgstr "Keine Tags für diese Filme gesetzt."
 
 # UsageConfig.py
 msgid "No timeout"
-msgstr "Keine Zeitüberschreitung"
+msgstr "Permanent"
 
 #
 msgid "No to all"
@@ -14091,7 +14091,7 @@ msgstr "Aufnahmeendzeit ändern"
 
 # ImageBackup.py
 msgid "Please check the manual of the receiver"
-msgstr "Schauen Sie bitte in das Handbuch Ihres Receivers."
+msgstr "Schauen Sie bitte in das Handbuch Ihres Receivers"
 
 #
 msgid "Please check your network settings!"
@@ -18150,7 +18150,7 @@ msgstr "Log anzeigen"
 
 # crashlog
 msgid "Show Log Manager in extensions list ?"
-msgstr "Logverwaltung in Erweiterungen anzeigen?"
+msgstr "Logverwaltung in Erweiterungen anzeigen"
 
 #
 msgid "Show Main Menu as"
@@ -18390,7 +18390,7 @@ msgid "Show in Standby"
 msgstr "Im Standby anzeigen"
 
 msgid "Show in extensions list ?"
-msgstr "Im Erweiterungsmenü anzeigen?"
+msgstr "Im Erweiterungsmenü anzeigen"
 
 msgid "Show info"
 msgstr "Infos anzeigen"
@@ -20961,10 +20961,10 @@ msgid "This option lets you adjust the transparency of the user interface"
 msgstr "Die Transparenz der Benutzeroberfläche anpassen."
 
 msgid "This option lets you choose the 3D mode"
-msgstr "Den 3D-Modus aktivieren"
+msgstr "Den 3D-Modus aktivieren."
 
 msgid "This option lets you show the option in the extension screen"
-msgstr "Die Option unter Erweiterungen anzeigen"
+msgstr "Die Option unter Erweiterungen anzeigen."
 
 msgid ""
 "This option moves the PVR status from the separate window into the "
@@ -21389,13 +21389,13 @@ msgid "Timeshift"
 msgstr "Timeshift"
 
 msgid "Timeshift buffer delete after zap?"
-msgstr "Timeshift-Puffer beim Umschalten löschen?"
+msgstr "Timeshift-Puffer beim Umschalten löschen"
 
 msgid "Timeshift buffer limit [in hours]"
 msgstr "Timeshift zwischenspeichern (in Stunden)"
 
 msgid "Timeshift checking for free space?"
-msgstr "Timeshift-Überprüfung auf freien Speicherplatz?"
+msgstr "Timeshift-Überprüfung auf freien Speicherplatz"
 
 msgid "Timeshift checking for older files [in minutes]"
 msgstr "Timeshift-Überprüfung auf ältere Dateien (in Minuten)"


### PR DESCRIPTION
"Für die Berechnung von Datei-Prüfsummen mit der Taste '9'." mit Punkt am Ende wie bei "... Zielordner für die Taste '5'." in Zeile 6562.
Punkte an Hilfstexte.
Fragezeichen in Menüpunkten weg.
Punkt nach "Schauen Sie bitte in das Handbuch Ihres Receivers" weg; ergibt dann "Schauen Sie bitte in das Handbuch Ihres Receivers wie das Image wiederhergestellt werden kann." (Wenn Imagebackup fertig ist.)