### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -15645,7 +15645,7 @@ msgid "Side by Side"
 msgstr "Nebeneinander"
 
 msgid "Side by side"
-msgstr ""
+msgstr "Nebeneinander"
 
 msgid "Sierra Leone"
 msgstr ""
@@ -15654,13 +15654,13 @@ msgid "Signal Finder"
 msgstr "Signal-Finder"
 
 msgid "Signal OK, proceeding"
-msgstr ""
+msgstr "Signal OK, fortfahren"
 
 msgid "Signal Strength:"
 msgstr "Signalstärke:\t"
 
 msgid "Signal quality"
-msgstr ""
+msgstr "Signalqualität"
 
 msgid "Signal strength:"
 msgstr "Signalstärke:\t"
@@ -15684,13 +15684,13 @@ msgid "Simple titleset (compatibility for legacy players)"
 msgstr "Schlicht (bessere Kompatibilität mit alten DVD-Playern)"
 
 msgid "Simple umounter mass storage device."
-msgstr ""
+msgstr "Einfaches Entfernen des Massenspeichergerätes..."
 
 msgid "Simple zoom"
 msgstr "Einfacher Zoom"
 
 msgid "SimpleUmount"
-msgstr ""
+msgstr "Einfaches Entfernen"
 
 msgid "Simplified Chinese"
 msgstr "Vereinfachtes Chinesisch"
@@ -17893,7 +17893,7 @@ msgid "Today"
 msgstr "Heute"
 
 msgid "Toggels between tv and radio..."
-msgstr ""
+msgstr "Zwischen TV und Radio wechseln"
 
 msgid "Toggle Digital downmix..."
 msgstr "Dolby Digital Downmix An/Aus"
@@ -18019,10 +18019,10 @@ msgid "Transponder Time"
 msgstr "Transponder Zeit"
 
 msgid "Transponder type"
-msgstr ""
+msgstr "Transpondertyp"
 
 msgid "Transport Stream Type"
-msgstr ""
+msgstr "Transportstreamtyp"
 
 msgid "Trashcan"
 msgstr "Papierkorb"


### PR DESCRIPTION
Bei "Einfaches Entfernen des Massenspeichergerätes..." drei Punkte ans Ende, weil es bei allen anderen Menüpunkten im Menü "Hilfe..." auch so ist.