### PR TITLE
[MenuList.py] Rename "list" variable to "menuList"

### DIFF
--- a/lib/python/Components/MenuList.py
+++ b/lib/python/Components/MenuList.py
@@ -4,12 +4,12 @@ from Components.GUIComponent import GUIComponent
 
 
 class MenuList(GUIComponent):
-	def __init__(self, list, enableWrapAround=True, content=eListboxPythonStringContent):
+	def __init__(self, menuList, enableWrapAround=True, content=eListboxPythonStringContent):
 		GUIComponent.__init__(self)
-		self.list = list
+		self.menuList = menuList
 		self.enableWrapAround = enableWrapAround
 		self.l = content()
-		self.l.setList(self.list)
+		self.l.setList(self.menuList)
 		self.onSelectionChanged = []
 
 	def getCurrent(self):
@@ -37,16 +37,16 @@ class MenuList(GUIComponent):
 	def getSelectedIndex(self):
 		return self.l.getCurrentSelectionIndex()
 
-	def setList(self, list):
-		self.list = list
-		self.l.setList(self.list)
+	def setList(self, menuList):
+		self.menuList = menuList
+		self.l.setList(self.menuList)
 
 	def moveToIndex(self, index):
 		if self.instance is not None:
 			self.instance.moveSelectionTo(index)
 
 	def count(self):
-		return len(self.list)
+		return len(self.menuList)
 
 	def top(self):
 		if self.instance is not None:


### PR DESCRIPTION
This removes any confusion between the "list" variable and the list data type.
