### PR TITLE
[timer.py] Add debugging for non integer times in timers

### DIFF
--- a/lib/python/timer.py
+++ b/lib/python/timer.py
@@ -81,7 +81,12 @@ class Timer:
 
 	def setNextActivation(self, now, when):
 		delay = (when - now) * 1000
-		self.timer.start(int(delay), True)
+		if isinstance(delay, float):
+			print("[Timer] DEBUG: The 'delay' variable is a float!  (It should be an integer.)")
+			from traceback import print_stack
+			print_stack()
+			delay = int(delay)
+		self.timer.start(delay, True)
 		self.next = when
 
 	def timeChanged(self, timer):


### PR DESCRIPTION
This debugging code is only temporary as we look for all code that uses float for begin and end times.  The begin and end times should only be integers but we are noticing some code is ending up with float based times.
