### PR TITLE
[config.py] Add ConfigSelection shortcuts

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -873,6 +873,12 @@ class ConfigSelection(ConfigElement):
 	def toDisplayString(self, val):
 		return self.description[val]
 
+	def getChoices(self):
+		return self.choices.__list__()
+
+	def getDescriptions(self):
+		return self.description.__list__()
+
 	def setChoices(self, choices, default=None):
 		value = self.value
 		self.choices = choicesList(choices)


### PR DESCRIPTION
Add two shortcut methods to access ConfigSelection data:
- getChoices() returns a list of all the choices (values) from a ConfigSelection object.
- getDescriptions() returns a list of all the choice descriptions from a ConfigSelection object.

Just to be clear:
- config.item.getChoices() is equivalent to config.item.choices.\_\_list\_\_().
- config.item.getDescriptions() is equivalent to config.item.description.\_\_list\_\_().
