### PR TITLE
replace incorrect translations of "turn on" in polish translations

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -2704,10 +2704,10 @@ msgid "Allows you to assign the selected function to this button."
 msgstr "Zezwól na przypisanie wybranej funkcji do tego przycisku."
 
 msgid "Allows you to enable the debug log. They contain very detailed information of everything the system does."
-msgstr "Umożliwia załączenie dziennika debugowania. Zawierają bardzo szczegółowe informacje o wszystkim co robi system."
+msgstr "Umożliwia włączenie dziennika debugowania. Zawierają bardzo szczegółowe informacje o wszystkim co robi system."
 
 msgid "Allows you to enable/disable displaying icons on the frontpanel."
-msgstr "Umożliwia załączenie/wyłączenie wyświetlania ikon na wyświetlaczu przednim."
+msgstr "Umożliwia włączenie/wyłączenie wyświetlania ikon na wyświetlaczu przednim."
 
 msgid "Allows you to hide the extensions of known file types."
 msgstr "Pozwala ukryć rozszerzenia znanych typów plików."
@@ -3210,7 +3210,7 @@ msgid "Automatically start timeshift after"
 msgstr "Automatycznie uruchom timeshift po"
 
 msgid "Automatically turn on external subtitles"
-msgstr "Automatyczne załączenie napisów zewnętrznych"
+msgstr "Automatyczne włączenie napisów zewnętrznych"
 
 msgid "Automatically update Client/Server View?"
 msgstr "Wyświetlić automatyczną aktualizacje Klient/Serwer?"
@@ -5245,7 +5245,7 @@ msgid "Contrast"
 msgstr "Kontrast"
 
 msgid "Control LED can be turned on or off here."
-msgstr "Tutaj można załączyć/wyłączyć kontrolkę LED."
+msgstr "Tutaj można włączyć/wyłączyć kontrolkę LED."
 
 msgid "Control of the position how finished timer are shown in the Timer List."
 msgstr "Kontrola, jaki czas pozycji zakończenia przedstawiono w liście timera."
@@ -5940,10 +5940,10 @@ msgid "Delay after diseqc reset command"
 msgstr "Opóźnienie po komendzie resetu DiSEqC"
 
 msgid "Delay after enable voltage before motor command"
-msgstr "Opóźnienie po załączeniu napięcia przed poleceniem silnika"
+msgstr "Opóźnienie po włączeniu napięcia przed poleceniem silnika"
 
 msgid "Delay after enable voltage before switch command"
-msgstr "Opóźnienie po załączeniu napięcia przed poleceniem switch"
+msgstr "Opóźnienie po włączeniu napięcia przed poleceniem switch"
 
 msgid "Delay after final continuous tone change"
 msgstr "Opóźnienie po ostatecznym continuous tone change"
@@ -6974,7 +6974,7 @@ msgid "Edit mode off"
 msgstr "Wyłącz tryb edycji"
 
 msgid "Edit mode on"
-msgstr "Załącz tryb edycji"
+msgstr "Włącz tryb edycji"
 
 msgid "Edit new entry"
 msgstr "Edycja nowego wpisu"
@@ -7036,186 +7036,186 @@ msgid "Empty slot"
 msgstr "Puste gniazdo"
 
 msgid "Enable"
-msgstr "Załącz"
+msgstr "Włącz"
 
 #, python-format
 msgid "Enable %s pro:"
-msgstr "Załącz %s pro:"
+msgstr "Włącz %s pro:"
 
 msgid "Enable 5V for active antenna"
-msgstr "Załącz 5V dla aktywnej anteny"
+msgstr "Włącz 5V dla aktywnej anteny"
 
 msgid "Enable AC3/Dolby"
-msgstr "Załącz AC3/Dolby"
+msgstr "Włącz AC3/Dolby"
 
 msgid "Enable BT Audio"
-msgstr "Załącz BT Audio"
+msgstr "Włącz BT Audio"
 
 msgid "Enable CIHelper for SLOT CI0"
-msgstr "Załącz CIHelper dla SLOT CI0"
+msgstr "Włącz CIHelper dla SLOT CI0"
 
 msgid "Enable CIHelper for SLOT CI1"
-msgstr "Załącz CIHelper dla SLOT CI1"
+msgstr "Włącz CIHelper dla SLOT CI1"
 
 msgid "Enable EIT EPG"
-msgstr "Załącz EIT EPG"
+msgstr "Włącz EIT EPG"
 
 msgid "Enable Focus Animation"
-msgstr "Załącz ostrość animacji"
+msgstr "Włącz ostrość animacji"
 
 msgid "Enable IceTV"
-msgstr "Załącz IceTV"
+msgstr "Włącz IceTV"
 
 msgid "Enable MHW EPG"
-msgstr "Załącz MHW EPG"
+msgstr "Włącz MHW EPG"
 
 msgid "Enable MiniTV"
-msgstr "Załącz MiniTV"
+msgstr "Włącz MiniTV"
 
 msgid "Enable Netmed EPG"
-msgstr "Załącz Netmed EPG"
+msgstr "Włącz Netmed EPG"
 
 msgid "Enable Network IP address check"
-msgstr "Załącz sprawdzanie adresu IP sieci"
+msgstr "Włącz sprawdzanie adresu IP sieci"
 
 msgid "Enable Network Traffic check"
-msgstr "Załącz sprawdzanie ruchu w sieci"
+msgstr "Włącz sprawdzanie ruchu w sieci"
 
 msgid "Enable OpenTV EPG"
-msgstr "Załącz OpenTV EPG"
+msgstr "Włącz OpenTV EPG"
 
 msgid "Enable Quad PIP"
-msgstr "Załącz Quad PIP"
+msgstr "Włącz Quad PIP"
 
 msgid "Enable Swap at startup"
 msgstr "Uruchom plik wymiany przy starcie"
 
 msgid "Enable Up / Down buttons for the 'all up / down' function? (at the beginning / end of the column)"
-msgstr "Załącz przyciski góra / dół dla funkcji 'wszystko w górę / w dół'? (na początku / końcu kolumny)"
+msgstr "Włącz przyciski góra / dół dla funkcji 'wszystko w górę / w dół'? (na początku / końcu kolumny)"
 
 msgid "Enable ViaSat EPG"
-msgstr "Załącz ViaSat EPG"
+msgstr "Włącz ViaSat EPG"
 
 msgid "Enable Virgin EPG"
-msgstr "Załącz Virgin EPG"
+msgstr "Włącz Virgin EPG"
 
 msgid "Enable Wake On LAN"
-msgstr "Załącz WOL"
+msgstr "Włącz WOL"
 
 msgid "Enable and set the duration of the second infobar (press OK twice) that may include more information on the current service."
-msgstr "Załącz i ustaw czas trwania wyświetlania drugiego paska info (naciśnij przycisk 'OK' dwa razy), może zawierać więcej informacji na temat bieżącego kanału."
+msgstr "Włącz i ustaw czas trwania wyświetlania drugiego paska info (naciśnij przycisk 'OK' dwa razy), może zawierać więcej informacji na temat bieżącego kanału."
 
 msgid "Enable auto cable scan"
