### PR TITLE
Add support for enabling and disabling CI devices

### DIFF
--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -1290,6 +1290,14 @@ PyObject *eDVBCIInterfaces::readCICaIds(int slotid)
 	return 0;
 }
 
+int eDVBCIInterfaces::setCIEnabled(int slotid, bool enabled)
+{
+	eDVBCISlot *slot = getSlot(slotid);
+	if (slot)
+		return slot->setEnabled(enabled);
+	return -1;
+}
+
 int eDVBCIInterfaces::setCIClockRate(int slotid, int rate)
 {
 	eDVBCISlot *slot = getSlot(slotid);
@@ -1551,6 +1559,20 @@ DEFINE_REF(eDVBCISlot);
 
 eDVBCISlot::eDVBCISlot(eMainloop *context, int nr)
 {
+	char configStr[255];
+	slotid = nr;
+	m_context = context;
+	state = stateDisabled;
+	snprintf(configStr, 255, "config.ci.%d.enabled", slotid);
+	std::string str = eConfigManager::getConfigValue(configStr);
+	if (strcasecmp(str.c_str(), "false"))
+		openDevice();
+	else
+		eDVBCI_UI::getInstance()->setState(getSlotID(), 3);
+}
+
+void eDVBCISlot::openDevice()
+{
 	char filename[128];
 
 	application_manager = 0;
@@ -1561,12 +1583,10 @@ eDVBCISlot::eDVBCISlot(eMainloop *context, int nr)
 	user_mapped = false;
 	plugged = true;
 
-	slotid = nr;
-
 #ifdef __sh__
-	sprintf(filename, "/dev/dvb/adapter0/ci%d", nr);
+	sprintf(filename, "/dev/dvb/adapter0/ci%d", slotid);
 #else
-	sprintf(filename, "/dev/ci%d", nr);
+	sprintf(filename, "/dev/ci%d", slotid);
 #endif
 
 //	possible_caids.insert(0x1702);
@@ -1591,7 +1611,7 @@ eDVBCISlot::eDVBCISlot(eMainloop *context, int nr)
 		last_poll_time.tv_sec = 0;
 		last_poll_time.tv_nsec = 0;
 #endif
-		notifier = eSocketNotifier::create(context, fd, eSocketNotifier::Read | eSocketNotifier::Priority | eSocketNotifier::Write);
+		notifier = eSocketNotifier::create(m_context, fd, eSocketNotifier::Read | eSocketNotifier::Priority | eSocketNotifier::Write);
 		CONNECT(notifier->activated, eDVBCISlot::data);
 #ifdef __sh__
 		reset();
@@ -1607,7 +1627,23 @@ eDVBCISlot::~eDVBCISlot()
 	eDVBCISession::deleteSessions(this);
 }
 
-void eDVBCISlot::setAppManager( eDVBCIApplicationManagerSession *session )
+void eDVBCISlot::closeDevice() 
+{
+	close(fd);
+	fd = -1;
+	notifier->stop();
+#ifdef __sh__
+	mmi_active = false;
+	eDVBCI_UI::getInstance()->setAppName(getSlotID(), "");
+	eDVBCISession::deleteSessions(this);
+	eDVBCIInterfaces::getInstance()->ciRemoved(this);
+#else
+	data(eSocketNotifier::Priority);
+#endif
+	state = stateDisabled;
+}
+
+void eDVBCISlot::setAppManager(eDVBCIApplicationManagerSession *session)
 {
 	application_manager=session;
 }
@@ -1864,6 +1900,24 @@ int eDVBCISlot::setClockRate(int rate)
 	snprintf(buf, sizeof(buf), "/proc/stb/tsmux/ci%d_tsclk", slotid);
 	if(CFile::write(buf, rate ? "high" : "normal") == -1)
 		return -1;
+	return 0;
+}
+
+int eDVBCISlot::setEnabled(bool enabled)
+{
+	eDebug("[CI] Slot: %d Enabled: %d, state %d", getSlotID(), enabled, state);
+	if (enabled && state != stateDisabled)
+		return 0;
+
+	if (!enabled && state == stateDisabled)
+		return 0;
+
+	if(enabled)
+		openDevice();
+	else {
+		closeDevice();
+		eDVBCI_UI::getInstance()->setState(getSlotID(), 3);
+	}
 	return 0;
 }
 

--- a/lib/dvb_ci/dvbci.h
+++ b/lib/dvb_ci/dvbci.h
@@ -100,6 +100,7 @@ class eDVBCISlot: public iObject, public sigc::trackable
 	bool user_mapped;
 	void data(int);
 	bool plugged;
