### PR TITLE
[TranslationData.py] File for translation triggers

### DIFF
--- a/lib/python/TranslationData.py
+++ b/lib/python/TranslationData.py
@@ -1,0 +1,20 @@
+# NOTE: This code should never be referenced or loaded!
+#
+# These dummy definitions use used to initialize the translation
+# harvester. These strings may be used in ngettext() computations
+# that can not be seen by the harvester.
+#
+value = 1
+dummy = ngettext("%d msec", "%d msecs", value) % value
+dummy = ngettext("%d Sec", "%d Secs", value) % value
+dummy = ngettext("%d sec", "%d secs", value) % value
+dummy = ngettext("%d Second", "%d Seconds", value) % value
+dummy = ngettext("%d second", "%d seconds", value) % value
+dummy = ngettext("%d Min", "%d Mins", value) % value
+dummy = ngettext("%d min", "%d mins", value) % value
+dummy = ngettext("%d Minute", "%d Minutes", value) % value
+dummy = ngettext("%d minute", "%d minutes", value) % value
+dummy = ngettext("%d Hour", "%d Hours", value) % value
+dummy = ngettext("%d hour", "%d hours", value) % value
+dummy = ngettext("%d Day", "%d Days", value) % value
+dummy = ngettext("%d day", "%d days", value) % value


### PR DESCRIPTION
This file contains dummy ngettext() definitions to be used to initialize the translation harvester. These strings may be used in ngettext() computations that can not be seen by the harvester.

NOTE: This code should never be referenced or loaded!