-msgstr "Załącz automatyczne skanowanie kablówki"
+msgstr "Włącz automatyczne skanowanie kablówki"
 
 msgid "Enable auto fast scan"
-msgstr "Załącz automatyczne szybkie skanowanie"
+msgstr "Włącz automatyczne szybkie skanowanie"
 
 #, python-format
 msgid "Enable auto fast scan for %s"
-msgstr "Załącz automatyczne szybkie skanowanie dla %s"
+msgstr "Włącz automatyczne szybkie skanowanie dla %s"
 
 msgid "Enable blinking rec symbol on the LCD Display"
 msgstr "Tutaj można aktywować ikonę migającą nagrywania na wyświetlaczu"
 
 msgid "Enable chapter support for video files"
-msgstr "Załącz obsługę rozdziałów dla plików wideo"
+msgstr "Włącz obsługę rozdziałów dla plików wideo"
 
 msgid "Enable command line function"
-msgstr "Załącz funkcję wiersza poleceń"
+msgstr "Włącz funkcję wiersza poleceń"
 
 msgid "Enable cut file support for audio files"
-msgstr "Załącz obsługę cięcia plików dla plików audio"
+msgstr "Włącz obsługę cięcia plików dla plików audio"
 
 msgid "Enable cut file support for audio files. (e.g. mp3)"
-msgstr "Załącz obsługę cięcia plików dla plików audio. (n.p. mp3)"
+msgstr "Włącz obsługę cięcia plików dla plików audio. (n.p. mp3)"
 
 msgid "Enable cut file support for non *.ts files"
-msgstr "Załącz obsługę wycinania plików dla plików innych niż *.ts"
+msgstr "Włącz obsługę wycinania plików dla plików innych niż *.ts"
 
 msgid "Enable cut file support for non *.ts files. (e.g. mp4)"
-msgstr "Załącz obsługę wycinania plików dla plików innych niż *.ts (n.p. mp4)"
+msgstr "Włącz obsługę wycinania plików dla plików innych niż *.ts (n.p. mp4)"
 
 msgid "Enable debug log"
-msgstr "Załącz dziennik debugowania"
+msgstr "Włącz dziennik debugowania"
 
 msgid "Enable debug log *"
-msgstr "Załącz dziennik debugowania *"
+msgstr "Włącz dziennik debugowania *"
 
 msgid "Enable digital downmix"
-msgstr "Załącz cyfrowy downmix"
+msgstr "Włącz cyfrowy downmix"
 
 msgid "Enable fallback remote receiver"
-msgstr "Załącz zdalny rezerwowy odbiornik"
+msgstr "Włącz zdalny rezerwowy odbiornik"
 
 msgid "Enable freesat EPG"
-msgstr "Załącz freesat EPG"
+msgstr "Włącz freesat EPG"
 
 msgid "Enable infobar fade-out"
-msgstr "Załącz wygaszacz paska informacyjnego"
+msgstr "Włącz wygaszacz paska informacyjnego"
 
 msgid "Enable intro screen"
-msgstr "Załącz ekran intro"
+msgstr "Włącz ekran intro"
 
 msgid "Enable multiple bouquets"
-msgstr "Załącz tryb wielu bukietów"
+msgstr "Włącz tryb wielu bukietów"
 
 msgid "Enable or disable using HDMI-CEC."
-msgstr "Załącz lub wyłącz obsługę HDMI-CEC."
+msgstr "Włącz lub wyłącz obsługę HDMI-CEC."
 
 msgid "Enable panic button"
 msgstr "Aktywuj przycisk alarmowy"
 
 msgid "Enable preview"
-msgstr "Załącz podgląd"
+msgstr "Włącz podgląd"
 
 msgid "Enable remote enigma2 receiver to be tried to tune into services that cannot be tuned into locally (e.g. tuner is occupied or service type is unavailable on the local tuner. Specify complete URL including http:// and port number (normally ...:8001), e.g. http://second_box:8001."
-msgstr "Załącz zdalny odbiornik enigma2, aby próbować dostroić się do usług, których nie można dostroić lokalnie (np. Tuner jest zajęty lub typ usługi jest niedostępny w lokalnym tunerze. Określ pełny adres URL zawierający http:// i numer portu (normalnie ...:8001), np http://second_box:8001."
+msgstr "Włącz zdalny odbiornik enigma2, aby próbować dostroić się do usług, których nie można dostroić lokalnie (np. Tuner jest zajęty lub typ usługi jest niedostępny w lokalnym tunerze. Określ pełny adres URL zawierający http:// i numer portu (normalnie ...:8001), np http://second_box:8001."
 
 msgid "Enable screenshot of LCD in /tmp"
-msgstr "Załącz zrzut ekranu LCD w /tmp"
+msgstr "Włącz zrzut ekranu LCD w /tmp"
 
 msgid "Enable teletext caching"
-msgstr "Załącz pamięć telegazety"
+msgstr "Włącz pamięć telegazety"
 
 msgid "Enable terrestrial LCN:"
-msgstr "Załącz naziemną LCN:"
+msgstr "Włącz naziemną LCN:"
 
 msgid "Enable the advanced HDMI-CEC setting options."
-msgstr "Załącz zaawansowane opcje HDMI-CEC."
+msgstr "Włącz zaawansowane opcje HDMI-CEC."
 
 msgid "Enable the current value of the slider at end of the slider bar."
-msgstr "Załącz bieżącą wartość suwaka na końcu paska suwaka."
+msgstr "Włącz bieżącą wartość suwaka na końcu paska suwaka."
 
 msgid "Enable this option to add action map / remote control mapping data to the debug log file."
-msgstr "Załącz tę opcję, aby dodać dane map akcji / mapowania zdalnego sterowania do pliku dziennika debugowania."
+msgstr "Włącz tę opcję, aby dodać dane map akcji / mapowania zdalnego sterowania do pliku dziennika debugowania."
 
 msgid "Enable this option to add keyboard keymap data to the debug log file."
-msgstr "Załącz tę opcję, aby dodać dane mapy klawiatury do pliku dziennika debugowania."
+msgstr "Włącz tę opcję, aby dodać dane mapy klawiatury do pliku dziennika debugowania."
 
 msgid "Enable this option to add opkg output data to the debug log file."
 msgstr "Dodaj dane wyjściowe opkg do pliku log."
 
 msgid "Enable this option to add remote control data to the debug log file."
-msgstr "Załącz tę opcję, aby dodać dane zdalnego sterowania do pliku dziennika debugowania."
+msgstr "Włącz tę opcję, aby dodać dane zdalnego sterowania do pliku dziennika debugowania."
 
 msgid "Enable this option to add screen names and resolution data to the debug log file."
-msgstr "Załącz tę opcję, aby dodać nazwy ekranów i dane rozdzielczości do pliku dziennika debugowania."
+msgstr "Włącz tę opcję, aby dodać nazwy ekranów i dane rozdzielczości do pliku dziennika debugowania."
 
 msgid "Enable this setting if your aerial system needs power"
