### PR TITLE
[ConfigList.py] Add a settings save notifier

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -233,6 +233,7 @@ class ConfigListScreen:
 		self.setCancelMessage(None)
 		self.setRestartMessage(None)
 		self.onChangedEntry = []
+		self.onSave = []
 		self.onExecBegin.append(self.showHelpWindow)
 		self.onExecEnd.append(self.hideHelpWindow)
 		self.onLayoutFinish.append(self.noNativeKeys)  # self.layoutFinished is already in use!
@@ -403,6 +404,8 @@ class ConfigListScreen:
 		self["config"].handleKey(ACTIONKEY_0 + number, self.entryChanged)
 
 	def keySave(self):
+		for notifier in self.onSave:
+			notifier()
 		if self.saveAll():
 			self.session.openWithCallback(self.restartConfirm, MessageBox, self.restartMsg, default=True, type=MessageBox.TYPE_YESNO)
 		else:
@@ -422,6 +425,19 @@ class ConfigListScreen:
 				item[1].save()
 		configfile.save()
 		return restart
+
+	def addSaveNotifier(self, notifier):
+		if callable(notifier):
+			self.onSave.append(notifier)
+		else:
+			raise TypeError("[ConfigList] Error: Notifier must be callable!")
+
+	def removeSaveNotifier(self, notifier):
+		while notifier in self.onSave:
+			self.onSave.remove(notifier)
+
+	def clearSaveNotifiers(self):
+		self.onSave = []
 
 	def keyCancel(self):
 		self.closeConfigList(())


### PR DESCRIPTION
This change adds a new facility to allow Setup sub class based code to be notified when the user saves changed settings.

This can be considered an alternative to setting notifiers on a number of individual settings.  It is particularly helpful if a number of different settings contribute to a single required change.  When using separate notifiers the same change code could be called multiple times.  With this simple notifier call back system a Setup sub class can register to be notified if nominated settings have been changed and then perform a required action once.

The following methods have been added:
- addSaveNotifier()
- removeSaveNotifier()
- clearSaveNotifiers()
The methods do as their names imply.

An example of how this change is intended to be used will soon be made to Time.py and NetworkTime.py.
