### PR TITLE
[ScrollLabel.py] Refactor and enhance the code

### DIFF
--- a/lib/python/Components/ScrollLabel.py
+++ b/lib/python/Components/ScrollLabel.py
@@ -1,177 +1,251 @@
-from enigma import eLabel, ePoint, eSize, eSlider, eWidget, fontRenderClass
+from enigma import eLabel, eListbox, ePoint, eSize, eSlider, eWidget, fontRenderClass
 
-from skin import applyAllAttributes
+from skin import applyAllAttributes, parseBoolean, parseHorizontalAlignment, parseScrollbarMode, parseScrollbarScroll, scrollLabelStyle
 from Components.GUIComponent import GUIComponent
 
 
 class ScrollLabel(GUIComponent):
-	def __init__(self, text="", showscrollbar=True):
+	def __init__(self, text=""):
 		GUIComponent.__init__(self)
-		self.message = text
-		self.showscrollbar = showscrollbar
+		self.msgText = text
 		self.instance = None
-		self.long_text = None
-		self.right_text = None
-		self.scrollbar = None
-		self.TotalTextHeight = 0
-		self.curPos = 0
-		self.pageHeight = 0
-		self.column = 0
+		self.leftText = None
+		self.rightText = None
+		self.slider = None
 		self.split = False