-msgstr "Załącz to ustawienie, jeśli system antenowy wymaga zasilania"
+msgstr "Włącz to ustawienie, jeśli system antenowy wymaga zasilania"
 
 msgid "Enable to display all true/false, yes/no, on/off and enable/disable set up options as a graphical switch."
-msgstr "Załącz wyświetlanie wszystkich prawda/fałsz, tak/nie, załączenie/wyłączanie i załączenie/wyłączanie opcji konfiguracji jako przełącznika graficznego."
+msgstr "Włącz wyświetlanie wszystkich prawda/fałsz, tak/nie, włączenie/wyłączanie i włączenie/wyłączanie opcji konfiguracji jako przełącznika graficznego."
 
 msgid "Enable unlinked bouquets"
-msgstr "Załącz niepowiązane bukiety"
+msgstr "Włącz niepowiązane bukiety"
 
 msgid "Enabled"
-msgstr "Załączone"
+msgstr "Włączone"
 
 msgid "Enables a feature so that the receiver can decrypt streams (if the ECM data is included in the stream and a valid card is available)."
-msgstr "Załącz funkcję, odbiornik może odkodować strumienie (jeśli zawiera dane ECM w strumieniu i ważność karty jest dostępna)."
+msgstr "Włącz funkcję, odbiornik może odkodować strumienie (jeśli zawiera dane ECM w strumieniu i ważność karty jest dostępna)."
 
 msgid "Encrypted: "
 msgstr "Szyfrowany: "
@@ -9174,19 +9174,19 @@ msgid "If editing a file, can you set the cursor start position at end or begin 
 msgstr "W przypadku edytowania pliku można ustawić pozycję początkową kursora na końcu lub na początku wiersza."
 
 msgid "If enabled the output resolution of the box will try to match the resolution of the video contents resolution"
-msgstr "Jeśli załączone - rozdzielczość wideo tunera spróbuje się dostosować do rozdzielczości wideo materiału"
+msgstr "Jeśli włączone - rozdzielczość wideo tunera spróbuje się dostosować do rozdzielczości wideo materiału"
 
 msgid "If enabled the video will always be de-interlaced."
 msgstr "Pozwala określić czy film powinien być zawsze z przeplotem."
 
 msgid "If enabled, AIT data is included in recordings."
-msgstr "Jeśli załączone, dane AIT są zawarte w nagraniach."
+msgstr "Jeśli włączone, dane AIT są zawarte w nagraniach."
 
 msgid "If enabled, a log will be kept of CEC protocol traffic. The log files are located with the other log files but named 'Enigma2-hdmicec-[date].log'."
-msgstr "Jeśli jest załączony, dziennik z protokołu CEC będzie przechowywany. Pliki dziennika znajdują się z innymi plikami dziennika, ale o nazwie Enigma2-hdmicec-[data].log ."
+msgstr "Jeśli jest włączony, dziennik z protokołu CEC będzie przechowywany. Pliki dziennika znajdują się z innymi plikami dziennika, ale o nazwie Enigma2-hdmicec-[data].log ."
 
 msgid "If enabled, using a time window to detect a wakeup from deep standby by a timer. Default setting ist disabled and used a special signal from the receiver. But some devices set a wrong or none signal and the wakeup detection can fails."
-msgstr "Jeśli jest załączona, używanie okna czasowego do wykrywania wybudzenia z głębokiego czuwania przez zegar. Domyślne ustawienie jest wyłączone i używane jest specjalny sygnał z odbiornika. Jednak niektóre urządzenia ustawiają zły sygnał lub go nie mają, a wykrywanie wybudzenia może się nie powieść."
+msgstr "Jeśli jest włączona, używanie okna czasowego do wykrywania wybudzenia z głębokiego czuwania przez zegar. Domyślne ustawienie jest wyłączone i używane jest specjalny sygnał z odbiornika. Jednak niektóre urządzenia ustawiają zły sygnał lub go nie mają, a wykrywanie wybudzenia może się nie powieść."
 
 msgid "If logs are using the set maximum space used the eldest will be deleted."
 msgstr "Jeśli zostanie przekroczona przestrzeń maksymalna,najstarsze zostaną usunięte."
@@ -9249,7 +9249,7 @@ msgid "If set to 'yes; the infobar will remain shown permanently in 'paused' sta
 msgstr "Jeśli jest ustawione na 'tak' pasek informacyjny pozostanie wyświetlany na stałe w stanie 'pauzy' (bez timeoutu)."
 
 msgid "If the deep standby workaround is enabled wait until the system time is synchronized. Depending on the requirement the device wake up will continuing after a maximum of 2 minutes."
-msgstr "Jeśli załączono obejście głębokiego czuwania, oczekuj do czasu aż system zostanie zsynchronizowany. W zależności od wymogu budzenie urządzenia będzie kontynuowane po maksymalnie 2 minutach."
+msgstr "Jeśli włączono obejście głębokiego czuwania, oczekuj do czasu aż system zostanie zsynchronizowany. W zależności od wymogu budzenie urządzenia będzie kontynuowane po maksymalnie 2 minutach."
 
 msgid "If the free space is less than setting value, then an attempt is made to delete the old timeshift files."
 msgstr "Jeśli ilość wolnego miejsca jest mniejsza niż ustawiona wartości, to następnie usuwa stare pliki Timeshiftu."
@@ -9340,7 +9340,7 @@ msgid "In expert mode, configure which tuners will be preferred for recordings, 
 msgstr "W trybie eksperta skonfiguruj, które tunery będą preferowane dla nagrań, gdy dostępny jest więcej niż jeden tuner."
 
 msgid "In most cases this should be set to No. Only enable if you have a very specific need."
-msgstr "W większości przypadków powinno to być ustawione na Nie. Załącz tylko, jeśli masz bardzo specyficzne potrzeby."
+msgstr "W większości przypadków powinno to być ustawione na Nie. Włącz tylko, jeśli masz bardzo specyficzne potrzeby."
 
 msgid ""
 "In order to allow you to access all the features of the IceTV smart recording service, we need to gather some basic information.\n"
@@ -9558,7 +9558,7 @@ msgstr "Instalacja"
 
 #, python-format
 msgid "Install '%s' and enable this operation"
-msgstr "Zainstaluj '%s' i załącz tę operację"
+msgstr "Zainstaluj '%s' i włącz tę operację"
 
 msgid "Install Failed !!"
 msgstr "Instalacja nieudana !!"
@@ -10239,13 +10239,13 @@ msgid "Limits cancelled"
 msgstr "Limity anulowane"
 
 msgid "Limits enabled"
-msgstr "Limity załączone"
+msgstr "Limity włączone"
 
 msgid "Limits off"
 msgstr "Limity wyłączone"
 
 msgid "Limits on"
-msgstr "Limity załączone"
+msgstr "Limity włączone"
 
 msgid "Lingala"
 msgstr "Lingala"
@@ -11095,7 +11095,7 @@ msgid "Move mode off"
 msgstr "Tryb przenoszenia wyłączony"
 
 msgid "Move mode on"
-msgstr "Tryb przenoszenia załączony"
+msgstr "Tryb przenoszenia włączony"
 
 msgid "Move the keyboard cursor down"
 msgstr "Przesuń kursor klawiatury w dół"
