### PR TITLE
lib/base/message.h: Use eventfd instead of a pipe

### DIFF
--- a/lib/base/message.h
+++ b/lib/base/message.h
@@ -8,7 +8,9 @@
 #include <unistd.h>
 #include <lib/base/elock.h>
 #include <lib/base/wrappers.h>
-
+#ifndef HAVE_HISILICON
+#include <sys/eventfd.h>
+#endif
 
 /**
  * \brief A generic messagepump.
@@ -31,6 +33,20 @@ protected:
 	int getOutputFD() const { return fd[0]; }
 };
 
+#ifndef HAVE_HISILICON
+class FD
+{
+protected:
+	int m_fd;
+public:
+	FD(int fd): m_fd(fd) {}
+	~FD()
+	{
+		::close(m_fd);
+	}
+};
+#endif
+
 /**
  * \brief A messagepump with fixed-length packets.
  *
@@ -38,15 +54,54 @@ protected:
  * Automatically creates a eSocketNotifier and gives you a callback.
  */
 template<class T>
+#ifndef HAVE_HISILICON
+class eFixedMessagePump: public sigc::trackable, FD
+#else
 class eFixedMessagePump: public sigc::trackable
+#endif
 {
-	ePtr<eSocketNotifier> sn;
-	std::queue<T> m_queue;
-	int m_pipe[2];
 	const char *name;
 	eSingleLock lock;
+	ePtr<eSocketNotifier> sn;
+	std::queue<T> m_queue;
+#ifdef HAVE_HISILICON
+	int m_pipe[2];
+#endif
 	void do_recv(int)
 	{
+#ifndef HAVE_HISILICON
+		uint64_t data;
+		if (::read(m_fd, &data, sizeof(data)) <= 0)
+		{
+			eWarning("[eFixedMessagePump<%s>] read error %m", name);
+			return;
+		}
+
+		/* eventfd reads the number of writes since the last read. This
+		 * will not exceed 4G, so an unsigned int is big enough to count
+		 * down the events. */
+		for(unsigned int count = (unsigned int)data; count != 0; --count)
+		{
+			lock.lock();
+			if (m_queue.empty())
+			{
+				lock.unlock();
+				eWarning("[eFixedMessagePump<%s>] Got event but queue is empty", name);
+				break;
+			}
+			T msg = m_queue.front();
+			m_queue.pop();
+			lock.unlock();
+			/*
+			 * We should not deliver the message while holding the lock,
+			 * not even if we would use a recursive mutex.
+			 * We would risk deadlock when pump writer and reader share another
+			 * mutex besides this one, which could be grabbed / released
+			 * in a different order
+			 */
+			/*emit*/ recv_msg(msg);
+		}
+#else
 		char byte;
 		if (singleRead(m_pipe[0], &byte, sizeof(byte)) <= 0) return;
 
@@ -69,7 +124,16 @@ class eFixedMessagePump: public sigc::trackable
 		{
 			lock.unlock();
 		}
+#endif
 	}
+#ifndef HAVE_HISILICON
+	void trigger_event()
+	{
+		static const uint64_t data = 1;
+		if (::write(m_fd, &data, sizeof(data)) < 0)
+			eFatal("[eFixedMessagePump<%s>] write error %m", name);
+	}
+#endif
 public:
 	sigc::signal1<void,const T&> recv_msg;
 	void send(const T &msg)
@@ -78,9 +142,30 @@ public:
 			eSingleLocker s(lock);
 			m_queue.push(msg);
 		}
+#ifndef HAVE_HISILICON
+		trigger_event();
+#else
 		char byte = 0;
 		writeAll(m_pipe[1], &byte, sizeof(byte));
+#endif
 	}
+#ifndef HAVE_HISILICON
+	eFixedMessagePump(eMainloop *context, int mt, const char *name):
+		FD(eventfd(0, EFD_CLOEXEC)),
+		name(name),
+		sn(eSocketNotifier::create(context, m_fd, eSocketNotifier::Read, false))
+	{
+		CONNECT(sn->activated, eFixedMessagePump<T>::do_recv);
+		sn->start();
+	}
+	eFixedMessagePump(eMainloop *context, int mt):
+		FD(eventfd(0, EFD_CLOEXEC)),
+		sn(eSocketNotifier::create(context, m_fd, eSocketNotifier::Read, false))
+	{
+		CONNECT(sn->activated, eFixedMessagePump<T>::do_recv);
+		sn->start();
+	}
+#else
 	eFixedMessagePump(eMainloop *context, int mt)
 	{
 		if (pipe(m_pipe) == -1)
@@ -91,21 +176,27 @@ public:
 		CONNECT(sn->activated, eFixedMessagePump<T>::do_recv);
 		sn->start();
 	}
-	eFixedMessagePump(eMainloop *context, int mt, const char *name)
+	eFixedMessagePump(eMainloop *context, int mt, const char *name):
+		name(name)
 	{
 		if (pipe(m_pipe) == -1)
 		{
 			eDebug("[eFixedMessagePump] failed to create pipe (%m)");
 		}
-		name = name;
 		sn = eSocketNotifier::create(context, m_pipe[0], eSocketNotifier::Read, false);
 		CONNECT(sn->activated, eFixedMessagePump<T>::do_recv);
 		sn->start();
 	}
+#endif
 	~eFixedMessagePump()
 	{
+#ifndef HAVE_HISILICON
+		/* sn is refcounted and still referenced, so call stop() here */
+		sn->stop();
+#else
 		close(m_pipe[0]);
 		close(m_pipe[1]);
+#endif
 	}
 };
 #endif


### PR DESCRIPTION
An eventfd uses much less resources than a pipe. A pipe allocates a
~64k buffer and two filehandles. An eventfd is only an uint64 in the
kernel.

see also ->
https://github.com/OpenViX/enigma2/commit/2920890b3f5880577c93a075f531f2d0606d8cdb
https://github.com/OpenViX/enigma2/commit/20dc9562c969bb091584b56421a1db12b5d025aa
https://github.com/OpenViX/enigma2/commit/9b77894d986dc95014476b68c70a6cc1261c8a5f