### PR TITLE
[config.py] Remove units argument from ConfigSelectionNumber

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -949,10 +949,10 @@ class ConfigSatlist(ConfigSatellite):
 # 	available for translations.
 #
 class ConfigSelectionNumber(ConfigSelection):
-	def __init__(self, min, max, stepwidth, default=None, wraparound=False, units=None):
+	def __init__(self, min, max, stepwidth, default=None, wraparound=False):
 		if default is None:
 			default = min
-		ConfigSelection.__init__(self, choices=[(x, (ngettext(units[0], units[1], x) % x if units and isinstance(units, (list, tuple)) else str(x))) for x in range(min, max + 1, stepwidth)], default=default)
+		ConfigSelection.__init__(self, choices=[(x, str(x)) for x in range(min, max + 1, stepwidth)], default=default)
 		self.wrapAround = wraparound
 
 	def handleKey(self, key, callback=None):


### PR DESCRIPTION
This change was made in conjunction with the addition of the new module TranslationData.py.  This was added as an aid to ensuring all strings are added to the translation harvest. After reviewing this code and discussing the feature with other developers we agree that this implementation will not deliver the results we want. It creates an opportunity for parts of the code to get out of sync.

We will now change ConfigSelectionNumber instances that require units into ConfigSelection instances with appropriate choices lists.
