### PR TITLE
[NetworkSetup] Refactor NameserverSetup into DNSSettings

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -243,6 +243,16 @@
 		<key id="KEY_TAB" mapto="menu" flags="m" />
 	</map>
 
+	<map context="DNSSettingsActions">
+		<key id="KEY_YELLOW" mapto="dnsAdd" flags="m" />
+		<key id="KEY_BLUE" mapto="dnsRemove" flags="m" />
+		<key id="KEY_TV" mapto="moveUp" flags="mr" />
+		<key id="KEY_RADIO" mapto="moveDown" flags="mr" />
+		<!-- Keyboard specific buttons -->
+		<key id="KEY_F7" mapto="dnsAdd" flags="m" />
+		<key id="KEY_F8" mapto="dnsRemove" flags="m" />
+	</map>
+
 	<map context="MsgBoxActions">
 		<!-- Also uses NavigationActions -->
 		<key id="KEY_EXIT" mapto="cancel" flags="m" />

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -140,6 +140,9 @@
 		<item level="0" text="Date style" description="Choose the front panel display formatting style for dates. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin." requires="config.usage.date.enabled_display">config.usage.date.display</item>
 		<item level="0" text="Time style" description="Choose the front panel display formatting style for times. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes.  ('HH' and 'hh' have leading zeros for single digit values.) The front panel display will be based on your choice but can be influenced any applicable skin." requires="config.usage.time.enabled_display">config.usage.time.display</item>
 	</setup>
+	<setup key="DNS" title="DNS Settings">
+		<item level="0" text="DNS data source" description="Select the source of the default DNS settings.">config.usage.dns</item>
+	</setup>
 	<setup key="EPG" title="EPG settings" level="2" showOpenWebIf="1">
 		<item level="2" text="EPG location" description="Choose the location where the EPG data will be stored when the %s %s is shut down. The location must be available at boot time.">config.misc.epgcachepath</item>
 		<item level="2" text="EPG filename" description="Choose the name of the file that holds the EPG data when the %s %s is shut down. This can be handy to differentiate between several boxes.">config.misc.epgcachefilename</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -77,23 +77,14 @@ def InitUsageConfig():
 	config.misc.ecm_info = ConfigYesNo(default=False)
 	config.usage.menu_show_numbers = ConfigYesNo(default=False)
 	config.usage.showScreenPath = ConfigSelection(default="off", choices=[("off", _("None")), ("small", _("Small")), ("large", _("Large"))])
-	if fileContains("/etc/network/interfaces", "iface eth0 inet static") and not fileContains("/etc/network/interfaces", "iface wlan0 inet dhcp") or fileContains("/etc/network/interfaces", "iface wlan0 inet static") and fileContains("/run/ifstate", "wlan0=wlan0"):
-		config.usage.dns = ConfigSelection(default="custom", choices=[
-			("custom", _("Static IP or Custom")),
-			("google", _("Google DNS")),
-			("cloudflare", _("Cloudflare")),
-			("opendns-familyshield", _("OpenDNS FamilyShield")),
-			("opendns-home", _("OpenDNS Home"))
-		])
-	else:
-		config.usage.dns = ConfigSelection(default="dhcp-router", choices=[
-			("dhcp-router", _("DHCP Router")),
-			("custom", _("Static IP or Custom")),
-			("google", _("Google DNS")),
-			("cloudflare", _("Cloudflare")),
-			("opendns-familyshield", _("OpenDNS FamilyShield")),
-			("opendns-home", _("OpenDNS Home"))
-		])
+	config.usage.dns = ConfigSelection(default="dhcp-router", choices=[
+		("dhcp-router", _("Router / Gateway")),
+		("custom", _("Static IP / Custom")),
+		("google", _("Google DNS")),
+		("cloudflare", _("Cloudflare DNS")),
+		("opendns-familyshield", _("OpenDNS FamilyShield")),
+		("opendns-home", _("OpenDNS Home"))
+	])
 
 	config.usage.subnetwork = ConfigYesNo(default=True)
 	config.usage.subnetwork_cable = ConfigYesNo(default=True)

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1,7 +1,6 @@
 from copy import copy as shallowcopy
 from os import fsync, rename, sep
 from os.path import realpath
