### PR TITLE
[VfdSymbols] Fix custom color for "on" mode

### DIFF
--- a/lib/python/Components/VfdSymbols.py
+++ b/lib/python/Components/VfdSymbols.py
@@ -153,7 +153,7 @@ class SymbolsCheckPoller:
 					else:
 						open("/proc/stb/fp/ledpowercolor", "w").write(config.usage.lcd_ledpowercolor.value)
 					self.led = "0"
-			elif self.led == "1":
+			else:
 				if Screens.Standby.inStandby:
 					open("/proc/stb/fp/ledpowercolor", "w").write(config.usage.lcd_ledstandbycolor.value)
 				else:

--- a/lib/python/Screens/ButtonSetup.py
+++ b/lib/python/Screens/ButtonSetup.py
@@ -228,6 +228,7 @@ def getButtonSetupFunctions():
 		ButtonSetupFunctions.append((_("Swap PIP"), "Infobar/swapPiP", "InfoBar"))
 		ButtonSetupFunctions.append((_("Move PIP"), "Infobar/movePiP", "InfoBar"))
 		ButtonSetupFunctions.append((_("Toggle PIPzap"), "Infobar/togglePipzap", "InfoBar"))
+		ButtonSetupFunctions.append((_("Cycle PIP(zap)"), "Infobar/activePiP", "InfoBar"))
 	ButtonSetupFunctions.append((_("Activate HbbTV (Redbutton)"), "Infobar/activateRedButton", "InfoBar"))
 	if getHaveHDMIinHD() == 'True' or getHaveHDMIinFHD() == 'True':
 		ButtonSetupFunctions.append((_("Toggle HDMI-In full screen"), "Infobar/HDMIInFull", "InfoBar"))


### PR DESCRIPTION
With custom color set for mode "on" there is a problem after recording
in "standby". It stays at color from standby.

Look like it affect many other boxes. This is for sf8008(m).

https://www.opena.tv/octagon-sf8008-4k-uhd/57653-oatv6-4-power-buton-led-color-recording.html