### PR TITLE
Dont' move the external rotor with "simulate" and "no_rotor_command_on_tune"

### DIFF
--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -1101,7 +1101,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 					sec_sequence.push_back( eSecCommand(eSecCommand::SLEEP, m_params[DELAY_AFTER_VOLTAGE_CHANGE_BEFORE_MOTOR_CMD]) );  // wait 150msec after voltage change
 			}
 
-			if (useExternalRotorCmd && !sat.no_rotor_command_on_tune) {
+			if (useExternalRotorCmd && !sat.no_rotor_command_on_tune && !simulate) {
 				move_external_rotor(slot_id_to_fe_id(slot_id), sat.orbital_position, sw_param.m_rotorPosNum);
 				sec_fe->setData(eDVBFrontend::NEW_ROTOR_POS, sat.orbital_position);
 				int mrt;

--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -1101,7 +1101,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 					sec_sequence.push_back( eSecCommand(eSecCommand::SLEEP, m_params[DELAY_AFTER_VOLTAGE_CHANGE_BEFORE_MOTOR_CMD]) );  // wait 150msec after voltage change
 			}
 
-			if (useExternalRotorCmd) {
+			if (useExternalRotorCmd && !sat.no_rotor_command_on_tune) {
 				move_external_rotor(slot_id_to_fe_id(slot_id), sat.orbital_position, sw_param.m_rotorPosNum);
 				sec_fe->setData(eDVBFrontend::NEW_ROTOR_POS, sat.orbital_position);
 				int mrt;


### PR DESCRIPTION
The EPGImporter plugin creates a fake, simulated, recording to check if a channel is available.
That causes an unnecessary movement of the dish while importing the epg. Adding the !simulate condition avoids that (first I tried with just no_rotor_command_on_tune but that doesn't work in this case).
Probably the !simulate condition should also be added to the branch sending commands to a diseqc rotor, but since I don't have one I didn't touch that part.