-from six import PY2
 from time import localtime, strftime, struct_time
 
 from enigma import getPrevAsciiCode
@@ -11,8 +10,6 @@ from Tools.Directories import SCOPE_CONFIG, fileAccess, resolveFilename
 from Tools.LoadPixmap import LoadPixmap
 from Tools.NumericalTextInput import NumericalTextInput
 from Components.Harddisk import harddiskmanager  # This import is order critical!
-
-pyunichr = unichr if PY2 else chr
 
 ACTIONKEY_LEFT = 0
 ACTIONKEY_RIGHT = 1
@@ -1299,7 +1296,7 @@ class ConfigClock(ConfigSequence):
 		newtime[4] = self._value[1]
 		newtime = struct_time(newtime)
 		value = strftime(config.usage.time.short.value.replace("%-I", "%_I").replace("%-H", "%_H"), newtime)
-		return value, mPos
+		return (value, mPos)
 
 
 class ConfigDate(ConfigSequence):
@@ -1359,7 +1356,6 @@ class ConfigPIN(ConfigInteger):
 			raise TypeError("[Config] Error: 'ConfigPIN' default must be an integer!")
 		if censor != "" and (isinstance(censor, str) and len(censor) != 1): # and (isinstance(censor, unicode) and len(censor) != 1):
 			raise ValueError("[Config] Error: Censor must be a single char (or \"\")!")
-		censor = censor.encode("UTF-8", errors="ignore") if PY2 else censor
 		ConfigInteger.__init__(self, default=default, limits=(0, (10 ** pinLength) - 1), censor=censor)
 		self.pinLength = pinLength
 
@@ -1370,26 +1366,32 @@ class ConfigPIN(ConfigInteger):
 class ConfigIP(ConfigSequence):
 	def __init__(self, default, auto_jump=False):
 		ConfigSequence.__init__(self, seperator=".", limits=[(0, 255), (0, 255), (0, 255), (0, 255)], default=default)
-		self.block_len = [len(str(x[1])) for x in self.limits]
-		self.marked_block = 0
+		self.autoJump = auto_jump
+		self.markedPos = 0
 		self.overwrite = True
-		self.auto_jump = auto_jump
 		self.zeroPad = False
 
 	def handleKey(self, key, callback=None):
-		if key == ACTIONKEY_LEFT:
-			if self.marked_block > 0:
-				self.marked_block -= 1
+		if key == ACTIONKEY_FIRST:
+			self.markedPos = 0
+			self.overwrite = True
+		elif key == ACTIONKEY_LEFT:
+			if self.markedPos > 0:
+				self.markedPos -= 1
 			self.overwrite = True
 		elif key == ACTIONKEY_RIGHT:
-			if self.marked_block < len(self.limits) - 1:
-				self.marked_block += 1
-			self.overwrite = True
-		elif key == ACTIONKEY_FIRST:
-			self.marked_block = 0
+			if self.markedPos < len(self.limits) - 1:
+				self.markedPos += 1
 			self.overwrite = True
 		elif key == ACTIONKEY_LAST:
-			self.marked_block = len(self.limits) - 1
+			self.markedPos = len(self.limits) - 1
+			self.overwrite = True
+		elif key in (ACTIONKEY_DELETE, ACTIONKEY_BACKSPACE):
+			self._value[self.markedPos] = 0
+			self.overwrite = True
+		elif key == ACTIONKEY_ERASE:
+			self.markedPos = 0
+			self._value = [0, 0, 0, 0]
 			self.overwrite = True
 		elif key in ACTIONKEY_NUMBERS or key == ACTIONKEY_ASCII:
 			if key == ACTIONKEY_ASCII:
@@ -1399,41 +1401,35 @@ class ConfigIP(ConfigSequence):
 				number = code - 48
 			else:
 				number = getKeyNumber(key)
