### PR TITLE
[RecordTimer.py] Add TIMERTYPE variables

### DIFF
--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -107,6 +107,10 @@ class TIMERTYPE:
 	def __init__(self):
 		pass
 
+	RECORD = 0
+	ZAP = 1
+	ZAP_RECORD = 2
+	
 	JUSTPLAY = config.recording.default_timertype.value == "zap"
 	ALWAYS_ZAP = config.recording.default_timertype.value == "zap+record"
 


### PR DESCRIPTION
Add three new TIMERTYPE variables that can be used in the new Timers.py code.  These new variables match the equivalent variables in PowerTimer.py.
