### PR TITLE
[skin.py] Enhance the padding options

### DIFF
--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -594,6 +594,21 @@ def parseScrollbarScroll(value):
 	return parseOptions(options, "scrollbarScroll", value, 0)
 
 
+def parseTextPadding(value):
+	if value in variables:
+		value = variables[value]
+	padding = [parseInteger(x.strip()) for x in value.split(",")]
+	count = len(offsets)
+	if count == 1:
+		return padding * 4
+	elif count == 2:
+		return padding * 2
+	elif count == 4:
+		return padding
+	print("[Skin] Error: Attribute 'textPadding' with value '%s' is invalid!  Attribute must have 1, 2 or 4 values." % value)
+	return [0, 0, 0, 0]
+
+
 def parseVerticalAlignment(value):
 	options = {
 		"top": 0,
@@ -905,10 +920,12 @@ class AttributeParser:
 		attribDeprecationWarning("textOffset", "textPadding")
 
 	def textPadding(self, value):
-		if value in variables:
-			value = variables[value]
-		(xOffset, yOffset) = [parseInteger(x.strip()) for x in value.split(",")]
-		self.guiObject.setTextPadding(ePoint(self.applyHorizontalScale(xOffset), self.applyVerticalScale(yOffset)))
+		leftPadding, topPadding, rightPadding, bottomPadding = parseTextPadding(value)
+		leftPadding = self.applyHorizontalScale(leftPadding)
+		topPadding = self.applyVerticalScale(topPadding)
+		rightPadding = self.applyHorizontalScale(rightPadding)
+		bottomPadding = self.applyVerticalScale(topPadding)
+		self.guiObject.setTextPadding(eRect(leftPadding, topPadding, rightPadding, bottomPadding))
 
 	def title(self, value):
 		if value:
@@ -1144,8 +1161,8 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_GUISKIN
 			borderWidth = parseInteger(slider.attrib.get("borderWidth", eSlider.DefaultBorderWidth), eSlider.DefaultBorderWidth)
 			eSlider.setDefaultBorderWidth(borderWidth)
 		for stringList in tag.findall("stringList"):
-			(xOffset, yOffset) = [parseInteger(x.strip()) for x in stringList.attrib.get("textPadding", "1,1").split(",")]
-			eListbox.setDefaultPadding(ePoint(xOffset, yOffset))
+			leftPadding, topPadding, rightPadding, bottomPadding = parseTextPadding(stringList.attrib.get("textPadding", "0,0,0,0"))
+			eListbox.setDefaultPadding(eRect(leftPadding, topPadding, rightPadding, bottomPadding))
 		for title in tag.findall("title"):
 			style.setTitleFont(parseFont(title.attrib.get("font", "Regular;20"), ((1, 1), (1, 1))))
 			style.setTitleOffset(parseSize(title.attrib.get("offset", "20,5"), ((1, 1), (1, 1))))


### PR DESCRIPTION
The widget padding options have now been enhanced.
1. Any eLabel widgets may now also have the "textPadding" attribute applied to them.  This makes sense, for example, for widgets that have a backgroundColor and you don't want the text being displayed too close to the edge of the widget.  This can also be used to align text in eLabel() widget headings to line up with padded list boxes, etc.
2. The "textPadding" attribute may now have 1, 2 or 4 values in a comma separated list.  If only one value is supplied then that padding value is used as the padding for the left, top, right and bottom edges of the widget.  If two values are supplied then the first value is used as the left and right padding while the second value is used as the top and bottom padding.  If four values are supplied then the four values are used as the left, top, right and bottom padding respectively.