-			oldvalue = self._value[self.marked_block]
+			prev = self._value[:]
 			if self.overwrite:
-				self._value[self.marked_block] = number
+				self._value[self.markedPos] = number
 				self.overwrite = False
 			else:
-				oldvalue *= 10
-				newvalue = oldvalue + number
-				if self.auto_jump and newvalue > self.limits[self.marked_block][1] and self.marked_block < len(self.limits) - 1:
+				newValue = (self._value[self.markedPos] * 10) + number
+				if self.autoJump and newValue > self.limits[self.markedPos][1] and self.markedPos < len(self.limits) - 1:
 					self.handleKey(ACTIONKEY_RIGHT, callback)
 					self.handleKey(key, callback)
 					return
 				else:
-					self._value[self.marked_block] = newvalue
-			if len(str(self._value[self.marked_block])) >= self.block_len[self.marked_block]:
+					self._value[self.markedPos] = newValue
+			if len(str(self._value[self.markedPos])) >= self.blockLen[self.markedPos]:
 				self.handleKey(ACTIONKEY_RIGHT, callback)
 			self.validate()
-			self.changed()
+			if self._value != prev:
+				self.changed()
+				if callable(callback):
+					callback()
 
 	def getMulti(self, selected):
 		(value, mBlock) = self.genText()
-		if self.enabled:
-			return ("mtext"[1 - selected:], value, mBlock)
-		else:
-			return ("text", value)
+		return ("mtext"[1 - selected:], value, mBlock) if self.enabled else ("text", value)
 
 	def genText(self):
-		value = ""
-		block_strlen = []
-		for i in self._value:
-			block_strlen.append(len(str(i)))
-			if value:
-				value += self.seperator
-			value += str(i)
-		leftPos = sum(block_strlen[:(self.marked_block)]) + self.marked_block
-		rightPos = sum(block_strlen[:(self.marked_block + 1)]) + self.marked_block
+		value = self.seperator.join([str(x) for x in self._value])
+		blockLen = [len(str(x)) for x in self._value]
+		leftPos = sum(blockLen[:self.markedPos]) + self.markedPos
+		rightPos = sum(blockLen[:self.markedPos + 1]) + self.markedPos
 		mBlock = list(range(leftPos, rightPos))
 		return (value, mBlock)
 
@@ -1656,7 +1652,7 @@ class ConfigText(ConfigElement, NumericalTextInput):
 			self.overwrite = not self.overwrite
 		elif key == ACTIONKEY_ASCII:
 			self.timeout()
-			newChar = pyunichr(getPrevAsciiCode())
+			newChar = chr(getPrevAsciiCode())
 			if not self.useableChars or newChar in self.useableChars:
 				if self.allmarked:
 					self.deleteAllChars()
@@ -1736,7 +1732,7 @@ class ConfigText(ConfigElement, NumericalTextInput):
 				self.offset = max(0, textlen - self.visible_width)
 
 	def getText(self):
-		return self.text.encode("UTF-8", errors="ignore") if PY2 else self.text
+		return self.text
 
 	def getMulti(self, selected):
 		padding = u"\u00A0" if selected else ""
@@ -1752,7 +1748,7 @@ class ConfigText(ConfigElement, NumericalTextInput):
 			else:
 				mark = [self.markedPos]
 			multi = "%s%s" % (self.text, padding)
-		return ("mtext"[1 - selected:], multi.encode("UTF-8", errors="ignore") if PY2 else multi, mark)
+		return ("mtext"[1 - selected:], multi, mark)
 
 	def showHelp(self, session):
 		if session is not None and self.help_window is not None:
@@ -1782,18 +1778,11 @@ class ConfigText(ConfigElement, NumericalTextInput):
 		ConfigElement.onDeselect(self, session)
 
 	def getValue(self):
-		if PY2:
-			try:
-				return self.text.encode("UTF-8", errors="strict")
-			except UnicodeDecodeError:
-				print("[Config] Broken UTF8!")
-				return self.text.encode("UTF-8", errors="ignore")
-		else:
-			return self.text
+		return self.text
 
 	def setValue(self, value):
 		prev = self.text if hasattr(self, "text") else None
