### PR TITLE
[NetworkSetup.py] Remove superfluous setTitle call

### DIFF
--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -272,7 +272,6 @@ class DNSSettings(Setup):
 		self.dnsServers = self.dnsOptions[option][:]
 		self.entryAdded = False
 		Setup.__init__(self, session=session, setup="DNS")
-		self.setTitle(_("DNS Settings"))
 		self["key_yellow"] = StaticText(_("Add"))
 		self["key_blue"] = StaticText("")
 		dnsDescription = _("DNS (Dynamic Name Server) Actions")


### PR DESCRIPTION
The DNSSettings screen title will now always reflect the title as assigned in setup.xml.
