### PR TITLE
Update QuickMenu.py

### DIFF
--- a/lib/python/Plugins/Extensions/Infopanel/QuickMenu.py
+++ b/lib/python/Plugins/Extensions/Infopanel/QuickMenu.py
@@ -24,7 +24,6 @@ from Screens.HarddiskSetup import HarddiskSelection, HarddiskFsckSelection, Hard
 from Screens.SkinSelector import LcdSkinSelector, SkinSelector
 from Screens.VideoMode import VideoSetup
 
-from Plugins.SystemPlugins.NetworkWizard.NetworkWizard import NetworkWizard
 from Plugins.Extensions.Infopanel.RestartNetwork import RestartNetwork
 from Plugins.Extensions.Infopanel.MountManager import HddMount
 from Plugins.Extensions.Infopanel.SoftcamPanel import *
@@ -416,7 +415,11 @@ class QuickMenu(Screen, ProtectedScreen):
 
 ######## Select Network Menu ##############################
 		if item[0] == _("Network Wizard"):
-			self.session.open(NetworkWizard)
+			try:
+				from Plugins.SystemPlugins.NetworkWizard.NetworkWizard import NetworkWizard
+				self.session.open(NetworkWizard)
+			except:
+				self.session.open(MessageBox, _("Sorry NetworkWizard is not installed!"), MessageBox.TYPE_INFO, timeout=10)
 		elif item[0] == _("Network Adapter Selection"):
 			self.session.open(NetworkAdapterSelection)
 		elif item[0] == _("Network Interface"):


### PR DESCRIPTION
Now on current branch. Sorry
I need this patch for uninstall NetworkWizard

jbleyel commented:
Not really needed because NetworkWizard is a mandatory Plugin.

i answer:
 **lib\python\Screens\NetworkSetup.py**
look there(3of 4):
(1 of 3) Line 187
`if os_path.exists(resolveFilename(SCOPE_PLUGINS, "SystemPlugins/NetworkWizard/networkwizard.xml")):
			self["key_blue"].setText(_("Network wizard"))
		self["list"].setList(self.list)`
(2 of 3) Line 243
`def openNetworkWizard(self):
		if os_path.exists(resolveFilename(SCOPE_PLUGINS, "SystemPlugins/NetworkWizard/networkwizard.xml")):
			try:
				from Plugins.SystemPlugins.NetworkWizard.NetworkWizard import NetworkWizard
			except ImportError:
				self.session.open(MessageBox, _("The network wizard extension is not installed!\nPlease install it."), type=MessageBox.TYPE_INFO, timeout=10)
			else:
				selection = self["list"].getCurrent()
				if selection is not None:
					self.session.openWithCallback(self.AdapterSetupClosed, NetworkWizard, selection[0])`
(3 of 3) Line 1069
`		if os_path.exists(resolveFilename(SCOPE_PLUGINS, "SystemPlugins/NetworkWizard/networkwizard.xml")):
			menu.append((_("Network wizard"), "openwizard"))
		# CHECK WHICH BOXES NOW SUPPORT MAC-CHANGE VIA GUI
		if getBoxType() not in ('DUMMY',) and self.iface == 'eth0':
			menu.append((_("Network MAC settings"), "mac"))`

And this should be safe too: (1of 4) Line 972
`		if self["menulist"].getCurrent()[1] == 'openwizard':
			from Plugins.SystemPlugins.NetworkWizard.NetworkWizard import NetworkWizard
			self.session.openWithCallback(self.AdapterSetupClosed, NetworkWizard, self.iface)`

My little patch is the one and only point, if u want uninstall...