-		if PY2 or isinstance(value, bytes): # DEBUG: If bytes on PY3 we can print this and then convert.
+		if isinstance(value, bytes):  # DEBUG: If bytes on PY3 we can print this and then convert.
 			try:
 				self.text = value.decode("UTF-8", errors="strict")
 			except UnicodeDecodeError:
@@ -1911,7 +1900,7 @@ class ConfigNumber(ConfigText):
 					return
 			else:
 				ascii = getKeyNumber(key) + 48
-			newChar = pyunichr(ascii)
+			newChar = chr(ascii)
 			if self.allmarked:
 				self.deleteAllChars()
 				self.allmarked = False
@@ -1957,7 +1946,7 @@ class ConfigPassword(ConfigText):
 		ConfigText.__init__(self, default=default, fixed_size=fixed_size, visible_width=visible_width)
 		if censor != "" and (isinstance(censor, str) and len(censor) != 1) and (isinstance(censor, unicode) and len(censor) != 1):
 			raise ValueError("[Config] Error: Censor must be a single char (or \"\")!")
-		self.censor = censor.encode("UTF-8", errors="ignore") if PY2 else censor
+		self.censor = censor
 		self.hidden = True
 
 	def getMulti(self, selected):
@@ -2218,12 +2207,8 @@ class Config(ConfigSubsection):
 	def loadFromFile(self, filename, baseFile=True, base_file=None):  # DEBUG: base_file is deprecated, only used in Components/PackageInfo.py
 		if base_file is not None:
 			baseFile = base_file
-		if PY2:
-			with open(filename, "r") as fd:
-				self.unpickle(fd, baseFile)
-		else:
-			with open(filename, "r", encoding="UTF-8") as fd:
-				self.unpickle(fd, baseFile)
+		with open(filename, "r", encoding="UTF-8") as fd:
+			self.unpickle(fd, baseFile)
 
 	def saveToFile(self, filename):
 		try:

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -37,8 +37,10 @@ from Screens.MessageBox import MessageBox
 from Screens.Screen import Screen
 from Screens.Setup import Setup
 from Screens.Standby import TryQuitMainloop
-from Tools.Directories import SCOPE_GUISKIN, SCOPE_PLUGINS, fileExists, resolveFilename
+from Tools.Directories import SCOPE_GUISKIN, SCOPE_PLUGINS, fileExists, fileReadLines, resolveFilename
 from Tools.LoadPixmap import LoadPixmap
+
+MODULE_NAME = __name__.split(".")[-1]
 
 if float(getVersionString()) >= 4.0:
 	basegroup = "packagegroup-base"
@@ -254,109 +256,169 @@ class NetworkAdapterSelection(Screen, HelpableScreen):
 					self.session.openWithCallback(self.AdapterSetupClosed, NetworkWizard, selection[0])
 
 
-class NameserverSetup(Screen, ConfigListScreen, HelpableScreen):
+class DNSSettings(Setup):
 	def __init__(self, session):
-		Screen.__init__(self, session)
-		HelpableScreen.__init__(self)
-		Screen.setTitle(self, _("Nameserver settings"))
-		self.backupNameserverList = iNetwork.getNameserverList()[:]
-		print("backup-list:", self.backupNameserverList)
-
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
+		self.dnsInitial = iNetwork.getNameserverList()
+		print("[NetworkSetup] DNSSettings: Initial DNS list: %s." % str(self.dnsInitial))
+		self.dnsOptions = {
+			"custom": [[0, 0, 0, 0]],
+			"dhcp-router": [list(x[1]) for x in self.getNetworkRoutes()],
+			"google": [[8, 8, 8, 8], [8, 8, 4, 4]],
+			"cloudflare": [[1, 1, 1, 1], [1, 0, 0, 1]],
+			"opendns-familyshield": [[208, 67, 222, 123], [208, 67, 220, 123]],
+			"opendns-home": [[208, 67, 222, 222], [208, 67, 220, 220]]
+		}
+		option = self.dnsCheck(self.dnsInitial, refresh=False)
+		self.dnsServers = self.dnsOptions[option][:]
+		self.entryAdded = False
+		Setup.__init__(self, session=session, setup="DNS")
+		self.setTitle(_("DNS Settings"))
 		self["key_yellow"] = StaticText(_("Add"))
