### PR TITLE
Fix sending datetime to CAM

### DIFF
--- a/lib/dvb_ci/dvbci_datetimemgr.cpp
+++ b/lib/dvb_ci/dvbci_datetimemgr.cpp
@@ -63,14 +63,14 @@ void eDVBCIDateTimeSession::sendDateTime()
 	tv %= 60;
 	uint8_t ss = tv;
 
-	msg[0] = 5; // not using offset
-	msg[1] = (mjd >> 8) & 0xff;
-	msg[2] = mjd & 0xff;
-	msg[3] = ((hh / 10) << 4) | (hh % 10);
-	msg[4] = ((mm / 10) << 4) | (mm % 10);
-	msg[5] = ((ss / 10) << 4) | (ss % 10);
+	// not using offset
+	msg[0] = (mjd >> 8) & 0xff;
+	msg[1] = mjd & 0xff;
+	msg[2] = ((hh / 10) << 4) | (hh % 10);
+	msg[3] = ((mm / 10) << 4) | (mm % 10);
+	msg[4] = ((ss / 10) << 4) | (ss % 10);
 
-	sendAPDU(tag, msg, 6);
+	sendAPDU(tag, msg, 5);
 
 	if (m_interval > 0)
 	{


### PR DESCRIPTION
This code seems very similar to https://github.com/atvcaptain/dvb-apps/blob/master/lib/libdvben50221/en50221_app_datetime.c#L100 but https://github.com/atvcaptain/dvb-apps/blob/9b74778ab215bbe8901cac7ff176d039c725a23c/lib/libdvben50221/en50221_session.c#L280 does not prepend the length of the packet to the data sent to the CAM.
So for enigma2 this ends up as:
90 02 00 04 9f 84 41 06 05 e9 1d 20 11 52
instead of:
90 02 00 04 9f 84 41 05 e9 1d 20 11 52