### PR TITLE
[Downloader.py] Refactor code

### DIFF
--- a/lib/python/Tools/Downloader.py
+++ b/lib/python/Tools/Downloader.py
@@ -1,85 +1,76 @@
-from boxbranding import getMachineBrand, getMachineName
+from os import unlink
+import requests
+from twisted.internet import reactor
+from urllib.request import urlopen, Request
 
-from twisted.web import client
-from twisted.internet import reactor, defer, ssl
+from enigma import eTimer
 
-
-class HTTPProgressDownloader(client.HTTPDownloader):
-	def __init__(self, url, outfile, headers=None):
-		client.HTTPDownloader.__init__(self, url, outfile, headers=headers, agent="Enigma2 HbbTV/1.1.1 (+PVR+RTSP+DL;OpenATV;;;)")
-		self.status = self.progress_callback = self.error_callback = self.end_callback = None
-		self.deferred = defer.Deferred()
-
-	def noPage(self, reason):
-		if self.status == b"304":
-			print(reason.getErrorMessage())
-			client.HTTPDownloader.page(self, "")
-		else:
-			client.HTTPDownloader.noPage(self, reason)
-		if self.error_callback:
-			self.error_callback(reason.getErrorMessage(), self.status)
-
-	def gotHeaders(self, headers):
-		if self.status == b"200":
-			if b"content-length" in headers:
-				self.totalbytes = int(headers[b"content-length"][0])
-			else:
-				self.totalbytes = 0
-			self.currentbytes = 0.0
-		return client.HTTPDownloader.gotHeaders(self, headers)
-
-	def pagePart(self, packet):
-		if self.status == b"200":
-			self.currentbytes += len(packet)
-		if self.totalbytes and self.progress_callback:
-			self.progress_callback(self.currentbytes, self.totalbytes)
-		return client.HTTPDownloader.pagePart(self, packet)
-
-	def pageEnd(self):
-		ret = client.HTTPDownloader.pageEnd(self)
-		if self.end_callback:
-			self.end_callback()
-		return ret
-
-
-class downloadWithProgress:
-	def __init__(self, url, outputfile, contextFactory=None, *args, **kwargs):
-		if hasattr(client, '_parse'):
-			scheme, host, port, path = client._parse(url)
-		else:
-			# _URI class renamed to URI in 15.0.0
-			try:
-				from twisted.web.client import _URI as URI
-			except ImportError:
-				from twisted.web.client import URI
-			# twisted wants bytes
-			if isinstance(url, str):
-				url = url.encode("UTF-8")
-			uri = URI.fromBytes(url)
-			scheme = uri.scheme
-			host = uri.host
-			port = uri.port
-			path = uri.path
-
-		self.factory = HTTPProgressDownloader(url, outputfile, *args, **kwargs)
-		if scheme == b"https":
-			self.connection = reactor.connectSSL(host, port, self.factory, ssl.ClientContextFactory())
-		else:
-			self.connection = reactor.connectTCP(host, port, self.factory)
+class DownloadWithProgress:
+	def __init__(self, url, outputFile):
+		self.url = url
+		self.outputFile = outputFile
+		self.userAgent = "Enigma2 HbbTV/1.1.1 (+PVR+RTSP+DL;OpenATV;;;)"
+		# self.agent = "Mozilla/5.0 (Windows; U; Windows NT 5.1; en; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5"
+		self.totalSize = 0
+		self.progress = 0
+		self.progressCallback = None
+		self.endCallback = None
+		self.errorCallback = None
+		self.stopFlag = False
+		self.timer = eTimer()
+		self.timer.callback.append(self.reportProgress)
 
 	def start(self):
-		return self.factory.deferred
+		request = Request(self.url, None, {"User-agent": self.userAgent})
+		feedFile = urlopen(request)
+		metaData = feedFile.info()
+		self.totalSize = int(metaData["Content-Length"])
+		# Set the transfer block size to a minimum of 1K and a maximum of 1% of the file size (or 128KB if the size is unknown) else use 64K.
+		self.blockSize = max(min(self.totalSize // 100, 1024), 131071) if self.totalSize else 65536
+		reactor.callInThread(self.run)
+
+	def run(self):
+		# requests.Response object = requests.get(url, params=None, allow_redirects=True, auth=None, cert=None, cookies=None, headers=None, proxies=None, stream=False, timeout=None, verify=True)
+		response = requests.get(self.url, headers={"User-agent": self.userAgent}, stream=True)  # Streaming, so we can iterate over the response.
+		try:
+			with open(self.outputFile, "wb") as fd:
+				for buffer in response.iter_content(self.blockSize):
+					if self.stopFlag:
+						response.close()
+						fd.close()
+						unlink(self.outputFile)
+						return True
+					self.progress += len(buffer)
+					if self.progressCallback:
+						self.timer.start(0, True)
+					fd.write(buffer)
+			if self.endCallback:
+				# self.endCallback(self.url, self.outputFile, self.progress)
+				self.endCallback()
+		except OSError as err:
+			if self.errorCallback:
+				# self.errorCallback(self.url, self.outputFile, err.errno, err.strerror)
+				self.errorCallback(err.errno, err.strerror)
+		return False
 
 	def stop(self):
-		if self.connection:
-			self.factory.progress_callback = self.factory.end_callback = self.factory.error_callback = None
-			self.connection.disconnect()
+		self.stopFlag = True
 
-	def addProgress(self, progress_callback):
-		self.factory.progress_callback = progress_callback
+	def reportProgress(self):
+		self.progressCallback(self.progress, self.totalSize)
 
-	def addEnd(self, end_callback):
-		self.factory.end_callback = end_callback
+	def addProgress(self, progressCallback):
+		self.progressCallback = progressCallback
 
-	def addError(self, error_callback):
-		self.factory.error_callback = error_callback
+	def addEnd(self, endCallback):
+		self.endCallback = endCallback
+
+	def addError(self, errorCallback):
+		self.errorCallback = errorCallback
+
+	def setAgent(self, userAgent):
+		self.userAgent = userAgent
+
+
+class downloadWithProgress(DownloadWithProgress):  # Class names should start with a Capital letter, this catches old code until that code can be updated.
+	pass


### PR DESCRIPTION
- Remove the deprecated HTTPProgressDownloader class as the functionality upon which it is based was deprecated in twisted version 16.7 and has been removed since twisted version 22.
- Use a current download method that can properly handle all http and https requests.
- Implement a refactored DownloadWithProgress class that uses the twisted reactor.callInThread call to do the fetch in another thread but still allow the UI to be updated with the download progress.  Note that the name has been changed to use a capital letter as the first character as is normal practice for class names.
- Add a downloadWithProgress class to provide compatibility with all old code that calls the class with a lowercase first letter.  (Classes should start with a capital letter.)
