### PR TITLE
[VfdSymbols] Fix wrong front panel led color after record in standby

### DIFF
--- a/lib/python/Components/VfdSymbols.py
+++ b/lib/python/Components/VfdSymbols.py
@@ -153,7 +153,7 @@ class SymbolsCheckPoller:
 					else:
 						open("/proc/stb/fp/ledpowercolor", "w").write(config.usage.lcd_ledpowercolor.value)
 					self.led = "0"
-			elif self.led == "1":
+			else:
 				if Screens.Standby.inStandby:
 					open("/proc/stb/fp/ledpowercolor", "w").write(config.usage.lcd_ledstandbycolor.value)
 				else:


### PR DESCRIPTION
Custom front panel color in "on" state

Seem to affect more boxes except sf8008(m)

https://www.opena.tv/octagon-sf8008-4k-uhd/57653-oatv6-4-power-buton-led-color-recording.html