### PR TITLE
[skin.py] Remove superfluous reloadWindowStyles() call

### DIFF
--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -187,7 +187,6 @@ def loadSkin(filename, scope=SCOPE_SKINS, desktop=getDesktop(GUI_SKIN_ID), scree
 					if config.crash.debugScreens.value:
 						print("[Skin] This skin has a windowstyle for screen ID='%s'." % scrnID)
 			# Element is not a screen or windowstyle element so no need for it any longer.
-		reloadWindowStyles()  # Reload the window style to ensure all skin changes are taken into account.
 		print("[Skin] Loading skin file '%s' complete." % filename)
 		if runCallbacks:
 			for method in callbacks:


### PR DESCRIPTION
This call was added to ensure that the current windowstyle is always activated.  The fact that window styles was repeatedly activated was not considered an issue.

Recent work on openATV has been targeted at optimising the performance and code.  With this in mind we would like to review this code and look to optimising it.

There are some new changes and enhancements coming to the window styles and we would like to see skin processing optimised to improve the speed of the UI and user experience.  If any skin developers or users detect any screen or skin changes resulting from this change please alert us as a matter of urgency.  Please only report any issues *DIRECTLY* caused by this one change!
