### PR TITLE
[Py2 > Py3] Fix TypeError: str.translate() takes exactly one argument…

### DIFF
--- a/lib/python/Components/Converter/VAudioInfo.py
+++ b/lib/python/Components/Converter/VAudioInfo.py
@@ -69,7 +69,7 @@ class VAudioInfo(Poll, Converter):
 		return description_str
 
 	def getAudioIcon(self, info):
-		description_str = self.get_short(self.getAudioCodec(info).translate(None, ' .').lower())
+		description_str = self.get_short(self.getAudioCodec(info).translate(str.maketrans("", "", ' .')).lower())
 		return description_str
 
 	def get_short(self, audioName):


### PR DESCRIPTION
… (2 given)