@@ -11508,7 +11508,7 @@ msgid "Neutrino  (keymap.ntr)"
 msgstr "Neutrino  (keymap.ntr)"
 
 msgid "Never decrypt the content while recording. This overrides the individual timer settings globally. If enabled, recordings are stored in crypted presentation and must be decrypted afterwards (sometimes called offline decoding). Default: off."
-msgstr "Nigdy nie odszyfrowuj zawartości podczas nagrywania. Zastępuje to globalnie indywidualne ustawienia timera. Jeśli opcja ta jest załączona, nagrania są przechowywane w postaci zaszyfrowanej i muszą być później odszyfrowane (czasami nazywane dekodowaniem offline). Domyślnie: wyłączone."
+msgstr "Nigdy nie odszyfrowuj zawartości podczas nagrywania. Zastępuje to globalnie indywidualne ustawienia timera. Jeśli opcja ta jest włączona, nagrania są przechowywane w postaci zaszyfrowanej i muszą być później odszyfrowane (czasami nazywane dekodowaniem offline). Domyślnie: wyłączone."
 
 msgid "Never decrypt while recording"
 msgstr "Nigdy nie deszyfruj podczas nagrywania"
@@ -11773,7 +11773,7 @@ msgid ""
 "No tuner is enabled!\n"
 "Please setup your tuner settings before you start a service scan."
 msgstr ""
-"Brak załączonego tunera!\n"
+"Brak włączonego tunera!\n"
 "Skonfiguruj tuner przed rozpoczęciem skanowania."
 
 msgid "No update required!"
@@ -11814,7 +11814,7 @@ msgid ""
 " Please verify that you have attached a compatible WLAN device or enable your local network interface."
 msgstr ""
 "Nie znaleziono działającego interfejsu sieci bezprzewodowej.\n"
-" Sprawdź czy podłączyłeś kompatybilne urządzenie WLAN lub czy załączyłeś lokalny interfejs sieciowy."
+" Sprawdź czy podłączyłeś kompatybilne urządzenie WLAN lub czy włączyłeś lokalny interfejs sieciowy."
 
 msgid "No, but restart from begin"
 msgstr "Nie, ale rozpocznij od początku"
@@ -11829,7 +11829,7 @@ msgid "No, do nothing."
 msgstr "Nie, nie rób nic."
 
 msgid "No, just start my %s %s"
-msgstr "Nie, po prostu załącz %s %s"
+msgstr "Nie, po prostu włącz %s %s"
 
 msgid "No, never"
 msgstr "Nie, nigdy"
@@ -12090,7 +12090,7 @@ msgid "Oman"
 msgstr "Oman"
 
 msgid "On"
-msgstr "Załącz"
+msgstr "Włącz"
 
 msgid "On device:"
 msgstr "Na urządzeniu:"
@@ -12253,7 +12253,7 @@ msgid "Option to disable picons on the Infobar"
 msgstr "Opcja wyłączenia pikon na pasku informacyjnym"
 
 msgid "Option to enable the Hardware Standby Timer"
-msgstr "Opcja załączania timera w trybie czuwania"
+msgstr "Opcja włączania timera w trybie czuwania"
 
 msgid "Orbital position"
 msgstr "Pozycja orbitalna"
@@ -13236,7 +13236,7 @@ msgid "Power LED State in Standby"
 msgstr "Stan LED zasilania podczas czuwania"
 
 msgid "Power LED can be turned on or off here."
-msgstr "Tutaj można załączyć lub wyłączyć diodę zasilania."
+msgstr "Tutaj można włączyć lub wyłączyć diodę zasilania."
 
 msgid "Power LED state during deep-standby."
 msgstr "Stan LED zasilania podczas głębokiego czuwania."
@@ -13245,7 +13245,7 @@ msgid "Power LED state during standby."
 msgstr "Stan LED zasilania podczas czuwania."
 
 msgid "Power On Display"
-msgstr "Załącz wyświetlacz"
+msgstr "Włącz wyświetlacz"
 
 msgid "Power long"
 msgstr "Przycisk ‘Power’ (długo)"
@@ -15081,13 +15081,13 @@ msgid "Select 'A' or 'B' if your aerial system requires this, otherwise select '
 msgstr "Wybierz \"A\" lub \"B\", jeśli wymaga tego system antenowy, w przeciwnym razie wybierz \"brak\". Jeśli nie masz pewności, wybierz \"brak\"."
 
 msgid "Select 'Yes' to enable editing of this device's settings. Selecting 'No' resets the devices settings to their default values."
-msgstr "Wybierz \"Tak\", aby załączyć edycję ustawień urządzenia. Wybierz \"Nie\" aby przywrócić domyślne ustawienia urządzenia."
+msgstr "Wybierz \"Tak\", aby włączyć edycję ustawień urządzenia. Wybierz \"Nie\" aby przywrócić domyślne ustawienia urządzenia."
 
 msgid "Select 'band' if using a 'universal' LNB, otherwise consult your LNB spec sheet."
 msgstr "Wybierz \"pasmo\", jeśli używasz \"uniwersalnego\" konwertera, w przeciwnym razie zapoznaj się z arkuszem specyfikacji konwertera."
 
 msgid "Select 'enabled' if this tuner has a signal cable connected, otherwise select 'nothing connected'."
-msgstr "Wybierz załączone, jeśli ten tuner ma podłączony sygnałowy, w przeciwnym razie wybierz nic nie podłączone."
+msgstr "Wybierz włączone, jeśli ten tuner ma podłączony sygnałowy, w przeciwnym razie wybierz nic nie podłączone."
 
 msgid "Select 'polarisation' if using a 'universal' LNB, otherwise consult your LNB spec sheet."
 msgstr "Wybierz opcję \"polaryzacja\", jeśli używasz \"uniwersalnego\" konwertera LNB, w przeciwnym razie zapoznaj się z arkuszem danych technicznych konwertera LNB."
@@ -15241,7 +15241,7 @@ msgid "Select how the satellite dish is set up. i.e. fixed dish, single LNB, DiS
 msgstr "Wybierz sposób konfiguracji anteny satelitarnej. tj. stała antena, pojedynczy LNB, przełącznik DiSEqC, pozycjoner itp."
 
 msgid "Select how to activate the Quick EPG mode:"
-msgstr "Wybierz sposób, aby załączyć tryb szybkiego EPG:"
+msgstr "Wybierz sposób, aby włączyć tryb szybkiego EPG:"
 
 msgid "Select how your box will upgrade."
 msgstr "Wybór trybu aktualizacji."
@@ -15707,7 +15707,7 @@ msgid "Services"
 msgstr "Kanały"
 
 msgid "Services may be grouped in bouquets. When enabled, you can use more than one bouquet."
-msgstr "Kanały mogą być pogrupowane w bukiety. Po załączeniu tej funkcji możesz użyć więcej niż jednego bukietu."
+msgstr "Kanały mogą być pogrupowane w bukiety. Po włączeniu tej funkcji możesz użyć więcej niż jednego bukietu."
 
 msgid "Set Basetime"
 msgstr "Ustaw czas bazowy"
