### PR TITLE
[MessageBox.py] Change "self.list" initialization

### DIFF
--- a/lib/python/Screens/MessageBox.py
+++ b/lib/python/Screens/MessageBox.py
@@ -49,7 +49,7 @@ class MessageBox(Screen, HelpableScreen):
 		else:
 			self["list"] = MenuList([])
 			self["list"].hide()
-			self.list = None
+			self.list = []
 		self.timeout = timeout
 		if close_on_any_key == True:  # Process legacy close_on_any_key argument.
 			closeOnAnyKey = True


### PR DESCRIPTION
This changes returns the initialization of the "self.list" variable to an empty list rather than None to protect skins with applet embedded Python code that uses "self.list" without checking that it exists or is a valid list.  The change improves compatibility with older screens that test the length of self.list without first checking that it exists as a list.

NOTE: All skin applets with embedded Python code should include try/except around all the code to ensure that errors in the skin Python do not crash the skin or Enigma2.
