### PR TITLE
Add InfoBarShowHide hook

### DIFF
--- a/lib/python/Plugins/Plugin.py
+++ b/lib/python/Plugins/Plugin.py
@@ -1,4 +1,5 @@
 from os.path import join as pathjoin
+
 from Components.config import ConfigSubsection, config
 from Tools.LoadPixmap import LoadPixmap
 
@@ -6,113 +7,87 @@ from Tools.LoadPixmap import LoadPixmap
 class PluginDescriptor(object):
 	"""An object to describe a plugin."""
 
-	# where to list the plugin. Note that there are different call arguments,
+	# Where to list the plugin. Note that there are different call arguments,
 	# so you might not be able to combine them.
-
-	# supported arguments are:
-	#   session
-	#   servicereference
-	#   reason
-
-	# you have to ignore unknown kwargs!
-
-	# argument: session
+	# Common arguments are:
+	# 	session
+	# 	servicereference
+	# 	reason
+	# You have to ignore unknown kwargs!
+	#
+	# Argument: session
 	WHERE_EXTENSIONSMENU = 1
 	WHERE_MAINMENU = 2
 	WHERE_PLUGINMENU = 3
-	# argument: session, serviceref (currently selected)
+	# Argument: session, serviceref (currently selected).
 	WHERE_MOVIELIST = 4
-	# argument: menuid. Fnc must return list with menuitems (4-tuple of name, fnc to call, entryid or None, weight or None)
+	# Argument: menuid. Fnc must return list with menuitems (4-tuple of name, fnc to call, entryid or None, weight or None).
 	WHERE_MENU = 5
-
-	# reason (0: start, 1: end)
+	# Argument: reason (0=start, 1=end).
 	WHERE_AUTOSTART = 6
-
-	# start as wizard. In that case, fnc must be tuple (priority,class) with class being a screen class!
+	# Start as wizard. In that case, fnc must be tuple (priority, class) with class being a screen class!
 	WHERE_WIZARD = 7
-
-	# like autostart, but for a session. currently, only session starts are
-	# delivered, and only on pre-loaded plugins
+	# Like autostart, but for a session. Currently, only session starts are
+	# delivered, and only on pre-loaded plugins.
 	WHERE_SESSIONSTART = 8
-
-	# start as teletext plugin. arguments: session, serviceref
+	# Arguments: session, serviceref. Start as teletext plugin.
 	WHERE_TELETEXT = 9
-
-	# file-scanner, fnc must return a list of Scanners
+	# File-scanner, fnc must return a list of Scanners.
 	WHERE_FILESCAN = 10
-
-	# fnc must take an interface name as parameter and return None if the plugin supports an extended setup
-	# or return a function which is called with session and the interface name for extended setup of this interface
+	# Fnc must take an interface name as parameter and return None if the plugin supports an extended setup
+	# or return a function which is called with session and the interface name for extended setup of this interface.
 	WHERE_NETWORKSETUP = 11
-
-	# show up this plugin (or a choicebox with all of them) for long INFO keypress
-	# or return a function which is called with session and the interface name for extended setup of this interface
+	# Show this plugin (or a choicebox with all of them) for long INFO keypress or return a function which is
+	# called with session and the interface name for extended setup of this interface.
 	WHERE_EVENTINFO = 12
-
-	# reason (True: Networkconfig read finished, False: Networkconfig reload initiated )
+	# Arguments: reason (True=Networkconfig read finished, False=Networkconfig reload initiated)
 	WHERE_NETWORKCONFIG_READ = 13
-
 	WHERE_AUDIOMENU = 14
-
-	# fnc 'SoftwareSupported' or  'AdvancedSoftwareSupported' must take a parameter and return None
-	# if the plugin should not be displayed inside Softwaremanger or return a function which is called with session
-	# and 'None' as parameter to call the plugin from the Softwaremanager menus. "menuEntryName" and "menuEntryDescription"
-	# should be provided to name and describe the new menu entry.
+	# If fnc is 'SoftwareSupported' or 'AdvancedSoftwareSupported' must take a parameter and return None if the
+	# plugin should not be displayed inside Softwaremanger or return a function which is called with session
+	# and 'None' as parameter to call the plugin from the Softwaremanager menus. "menuEntryName" and
+	# "menuEntryDescription" should be provided to name and describe the new menu entry.
 	WHERE_SOFTWAREMANAGER = 15