-		self.splitchar = "|"
-		self.lineheight = None
-		self.scrollbarmode = "showOnDemand"
-
-	def applySkin(self, desktop, parent):
-		scrollbarWidth = 10
-		itemHeight = 30
-		scrollbarBorderWidth = 1
-		ret = False
-		if self.skinAttributes:
-			widget_attribs = []
-			scrollbar_attribs = []
-			scrollbarAttrib = ["scrollbarSliderForegroundColor", "scrollbarSliderBorderColor", "scrollbarSliderPicture", "scrollbarBackgroundPicture"]
-			for (attrib, value) in self.skinAttributes[:]:
-				if attrib in scrollbarAttrib:
-					scrollbar_attribs.append((attrib, value))
-					self.skinAttributes.remove((attrib, value))
-				elif "borderColor" in attrib or "borderWidth" in attrib:
-					scrollbar_attribs.append((attrib, value))
-				elif "itemHeight" in attrib:
-					itemHeight = int(value)
-					self.skinAttributes.remove((attrib, value))
-				elif "scrollbarMode" in attrib:
-					self.scrollbarmode = value
-					self.skinAttributes.remove((attrib, value))
-				elif "transparent" in attrib or "backgroundColor" in attrib:
-					widget_attribs.append((attrib, value))
-				elif "scrollbarWidth" in attrib:
-					scrollbarWidth = int(value)
-					self.skinAttributes.remove((attrib, value))
-				elif "scrollbarSliderBorderWidth" in attrib:
-					scrollbarBorderWidth = int(value)
-					self.skinAttributes.remove((attrib, value))
-				elif "split" in attrib:
-					self.split = 1 if value.lower() in ("1", "enabled", "on", "split", "true", "yes") else 0
-					if self.split:
-						self.right_text = eLabel(self.instance)
-					self.skinAttributes.remove((attrib, value))
-				elif "colposition" in attrib or "colPosition" in attrib:
-					self.column = int(value)
-				elif "dividechar" in attrib or "divideChar" in attrib:
-					self.splitchar = value
-			if self.split:
-				applyAllAttributes(self.long_text, desktop, self.skinAttributes + [("halign", "left")], parent.scale)
-				applyAllAttributes(self.right_text, desktop, self.skinAttributes + [("transparent", "1"), ("halign", "left" if self.column else "right")], parent.scale)
-			else:
-				applyAllAttributes(self.long_text, desktop, self.skinAttributes, parent.scale)
-			applyAllAttributes(self.instance, desktop, widget_attribs, parent.scale)
-			applyAllAttributes(self.scrollbar, desktop, scrollbar_attribs + widget_attribs, parent.scale)
-			ret = True
-		self.pageWidth = self.long_text.size().width()
-		self.lineheight = fontRenderClass.getInstance().getLineHeight(self.long_text.getFont()) or itemHeight # assume a random lineheight if nothing is visible
-		lines = int(self.long_text.size().height() / self.lineheight)
-		self.pageHeight = int(lines * self.lineheight)
-		self.instance.move(self.long_text.position())
-		self.instance.resize(eSize(self.pageWidth, self.pageHeight + int(self.lineheight / 6)))
-		self.scrollbar.move(ePoint(self.pageWidth - scrollbarWidth, 0))
-		self.scrollbar.resize(eSize(scrollbarWidth, self.pageHeight + int(self.lineheight / 6)))
-		self.scrollbar.setOrientation(eSlider.orVertical)
-		self.scrollbar.setRange(0, 100)
-		self.scrollbar.setBorderWidth(scrollbarBorderWidth)
-		self.setText(self.message)
-		return ret
-
-	def setPos(self, pos):
-		self.curPos = max(0, min(pos, self.TotalTextHeight - self.pageHeight))
-		self.long_text.move(ePoint(0, -self.curPos))
-		self.split and self.right_text.move(ePoint(self.column, -self.curPos))
-
-	def setText(self, text, showBottom=False):
-		self.message = text
-		text = text.rstrip()
-		if self.pageHeight:
-			if self.split:
-				left = []
-				right = []
-				for line in text.split("\n"):
-					line = line.split(self.splitchar, 1)
-					left.append(line[0])
-					right.append("" if len(line) < 2 else line[1].lstrip())
-				self.long_text.setText("\n".join(left))
-				self.right_text.setText("\n".join(right))
-			else:
-				self.long_text.setText(text)
-			self.TotalTextHeight = self.long_text.calculateSize().height()
-			self.long_text.resize(eSize(self.pageWidth - 30, self.TotalTextHeight))
-			self.split and self.right_text.resize(eSize(self.pageWidth - self.column - 30, self.TotalTextHeight))
-			if showBottom:
-				self.lastPage()
-			else:
-				self.setPos(0)
-			if (self.scrollbarmode == "showAlways") or ((self.scrollbarmode == "showOnDemand") and self.showscrollbar and self.TotalTextHeight > self.pageHeight):
-				self.scrollbar.show()
-				self.updateScrollbar()
-			else:
-				self.scrollbar.hide()
-
-	def appendText(self, text, showBottom=True):
-		self.setText(self.message + text, showBottom)
-
-	def moveTop(self):
-		self.setPos(0)
-		self.updateScrollbar()
-
-	def homePage(self):
-		return self.moveTop()
-
-	def pageUp(self):
-		if self.TotalTextHeight > self.pageHeight:
-			self.setPos(self.curPos - self.pageHeight)
-			self.updateScrollbar()
-
-	def moveUp(self):
-		self.setPos(self.curPos - int(self.lineheight))
-		self.updateScrollbar()
-
-	def moveDown(self):
-		self.setPos(self.curPos + int(self.lineheight))
-		self.updateScrollbar()
-
-	def pageDown(self):
-		if self.TotalTextHeight > self.pageHeight:
-			self.setPos(self.curPos + self.pageHeight)
-			self.updateScrollbar()
-
-	def moveBottom(self):
-		self.lastPage()
-		self.updateScrollbar()
-
-	def endPage(self):
-		return self.moveBottom()
-
-	def lastPage(self):
-		self.setPos(self.TotalTextHeight - self.pageHeight)
-
-	def isAtLastPage(self):
-		return self.TotalTextHeight <= self.pageHeight or self.curPos == self.TotalTextHeight - self.pageHeight
-
-	def updateScrollbar(self):
-		vis = max(100 * self.pageHeight // self.TotalTextHeight, 3)
-		start = (100 - vis) * self.curPos // ((self.TotalTextHeight - self.pageHeight) or 1)
-		self.scrollbar.setStartEnd(start, start + vis)
+		self.splitCharacter = "|"
+		self.splitTrim = False
+		self.pageWidth = 0
+		self.pageHeight = 0
+		self.totalTextHeight = 0
+		self.currentPosition = 0
+		self.leftColX = 0
+		self.rightColX = 0
 
 	def GUIcreate(self, parent):
 		self.instance = eWidget(parent)
-		self.scrollbar = eSlider(self.instance)
-		self.scrollbar.setIsScrollbar()
-		self.long_text = eLabel(self.instance)
+		self.leftText = eLabel(self.instance)
+		self.rightText = eLabel(self.instance)
+		self.slider = eSlider(self.instance)
+		self.slider.setIsScrollbar()
 
 	def GUIdelete(self):
-		self.long_text = None
-		self.scrollbar = None
+		self.leftText = None
+		self.rightText = None
+		self.slider = None
 		self.instance = None
-		self.right_text = None
+
+	def applySkin(self, desktop, parent):
+		scrollLabelDefaults = (
+			("scrollbarBorderWidth", eListbox.DefaultScrollBarBorderWidth),
+			("scrollbarMode", eListbox.showOnDemand),
+			("scrollbarOffset", eListbox.DefaultScrollBarOffset),
+			("scrollbarScroll", eListbox.DefaultScrollBarScroll),
+			("scrollbarWidth", eListbox.DefaultScrollBarWidth)
+		)
+		for attribute, default in scrollLabelDefaults:
+			if attribute not in scrollLabelStyle:
+				scrollLabelStyle[attribute] = default
+		splitMargin = 0
+		splitPosition = None
+		splitSeparated = False
+		sliderBorderWidth = scrollLabelStyle["scrollbarBorderWidth"]
+		sliderMode = scrollLabelStyle["scrollbarMode"]
+		sliderScroll = scrollLabelStyle["scrollbarScroll"]
+		sliderOffset = scrollLabelStyle["scrollbarOffset"]
+		sliderWidth = scrollLabelStyle["scrollbarWidth"]
+		if self.skinAttributes:
+			sliderProperties = (
+				"scrollbarBorderColor",
+				"scrollbarBorderWidth",
+				"scrollbarBackgroundColor",
+				"scrollbarForegroundColor",
+				"scrollbarBackgroundPixmap",
+				"scrollbarForegroundPixmap"
+			)
+			leftLabelAttributes = []
+			rightLabelAttributes = []
+			sliderAttributes = []
+			leftAlign = "left"
+			rightAlign = "left"
+			for attribute, value in self.skinAttributes:
+				if attribute in sliderProperties:
+					sliderAttributes.append((attribute, value))
+				else:
+					try:
+						if attribute == "leftColumnAlignment":
+							leftAlign = parseHorizontalAlignment(value)  # The parser is used to check if the value is valid, an exception is raised if it isn't!
+							leftAlign = value
+						elif attribute == "rightColumnAlignment":
+							rightAlign = parseHorizontalAlignment(value)  # The parser is used to check if the value is valid, an exception is raised if it isn't!
+							rightAlign = value
+							self.split = True
+						elif attribute == "split":
+							self.split = parseBoolean("split", value)
+						elif attribute in ("splitCharacter", "divideChar", "dividechar"):
+							self.splitCharacter = value
+							self.split = True
+						elif attribute == "splitMargin":
+							splitMargin = int(value)
+						elif attribute in ("splitPosition", "colPosition", "colposition"):
+							splitPosition = int(value)
+							self.split = True
+						elif attribute == "splitSeparated":
+							splitSeparated = parseBoolean("splitSeparated", value)
+							self.split = True
+						elif attribute == "splitTrim":
+							self.splitTrim = parseBoolean("splitTrim", value)
+						elif attribute == "scrollbarBorderWidth":
+							sliderBorderWidth = int(value)
+						elif attribute == "scrollbarMode":
+							sliderMode = parseScrollbarMode(value)
+						elif attribute == "scrollbarScroll":
+							sliderScroll = parseScrollbarScroll(value)
+						elif attribute == "scrollbarOffset":
+							sliderOffset = int(value)
+						elif attribute == "scrollbarWidth":
+							sliderWidth = int(value)
+						else:
+							leftLabelAttributes.append((attribute, value))
+							rightLabelAttributes.append((attribute, value))
+					except Exception as err:
+						print("[ScrollLabel]%s" % err)  # The real error  text will be generated by the SkinError class in Skin.py.
+			if self.split:
+				for attribute, value in leftLabelAttributes[:]:
+					if attribute == "noWrap":  # Remove "noWrap" attribute so it can be set later.
+						leftLabelAttributes.remove((attribute, value))
+						break
+				for attribute, value in rightLabelAttributes[:]:
+					if attribute == "noWrap":  # Remove "noWrap" attribute so it can be set later.
+						rightLabelAttributes.remove((attribute, value))
+						break
+				if not splitSeparated:
+					leftAlign = "left"  # If columns are used and not separated then left column needs to be "left" aligned to avoid overlapping text.
+					rightLabelAttributes.append(("transparent", "1"))  # Also, the right column needs to be transparent to allow for left column text overflow.
+				leftLabelAttributes.extend([("horizontalAlignment", leftAlign), ("noWrap", "1")])  # Set "noWrap" to keep lines synchronized.
+				rightLabelAttributes.extend([("horizontalAlignment", rightAlign), ("noWrap", "1")])  # Set "noWrap" to keep lines synchronized.
+			applyAllAttributes(self.leftText, desktop, leftLabelAttributes, parent.scale)
+			applyAllAttributes(self.rightText, desktop, rightLabelAttributes, parent.scale)
+			applyAllAttributes(self.slider, desktop, sliderAttributes, parent.scale)
+			retVal = True
+		else:
+			retVal = False
+		lineHeight = int(fontRenderClass.getInstance().getLineHeight(self.leftText.getFont()) or 25)  # Assume a random line height if nothing is visible.
+		self.pageWidth = self.leftText.size().width()
+		self.pageHeight = (self.leftText.size().height() // lineHeight) * lineHeight
+		self.instance.move(self.leftText.position())
+		self.instance.resize(eSize(self.pageWidth, self.pageHeight))
+		self.sliderWidth = sliderOffset + sliderWidth
+		if splitPosition and sliderMode != eListbox.showNever:  # Check that there is space for the scrollbar in the split.
+			if abs(splitPosition) < self.sliderWidth:
+				splitPosition = None
+			elif abs(self.pageWidth - splitPosition) < self.sliderWidth:
+				splitPosition = None
+		splitPosition = self.pageWidth // 2 if splitPosition is None else splitPosition
+		self.leftWidth = (splitPosition - splitMargin) if splitSeparated else self.pageWidth
+		self.rightColX = splitPosition + splitMargin
+		self.rightWidth = self.pageWidth - splitPosition - splitMargin
+		self.leftText.move(ePoint(0, 0))
+		self.rightText.move(ePoint(self.rightColX, 0))
+		self.slider.move(ePoint(0 if sliderMode in (eListbox.showLeftOnDemand, eListbox.showLeftAlways) else (self.pageWidth - sliderWidth), 0))
+		self.slider.resize(eSize(sliderWidth, self.pageHeight))
+		self.slider.setOrientation(eSlider.orVertical)
+		self.slider.setRange(0, 1000)
+		self.slider.setBorderWidth(sliderBorderWidth)
+		self.sliderMode = sliderMode
+		self.sliderScroll = lineHeight if sliderScroll else self.pageHeight
+		self.setText(self.msgText)
+		return retVal
 
 	def getText(self):
-		return self.message
+		return self.msgText
+
+	def setText(self, text, showBottom=False):
+		self.msgText = text
+		text = text.rstrip()
+		if self.pageHeight:
+			if self.split:
+				leftText = []
+				rightText = []
+				for line in text.split("\n"):
+					line = line.split(self.splitCharacter, 1)
+					leftText.append(line[0])
+					rightText.append("" if len(line) < 2 else (line[1].lstrip() if self.splitTrim else line[1]))
+				self.leftText.setText("\n".join(leftText))
+				self.rightText.setText("\n".join(rightText))
+			else:
+				self.leftText.setText(text)
+			self.totalTextHeight = self.leftText.calculateSize().height()
+			leftWidth = self.leftWidth
+			rightWidth = self.rightWidth
+			if self.isSliderVisible():
+				self.slider.show()
+				if self.sliderMode in (eListbox.showLeftAlways, eListbox.showLeftAlways):
+					self.leftColX = self.sliderWidth
+					leftWidth = self.leftWidth - self.sliderWidth
+				else:
+					rightWidth = self.rightWidth - self.sliderWidth
+			else:
+				self.slider.hide()
+			self.leftText.resize(eSize(leftWidth, self.totalTextHeight))
+			self.rightText.resize(eSize(rightWidth, self.totalTextHeight))
+			if showBottom:
+				self.moveBottom()
+			else:
+				self.setPosition(0)
+
+	text = property(getText, setText)
+
+	def appendText(self, text, showBottom=True):
+		self.setText("%s%s" % (self.msgText, text), showBottom)
+
+	def isSliderVisible(self):
+		return self.sliderMode in (eListbox.showAlways, eListbox.showLeftAlways) or (self.sliderMode in (eListbox.showOnDemand, eListbox.showLeftOnDemand) and self.totalTextHeight > self.pageHeight)
+
+	def setPosition(self, pos):
+		self.currentPosition = max(0, min(pos, self.totalTextHeight - self.pageHeight))
+		if self.isSliderVisible():
+			self.updateScrollbar()
+		self.leftText.move(ePoint(self.leftColX, -self.currentPosition))
+		self.rightText.move(ePoint(self.rightColX, -self.currentPosition))
+
+	def moveTop(self):
+		if self.totalTextHeight > self.pageHeight:
+			self.setPosition(0)
+
+	def homePage(self):  # Deprecated navigation (no use found).
+		return self.moveTop()
+
+	def pageUp(self):
+		if self.totalTextHeight > self.pageHeight:
+			self.setPosition(self.currentPosition - self.pageHeight)
+
+	def moveUp(self):
+		if self.totalTextHeight > self.pageHeight:
+			self.setPosition(self.currentPosition - self.sliderScroll)
+
+	def moveDown(self):
+		if self.totalTextHeight > self.pageHeight:
+			self.setPosition(self.currentPosition + self.sliderScroll)
+
+	def pageDown(self):
+		if self.totalTextHeight > self.pageHeight:
+			self.setPosition(self.currentPosition + self.pageHeight)
+
+	def moveBottom(self):
+		if self.totalTextHeight > self.pageHeight:
+			self.setPosition(self.totalTextHeight - self.pageHeight)
+
+	def endPage(self):  # Deprecated navigation (no use found).
+		return self.moveBottom()
+
+	def lastPage(self):  # Deprecated navigation (only minimal use).
+		return self.moveBottom()
+
+	def updateScrollbar(self):
+		visible = min(max(1000 * self.pageHeight // self.totalTextHeight, 4), 1000)
+		start = (1000 - visible) * self.currentPosition // ((self.totalTextHeight - self.pageHeight) or 1)
+		self.slider.setStartEnd(start, start + visible)
+
+	def isAtLastPage(self):
+		return self.totalTextHeight <= self.pageHeight or self.currentPosition == self.totalTextHeight - self.pageHeight


### PR DESCRIPTION
- Locally process all ScrollLabel specific skin attributes.  They are no longer passed to skin.py for processing.
- Use new skin.py based attribute validation / processing methods rather than duplicating the code.
- Remove the "showscrollbar" argument as this functionality is now skinable.
- Remove duplicate execution of the updateScrollbar() method.
- Improve variable names to make the code easier to read and follow.
- Force the left and right columns into "noWrap" mode to ensure that the left and right columns remain synchronised.
- Create and manage both the left and right eLabels on GUI creation so that the attributes can be applied to both on their creation.
- Optimise the list navigation.
- Rename some attributes to clarify their meaning:
  - "colposition" is now "splitPosition".
  - "dividechar: is now "splitCharacter".
- Add attributes to enhance functionality:
  - "splitMargin" allows the skinner to create a separation between the left and right columns of a two column display.  The margin is taken from both the left and right columns so the actual spacing will be twice the "splitMargin" value.
  - "splitTrim", when enabled, causes the split lines to be white space trimmed at the cut point.
  - "splitSeparated" forces the left and right column to be separated.  In this mode text in the left column will no longer flow across into the right column.  The advantage of this options is to allow the left column to be horizontally aligned to a value other than "left".  When this option is not specified the left column alignment is forced to be "left".
  - "leftColumnAlignment" sets the left column alignment.  Only "left" is accepted unless "splitSeparated" is enabled!
  - "rightColumnAlignment" sets the right column alignment.  This can be set without regard to the "splitSeparated" setting.
  - All the standard scrollbar attributes can also be used with ScrollLabel() and will be transferred to the eSlider widget.
  - "scrollbarScroll" sets the mode of scrolling the ScrollLabel widget.  The default is "byPage" and is the traditional way of scrolling windows in Enigma2.  When the user presses DOWN on the last line of a screen the cursor will move to the top line of the next screen.  The scrollbar will show the proportion of screens to be displayed.  That is, if two screens are available then the scrollbar thumb will be 50% of the scrollbar height.  The new option is "byLine", this allows the screens to scroll one line at a time.  When the user presses DOWN on the last line of a screen the cursor position is not changed but the top line of the screen is scrolled out of view and the next line of the list is added to the bottom of the screen and is selected.  The scrollbar is changed to show the proportion of lines to be displayed.  If all lines are displayed then the scrollbar is shown as full height.  If there is only one extra line to be displayed then the scrollbar will occupy the bulk of the scrollbar space.  The thumb will move in proportion to the position of the current line within the complete list.

The new skin "windowstyle" defaults has a tag to cover the default look and feel of all ScrollLabel() widgets.  Where there is no "scrolllabel" default assigned in the "windowstyle" section then the "eListbox" defaults will be used.  That is, any "scrolllabel" defaults that are not specifically defined will use the equivalent "eListbox" default.   This will allow all ScrollLabel widgets, by default, to match the look and feel of the sibling "eListbox" widgets.
