### PR TITLE
[skin.py] Rename textOffset to textPadding

### DIFF
--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -901,10 +901,14 @@ class AttributeParser:
 		self.guiObject.setText(value)
 
 	def textOffset(self, value):
+		self.textPadding(value)
+		attribDeprecationWarning("textOffset", "textPadding")
+
+	def textPadding(self, value):
 		if value in variables:
 			value = variables[value]
 		(xOffset, yOffset) = [parseInteger(x.strip()) for x in value.split(",")]
-		self.guiObject.setTextOffset(ePoint(self.applyHorizontalScale(xOffset), self.applyVerticalScale(yOffset)))
+		self.guiObject.setTextPadding(ePoint(self.applyHorizontalScale(xOffset), self.applyVerticalScale(yOffset)))
 
 	def title(self, value):
 		if value:


### PR DESCRIPTION
This name change better reflects what this skin attribute does.  As per the HTML concept of padding this is the horizontal and vertical space to add before the content is displayed.  The "textPadding" attribute specifies the horizontal and vertical padding, in pixels, to be applied to text based list boxes.   This attribute is only used by "eListboxPythonStringContent()" widgets which includes "MenuList()" widgets and StringList conversions.

For example, a textPadding="10,2" of a MenuList widget will indent the text 10 pixels from the X (left) position of the widget and will drop the text 2 pixels from the Y (top) position of the widget.  Note that these values are symmetrical in that the padding will also be affect the left and bottom padding of the widget.  The space available in the widget to display the text will be the widget width minus two times the horizontal padding and the widget height minus two times the vertical padding.  *Make sure you allow enough space in the skin design to still display the desired text without it being clipped!*