-
-	# start as channellist context menu plugin. session, serviceref (currently selected)
+	# Arguments: session, serviceref (currently selected). Start as channellist context menu plugin.
 	WHERE_CHANNEL_CONTEXT_MENU = 16
-
-	# fnc must take an interface name as parameter and return None if the plugin supports an extended setup
-	# or return a function which is called with session and the interface name for extended setup of this interface
+	# The fnc must take an interface name as parameter and return None if the plugin supports an extended setup
+	# or return a function which is called with session and the interface name for extended setup of this interface.
 	WHERE_NETWORKMOUNTS = 17
-
 	WHERE_VIXMENU = 18
-
-	# override internal RecordTimer navigation instance
-	# fnc must return the custom instance or None to skip it
+	# Override internal RecordTimer navigation instance fnc must return the custom instance or None to skip it.
 	WHERE_RECORDTIMER = 19
-
 	WHERE_SATCONFIGCHANGED = 20
-
 	WHERE_SERVICESCAN = 21
-
 	WHERE_EXTENSIONSINGLE = 22
-
-	# support zap hook to modify the service ref
+	# Support zap hook to modify the service ref.
 	WHERE_CHANNEL_ZAP = 23
+	# Arguments: reason, session, instance, type.
+	WHERE_INFOBARLOADED = 24
 
 	def __init__(self, name="Plugin", where=None, description="", icon=None, fnc=None, wakeupfnc=None, needsRestart=None, internal=False, weight=0):
+		self.name = name
 		if not where:
 			where = []
-		self.name = name
-		self.internal = internal
-		self.needsRestart = needsRestart
-		self.path = None
-		if isinstance(where, list):
-			self.where = where
-		else:
-			self.where = [where]
+		self.where = where if isinstance(where, list) else [where]
 		self.description = description
-
 		if icon is None or isinstance(icon, str):
 			self.iconstr = icon
 			self._icon = None
 		else:
 			self.iconstr = None
 			self._icon = icon
-
-		self.weight = weight
-
-		self.wakeupfnc = wakeupfnc
-
 		self._fnc = fnc
+		self.wakeupfnc = wakeupfnc
+		self.needsRestart = needsRestart
+		self.internal = internal
+		self.weight = weight
+		self.path = None
 
 	def __call__(self, *args, **kwargs):
 		if callable(self._fnc):
 			return self._fnc(*args, **kwargs)
 		else:
-			print("PluginDescriptor called without a function!")
+			print("[Plugin] Error: PluginDescriptor called without a function!")
 			return []
 
 	def __getattribute__(self, name):
@@ -128,10 +103,7 @@ class PluginDescriptor(object):
 
 	@property
 	def icon(self):
-		if self.iconstr and self.path:
-			return LoadPixmap(pathjoin(self.path, self.iconstr))
-		else:
-			return self._icon
+		return LoadPixmap(pathjoin(self.path, self.iconstr)) if self.iconstr and self.path else self._icon
 
 	def __eq__(self, other):
 		return self._fnc == other._fnc

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -671,6 +671,13 @@ class InfoBarShowHide(InfoBarScreenSaver):
 			self.SwitchSecondInfoBarScreen()
 		self.onLayoutFinish.append(self.__layoutFinished)
 		self.onExecBegin.append(self.__onExecBegin)
+		for plugin in plugins.getPlugins(PluginDescriptor.WHERE_INFOBARLOADED):
+			plugin(reason=1, session=self.session, instance=self, typeInfoBar=self.__class__.__name__)
+		self.onClose.append(self.__onClose)
+
+	def __onClose(self):
+		for plugin in plugins.getPlugins(PluginDescriptor.WHERE_INFOBARLOADED):
+			plugin(reason=0, session=self.session, instance=self, typeInfoBar=self.__class__.__name__)
 
 	def __onExecBegin(self):
 		self.showHideVBI()


### PR DESCRIPTION
This change allows plugins to be notified when the InfoBarShowHide class is loaded.  The notification will include the reason (1=Started, 0=Stopped), the instance of the InfoBar being started/stopped and the type of InfoBar that is being started/stopped.

[InfobarGenerics.py]
- Add the plugin hooks for the WHERE_INFOBARLOADED event.

[Plugin.py]
- Add the WHERE_INFOBARLOADED type of event.
- Tidy up the code.  Sort the imports.  Optimize the code.
