### PR TITLE
[config.py] Code fix and small tidy ups

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -605,13 +605,13 @@ class ConfigDictionarySet(ConfigElement):
 		self.dirs = self.value
 
 	def save(self):
-		del_keys = []
+		delKeys = []
 		for key in self.dirs:
 			if not len(self.dirs[key]):
-				del_keys.append(key)
-		for del_key in del_keys:
+				delKeys.append(key)
+		for delKey in delKeys:
 			try:
-				del self.dirs[del_key]
+				del self.dirs[delKey]
 			except KeyError:
 				pass
 			self.changed()

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -408,8 +408,7 @@ class choicesList():
 		except (ValueError, IndexError):  # Occurs, for example, when default is not in list.
 			return 0  # DEBUG: Is it appropriate to return the first item if the index is invalid?
 
-	# only used in nimmanager.py / connectedToChanged
-	def updateItemDescription(self, index, descr):
+	def updateItemDescription(self, index, descr):  # This is only used in nimmanager.py / connectedToChanged.
 		if self.type == choicesList.TYPE_LIST:
 			orig = self.choices[index]
 			if isinstance(orig, tuple):
@@ -417,6 +416,7 @@ class choicesList():
 		else:
 			key = list(self.choices.keys())[index]
 			self.choices[key] = descr
+
 
 class descriptionsList(choicesList):
 	def __getitem__(self, index):
@@ -485,7 +485,7 @@ class ConfigBoolean(ConfigElement):
 		self.value = default
 		self.descriptions = descriptions
 		self.graphic = graphic
-		self.trueValues = ("1", "enabled", "on", "true", "yes")
+		self.trueValues = ("1", "enable", "enabled", "on", "true", "yes")
 
 	def handleKey(self, key, callback=None):
 		prev = self.value
@@ -665,9 +665,6 @@ class ConfigDictionarySet(ConfigElement):
 			if callable(self.callback):
 				self.callback()
 
-	def getKeys(self):
-		return self.dir_pathes
-
 
 # This is the control, and base class, for location settings.
 #
@@ -693,7 +690,7 @@ class ConfigLocations(ConfigElement):
 
 	def load(self):
 		ConfigElement.load(self)
-		self.loadValue = list(set(self.loadValue))  # Remove any duplicated entries.
+		self.loadValue = list(dict.fromkeys(self.loadValue))  # Remove any duplicated entries.
 		self.locations = [[x, None, False] for x in self.loadValue]
 		self.refreshMountPoints()
 		for location in self.locations:
@@ -746,8 +743,8 @@ class ConfigLocations(ConfigElement):
 		self.checkChangedMountPoints()
 		return [x[0] for x in self.locations if x[2]]
 
-	def setValue(self, value):
-		value = list(set(value))  # Remove any duplicated entries.
+	def setValue(self, value):  # Do not sort the locations here, this should be done as required in the UI.
+		value = list(dict.fromkeys(value))  # Remove any duplicated entries.
 		newLocations = []
 		for location in self.locations:
 			if location[0] in value:
@@ -755,7 +752,6 @@ class ConfigLocations(ConfigElement):
 				value.remove(location[0])
 		for location in value:
 			newLocations.append([location, self.getMountPoint(location), fileAccess(location)])
-		newLocations.sort(key=lambda x: x[0])
 		if newLocations != self.locations:
 			self.locations = newLocations
 			self.changed()
@@ -1354,7 +1350,7 @@ class ConfigPIN(ConfigInteger):
 	def __init__(self, default, pinLength=4, censor=u"\u2022"):
 		if not isinstance(default, int):
 			raise TypeError("[Config] Error: 'ConfigPIN' default must be an integer!")
-		if censor != "" and (isinstance(censor, str) and len(censor) != 1): # and (isinstance(censor, unicode) and len(censor) != 1):
+		if censor != "" and (isinstance(censor, str) and len(censor) != 1):  # and (isinstance(censor, unicode) and len(censor) != 1):
 			raise ValueError("[Config] Error: Censor must be a single char (or \"\")!")
 		ConfigInteger.__init__(self, default=default, limits=(0, (10 ** pinLength) - 1), censor=censor)
 		self.pinLength = pinLength


### PR DESCRIPTION
- Remove the use of "set()" function that makes "ConfigLocation" class "load()" and "setValue()" lists unique.  The "set()" function now has a side effect of changing the list into a random order.  This is undesirable for some users.  Similarly sorting the list here is also seen, by some users, as undesirable.  A change has been planned for the future where users will be given control of the order list in the UI.
- Implement a new (Python 3.7 or newer) function to ensure the the "ConfigLocation" values are unique.  This new function does *not* change the list order.
- Make a few more PEP8 clean ups.
- Remove an unused and broken method "getKeys()" from the "ConfigDictionarySet" class.
- Add a new value of "enable" to the Boolean True values validation list.
- camelCase a variable.