+	eMainloop *m_context;
 #ifdef __sh__
 	//dagobert
 	char connection_id;
@@ -108,9 +109,11 @@ class eDVBCISlot: public iObject, public sigc::trackable
 	unsigned char* receivedData;
 #endif
 public:
-	enum {stateRemoved, stateInserted, stateInvalid, stateResetted};
+	enum {stateRemoved, stateInserted, stateInvalid, stateResetted, stateDisabled};
 	eDVBCISlot(eMainloop *context, int nr);
 	~eDVBCISlot();
+    void closeDevice();
+	void openDevice();
 
 	int send(const unsigned char *data, size_t len);
 
@@ -136,6 +139,7 @@ public:
 	int getNumOfServices() { return running_services.size(); }
 	int setSource(const std::string &source);
 	int setClockRate(int);
+	int setEnabled(bool);
 	static std::string getTunerLetter(int tuner_no) { return std::string(1, char(65 + tuner_no)); }
 #ifdef __sh__
 	bool checkQueueSize();
@@ -208,6 +212,7 @@ public:
 	void ciRemoved(eDVBCISlot *slot);
 	int getSlotState(int slot);
 
+	int setCIEnabled(int slot, bool enabled);
 	int reset(int slot);
 	int initialize(int slot);
 	int startMMI(int slot);

--- a/lib/dvb_ci/dvbci_ui.cpp
+++ b/lib/dvb_ci/dvbci_ui.cpp
@@ -76,5 +76,10 @@ int eDVBCI_UI::setClockRate(int slot, int rate)
 	return eDVBCIInterfaces::getInstance()->setCIClockRate(slot, rate);
 }
 
+int eDVBCI_UI::setEnabled(int slot, bool enabled)
+{
+	return eDVBCIInterfaces::getInstance()->setCIEnabled(slot, enabled);
+}
+
 //FIXME: correct "run/startlevel"
 eAutoInitP0<eDVBCI_UI> init_dvbciui(eAutoInitNumbers::rc, "DVB-CI UI");

--- a/lib/dvb_ci/dvbci_ui.h
+++ b/lib/dvb_ci/dvbci_ui.h
@@ -28,6 +28,7 @@ public:
 	int answerEnq(int slot, char *val);
 	int cancelEnq(int slot);
 	int setClockRate(int slot, int rate);
+	int setEnabled(int slot, bool enabled);
 };
 
 #endif

--- a/lib/python/Screens/Ci.py
+++ b/lib/python/Screens/Ci.py
@@ -33,6 +33,8 @@ def setCIBitrate(configElement):
 	else:
 		eDVBCI_UI.getInstance().setClockRate(configElement.slotid, eDVBCI_UI.rateHigh)
 
+def setCIEnabled(configElement):
+    eDVBCI_UI.getInstance().setEnabled(configElement.slotid, configElement.value)
 
 def setdvbCiDelay(configElement):
 	f = open("/proc/stb/tsmux/rmx_delay", "w")
@@ -53,6 +55,9 @@ def InitCiConfig():
 	config.cimisc = ConfigSubsection()
 	for slot in list(range(MAX_NUM_CI)):
 		config.ci.append(ConfigSubsection())
+		config.ci[slot].enabled = ConfigYesNo(default=True)
+		config.ci[slot].enabled.slotid = slot
+		config.ci[slot].enabled.addNotifier(setCIEnabled)
 		config.ci[slot].canDescrambleMultipleServices = ConfigSelection(choices=[("auto", _("Auto")), ("no", _("No")), ("yes", _("Yes"))], default="auto")
 		config.ci[slot].use_static_pin = ConfigYesNo(default=True)
 		config.ci[slot].static_pin = ConfigPIN(default=0)
@@ -561,6 +566,9 @@ class CiSelection(Screen):
 		self.list = []
 		self.entryData = []
 		for slot in self.slots:
+			self.addToList(getConfigListEntry(_("CI %s enabled" % slot), config.ci[slot].enabled), -1, slot)
+			if self.state[slot] == 3:  # module disabled by the user
+				continue
 			self.addToList((_("Reset"), ConfigNothing()), 0, slot)
 			self.addToList((_("Init"), ConfigNothing()), 1, slot)
 


### PR DESCRIPTION
- By default every device is enabled
- Allows the user to disable the CI device from the menu (to be used by other software)
- At startup a disabled device will not initialize but will appear in the menu as disabled and the user can choose to enable it

This functionality triggers also a Reset. @atvcaptain do you think we should remove the Reset functionality or leave it as it is.