-		self["key_blue"] = StaticText(_("Delete"))
+		self["key_blue"] = StaticText("")
+		dnsDescription = _("DNS (Dynamic Name Server) Actions")
+		self["addAction"] = HelpableActionMap(self, ["DNSSettingsActions"], {
+			"dnsAdd": (self.addDNSServer, _("Add a DNS entry"))
+		}, prio=0, description=dnsDescription)
+		self["removeAction"] = HelpableActionMap(self, ["DNSSettingsActions"], {
+			"dnsRemove": (self.removeDNSServer, _("Remove a DNS entry"))
+		}, prio=0, description=dnsDescription)
+		self["removeAction"].setEnabled(False)
+		self["moveUpAction"] = HelpableActionMap(self, ["DNSSettingsActions"], {
+			"moveUp": (self.moveEntryUp, _("Move the current DNS entry up one line"))
+		}, prio=0, description=dnsDescription)
+		self["moveUpAction"].setEnabled(False)
+		self["moveDownAction"] = HelpableActionMap(self, ["DNSSettingsActions"], {
+			"moveDown": (self.moveEntryDown, _("Move the current DNS entry down one line"))
+		}, prio=0, description=dnsDescription)
+		self["moveDownAction"].setEnabled(False)
 
-		self["introduction"] = StaticText(_("Press OK to activate the settings."))
-		self.createConfig()
+	def dnsCheck(self, dnsServers, refresh=True):
+		def dnsRefresh(refresh):
+			if refresh:
+				for item in self["config"].getList():
+					if item[1] == config.usage.dns:
+						self["config"].invalidate(item)
+						break
 
-		self["OkCancelActions"] = HelpableActionMap(self, "OkCancelActions",
-			{
-			"cancel": (self.cancel, _("Exit nameserver configuration")),
-			"ok": (self.ok, _("Activate current configuration")),
-			})
-
-		self["ColorActions"] = HelpableActionMap(self, "ColorActions",
-			{
-			"red": (self.cancel, _("Exit nameserver configuration")),
-			"green": (self.ok, _("Activate current configuration")),
-			"yellow": (self.add, _("Add a nameserver entry")),
-			"blue": (self.remove, _("Remove a nameserver entry")),
-			})
-
-		self["actions"] = NumberActionMap(["SetupActions"],
-		{
-			"ok": self.ok,
-		}, -2)
-
-		self.list = []
-		ConfigListScreen.__init__(self, self.list)
-		self.createSetup()
-
-	def createConfig(self):
-		self.nameservers = iNetwork.getNameserverList()
-		if config.usage.dns.value == 'google':
-			self.nameserverEntries = [NoSave(ConfigIP(default=[8, 8, 8, 8])), NoSave(ConfigIP(default=[8, 8, 4, 4]))]
-		elif config.usage.dns.value == 'cloudflare':
-			self.nameserverEntries = [NoSave(ConfigIP(default=[1, 1, 1, 1])), NoSave(ConfigIP(default=[1, 0, 0, 1]))]
-		elif config.usage.dns.value == 'opendns-familyshield':
-			self.nameserverEntries = [NoSave(ConfigIP(default=[208, 67, 222, 123])), NoSave(ConfigIP(default=[208, 67, 220, 123]))]
-		elif config.usage.dns.value == 'opendns-home':
-			self.nameserverEntries = [NoSave(ConfigIP(default=[208, 67, 222, 222])), NoSave(ConfigIP(default=[208, 67, 220, 220]))]
-		elif config.usage.dns.value == 'custom' or config.usage.dns.value == 'dhcp-router':
-			self.nameserverEntries = [NoSave(ConfigIP(default=nameserver)) for nameserver in self.nameservers]
+		for option in self.dnsOptions.keys():
+			if dnsServers == self.dnsOptions[option]:
+				if option != "custom":
+					self.dnsOptions["custom"] = [[0, 0, 0, 0]]
+				config.usage.dns.value = option
+				config.usage.dns.save()
+				dnsRefresh(refresh)
+				return option
+		option = "custom"
+		self.dnsOptions[option] = dnsServers[:]
+		config.usage.dns.value = option
+		config.usage.dns.save()
+		dnsRefresh(refresh)
+		return option
 
 	def createSetup(self):
