### PR TITLE
[Menu.py] Don't require mandatory widgets

### DIFF
--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -202,7 +202,7 @@ class Menu(Screen, HelpableScreen, ProtectedScreen):
 	png_cache = {}
 
 	def __init__(self, session, parent):
-		Screen.__init__(self, session, mandatoryWidgets=["description"])
+		Screen.__init__(self, session)
 		HelpableScreen.__init__(self)
 		self.parentMenu = parent
 		self.menuList = []


### PR DESCRIPTION
Don't require skins to have a "description" widget.  This was required for some testing and was not intended for production code.
