### PR TITLE
[MenuList.py] Add a "getList()" method

### DIFF
--- a/lib/python/Components/MenuList.py
+++ b/lib/python/Components/MenuList.py
@@ -37,6 +37,9 @@ class MenuList(GUIComponent):
 	def getSelectedIndex(self):
 		return self.l.getCurrentSelectionIndex()
 
+	def getList(self):
+		return self.list
+
 	def setList(self, list):
 		self.list = list
 		self.l.setList(self.list)


### PR DESCRIPTION
This will give codes a better way to access the MenuList's list without directly groping for an internal variable.

In the future this will allow us to rename the "list" variable to something else to avoid confusion with the list data type.
