### PR TITLE
Update nl.po

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -1,12 +1,12 @@
 # Dutch translations for Enigma2:
 #
-# Snoete <snoete@hotmail.com>, 2021.#
+# Snoete <snoete@hotmail.com>, 2022.#
 msgid ""
 msgstr ""
 "Project-Id-Version: OpenATV\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-04-16 19:22+0430\n"
-"PO-Revision-Date: 2021-12-31 10:41+0100\n"
+"PO-Revision-Date: 2022-01-16 10:40+0100\n"
 "Last-Translator: Snoete <snoete@hotmail.com>\n"
 "Language-Team: neoatomic\n"
 "Language: nl\n"
@@ -11184,7 +11184,7 @@ msgid "Random"
 msgstr "Willekeurig"
 
 msgid "Random password"
-msgstr "Willekeurig wachtwoord"
+msgstr "Random wachtwoord"
 
 #, python-format
 msgid "Rating defined by broadcaster - %d"


### PR DESCRIPTION
The Original translation doesn't fit, it's one letter short, there are no real alternatives. 
This is a compromise, and now the same as in OATV7.0.