@@ -17696,7 +17696,7 @@ msgid "Switch EPG Page Up"
 msgstr "Przełącz stronę EPG w górę"
 
 msgid "Switch Mode to enable HDR Modes or PIP Functions"
-msgstr "Tryb przełączania, aby załączyć tryby HDR lub funkcje PIP"
+msgstr "Tryb przełączania, aby włączyć tryby HDR lub funkcje PIP"
 
 msgid "Switch TV to correct input"
 msgstr "Przełącz TV na odpowiednie wejście"
@@ -18125,7 +18125,7 @@ msgid "The IceTV server has requested password for %s."
 msgstr "Serwer IceTV zażądał hasła dla %s."
 
 msgid "The Image Viewer component of the File Commander requires the PicturePlayer extension. Install PicturePlayer to enable this operation."
-msgstr "Komponent Image Viewer w File Commander wymaga rozszerzenia PicturePlayer. Zainstaluj program PicturePlayer, aby załączyć tę operację."
+msgstr "Komponent Image Viewer w File Commander wymaga rozszerzenia PicturePlayer. Zainstaluj program PicturePlayer, aby włączyć tę operację."
 
 msgid ""
 "The MediaCenter plugin is not installed!\n"
@@ -18528,10 +18528,10 @@ msgid "This option allows you can config the Colorspace from Auto to RGB"
 msgstr "Ta opcja pozwala na ustawienie przestrzeni kolorów z Auto na RGB"
 
 msgid "This option allows you can enable or disable the 10 Bit Color Mode"
-msgstr "Ta opcja pozwala załączyć lub wyłączyć tryb 10-bitowych kolorów"
+msgstr "Ta opcja pozwala włączyć lub wyłączyć tryb 10-bitowych kolorów"
 
 msgid "This option allows you can enable or disable the 12 Bit Color Mode"
-msgstr "Ta opcja pozwala załączyć lub wyłączyć tryb 12-bitowych kolorów"
+msgstr "Ta opcja pozwala włączyć lub wyłączyć tryb 12-bitowych kolorów"
 
 msgid "This option allows you can force the HDR Modes for UHD"
 msgstr "Ta opcja pozwala wymusić tryby HDR dla UHD"
@@ -18564,10 +18564,10 @@ msgid "This option allows you choose the background colour of transparent picons
 msgstr "Ta opcja pozwala wybrać kolor tła dla przezroczystych pikon."
 
 msgid "This option allows you enable smoothing filter to control the dithering process."
-msgstr "Ta opcja pozwala załączyć filtr wygładzający proces kontroli symulowania."
+msgstr "Ta opcja pozwala włączyć filtr wygładzający proces kontroli symulowania."
 
 msgid "This option allows you enable the vertical scaler dejagging."
-msgstr "Ta opcja pozwala załączyć skalowanie pionowe."
+msgstr "Ta opcja pozwala włączyć skalowanie pionowe."
 
 msgid "This option allows you set the layout view (Text or Graphics)."
 msgstr "Ta opcja pozwala ustawić widok układu (tekst lub grafika)."
@@ -18636,7 +18636,7 @@ msgid "This option allows you to disable sorting of the option in setting screen
 msgstr "Ta opcja pozwala na wyłączenie sortowania opcji w ustawieniach ekranu"
 
 msgid "This option allows you to enable 3D Surround Sound."
-msgstr "Ta opcja umożliwia załączenie dźwięku przestrzennego 3D."
+msgstr "Ta opcja umożliwia włączenie dźwięku przestrzennego 3D."
 
 msgid "This option allows you to hide and sorting of the menus"
 msgstr "Ta opcja umożliwia ukrywanie i sortowanie w menu"
@@ -18806,10 +18806,10 @@ msgid ""
 "-verify that you have a configured and working DHCP server in your network."
 msgstr ""
 "Ten test sprawdzi czy adapter LAN jest skonfigurowany do pracy z DHCP.\n"
-"Jeśli otrzymasz komunikat:'załączony'\n"
+"Jeśli otrzymasz komunikat:'włączony'\n"
 "-w adapterze LAN jest ręcznie wpisany adres IP\n"
 "-sprawdź czy masz wpisane poprawne informacje dotyczące IP w oknie ustawień adaptera sieciowego.\n"
-"Jesli otrzymasz wiadomość:'załączone'\n"
+"Jesli otrzymasz wiadomość:'włączone'\n"
 "-sprawdź czy w sieci znajduje się serwer DHCP."
 
 msgid "This test detects your configured LAN adapter."
@@ -19089,8 +19089,8 @@ msgid ""
 "3) Wait for bootup and follow instructions of the wizard."
 msgstr ""
 "Aby zaktualizować oprogramowanie %s %s , wykonaj następujące czynności:\n"
-"1) Załącz odbiornik tylnym wyłącznikiem zasilania i upewnij się, że bootowalny pendrive jest podłączony.\n"
-"2) Załącz zasilanie ponownie i przytrzymaj przycisk na panelu przednim przez 10 sekund.\n"
+"1) Wyłącz odbiornik tylnym wyłącznikiem zasilania i upewnij się, że bootowalny pendrive jest podłączony.\n"
+"2) Włącz zasilanie ponownie i przytrzymaj przycisk na panelu przednim przez 10 sekund.\n"
 "3) Poczekaj na start odbiornika i postępuj zgodnie z instrukcjami kreatora."
 
 msgid "Today"
@@ -19396,16 +19396,16 @@ msgid "Turn off HDMI-IN PiP mode"
 msgstr "Wyłączyć HDMI-IN w trybie PiP"
 
 msgid "Turn on HDMI-IN Full screen mode"
-msgstr "Załącz HDMI-IN w trybie pełnoekranowy"
+msgstr "Włącz HDMI-IN w trybie pełnoekranowy"
 
 msgid "Turn on HDMI-IN PiP mode"
-msgstr "Załącz HDMI-IN w trybie PiP"
+msgstr "Włącz HDMI-IN w trybie PiP"
 
 msgid "Turn on the control LED"
-msgstr "Załącz kontrolkę LED"
+msgstr "Włącz kontrolkę LED"
 
 msgid "Turn on the power LED"
-msgstr "Załącz kontrolkę zasilania LED"
+msgstr "Włącz kontrolkę zasilania LED"
 
 msgid "Turning step size"
 msgstr "Kąt obrotu pojedynczego kroku"
@@ -20013,7 +20013,7 @@ msgid "Using old profile: "
 msgstr "Użyj starego profilu: "
 
 msgid "Usually when the subtitle language is the same as the audio language, the subtitles will not be used. Enable this option to allow these subtitles to be used."
-msgstr "Normalnie gdy język napisów jest taki sam jak ścieżka audio napisy nie są wyświetlane. Załączenie tej opcji pozwala wyświetlić napisy w takiej sytuacji."
+msgstr "Normalnie gdy język napisów jest taki sam jak ścieżka audio napisy nie są wyświetlane. Włączenie tej opcji pozwala wyświetlić napisy w takiej sytuacji."
 
 msgid "Uzbek"
 msgstr "Uzbecki"
