### PR TITLE
[ChoiceList.py] Clean up and improve the code

### DIFF
--- a/lib/python/Components/ChoiceList.py
+++ b/lib/python/Components/ChoiceList.py
@@ -5,23 +5,18 @@ from Components.MenuList import MenuList
 from Tools.Directories import SCOPE_GUISKIN, resolveFilename
 from Tools.LoadPixmap import LoadPixmap
 
-# DEBUG What's this
-def row_delta_y():
-	font = fonts["ChoiceList"]
-	return (int(font[2]) - int(font[1])) / 2
-
 
 def ChoiceEntryComponent(key=None, text=None):
 	text = ["--"] if text is None else text
 	res = [text]
 	if text[0] == "--":
-		x, y, w, h = parameters.get("ChoicelistDash", (0, 2, 800, 25))
-		res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT, "-" * 200))
+		x, y, w, h = parameters.get("ChoicelistDash", (0, 0, 1280, 25))
+		res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, "\u2014" * 200))
 	else:
 		if key:
-			x, y, w, h = parameters.get("ChoicelistName", (45, 2, 800, 25))
-			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT, text[0]))
-			if key == "dummy":
+			x, y, w, h = parameters.get("ChoicelistName", (45, 0, 1235, 25))
+			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, text[0]))
+			if key in ("dummy", "none"):
 				png = None
 			elif key == "expandable":
 				png = LoadPixmap(resolveFilename(SCOPE_GUISKIN, "icons/expandable.png"))
@@ -35,24 +30,20 @@ def ChoiceEntryComponent(key=None, text=None):
 				png = LoadPixmap(resolveFilename(SCOPE_GUISKIN, "buttons/key_%s.png" % key))
 			if png:
 				x, y, w, h = parameters.get("ChoicelistIcon", (5, 0, 35, 25))
-				if key in ("verticalline", "expanded"):
-					h = 100
-					if key == "verticalline":
-						y = 0
 				res.append((eListboxPythonMultiContent.TYPE_PIXMAP_ALPHABLEND, x, y, w, h, png))
 		else:
-			x, y, w, h = parameters.get("ChoicelistName", (5, 2, 800, 25))
-			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT, text[0]))
+			x, y, w, h = parameters.get("ChoicelistNameSingle", (5, 0, 1275, 25))
+			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, text[0]))
 	return res
 
 
 class ChoiceList(MenuList):
 	def __init__(self, list, selection=0, enableWrapAround=False):
 		MenuList.__init__(self, list, enableWrapAround, eListboxPythonMultiContent)
-		font = fonts.get("ChoiceList", ("Regular", 20, 30))
+		font = fonts.get("ChoiceList", ("Regular", 20, 25))
 		self.l.setFont(0, gFont(font[0], font[1]))
 		self.l.setItemHeight(font[2])
-		self.ItemHeight = font[2]
+		self.itemHeight = font[2]
 		self.selection = selection
 
 	def postWidgetCreate(self, instance):
@@ -61,4 +52,4 @@ class ChoiceList(MenuList):
 		self.instance.setWrapAround(True)
 
 	def getItemHeight(self):
-		return self.ItemHeight
+		return self.itemHeight


### PR DESCRIPTION
- Remove the unused "row_delta_y()" method.
- Remove the odd coordinate manipulation code.  It uses fixed magic numbers that may interfere with or not suit the current skin.
- Remove the template vertical offsets and use RT_VALIGN_CENTER instead.
- Widen the default template width to suit the default HD resolution.
- Make the horizontal line use the UTF-8 dash character rather than "-" (minus) to draw a continuous line.
- Add a more logical "none" key to do the same as the "dummy" key.
- Match the default font height to suit the template height.
- camelCase the variable "ItemHeight" to "itemHeight".
