### PR TITLE
[Setup.py] Correct setup element list

### DIFF
--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -118,7 +118,9 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 		if title:
 			title = dgettext(self.pluginLanguageDomain, title) if self.pluginLanguageDomain else _(title)
 		self.setTitle(title if title else _("Setup"))
-		if self.list != oldList or self.showDefaultChanged or self.graphicSwitchChanged:
+		if not self.setupList:
+			self["config"].setList(self.setupList)
+		elif self.setupList != oldList or self.showDefaultChanged or self.graphicSwitchChanged:
 			currentItem = self["config"].getCurrent()
 			self["config"].setList(self.list)
 			if config.usage.sort_settings.value:


### PR DESCRIPTION
This change forces the self["config"] list to be cleared if there are no eligible items available to be displayed.
