### PR TITLE
[config.py] Enhance getResolvedKey() method

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -2234,13 +2234,18 @@ class ConfigFile:
 			return self.__resolveValue(pickles[1:], cmap[key].dict()) if len(pickles) > 1 else str(cmap[key].value)
 		return None
 
-	def getResolvedKey(self, key):
+	# If silent is True don't display an error on a missing key just return None
+	# to indicate this fact to the calling code.
+	#
+	def getResolvedKey(self, key, silent=False):
 		names = key.split(".")
 		if len(names) > 1:
 			if names[0] == "config":
 				val = self.__resolveValue(names[1:], config.content.items)
 				if val and len(val) or val == "":
 					return val
+		if silent:
+			return None
 		print("[Config] Error: getResolvedKey '%s' failed!  (Typo?)" % key)
 		return ""
 


### PR DESCRIPTION
This change adds an optional new argument to the getResolvedKey() method.  This option, "silent", allows code to call getResolvedKey() and, if the key is missing/invalid, return None rather than an empty string.  The silent option also suppresses the error log for the key error.

This option has been added for code, like the ConfigEntryTest converter, that may access invalid config items.  The option suppresses all the unwanted log entries.  The option also allows the calling code to identify if the requested key was not found instead of just returning an empty string value.

The reason for adding this option was triggered by skins wanting to know if the IceTV plugin is installed and active.  If the plugin is not installed then the required key was not available and the logs could fill with appropriate missing key errors.  This option silences those unwanted logs.
