### PR TITLE
[Menu.py] Add menu images

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -691,9 +691,9 @@
 		<item level="2" text="Enable chapter support for video files" description="Show chapter positions for supported video files. (gstreamer version must be greather than 1)">config.usage.useChapterInfo</item>
 	</setup>
 	<setup key="UserInterface" title="OSD Settings" showOpenWebIf="1">
-		<item level="0" text="Show Main Menu as" description="Choose style of main menus">config.usage.menutype</item>
-		<item level="0" text="Show menu numbers" description="This option allows you to show menu number quick links." requires="config.usage.menutype" value="standard">config.usage.menu_show_numbers</item>
-		<item level="0" text="Menu entry sort order" description="Select the sort order of the menu entries.  User defined also allows the menu entries to be hidden.">config.usage.menu_sort_mode</item>
+		<item level="0" text="Menu style" description="Select the display design for menus.">config.usage.menuType</item>
+		<item level="0" text="Menu entry style" description="Select the display options for each menu entry item. If menu numbers are available then the numbers can be used to directly select specific menu entries directly." requires="config.usage.menuType" value="standard">config.usage.menuEntryStyle</item>
+		<item level="0" text="Menu entry sort order" description="Select the sort order of the menu entries.  User defined also allows the menu entries to be hidden.">config.usage.menuSortOrder</item>
 		<item level="1" text="Show screen menu path" description="Select if the screen menu path history is displayed and, if so, how it is to be displayed.">config.usage.showScreenPath</item>
 		<item level="1" text="Sort Extensions menu" description="Enable to display the Extension menu entries alphabetically.">config.usage.sort_extensionslist</item>
 		<item level="1" text="Show Restart Network in Extensions *" description="Enable to show the 'Restart Network' entry in the Extensions menu.">config.usage.show_restart_network_extensionslist</item>
@@ -702,7 +702,7 @@
 		<item level="1" text="Show setup default value" description="Select if the default value for a setup entry is shown and, if so, where it is displayed in relation to the description.">config.usage.setupShowDefault</item>
 		<item level="2" text="Show True/False as graphical switch" description="Enable to display all True/False, Yes/No, On/Off and Enable/Disable setup options as a graphical switch.">config.usage.boolean_graphic</item>
 		<item level="2" text="Show additional slider value" description="Enable to display the current value of the slider at end of the slider bar.">config.usage.show_slider_value</item>
-		<item level="0" text="Sort order for help screen" description="Choose the order in which items are displayed in Help windows">config.usage.helpSortOrder</item>
+		<item level="0" text="Help screen style" description="Choose the style/order in which items are displayed in help windows.">config.usage.helpSortOrder</item>
 		<item level="0" text="Help animation speed" description="Select the animation speed of the button indicators in the help screens. 'Disabled' turns off animation so that indicators jump between buttons.">config.usage.helpAnimationSpeed</item>
 		<item level="0" text="Show animation while busy" description="Show a spinning logo when the system is busy.">config.usage.show_spinner</item>
 		<item level="2" text="Show screensaver" description="Configure the duration in minutes before the screen saver will be displayed.">config.usage.screen_saver</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -56,7 +56,62 @@ def InitUsageConfig():
 
 	config.usage = ConfigSubsection()
 
