### PR TITLE
[UnhandledKey.py] Add ability to display UnhandledKey

### DIFF
--- a/lib/python/Screens/UnhandledKey.py
+++ b/lib/python/Screens/UnhandledKey.py
@@ -1,8 +1,18 @@
-from Screens.Screen import Screen
+from enigma import eTimer
+
 from Components.Pixmap import Pixmap
+from Screens.Screen import Screen
 
 
 class UnhandledKey(Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
 		self["UnhandledKeyPixmap"] = Pixmap()
+		self.unhandledKeyTimer = eTimer()
+		self.unhandledKeyTimer.callback.append(self.hide)
+		# if BoxInfo.getItem("OSDAnimation"):
+		# 	self.unhandledKeyDialog.setAnimationMode(0)
+
+	def displayUnhandledKey(self):
+		self.show()
+		self.unhandledKeyTimer.start(2000, True)


### PR DESCRIPTION
This is a code proposal to allow any module or method to invoke the UnhandledKey icon without needing that supporting code to be replicated.

For any code to display the UnhandledKey icon simply use code like:
	from Screens.UnhandledKey import UnhandledKey
	UnhandledKey.displayUnhandledKey(self)

This will trigger the timed display of the UnhandledKey icon.
