### PR TITLE
[NetworkTime] Refactor code

### DIFF
--- a/lib/python/Components/NetworkTime.py
+++ b/lib/python/Components/NetworkTime.py
@@ -1,59 +1,66 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from Components.Console import Console
-from Components.config import config
+from time import ctime, time
+
 from enigma import eTimer, eDVBLocalTimeHandler, eEPGCache
+
+from Components.config import config
+from Components.Console import Console
 from Tools.StbHardware import setRTCtime
-from time import time, ctime
-
-# _session = None
-#
-
-
-def AutoNTPSync(session=None, **kwargs):
-	global ntpsyncpoller
-	ntpsyncpoller = NTPSyncPoller()
-	ntpsyncpoller.start()
 
 
 class NTPSyncPoller:
 	"""Automatically Poll NTP"""
 
 	def __init__(self):
-		# Init Timer
 		self.timer = eTimer()
 		self.Console = Console()
 
-	def start(self):
-		if self.timecheck not in self.timer.callback:
-			self.timer.callback.append(self.timecheck)
+	def syncTimeUsingChanged(self, configElement):
+		print("[NetworkTime] Time reference changed to '%s'." % configElement.toDisplayString(configElement.value))
+		eDVBLocalTimeHandler.getInstance().setUseDVBTime(configElement.value == "0")
+		eEPGCache.getInstance().timeUpdated()
 		self.timer.startLongTimer(0)
 
-	def stop(self):
-		if self.timecheck in self.timer.callback:
-			self.timer.callback.remove(self.timecheck)
+	def ntpServerChanged(self, configElement):
+		print("[NetworkTime] Time server changed to '%s'." % configElement.value)
+		self.timeCheck()
+
+	def useNTPminutesChanged(self, configElement):
+		print("[NetworkTime] Time sync period changed to '%s'." % configElement.toDisplayString(configElement.value))
+		self.timeCheck()
+
+	def startTimer(self):
+		if self.timeCheck not in self.timer.callback:
+			self.timer.callback.append(self.timeCheck)
+			config.misc.SyncTimeUsing.addNotifier(self.syncTimeUsingChanged, initial_call=False, immediate_feedback=False)
+			config.misc.NTPserver.addNotifier(self.ntpServerChanged, initial_call=False, immediate_feedback=False)
+			config.misc.useNTPminutes.addNotifier(self.useNTPminutesChanged, initial_call=False, immediate_feedback=False)
+		self.timer.startLongTimer(0)
+
+	def stopTimer(self):
+		if self.timeCheck in self.timer.callback:
+			self.timer.callback.remove(self.timeCheck)
 		self.timer.stop()
 
-	def timecheck(self):
+	def timeCheck(self):
 		if config.misc.SyncTimeUsing.value == "1":
-			print('[NTP]: Updating')
-			self.Console.ePopen('/usr/bin/ntpdate-sync', self.update_schedule)
+			print("[NetworkTime] Updating time via NTP.")
+			self.Console.ePopen(["/usr/sbin/ntpd", "/usr/sbin/ntpd", "-nq", "-p", config.misc.NTPserver.value], self.updateSchedule)
 		else:
-			self.update_schedule()
+			self.updateSchedule()
 
-	def update_schedule(self, result=None, retval=None, extra_args=None):
+	def updateSchedule(self, data=None, retVal=None, extraArgs=None):
+		if retVal and data:
+			print("[NetworkTime] Error %d: /usr/sbin/ntpd was unable to synchronize the time!\n%s" % (retVal, data.strip()))
 		nowTime = time()
-		nowTimereal = ctime(nowTime)
 		if nowTime > 10000:
-			print('[NTP]: setting E2 unixtime:', nowTime)
-			print('[NTP]: setting E2 realtime:', nowTimereal)
+			print("[NetworkTime] Setting time to '%s' (%s)." % (ctime(nowTime), str(nowTime)))
 			setRTCtime(nowTime)
-			if config.misc.SyncTimeUsing.value == "1":
-				eDVBLocalTimeHandler.getInstance().setUseDVBTime(False)
-			else:
-				eDVBLocalTimeHandler.getInstance().setUseDVBTime(True)
+			eDVBLocalTimeHandler.getInstance().setUseDVBTime(config.misc.SyncTimeUsing.value == "0")
 			eEPGCache.getInstance().timeUpdated()
 			self.timer.startLongTimer(int(config.misc.useNTPminutes.value) * 60)
 		else:
-			print('NO TIME SET')
+			print("[NetworkTime] System time not yet available.")
 			self.timer.startLongTimer(10)
+
+
+ntpSyncPoller = NTPSyncPoller()

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -588,30 +588,6 @@ def setLoadUnlinkedUserbouquets(configElement):
 	enigma.eDVBDB.getInstance().setLoadUnlinkedUserbouquets(configElement.value)
 
 
-def useSyncUsingChanged(configelement):
-	if config.misc.SyncTimeUsing.value == "0":
-		print("[Time By]: Transponder")
-		enigma.eDVBLocalTimeHandler.getInstance().setUseDVBTime(True)
-		enigma.eEPGCache.getInstance().timeUpdated()
-	else:
-		print("[Time By]: NTP")
-		enigma.eDVBLocalTimeHandler.getInstance().setUseDVBTime(False)
-		enigma.eEPGCache.getInstance().timeUpdated()
-
-
-def NTPserverChanged(configelement):
-	if config.misc.NTPserver.value == "pool.ntp.org":
-		return
-	print("[NTPDATE] save /etc/default/ntpdate")
-	f = open("/etc/default/ntpdate", "w")
-	f.write('NTPSERVERS="' + config.misc.NTPserver.value + '"')
-	f.close()
-	os.chmod("/etc/default/ntpdate", 0o755)
-	from Components.Console import Console
-	Console = Console()
-	Console.ePopen('/usr/bin/ntpdate-sync')
-
-
 def dump(dir, p=""):
 	had = dict()
 	if isinstance(dir, dict):
@@ -816,9 +792,6 @@ config.misc.startCounter = ConfigInteger(default=0) # number of e2 starts...
 config.misc.standbyCounter = NoSave(ConfigInteger(default=0)) # number of standby
 config.misc.DeepStandby = NoSave(ConfigYesNo(default=False)) # detect deepstandby
 
-config.misc.SyncTimeUsing.addNotifier(useSyncUsingChanged)
-config.misc.NTPserver.addNotifier(NTPserverChanged, immediate_feedback=True)
-
 profile("LOAD:Plugin")
 # initialize autorun plugins and plugin menu entries
 from Components.PluginComponent import plugins
@@ -894,8 +867,8 @@ import Screens.LogManager
 Screens.LogManager.AutoLogManager()
 
 profile("Init:NTPSync")
-import Components.NetworkTime
-Components.NetworkTime.AutoNTPSync()
+from Components.NetworkTime import ntpSyncPoller
+ntpSyncPoller.startTimer()
 
 profile("keymapparser")
 import keymapparser


### PR DESCRIPTION
- Refactor and simplify NetworkTime code.  (Camel case variables, improve logging and simplify the code.)
- Move from using the deprecated "/usr/bin/ntpdate-sync" shell script to the "/usr/sbin/ntpd" program.
- Move all the network time management code from "StartEnigma.py" to" NetworkTime.py".
- Add notifier for changes to network time sync period.  (In the past changes to the time period were not enacted until the old time period had expired.  Thus if you changed from once a day to 30 minutes the change would not happen until the full day timer expired.  The code now triggers a time update when the time period is changed and then the new period is immediately implemented.)
