### PR TITLE
[Time.py] Implement new saveNotifier system

### DIFF
--- a/lib/python/Components/NetworkTime.py
+++ b/lib/python/Components/NetworkTime.py
@@ -14,26 +14,9 @@ class NTPSyncPoller:
 		self.timer = eTimer()
 		self.Console = Console()
 
-	def syncTimeUsingChanged(self, configElement):
-		print("[NetworkTime] Time reference changed to '%s'." % configElement.toDisplayString(configElement.value))
-		eDVBLocalTimeHandler.getInstance().setUseDVBTime(configElement.value == "0")
-		eEPGCache.getInstance().timeUpdated()
-		self.timer.startLongTimer(0)
-
-	def ntpServerChanged(self, configElement):
-		print("[NetworkTime] Time server changed to '%s'." % configElement.value)
-		self.timeCheck()
-
-	def useNTPminutesChanged(self, configElement):
-		print("[NetworkTime] Time sync period changed to '%s'." % configElement.toDisplayString(configElement.value))
-		self.timeCheck()
-
 	def startTimer(self):
 		if self.timeCheck not in self.timer.callback:
 			self.timer.callback.append(self.timeCheck)
-			config.misc.SyncTimeUsing.addNotifier(self.syncTimeUsingChanged, initial_call=False, immediate_feedback=False)
-			config.misc.NTPserver.addNotifier(self.ntpServerChanged, initial_call=False, immediate_feedback=False)
-			config.misc.useNTPminutes.addNotifier(self.useNTPminutesChanged, initial_call=False, immediate_feedback=False)
 		self.timer.startLongTimer(0)
 
 	def stopTimer(self):
@@ -43,19 +26,19 @@ class NTPSyncPoller:
 
 	def timeCheck(self):
 		if config.misc.SyncTimeUsing.value == "1":
-			print("[NetworkTime] Updating time via NTP.")
 			self.Console.ePopen(["/usr/sbin/ntpd", "/usr/sbin/ntpd", "-nq", "-p", config.misc.NTPserver.value], self.updateSchedule)
 		else:
 			self.updateSchedule()
 
 	def updateSchedule(self, data=None, retVal=None, extraArgs=None):
 		if retVal and data:
-			print("[NetworkTime] Error %d: /usr/sbin/ntpd was unable to synchronize the time!\n%s" % (retVal, data.strip()))
+			print("[NetworkTime] Error %d: Unable to synchronize the time!\n%s" % (retVal, data.strip()))
 		nowTime = time()
 		if nowTime > 10000:
-			print("[NetworkTime] Setting time to '%s' (%s)." % (ctime(nowTime), str(nowTime)))
+			timeSource = config.misc.SyncTimeUsing.value
+			print("[NetworkTime] Setting time to '%s' (%s) from '%s'." % (ctime(nowTime), str(nowTime), config.misc.SyncTimeUsing.toDisplayString(timeSource)))
 			setRTCtime(nowTime)
-			eDVBLocalTimeHandler.getInstance().setUseDVBTime(config.misc.SyncTimeUsing.value == "0")
+			eDVBLocalTimeHandler.getInstance().setUseDVBTime(timeSource == "0")
 			eEPGCache.getInstance().timeUpdated()
 			self.timer.startLongTimer(int(config.misc.useNTPminutes.value) * 60)
 		else:

--- a/lib/python/Screens/Time.py
+++ b/lib/python/Screens/Time.py
@@ -1,5 +1,6 @@
 from Components.ActionMap import HelpableActionMap
 from Components.config import config
+from Components.NetworkTime import ntpSyncPoller
 from Components.Sources.StaticText import StaticText
 from Screens.Setup import Setup
 from Tools.Geolocation import geolocation
@@ -8,11 +9,16 @@ from Tools.Geolocation import geolocation
 class Time(Setup):
 	def __init__(self, session):
 		Setup.__init__(self, session=session, setup="Time")
+		self.addSaveNotifier(self.updateNetworkTime)
 		self["key_yellow"] = StaticText("")
 		self["geolocationActions"] = HelpableActionMap(self, "ColorActions", {
 			"yellow": (self.useGeolocation, _("Use geolocation to set the current time zone location"))
 		}, prio=0, description=_("Time Setup Actions"))
 		self.selectionChanged()
+
+	def updateNetworkTime(self):
+		if config.misc.SyncTimeUsing.isChanged() or config.misc.NTPserver.isChanged() or config.misc.useNTPminutes.isChanged():
+			ntpSyncPoller.timeCheck()
 
 	def selectionChanged(self):
 		if Setup.getCurrentItem(self) in (config.timezone.area, config.timezone.val):


### PR DESCRIPTION
This change uses the new saveNotifier call back notification system added to "ConfigList.py" to allow the system to track any changes made to any of the "Sync time using", "NTP server" or "Sync NTP every (minutes)" settings.  If, and only if, any of these settings are changed and saved when the user edits the "Time Settings" screen will cause the "timeCheck()" method inside the "NetworkTime.py" module will be called to update the time synchronization policy as changed by the user.  The network time change will only be run ONCE no matter haw many of the dependent settings have been changed.  The code will only be run if any of the settings in the "Time Settings" screen affecting the network time have been changed.

**NOTE: This pull request must be merged *AFTER* #2237!**
