### PR TITLE
[skin.py] Provide a default font alias height

### DIFF
--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1004,7 +1004,7 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_GUISKIN
 			name = alias.attrib.get("name")
 			font = alias.attrib.get("font")
 			size = parseInteger(alias.attrib.get("size"), 20)
-			height = parseInteger(alias.attrib.get("height"), 25)  # To be calculated some day.
+			height = parseInteger(alias.attrib.get("height", 25), 25)  # To be calculated some day.
 			width = parseInteger(alias.attrib.get("width", 18), 18)  # To be calculated some day.
 			if name and font and size:
 				fonts[name] = (font, size, height, width)


### PR DESCRIPTION
This change provides a default value for font alias heights if the height attribute is not specified in the skin.  In the past this was silently ignored.  When the parseInteger() method was added this situation was detected and the issue reported and the new parse code then substituted a safe value.  This code change adds a default value to be used if the attribute is undefined in the skin.  Doing this eliminates the "[Skin] Error: The value 'None' is not a valid integer!" error in the logs.
