### PR TITLE
[config.py] Correct trueValues list

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -488,7 +488,7 @@ class ConfigBoolean(ConfigElement):
 		self.value = default
 		self.descriptions = descriptions
 		self.graphic = graphic
-		self.trueValues = ("1", "enable", "on", "true", "yes")
+		self.trueValues = ("1", "enabled", "on", "true", "yes")
 
 	def handleKey(self, key, callback=None):
 		prev = self.value


### PR DESCRIPTION
The value "enable" should be "enabled" to match all other cases of this logic test.