@@ -20600,154 +20600,154 @@ msgid "What would you like to do?"
 msgstr "Co chcesz zrobić?"
 
 msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
-msgstr "Po załączeniu enigma2 ładuje niepowiązane bukiety użytkowników. Oznacza to, że bukiety użytkowników, które są dostępne, ale nie są zawarte w plikach bouquets.tv lub bouquets.radio, nadal będą ładowane. Pozwala to na przykład zachować własny bukiet użytkowników podczas aktualizacji zainstalowanych ustawień"
+msgstr "Po włączeniu enigma2 ładuje niepowiązane bukiety użytkowników. Oznacza to, że bukiety użytkowników, które są dostępne, ale nie są zawarte w plikach bouquets.tv lub bouquets.radio, nadal będą ładowane. Pozwala to na przykład zachować własny bukiet użytkowników podczas aktualizacji zainstalowanych ustawień"
 
 msgid "When enabled the PiP can be closed by the exit button."
-msgstr "Po załączeniu PiP można zamknąć za pomocą przycisku wyjścia."
+msgstr "Po włączeniu PiP można zamknąć za pomocą przycisku wyjścia."
 
 msgid "When enabled the online checker will also check for experimental versions"
-msgstr "Gdy załączone, w trybie online sprawdzane będą także wersje eksperymentalne"
+msgstr "Gdy włączone, w trybie online sprawdzane będą także wersje eksperymentalne"
 
 msgid "When enabled the receiver will automatically be switched off."
-msgstr "Jeśli załączone, urządzenie będzie automatycznie wyłączane."
+msgstr "Jeśli włączone, urządzenie będzie automatycznie wyłączane."
 
 msgid "When enabled the receiver will automatically be switched on."
-msgstr "Jeśli załączone, urządzenie będzie automatycznie załączane."
+msgstr "Jeśli włączone, urządzenie będzie automatycznie włączane."
 
 msgid "When enabled the receiver will automatically return to standby when the TV is turned off."
-msgstr "Jeśli załączone, urządzenie automatycznie powróci do trybu czuwania jeśli TV jest wyłączony."
+msgstr "Jeśli włączone, urządzenie automatycznie powróci do trybu czuwania jeśli TV jest wyłączony."
 
 msgid "When enabled the receiver will automatically wake from standby when the TV is turned on."
-msgstr "Jeśli załączone, urządzenie będzie automatycznie wybudzanie jeśli TV jest załączony."
+msgstr "Jeśli włączone, urządzenie będzie automatycznie wybudzanie jeśli TV jest włączony."
 
 msgid "When enabled, AIT data will be included in http streams. This allows a client receiver to use HbbTV."
-msgstr "Gdy załączone, dane AIT będą zawarte w strumieniu http. To pozwala używać HbbTV na odbiorniku 'kliencie'."
+msgstr "Gdy włączone, dane AIT będą zawarte w strumieniu http. To pozwala używać HbbTV na odbiorniku 'kliencie'."
 
 msgid "When enabled, EIT data will be included in http streams. This allows a client receiver to show EPG."
-msgstr "Jeśli opcja jest załączona, dane EIT osadzone w strumieniach HTTP. umożliwiają wyświetlanie EPG klientowi ."
+msgstr "Jeśli opcja jest włączona, dane EIT osadzone w strumieniach HTTP. umożliwiają wyświetlanie EPG klientowi ."
 
 msgid "When enabled, Enigma2 will load unlinked bouquets. This means that bouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
-msgstr "Po załączeniu Enigma2 będzie ładować niepowiązane bukiety. Oznacza to, że bukiety, które są dostępne, ale nie są zawarte w plikach bouquets.tv lub bouquets.radio, nadal będą ładowane. Pozwala to na przykład zachować własny bukiet użytkowników podczas aktualizacji zainstalowanych ustawień"
+msgstr "Po włączeniu Enigma2 będzie ładować niepowiązane bukiety. Oznacza to, że bukiety, które są dostępne, ale nie są zawarte w plikach bouquets.tv lub bouquets.radio, nadal będą ładowane. Pozwala to na przykład zachować własny bukiet użytkowników podczas aktualizacji zainstalowanych ustawień"
 
 msgid "When enabled, a popup message will be shown when a movie has finished and the next one will start."
-msgstr "Gdy załączone, okno wiadomość pojawi się gdy film się skończy i rozpocznie następny."
+msgstr "Gdy włączone, okno wiadomość pojawi się gdy film się skończy i rozpocznie następny."
 
 msgid "When enabled, a popup message will be shown when a recording starts."
-msgstr "Gdy załączone, okno wiadomość pojawi się gdy rozpocznie się nagrywanie."
+msgstr "Gdy włączone, okno wiadomość pojawi się gdy rozpocznie się nagrywanie."
 
 msgid "When enabled, a recording is allowed to abort picture-in-picture mode, when there are no free tuners."
-msgstr "Po załączeniu, dozwolone jest przerwanie nagrania w trybie PiP, gdy nie ma wolnych tunerów."
+msgstr "Po włączeniu, dozwolone jest przerwanie nagrania w trybie PiP, gdy nie ma wolnych tunerów."
 
 msgid "When enabled, a recording is allowed to abort pseudo recordings, when there are no free tuners."
-msgstr "Po załączeniu nagrywanie może przerywać pseudo nagrania, gdy nie ma wolnych tunerów."
+msgstr "Po włączeniu nagrywanie może przerywać pseudo nagrania, gdy nie ma wolnych tunerów."
 
 msgid "When enabled, a recording is allowed to abort streaming, when there are no free tuners."
-msgstr "Po załączeniu nagrywanie może zostać przerwane strumieniowanie, gdy nie ma wolnych tunerów."
+msgstr "Po włączeniu nagrywanie może zostać przerwane strumieniowanie, gdy nie ma wolnych tunerów."
 
 msgid "When enabled, a recording is allowed to interrupt live tv, when there are no free tuners."
-msgstr "Gdy załączone, nagranie może przerwać oglądanie TV, gdy nie ma wolnych tunerów."
+msgstr "Gdy włączone, nagranie może przerwać oglądanie TV, gdy nie ma wolnych tunerów."
 
 msgid "When enabled, a warning will be displayed and the user will get an option to stop or to continue the timeshift."
-msgstr "Po załączeniu, zostanie wyświetlone ostrzeżenie a użytkownik otrzyma możliwość zatrzymania lub kontynuowania timeshiftu."
+msgstr "Po włączeniu, zostanie wyświetlone ostrzeżenie a użytkownik otrzyma możliwość zatrzymania lub kontynuowania timeshiftu."
 
 msgid "When enabled, always descramble receiving http streams. This takes up more resources (descrambling demuxers), only enable if necessary. Individual streams are always descrambled if 0x100 is added to the service type, regardless of this setting."
