### PR TITLE
[skin.py] More improvements and fixes

### DIFF
--- a/lib/python/Components/Pixmap.py
+++ b/lib/python/Components/Pixmap.py
@@ -1,7 +1,8 @@
-from enigma import ePixmap, eTimer
 from os.path import isfile
 
-from skin import domScreens, loadPixmap
+from enigma import ePixmap, eTimer
+
+from skin import domScreens, parsePixmap
 from Components.ConditionalWidget import ConditionalWidget
 from Components.GUIComponent import GUIComponent
 from Tools.Directories import SCOPE_LCDSKIN, SCOPE_GUISKIN, fileExists, resolveFilename
@@ -158,7 +159,7 @@ class MultiPixmap(Pixmap):
 						else:
 							pngfile = ""
 						if pngfile and isfile(pngfile):
-							self.pixmaps.append(loadPixmap(pngfile, desktop))
+							self.pixmaps.append(parsePixmap(pngfile, desktop))
 					if not pixmap:
 						if fileExists(resolveFilename(SCOPE_GUISKIN, pixmaps[0], path_prefix=skinPathPrefix)):
 							pixmap = resolveFilename(SCOPE_GUISKIN, pixmaps[0], path_prefix=skinPathPrefix)


### PR DESCRIPTION
[skin.py] More improvements and fixes
- Refactor "loadPixmap()" method into "parsePixmap()".  Improve error reporting.
- Use "parseInteger()" method in more places to protect more of the skin code from crashing.
- Don't translate the "text" or "title" attributes if they are empty strings.

[Pixmap.py] Import update

- Change the "loadPixmap()" method import to "parsePixmap()" to match a change in "skin.py".
