### PR TITLE
[List.py] Correct list navigation and clean code

### DIFF
--- a/lib/python/Components/Sources/List.py
+++ b/lib/python/Components/Sources/List.py
@@ -11,44 +11,46 @@ setup the "fonts".
 This has been done so another converter could convert the list to a different format, for example
 to generate HTML."""
 
+	# NOTE: The calling arguments enableWraparound, item_height and fonts are not
+	# used but remain here so that calling code does not need to be modified.
+	# The enableWrapAround function is correctly handles by the C++ code and the 
+	# use of the enableWrapAround="1" attribute in the skin. Similarly the 
+	# itemHeight and font specifications are handled by the skin.
+	#
 	def __init__(self, list=[], enableWrapAround=False, item_height=25, fonts=[]):
 		Source.__init__(self)
-		self.__list = list
-		self.enableWrapAround = enableWrapAround
-		self.item_height = item_height
-		self.fonts = fonts
+		self.listData = list
 		self.onSelectionChanged = []
-		self.disable_callbacks = False
-		self.__style = "default"  # Style might be an optional string which can be used to define different visualisations in the skin.
+		self.disableCallbacks = False
+		self.listStyle = "default"  # Style might be an optional string which can be used to define different visualizations in the skin.
 
-	def setList(self, list):
-		self.__list = list
+	def setList(self, listData):
+		self.listData = listData
 		self.changed((self.CHANGED_ALL,))
 
-	list = property(lambda self: self.__list, setList)
+	list = property(lambda self: self.listData, setList)
 
-	def updateList(self, list):
+	def updateList(self, listData):
 		"""Changes the list without changing the selection or emitting changed Events"""
-		maxIndex = len(list) - 1
+		maxIndex = len(listData) - 1
 		oldIndex = min(self.index, maxIndex)
-		self.disable_callbacks = True
-		self.list = list
+		self.disableCallbacks = True
+		self.listData = listData
 		self.index = oldIndex
-		self.disable_callbacks = False
+		self.disableCallbacks = False
 
 	def entry_changed(self, index):
-		if not self.disable_callbacks:
+		if not self.disableCallbacks:
 			self.downstream_elements.entry_changed(index)
 
 	def modifyEntry(self, index, data):
-		self.__list[index] = data
+		self.listData[index] = data
 		self.entry_changed(index)
 
 	def selectionChanged(self, index):
-		if self.disable_callbacks:
+		if self.disableCallbacks:
 			return
-		# Update all non-master targets.
-		for x in self.downstream_elements:
+		for x in self.downstream_elements:  # Update all non-master targets.
 			if x is not self.master:
 				x.index = index
 		for x in self.onSelectionChanged:
@@ -75,11 +77,11 @@ to generate HTML."""
 
 	@cached
 	def getStyle(self):
-		return self.__style
+		return self.listStyle
 
 	def setStyle(self, style):
-		if self.__style != style:
-			self.__style = style
+		if self.listStyle != style:
+			self.listStyle = style
 			self.changed((self.CHANGED_SPECIFIC, "style"))
 
 	style = property(getStyle, setStyle)
@@ -88,23 +90,13 @@ to generate HTML."""
 		return self.getIndex()
 
 	def count(self):
-		return len(self.__list)
+		return len(self.listData)
 
-	def selectPrevious(self):
-		if self.getIndex() - 1 < 0:
-			if self.enableWrapAround:
-				self.index = self.count() - 1
-		else:
-			self.index -= 1
-		self.setIndex(self.index)
+	def selectPrevious(self):  # This is a hack to protect code that was modified to use the previous up/down hack!
+		self.up()
 
-	def selectNext(self):
-		if self.getIndex() + 1 >= self.count():
-			if self.enableWrapAround:
-				self.index = 0
-		else:
-			self.index += 1
-		self.setIndex(self.index)
+	def selectNext(self):  # This is a hack to protect code that was modified to use the previous up/down hack!
+		self.down()
 
 	def top(self):
 		try:
@@ -121,10 +113,18 @@ to generate HTML."""
 			return
 
 	def up(self):
-		self.selectPrevious()
+		try:
+			instance = self.master.master.instance
+			instance.moveSelection(instance.moveUp)
+		except AttributeError:
+			return
 
 	def down(self):
-		self.selectNext()
+		try:
+			instance = self.master.master.instance
+			instance.moveSelection(instance.moveDown)
+		except AttributeError:
+			return
 
 	def pageDown(self):
 		try:


### PR DESCRIPTION
- The up() and down() methods did not respect the C++ code list navigation.  A previous edit introduced a local/Python version of enableWrapAround that required Python code to enable the wrap around functionality and caused the skin attribute enableWrapAround="0" or "1" to be ignored.  The original functionality has been restored.  The old calling arguments are still accepted for compatibility with calling code but are ignored.  If you wish to control the wrap around status of a widget please use the skin enableWrapAround attribute.
- The selectPrevious() and selectNext() methods are no longer required for managing the wrap around status and now simply call the up() and down() methods respectively.  These methods should be removed as soon as all calling code is fixed to go back to the original up() and down() methods.
- Use camelCase for more of the variables.
- Avoid using "list" as a variable where possible.
- Add comments to explain the code changes.
