### PR TITLE
[skin.py] Fix setDefaultPadding arguments

### DIFF
--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1145,7 +1145,7 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_GUISKIN
 			eSlider.setDefaultBorderWidth(borderWidth)
 		for stringList in tag.findall("stringList"):
 			(xOffset, yOffset) = [parseInteger(x.strip()) for x in stringList.attrib.get("textPadding", "1,1").split(",")]
-			eListbox.setDefaultPadding(ePoint(self.applyHorizontalScale(xOffset), self.applyVerticalScale(yOffset)))
+			eListbox.setDefaultPadding(ePoint(xOffset, yOffset))
 		for title in tag.findall("title"):
 			style.setTitleFont(parseFont(title.attrib.get("font", "Regular;20"), ((1, 1), (1, 1))))
 			style.setTitleOffset(parseSize(title.attrib.get("offset", "20,5"), ((1, 1), (1, 1))))


### PR DESCRIPTION
The scaling methods are inappropriate in this situation as the values are taken from the skin and should already be correctly scaled.  The methods are not available here anyway.