-		self.list = []
-		self.DNSEntry = getConfigListEntry(_("Nameserver configuration"), config.usage.dns)
-		self.list.append(self.DNSEntry)
+		Setup.createSetup(self)
+		dnsList = self["config"].getList()
+		self.dnsStart = len(dnsList)
+		for item, entry in enumerate([NoSave(ConfigIP(default=x)) for x in self.dnsServers], start=1):
+			dnsList.append(getConfigListEntry(_("Name server %d") % item, entry, _("Enter DNS (Dynamic Name Server) %d's IP address.") % item))
+		self.dnsLength = item
+		if self.entryAdded:
+			entry.default = [256, 256, 256, 256]  # This triggers a cancel confirmation for unedited new entries.
+			self.entryAdded = False
+		self["config"].setList(dnsList)
 
-		i = 1
-		for x in self.nameserverEntries:
-			self.list.append(getConfigListEntry(_("Nameserver %d") % i, x))
-			i += 1
+	def changedEntry(self):
+		current = self["config"].getCurrent()[1]
+		index = self["config"].getCurrentIndex()
+		if current == config.usage.dns:
+			self.dnsServers = self.dnsOptions[config.usage.dns.value][:]
+		elif self.dnsStart <= index < self.dnsStart + self.dnsLength:
+			self.dnsServers[index - self.dnsStart] = current.value[:]
+			option = self.dnsCheck(self.dnsServers, refresh=True)
+		Setup.changedEntry(self)
+		self.updateControls()
 
-		self["config"].list = self.list
-		self["config"].l.setList(self.list)
+	def selectionChanged(self):
+		Setup.selectionChanged(self)
+		self.updateControls()
 
-	def ok(self):
-		self.RefreshNameServerUsed()
+	def updateControls(self):
+		index = self["config"].getCurrentIndex() - self.dnsStart
+		if 0 <= index < self.dnsLength:
+			self["key_blue"].setText(_("Delete") if self.dnsLength > 1 or self.dnsServers[0] != [0, 0, 0, 0] else "")
+			self["removeAction"].setEnabled(self.dnsLength > 1 or self.dnsServers[0] != [0, 0, 0, 0])
+			self["moveUpAction"].setEnabled(index > 0)
+			self["moveDownAction"].setEnabled(index < self.dnsLength - 1)
+		else:
+			self["key_blue"].setText("")
+			self["removeAction"].setEnabled(False)
+			self["moveUpAction"].setEnabled(False)
+			self["moveDownAction"].setEnabled(False)
+
+	def keySave(self):
 		iNetwork.clearNameservers()
-		for nameserver in self.nameserverEntries:
-			iNetwork.addNameserver(nameserver.value)
+		for dnsServer in self.dnsServers:
+			iNetwork.addNameserver(dnsServer)
+		print("[NetworkSetup] DNSSettings: Saved DNS list: %s." % str(iNetwork.getNameserverList()))
+		# iNetwork.saveNameserverConfig()
 		iNetwork.writeNameserverConfig()
-		config.usage.dns.save()
-		self.close()
+		Setup.keySave(self)
 
