### PR TITLE
Remove hard coded enableWrapAround

### DIFF
--- a/lib/python/Components/ChoiceList.py
+++ b/lib/python/Components/ChoiceList.py
@@ -53,7 +53,6 @@ class ChoiceList(MenuList):
 	def postWidgetCreate(self, instance):
 		MenuList.postWidgetCreate(self, instance)
 		self.moveToIndex(self.selection)
-		self.instance.setWrapAround(True)
 
 	def getItemHeight(self):
 		return self.itemHeight

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -100,7 +100,6 @@ class ConfigList(GUIComponent):
 	def postWidgetCreate(self, instance):
 		instance.selectionChanged.get().append(self.selectionChanged)
 		instance.setContent(self.l)
-		self.instance.setWrapAround(True)
 
 	def preWidgetRemove(self, instance):
 		if isinstance(self.current, tuple) and len(self.current) >= 2:

--- a/lib/python/Components/MenuList.py
+++ b/lib/python/Components/MenuList.py
@@ -4,10 +4,9 @@ from Components.GUIComponent import GUIComponent
 
 
 class MenuList(GUIComponent):
-	def __init__(self, list, enableWrapAround=True, content=eListboxPythonStringContent):
+	def __init__(self, list, enableWrapAround=True, content=eListboxPythonStringContent):  # enableWrapAround is deprecated as this is now controllable in the skin and windowstyle.
 		GUIComponent.__init__(self)
 		self.list = list
-		self.enableWrapAround = enableWrapAround
 		self.l = content()
 		self.l.setList(self.list)
 		self.onSelectionChanged = []
@@ -20,8 +19,6 @@ class MenuList(GUIComponent):
 	def postWidgetCreate(self, instance):
 		instance.setContent(self.l)
 		instance.selectionChanged.get().append(self.selectionChanged)
-		if self.enableWrapAround:
-			self.instance.setWrapAround(True)
 
 	def preWidgetRemove(self, instance):
 		instance.setContent(None)

--- a/lib/python/Components/ServiceList.py
+++ b/lib/python/Components/ServiceList.py
@@ -353,7 +353,6 @@ class ServiceList(GUIComponent):
 		self.l.setElementFont(self.l.celServiceInfo, self.ServiceInfoFont)
 
 	def postWidgetCreate(self, instance):
-		instance.setWrapAround(True)
 		instance.setContent(self.l)
 		instance.selectionChanged.get().append(self.selectionChanged)
 		self.setFontsize()

--- a/lib/python/Components/TimerList.py
+++ b/lib/python/Components/TimerList.py
@@ -177,7 +177,6 @@ class TimerList(GUIComponent):
 	def postWidgetCreate(self, instance):
 		instance.setContent(self.l)
 		self.instance = instance
-		instance.setWrapAround(True)
 
 	def moveToIndex(self, index):
 		self.instance.moveSelectionTo(index)

--- a/lib/python/Screens/HelpMenu.py
+++ b/lib/python/Screens/HelpMenu.py
@@ -294,7 +294,6 @@ class HelpMenuListOld(GUIComponent):
 	def postWidgetCreate(self, instance):
 		instance.setContent(self.l)
 		instance.selectionChanged.get().append(self.selectionChanged)
-		self.instance.setWrapAround(True)
 
 	def preWidgetRemove(self, instance):
 		instance.setContent(None)


### PR DESCRIPTION
Now that the skin "windowstyle" allows for the skin's default of enableWrapAround to be set it is no longer necessary to hard code the default.  The system default has been adjusted to set the system default to enabled.  The skin default can be set in the "listbox" tag in the "windowstyle" block of the skin.  As before individual screens can still have an "enableWrapAround " attribute to modify the settings for any individual screen.