-msgstr "Po załączeniu zawsze rozszyfruj odbieranie strumieni HTTP. Zajmuje to więcej zasobów (deszyfrowanie demultiplekserów), załącz tylko w razie potrzeby. Poszczególne strumienie są zawsze deszyfrowane, jeśli do typu usługi dodano 0x100, niezależnie od tego ustawienia."
+msgstr "Po włączeniu zawsze rozszyfruj odbieranie strumieni HTTP. Zajmuje to więcej zasobów (deszyfrowanie demultiplekserów), włącz tylko w razie potrzeby. Poszczególne strumienie są zawsze deszyfrowane, jeśli do typu usługi dodano 0x100, niezależnie od tego ustawienia."
 
 msgid "When enabled, authentication is required to watch http streams."
-msgstr "Gdy załączone,wymagana jest autoryzacja do oglądania strumieni http."
+msgstr "Gdy włączone,wymagana jest autoryzacja do oglądania strumieni http."
 
 msgid "When enabled, before opkg update there will be opkg clean to make sure nothing ruine the update but only enable this when you can not update online."
-msgstr "Gdy załączone, przed aktualizacją opkg będzie wyczyszczone. Załącz to tylko wtedy jeśli nie korzystasz z aktualizacji online."
+msgstr "Gdy włączone, przed aktualizacją opkg będzie wyczyszczone. Włącz to tylko wtedy jeśli nie korzystasz z aktualizacji online."
 
 msgid "When enabled, channel numbering will start at '1' for each bouquet."
-msgstr "Gdy załączone, numerowanie kanałów będzie zaczynać się od '1' dla każdego bukietu."
+msgstr "Gdy włączone, numerowanie kanałów będzie zaczynać się od '1' dla każdego bukietu."
 
 msgid "When enabled, content with an aspect ratio of 4:3 will be stretched to fit the screen."
-msgstr "Gdy załączone, zawartość proporcji obrazu 4:3 będzie rozciągana aby dopasować do ekranu."
+msgstr "Gdy włączone, zawartość proporcji obrazu 4:3 będzie rozciągana aby dopasować do ekranu."
 
 msgid "When enabled, continue to the next bouquet when the last channel of the current bouquet is reached while changing channels."
-msgstr "Gdy załączone, po dojściu do ostatniego kanału w danym bukiecie podczas przełączania, automatycznie nastąpi przejście do kolejnego bukietu."
+msgstr "Gdy włączone, po dojściu do ostatniego kanału w danym bukiecie podczas przełączania, automatycznie nastąpi przejście do kolejnego bukietu."
 
 msgid "When enabled, deleted recordings are moved to the trash can, instead of being deleted immediately."
-msgstr "Gdy załączone, usunięte nagrania zostaną przeniesione do 'kosza', zamiast natychmiastowego usunięcia."
+msgstr "Gdy włączone, usunięte nagrania zostaną przeniesione do 'kosza', zamiast natychmiastowego usunięcia."
 
 msgid "When enabled, external subtitles will be always turned on for playback movie."
-msgstr "Gdy załączone, napisy zewnętrzne będą zawsze załączone do odtwarzania filmu."
+msgstr "Gdy włączone, napisy zewnętrzne będą zawsze włączone do odtwarzania filmu."
 
 msgid "When enabled, graphical DVB subtitles are preferred over teletext subtitles, when both types are available."
-msgstr "Gdy załączone, graficzne napisy DVB będą preferowane przed napisami telegazety, gdy oba typy są dostępne."
+msgstr "Gdy włączone, graficzne napisy DVB będą preferowane przed napisami telegazety, gdy oba typy są dostępne."
 
 msgid "When enabled, graphical DVB subtitles will be displayed at their original position."
-msgstr "Gdy załączone, graficzne napisy DVB będą wyświetlane w ich oryginalnym położeniu."
+msgstr "Gdy włączone, graficzne napisy DVB będą wyświetlane w ich oryginalnym położeniu."
 
 msgid "When enabled, graphical DVB subtitles will be displayed in yellow, instead of the original color."
-msgstr "Gdy załączone, graficzne napisy DVB będą wyświetlane na żółto zamiast oryginalnego koloru."
+msgstr "Gdy włączone, graficzne napisy DVB będą wyświetlane na żółto zamiast oryginalnego koloru."
 
 msgid "When enabled, it is possible to leave the movieplayer with exit."
-msgstr "Gdy jest załączona,możliwe jest opuszczenie odtwarzacz filmów przyciskiem'Exit'."
+msgstr "Gdy jest włączona,możliwe jest opuszczenie odtwarzacz filmów przyciskiem'Exit'."
 
 msgid "When enabled, measure power consumption to detect when the rotor stops turning (when supported by the tuner)."
-msgstr "Gdy załączone, pomiar zużycia energii w celu wykrycia, kiedy rotor zatrzymuje obrót (jeśli jest obsługa w tunerze)."
+msgstr "Gdy włączone, pomiar zużycia energii w celu wykrycia, kiedy rotor zatrzymuje obrót (jeśli jest obsługa w tunerze)."
 
 msgid "When enabled, network trash cans are probed for cleaning."
-msgstr "Gdy ta opcja jest załączona, sieciowe kosze są sprawdzane pod kątem czyszczenia."
+msgstr "Gdy ta opcja jest włączona, sieciowe kosze są sprawdzane pod kątem czyszczenia."
 
 msgid "When enabled, number markers will be hidden."
-msgstr "Po załączeniu znaczniki liczb będą ukryte."
+msgstr "Po włączeniu znaczniki liczb będą ukryte."
 
 msgid "When enabled, pressing '0' will zap you to the first channel in your first bouquet and delete your zap-history."
-msgstr "Gdy załączone, naciskając przycisk '0 'będzie przełączony do pierwszego kanału w pierwszym bukiecie i usunie historię przełączania."
+msgstr "Gdy włączone, naciskając przycisk '0 'będzie przełączony do pierwszego kanału w pierwszym bukiecie i usunie historię przełączania."
 
 msgid "When enabled, reformat subtitles to match the width of the screen."
-msgstr "Po załączeniu sformatuj napisy w celu dopasowania do szerokości ekranu."
+msgstr "Po włączeniu sformatuj napisy w celu dopasowania do szerokości ekranu."
 
 msgid "When enabled, show channel numbers in the channel selection screen."
-msgstr "Gdy załączone, wyświetla numery w liście wyboru kanałów."
+msgstr "Gdy włączone, wyświetla numery w liście wyboru kanałów."
 
 msgid "When enabled, show status or error messages."
-msgstr "Po załączeniu pokaż komunikaty o stanie lub komunikaty o błędach."
+msgstr "Po włączeniu pokaż komunikaty o stanie lub komunikaty o błędach."
 
 msgid "When enabled, subtitles for the hearing impaired can be used."
-msgstr "Gdy załączone, można stosować napisy dla niesłyszących ."
+msgstr "Gdy włączone, można stosować napisy dla niesłyszących ."
 
 msgid "When enabled, subtitles for the hearing impaired will be preferred over normal subtitles, when both types are available."
-msgstr "Gdy załączone, napisy dla niesłyszących będą preferowane przed normalnymi napisami, jeżeli oba rodzaje są dostępne."
+msgstr "Gdy włączone, napisy dla niesłyszących będą preferowane przed normalnymi napisami, jeżeli oba rodzaje są dostępne."
 
 msgid "When enabled, teletext pages will be cached, allowing faster access."
