### PR TITLE
[SleepTimer.py] Add button mode

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -574,8 +574,10 @@
 	<setup key="SleepTimer" title="Sleep Timer Settings" showOpenWebIf="1">
 		<item text="Sleep timer activation delay" description="Configure the duration, in minutes, before the sleep timer activates.">config.usage.sleepTimer</item>
 		<item text="Sleep timer action" description="Select the type of shutdown desired when the steep timer activates.">config.usage.sleepTimerAction</item>
-		<item text="Energy saver activation delay" description="Configure the duration, in minutes, before the energy saver timer activates.">config.usage.energyTimer</item>
-		<item text="Energy saver action" description="Select the type of shutdown desired when the energy timer activates.">config.usage.energyTimerAction</item>
+		<if conditional="self.setupMode">
+			<item text="Energy saver activation delay" description="Configure the duration, in minutes, before the energy saver timer activates.">config.usage.energyTimer</item>
+			<item text="Energy saver action" description="Select the type of shutdown desired when the energy timer activates.">config.usage.energyTimerAction</item>
+		</if>
 	</setup>
 	<setup key="Softcam" title="Softcam Settings" showOpenWebIf="1">
 		<item level="0" text="Select softcam" description="Select a softcam from the available list.">config.misc.softcams</item>

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -277,8 +277,8 @@ class InfoBar(InfoBarBase, InfoBarShowHide,
 			self.session.open(MessageBox, _("The MediaCenter plugin is not installed!\nPlease install it."), type=MessageBox.TYPE_INFO, timeout=10)
 
 	def openSleepTimer(self):
-		from Screens.SleepTimer import SleepTimer
-		self.session.open(SleepTimer)
+		from Screens.SleepTimer import SleepTimerButton
+		self.session.open(SleepTimerButton)
 
 	def openTimerList(self):
 		from Screens.TimerEdit import TimerEditList

--- a/lib/python/Screens/SleepTimer.py
+++ b/lib/python/Screens/SleepTimer.py
@@ -8,9 +8,10 @@ from Screens.Setup import Setup
 
 
 class SleepTimer(Setup):
-	def __init__(self, session):
+	def __init__(self, session, setupMode=True):
 		if not InfoBar and not InfoBar.instance:
 			self.close()
+		self.setupMode = setupMode
 		Setup.__init__(self, session=session, setup="SleepTimer")
 		self.timer = eTimer()
 		self.timer.callback.append(self.timeout)
@@ -70,3 +71,11 @@ class SleepTimer(Setup):
 	def clearTimer(self):
 		self.timer.stop()
 		self.timer.callback.remove(self.timeout)
+
+
+class SleepTimerButton(SleepTimer):
+	def __init__(self, session):
+		SleepTimer.__init__(self, session, setupMode=False)
+
+	def keySelect(self):
+		SleepTimer.keySave(self)

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -289,8 +289,8 @@ class PowerKey:
 			self.session.open(Screens.Standby.Standby)
 
 	def openSleepTimer(self):
-		from Screens.SleepTimer import SleepTimer
-		self.session.open(SleepTimer)
+		from Screens.SleepTimer import SleepTimerButton
+		self.session.open(SleepTimerButton)
 
 	def setSleepTimer(self, val):
 		from PowerTimer import PowerTimerEntry


### PR DESCRIPTION
This change allows the user to press SLEEP, or assign another button to act as SLEEP, to bring up an interactive version of the SleepTimer screen where only the Sleep Timer options are shown and the user may press OK to select and save the Sleep Timer options.

The user interface for this screen when called from a menu is unchanged.