-	#settings for servicemp3 and handling from cuesheet file
+	# "UserInterface" settings.
+	#
+	config.usage.menuType = ConfigSelection(default="standard", choices=[
+		("horzanim", _("Horizontal menu")),
+		("horzicon", _("Horizontal icons")),
+		("standard", _("Vertical menu"))
+	])
+	config.usage.menuEntryStyle = ConfigSelection(default="text", choices=[
+		("text", _("Entry text only")),
+		("number", _("Entry number and text")),
+		("image", _("Entry image and text")),
+		("both", _("Entry image, number and text")),
+	])
+	config.usage.menuSortOrder = ConfigSelection(default="user", choices=[
+		("alpha", _("Alphabetical")),
+		("default", _("Default")),
+		("user", _("User defined"))
+	])
+	config.usage.showScreenPath = ConfigSelection(default="off", choices=[
+		("off", _("None")),
+		("small", _("Small")),
+		("large", _("Large"))
+	])
+	config.usage.sort_extensionslist = ConfigYesNo(default=False)
+	config.usage.show_restart_network_extensionslist = ConfigYesNo(default=True)
+	config.usage.sort_pluginlist = ConfigYesNo(default=True)
+	config.usage.helpSortOrder = ConfigSelection(default="headings+alphabetic", choices=[
+		("headings+alphabetic", _("Alphabetical under headings")),
+		("flat+alphabetic", _("Flat alphabetical")),
+		("flat+remotepos", _("Flat by position on remote")),
+		("flat+remotegroups", _("Flat by key group on remote"))
+	])
+	config.usage.setupShowDefault = ConfigSelection(default="newline", choices=[
+		("", _("Don't show default")),
+		("spaces", _("Show default after description")),
+		("newline", _("Show default on new line"))
+	])
+	config.usage.helpAnimationSpeed = ConfigSelection(default=10, choices=[
+		(1, _("Very fast")),
+		(5, _("Fast")),
+		(10, _("Default")),
+		(20, _("Slow")),
+		(50, _("Very slow"))
+	])
+	config.usage.show_spinner = ConfigYesNo(default=True)
+	choiceList = [(0, _("Disabled"))]
+	for delay in (5, 30, 60, 300, 600, 900, 1200, 1800, 2700, 3600):
+		if delay < 60:
+			message = ngettext("%d second", "%d seconds", delay) % delay
+		else:
+			message = abs(delay / 60)
+			message = ngettext("%d minute", "%d minutes", message) % message
+		choiceList.append((delay, message))
+	config.usage.screen_saver = ConfigSelection(default="0", choices=choiceList)
+
+	# settings for servicemp3 and handling from cue sheet file.
 	config.usage.useVideoCuesheet = ConfigYesNo(default=True)		#use marker for video media file
 	config.usage.useAudioCuesheet = ConfigYesNo(default=True)		#use marker for audio media file
 	config.usage.useChapterInfo = ConfigYesNo(default=True) 		#show chapter positions (gst >= 1 and supported media files)
@@ -75,8 +130,6 @@ def InitUsageConfig():
 	config.usage.use_pig = ConfigYesNo(default=False)
 	config.usage.update_available = NoSave(ConfigYesNo(default=False))
 	config.misc.ecm_info = ConfigYesNo(default=False)
-	config.usage.menu_show_numbers = ConfigYesNo(default=False)
-	config.usage.showScreenPath = ConfigSelection(default="off", choices=[("off", _("None")), ("small", _("Small")), ("large", _("Large"))])
 	config.usage.dns = ConfigSelection(default="dhcp-router", choices=[
 		("dhcp-router", _("Router / Gateway")),
 		("custom", _("Static IP / Custom")),
@@ -203,7 +256,6 @@ def InitUsageConfig():
 
 	config.usage.show_picon_bkgrn = ConfigSelection(default="transparent", choices=[("none", _("Disabled")), ("transparent", _("Transparent")), ("blue", _("Blue")), ("red", _("Red")), ("black", _("Black")), ("white", _("White")), ("lightgrey", _("Light Grey")), ("grey", _("Grey"))])
 	config.usage.show_genre_info = ConfigYesNo(default=True)
-	config.usage.show_spinner = ConfigYesNo(default=True)
 	config.usage.enable_tt_caching = ConfigYesNo(default=True)
 
 	config.usage.tuxtxt_font_and_res = ConfigSelection(default="TTF_SD", choices=[("X11_SD", _("Fixed X11 font (SD)")), ("TTF_SD", _("TrueType font (SD)")), ("TTF_HD", _("TrueType font (HD)")), ("TTF_FHD", _("TrueType font (full-HD)")), ("expert_mode", _("Expert mode"))])
@@ -244,13 +296,6 @@ def InitUsageConfig():
 		("user", _("user defined")), ])
 	config.usage.plugin_sort_weight = ConfigDictionarySet()
 	config.usage.menu_sort_weight = ConfigDictionarySet(default={"mainmenu": {"submenu": {}}})
