### PR TITLE
ConfigListScreen hints text

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -300,6 +300,8 @@ class ConfigListScreen:
 				self.showVirtualKeyBoard(False)
 			if isinstance(currConfig[1], ConfigNumber):
 				self.showVirtualKeyBoard(False)
+			if "description" in self:
+				self["description"].text = self.getCurrentDescription()
 
 	def showVirtualKeyBoard(self, state):
 		if "key_text" in self or "VKeyIcon" in self:

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -213,9 +213,6 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 	def selectionChanged(self):
 		if self["config"]:
 			self.setFootnote(None)
-			self["description"].text = self.getCurrentDescription()
-		else:
-			self["description"].text = _("There are no items currently available for this screen.")
 
 	def layoutFinished(self):
 		if self.setupImage:

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -213,6 +213,8 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 	def selectionChanged(self):
 		if self["config"]:
 			self.setFootnote(None)
+		else:
+			self["description"].text = _("There are no items currently available for this screen.")
 
 	def layoutFinished(self):
 		if self.setupImage:


### PR DESCRIPTION
This avoids adding pointless code in plugins such as here:
https://github.com/oe-mirrors/e2m3u2bouquet-plugin/commit/6725d52e3a462add46cbe06d58680b55ffff93f0

self["config"].onSelectionChanged.append(self.selectionChanged)

def getCurrentDescription(self):
    return self["config"].getCurrent() and len(self["config"].getCurrent()) > 2 and self["config"].getCurrent()[2] or ""

def selectionChanged(self):
    if self["config"]:
        self["description"].text = self.getCurrentDescription()

This code should be inherited, not duplicated.

This commit allows the removal of pointless hints text code throughout enigma and in plugins