### PR TITLE
[ConfigEntryTest.py] Code enhancement

### DIFF
--- a/lib/python/Components/Converter/ConfigEntryTest.py
+++ b/lib/python/Components/Converter/ConfigEntryTest.py
@@ -11,6 +11,7 @@ class ConfigEntryTest(Converter):
 		self.checkSourceBoolean = False
 		self.checkInvertSourceBoolean = False
 		self.invert = False
+		self.ignore = False
 		self.configKey = None
 		self.configValue = None
 		if len(args) < 2:
@@ -23,6 +24,8 @@ class ConfigEntryTest(Converter):
 				def checkArg(arg):
 					if arg == "Invert":
 						self.invert = True
+					elif arg == "Ignore":
+						self.ignore = True
 					elif arg == "CheckSourceBoolean":
 						self.checkSourceBoolean = True
 					elif arg == "CheckInvertSourceBoolean":
@@ -34,10 +37,12 @@ class ConfigEntryTest(Converter):
 					checkArg(args[2])
 				if len(args) > 3:
 					checkArg(args[3])
+				if len(args) > 4:
+					checkArg(args[4])
 			else:
 				self.argError = True
 		if self.argError:
-			print("[ConfigEntryTest] Converter got incorrect arguments '%s'! The arg[0] must start with 'config.', arg[1] is the compare string, arg[2], arg[3] are optional arguments and must be 'Invert' or 'CheckSourceBoolean'." % str(args))
+			print("[ConfigEntryTest] Converter got incorrect arguments '%s'! The arg[0] must start with 'config.', arg[1] is the compare string, arg[2] - arg[4] are optional arguments and must be 'Invert', 'Ignore', 'CheckSourceBoolean' or 'CheckInvertSourceBoolean'." % str(args))
 
 	@cached
 	def getBoolean(self):
@@ -48,7 +53,10 @@ class ConfigEntryTest(Converter):
 			return False
 		if self.checkInvertSourceBoolean and self.source.boolean:
 			return False
-		retVal = configfile.getResolvedKey(self.configKey, silent=True) == self.configValue  # Invalid/non-existent keys will return None.
+		value = configfile.getResolvedKey(self.configKey, silent=True)  # Invalid/non-existent keys will return None.
+		if value is None and not self.ignore:
+			print("[ConfigEntryTest] Converter argument '%s' is missing or invalid!" % self.configKey)
+		retVal = value == self.configValue
 		return retVal ^ self.invert
 
 	boolean = property(getBoolean)


### PR DESCRIPTION
- In my last change I presumed that everyone would want invalid key errors to be suppressed.  This presumption was inappropriate. I have now added a new optional argument, "Ignore", that instructs the code to ignore the key error.  If the option is not used then the error is once again reported.  The difference is that the error condition is now associated with this converter so it should be easier to find and address any skin issues. Skinners can now decide when, and when not, to report config key errors.
- Correct the option list when reporting invalid arguments.