-	config.usage.menu_sort_mode = ConfigSelection(default="user", choices=[
-		("a_z", _("alphabetical")),
-		("default", _("Default")),
-		("user", _("user defined")), ])
-	config.usage.sort_pluginlist = ConfigYesNo(default=True)
-	config.usage.sort_extensionslist = ConfigYesNo(default=False)
-	config.usage.show_restart_network_extensionslist = ConfigYesNo(default=True)
 	config.usage.movieplayer_pvrstate = ConfigYesNo(default=False)
 #	config.usage.rc_model = ConfigSelection(default=DefaultRemote, choices=RemoteChoices)
 
@@ -354,27 +399,6 @@ def InitUsageConfig():
 		("intermediate", _("Intermediate")),
 		("expert", _("Expert"))])
 
-	config.usage.setupShowDefault = ConfigSelection(default="newline", choices=[
-		("", _("Don't show default")),
-		("spaces", _("Show default after description")),
-		("newline", _("Show default on new line"))
-	])
-
-	config.usage.helpSortOrder = ConfigSelection(default="headings+alphabetic", choices=[
-		("headings+alphabetic", _("Alphabetical under headings")),
-		("flat+alphabetic", _("Flat alphabetical")),
-		("flat+remotepos", _("Flat by position on remote")),
-		("flat+remotegroups", _("Flat by key group on remote"))
-	])
-
-	config.usage.helpAnimationSpeed = ConfigSelection(default="10", choices=[
-		("1", _("Very fast")),
-		("5", _("Fast")),
-		("10", _("Default")),
-		("20", _("Slow")),
-		("50", _("Very slow"))
-	])
-
 	choiceList = [
 		(0, _("Disabled")),
 		(-1, _("At end of current program"))
@@ -410,16 +434,6 @@ def InitUsageConfig():
 		(str(KEYIDS["KEY_TEXT"]), _("Teletext")),
 		(str(KEYIDS["KEY_SUBTITLE"]), _("Subtitle")),
 		(str(KEYIDS["KEY_FAVORITES"]), _("Favorites"))])
-
-	choicelist = [("0", _("Disabled"))]
-	for i in (5, 30, 60, 300, 600, 900, 1200, 1800, 2700, 3600):
-		if i < 60:
-			m = ngettext("%d second", "%d seconds", i) % i
-		else:
-			m = abs(i / 60)
-			m = ngettext("%d minute", "%d minutes", m) % m
-		choicelist.append(("%d" % i, m))
-	config.usage.screen_saver = ConfigSelection(default="0", choices=choicelist)
 
 	config.usage.check_timeshift = ConfigYesNo(default=True)
 
@@ -498,8 +512,6 @@ def InitUsageConfig():
 	config.usage.recording_frontend_priority_strictly = ConfigSelection(default="no", choices=priority_strictly_choices)
 	config.usage.recording_frontend_priority_intval = NoSave(ConfigInteger(default=0, limits=(-99, maxsize)))
 	config.misc.disable_background_scan = ConfigYesNo(default=False)
-
-	config.usage.menutype = ConfigSelection(default='standard', choices=[('horzanim', _('Horizontal menu')), ('horzicon', _('Horizontal icons')), ('standard', _('Standard menu'))])
 
 	config.usage.jobtaksextensions = ConfigYesNo(default=True)
 


### PR DESCRIPTION
This change adds menu images to all "Menu.py" based screens.  This is done in a style similar to how images were added to "Setup.py" screens.  The images are defined in a "menus" block within the skin.  Each "menu" tag in the block contains a "key" attribute which is the "entryID" of the menu entry to which this image will be attached.  The "menu" tag also contains an "image" attribute that is the path to the menu image to be used for that menu entry.

Similar to "Setup.py" "Setup" screen the "Menu.py" "Menu" screen can have a "menuimage" widget which defines where the menu image will be displayed.  This image will change to reflect the currently selected menu entry.  If a "default" image is defined then this image will be used for all menu entries that do not have a specifically assigned image.

The new "Menu.py" also allows for a smaller version of the image to be displayed on each menu entry line.  This is similar to the old "Info" screen which was retired because this new system was in development.  How the menu entries are displayed is controlled by the new "Menu entry style" setting in the "OSD Settings" setup screen.  This option is a replacement for the old "Show menu numbers" setting.  The reason for the change is that menu entries can now have the text alone, the text with a number, the text with an image or the text with an image and a number.

Note that all the setting controls for "Menu.py" are now all located together in the "OSD Settings" screen.