-msgstr "Gdy załączone, strony telegazety będą buforowane, co pozwala na szybszy dostęp."
+msgstr "Gdy włączone, strony telegazety będą buforowane, co pozwala na szybszy dostęp."
 
 msgid "When enabled, teletext subtitles will be displayed at their original position."
-msgstr "Gdy załączone, napisy telegazety będą wyświetlane w oryginalnym położeniu."
+msgstr "Gdy włączone, napisy telegazety będą wyświetlane w oryginalnym położeniu."
 
 msgid "When enabled, the VCR scart option will be shown on the main menu"
-msgstr "Po załączeniu opcji VCR SCART będzie widoczne w menu głównym"
+msgstr "Po włączeniu opcji VCR SCART będzie widoczne w menu głównym"
 
 msgid "When enabled, the length of each recording will be shown in the movie list (this might cause some additional loading time)."
-msgstr "Gdy załączone, długość nagrania będzie widoczna na liście filmów (może to nieznacznie wydłużyć czas ładowania)."
+msgstr "Gdy włączone, długość nagrania będzie widoczna na liście filmów (może to nieznacznie wydłużyć czas ładowania)."
 
 msgid "When enabled, the receiver will automatically use the audio track which you selected before."
-msgstr "Gdy załączone, automatycznie zostanie załączona ścieżka audio ostatnio wybrana na danym kanale."
+msgstr "Gdy włączone, automatycznie zostanie włączona ścieżka audio ostatnio wybrana na danym kanale."
 
 msgid "When enabled, the receiver will automatically use the subtitles which you selected before."
-msgstr "Gdy załączone, automatycznie zostaną załączone napisy ostatnio wybrane na danym kanale."
+msgstr "Gdy włączone, automatycznie zostaną włączone napisy ostatnio wybrane na danym kanale."
 
 msgid "When enabled, the receiver will select an AC3 track (when available)."
-msgstr "Gdy załączone, zostanie wybrana ścieżka audio AC3 (jeśli jest dostępna)."
+msgstr "Gdy włączone, zostanie wybrana ścieżka audio AC3 (jeśli jest dostępna)."
 
 msgid "When enabled, the receiver will select an AC3+ track (when available)."
-msgstr "Gdy załączone, zostanie wybrana ścieżka AC3 + (jeśli jest dostępna)."
+msgstr "Gdy włączone, zostanie wybrana ścieżka AC3 + (jeśli jest dostępna)."
 
 msgid "When enabled, timeshift starts automatically in background after specified time."
-msgstr "Po załączeniu, przesunięcie czasu rozpoczyna się w tle automatycznie po określonym czasie."
+msgstr "Po włączeniu, przesunięcie czasu rozpoczyna się w tle automatycznie po określonym czasie."
 
 msgid "When enabled, use DHCP for the IP configuration."
-msgstr "Gdy załączone, zostanie użyty będzie serwer DHCP do konfiguracji IP."
+msgstr "Gdy włączone, zostanie użyty będzie serwer DHCP do konfiguracji IP."
 
 msgid "When enabled, you will see dev, staticdev, dbg, doc, src and po packages in opkg list."
-msgstr "Gdy załączone, w liście pakietów będą widoczne pakiety dev, staticdev, dbg, doc, src i po."
+msgstr "Gdy włączone, w liście pakietów będą widoczne pakiety dev, staticdev, dbg, doc, src i po."
 
 msgid "When enabled, your receiver will detect activity on the VCR SCART input."
-msgstr "Gdy załączone, odbiornik wykryje aktywność na wejściu SCART."
+msgstr "Gdy włączone, odbiornik wykryje aktywność na wejściu SCART."
 
 msgid "When nonzero, a recording will start earlier than the starting time indicated by the EPG."
 msgstr "Gdy różne od '0', nagrywanie rozpocznie się wcześniej niż w chwili startu określonego przez EPG."
@@ -20845,7 +20845,7 @@ msgid "Wissenschaft"
 msgstr "Nauka"
 
 msgid "With T2MI RAW mode disabled (default) we can use single T2MI PLP de-encapsulation. With T2MI RAW mode enabled we can use astra-sm to analyze T2MI"
-msgstr "Przy wyłączonym trybie T2MI RAW (domyślnie) możemy użyć pojedynczego dekapsułkowania PLP T2MI. Przy załączonym trybie T2MI RAW możemy używać astra-sm do analizy T2MI"
+msgstr "Przy wyłączonym trybie T2MI RAW (domyślnie) możemy użyć pojedynczego dekapsułkowania PLP T2MI. Przy włączonym trybie T2MI RAW możemy używać astra-sm do analizy T2MI"
 
 msgid "With errors:"
 msgstr "Z błędami:"
@@ -21564,7 +21564,7 @@ msgid "activate network adapter configuration"
 msgstr "aktywuj konfigurację adaptera sieciowego"
 
 msgid "activatePiP"
-msgstr "Załącz PiP"
+msgstr "Włącz PiP"
 
 msgid "active"
 msgstr "aktywny"
@@ -21958,19 +21958,19 @@ msgid "empty"
 msgstr "pusty"
 
 msgid "enable PIP no HDR"
-msgstr "załącz PIP bez HDR"
+msgstr "włącz PIP bez HDR"
 
 msgid "enable bouquet edit"
-msgstr "Załącz edycję bukietu"
+msgstr "Włącz edycję bukietu"
 
 msgid "enable favourite edit"
-msgstr "załącz edycję ulubionych"
+msgstr "włącz edycję ulubionych"
 
 msgid "enable move mode"
-msgstr "Załącz tryb przenoszenia"
+msgstr "Włącz tryb przenoszenia"
 
 msgid "enabled"
-msgstr "załączony"
+msgstr "włączony"
 
 msgid "end alternatives edit"
 msgstr "koniec edycji alternatywnych"
@@ -22114,7 +22114,7 @@ msgid "force disabled"
 msgstr "wymuszanie wyłączone"
 
 msgid "force enabled"
-msgstr "wymuszanie załączone"
+msgstr "wymuszanie włączone"
 
 msgid "foreign countries/expeditions"
 msgstr "wyprawy/podróże"
@@ -22543,7 +22543,7 @@ msgid "off"
 msgstr "wyłączony"
 
 msgid "off or wpa2 on"
-msgstr "wyłączone lub wpa2 załączone"
+msgstr "wyłączone lub wpa2 włączone"
 
 msgid "offset is"
 msgstr "jest wyłączone"


### PR DESCRIPTION
The author of the translation used incorrect form for "enable", "turn on". In fact "Załącz" means "Attach" (like "attach file to email"). Some people in Poland uses "załącz" (attach) instead of "włącz" (enable/turn on) because second one is very similar to "wyłącz" (disable/turn off). But according to Polish Dictionary this is incorrect and in fact confusing for most people in Poland. Even google translator report it as a potential mistake.

```
załącz -> attach
włącz  -> enable / turn on
wyłącz -> disable / turn off
```