-	def run(self):
-		self.ok()
-
-	def cancel(self):
-		iNetwork.clearNameservers()
-		print("backup-list:", self.backupNameserverList)
-		for nameserver in self.backupNameserverList:
-			iNetwork.addNameserver(nameserver)
-		self.close()
-
-	def add(self):
-		iNetwork.addNameserver([0, 0, 0, 0])
-		self.createConfig()
+	def addDNSServer(self):
+		self.entryAdded = True
+		self.dnsServers = self.dnsServers + [[0, 0, 0, 0]]
+		self.dnsCheck(self.dnsServers, refresh=False)
 		self.createSetup()
+		self["config"].setCurrentIndex(self.dnsStart + self.dnsLength - 1)
 
-	def remove(self):
-		print("currentIndex:", self["config"].getCurrentIndex())
-		index = self["config"].getCurrentIndex()
-		if index < len(self.nameservers):
-			iNetwork.removeNameserver(self.nameservers[index])
-			self.createConfig()
-			self.createSetup()
+	def removeDNSServer(self):
+		index = self["config"].getCurrentIndex() - self.dnsStart
+		if self.dnsLength == 1:
+			self.dnsServers = [[0, 0, 0, 0]]
+		else:
+			del self.dnsServers[index]
+		self.dnsCheck(self.dnsServers, refresh=False)
+		self.createSetup()
+		if index == self.dnsLength:
+			index -= 1
+		self["config"].setCurrentIndex(self.dnsStart + index)
 
-	def RefreshNameServerUsed(self):
-		print("[NetworkSetup] currentIndex:", self["config"].getCurrentIndex())
-		index = self["config"].getCurrentIndex()
-		if index < len(self.nameservers):
-			self.createConfig()
-			self.createSetup()
+	def moveEntryUp(self):
+		index = self["config"].getCurrentIndex() - self.dnsStart - 1
+		self.dnsServers.insert(index, self.dnsServers.pop(index + 1))
+		self.dnsCheck(self.dnsServers, refresh=False)
+		self.createSetup()
+		self["config"].setCurrentIndex(self.dnsStart + index)
+
+	def moveEntryDown(self):
+		index = self["config"].getCurrentIndex() - self.dnsStart + 1
+		self.dnsServers.insert(index, self.dnsServers.pop(index - 1))
+		self.dnsCheck(self.dnsServers, refresh=False)
+		self.createSetup()
+		self["config"].setCurrentIndex(self.dnsStart + index)
+
+	def run(self):  # Invoked from the Wizard.
+		self.keySave()
+
+	def getNetworkRoutes(self):
+		# # cat /proc/net/route
+		# Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT
+		# eth0    00000000        FE08A8C0        0003    0       0       0       00000000        0       0       0
+		# eth0    0008A8C0        00000000        0001    0       0       0       00FFFFFF        0       0       0
+		gateways = []
+		lines = []
+		lines = fileReadLines("/proc/net/route", lines, source=MODULE_NAME)
+		headings = lines.pop(0)
+		for line in lines:
+			data = line.split()
+			if data[1] == "00000000" and int(data[3]) & 0x03 and data[7] == "00000000":  # If int(flags) & 0x03 is True this is a gateway (0x02) and it is up (0x01).
+				gateways.append((data[0], tuple(reversed([int(data[2][x:x + 2], 16) for x in range(0, len(data[2]), 2)]))))
+		return gateways
+
+
+class NameserverSetup(DNSSettings):
+	def __init__(self, session):
+		DNSSettings.__init__(self, session=session)
 
 
 class NetworkMacSetup(Screen, ConfigListScreen, HelpableScreen):


### PR DESCRIPTION
- Refactor and optimize the code to create the new DNSSettings class.
- Provide a NameserverSetup redirection class to capture access from older code.
- Make the DNSSettings class a sub class of Setup.
- Fix and improve the ConfigIP class.
- Add a "DNS" section to "setup.xml".
- Add a "DNSSettingsActions" section to "keymap.xml".
- Simplify the "UsageConfig.py" definition of "config.usage.dns".  (All devices that can connect to the Internet have a router or gateway.)
- Allow the DELETE or BACKSPACE buttons to delete the current octet of the IP address being edited.
- Allow the ERASE button to reset the current IP address to 0.0.0.0 and position the cursor onto the first octet.
