### PR TITLE
[ScreenSaver.py] Match class name to module name

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -51,7 +51,7 @@ from Screens.PVRState import PVRState, TimeshiftState
 from Screens.SubtitleDisplay import SubtitleDisplay
 from Screens.RdsDisplay import RassInteractive, RdsInfoDisplay
 from Screens.Screen import Screen
-from Screens.ScreenSaver import Screensaver  # TODO: Make this ScreenSaver!
+from Screens.ScreenSaver import ScreenSaver
 from Screens.Setup import Setup
 import Screens.Standby
 from Screens.Standby import Standby, TryQuitMainloop
@@ -330,7 +330,7 @@ class InfoBarScreenSaver:
 		self.onExecEnd.append(self.__onExecEnd)
 		self.screenSaverTimer = eTimer()
 		self.screenSaverTimer.callback.append(self.screensaverTimeout)
-		self.screensaver = self.session.instantiateDialog(Screensaver)  # TODO: Make this ScreenSaver!
+		self.screensaver = self.session.instantiateDialog(ScreenSaver)
 		self.onLayoutFinish.append(self.__layoutFinished)
 
 	def __layoutFinished(self):

--- a/lib/python/Screens/ScreenSaver.py
+++ b/lib/python/Screens/ScreenSaver.py
@@ -1,52 +1,53 @@
-from Screens.Screen import Screen
-from Components.MovieList import AUDIO_EXTENSIONS
-from Components.ServiceEventTracker import ServiceEventTracker
-from Components.Pixmap import Pixmap
+from random import randrange
+from os.path import splitext
+
 from enigma import ePoint, eTimer, iPlayableService
-import os
-import random
+
+from Components.MovieList import AUDIO_EXTENSIONS
+from Components.Pixmap import Pixmap
+from Components.ServiceEventTracker import ServiceEventTracker
+from Screens.Screen import Screen
 
 
-class Screensaver(Screen):
+class ScreenSaver(Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
-
+		self.skinName = ["ScreenSaver", "Screensaver"]
+		self["picture"] = Pixmap()
+		self.onShow.append(self.showScreenSaver)
+		self.onHide.append(self.hideScreenSaver)
+		self.onLayoutFinish.append(self.layoutFinished)
 		self.moveLogoTimer = eTimer()
 		self.moveLogoTimer.callback.append(self.doMovePicture)
-		self.onShow.append(self.__onShow)
-		self.onHide.append(self.__onHide)
-
 		self.__event_tracker = ServiceEventTracker(screen=self, eventmap={
-				iPlayableService.evStart: self.serviceStarted
-			})
+			iPlayableService.evStart: self.serviceStarted
+		})
 
-		self["picture"] = Pixmap()
+	def showScreenSaver(self):
+		self.moveLogoTimer.startLongTimer(5)
 
-		self.onLayoutFinish.append(self.layoutFinished)
-
-	def layoutFinished(self):
-		picturesize = self["picture"].getSize()
-		self.maxx = self.instance.size().width() - picturesize[0]
-		self.maxy = self.instance.size().height() - picturesize[1]
-		self.doMovePicture()
-
-	def __onHide(self):
+	def hideScreenSaver(self):
 		self.moveLogoTimer.stop()
 
-	def __onShow(self):
-		self.moveLogoTimer.startLongTimer(5)
+	def layoutFinished(self):
+		pictureSize = self["picture"].getSize()
+		self.maxX = self.instance.size().width() - pictureSize[0]
+		self.maxY = self.instance.size().height() - pictureSize[1]
+		print("[ScreenSaver] layoutFinished DEBUG: X=%d, Y=%d." % (self.maxX, self.maxY))
+		self.doMovePicture()
+
+	def doMovePicture(self):
+		print("[ScreenSaver] doMovePicture DEBUG: X=%d, Y=%d." % (self.maxX, self.maxY))
+		self.posX = randrange(self.maxX)
+		self.posY = randrange(self.maxY)
+		self["picture"].instance.move(ePoint(self.posX, self.posY))
+		self.moveLogoTimer.startLongTimer(9)
 
 	def serviceStarted(self):
 		if self.shown:
 			ref = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 			if ref:
 				ref = ref.toString().split(":")
-				flag = ref[2] == "2" or ref[2] == "A" or os.path.splitext(ref[10])[1].lower() in AUDIO_EXTENSIONS
+				flag = ref[2] == "2" or ref[2] == "A" or splitext(ref[10])[1].lower() in AUDIO_EXTENSIONS
 				if not flag:
 					self.hide()
-
-	def doMovePicture(self):
-		self.posx = random.randint(1, self.maxx)
-		self.posy = random.randint(1, self.maxy)
-		self["picture"].instance.move(ePoint(self.posx, self.posy))
-		self.moveLogoTimer.startLongTimer(9)


### PR DESCRIPTION
This change makes the class name match the module name.  The code has also been tidied up with the imports sorted and optimized and variables camelCased.  Also the randint() function has been replaced with the base randrange() function as the lowest value for the X and Y coordinates should be 0 not 1 (the left and top screen coordinates are 0 not 1).

The class name change is also reflected in "InfoBarGenerics.py".

The code defaults to using the newer screen name of "ScreenSaver" but will fall back to using the previous "Screensaver" screen name for skins that aren't updated.
