### PR TITLE
[FactoryReset.py] Remove superfluous setTitle call

### DIFF
--- a/lib/python/Screens/FactoryReset.py
+++ b/lib/python/Screens/FactoryReset.py
@@ -29,7 +29,6 @@ class FactoryReset(Setup, ProtectedScreen):
 		config.factory.resetOthers = NoSave(ConfigYesNo(default=True))
 		Setup.__init__(self, session=session, setup="FactoryReset")
 		ProtectedScreen.__init__(self)
-		self.setTitle(_("Factory Reset"))
 		self["key_green"].text = _("Reset")
 
 	def isProtected(self):


### PR DESCRIPTION
This change results from https://github.com/openatv/enigma2/commit/a4837d4701f28cd0c2998e69e6a715a05ae5f789 where the inappropriate title text was masked by this setTitle.  This screen title will now always reflect the title as assigned in setup.xml.
