### PR TITLE
[MediaPlayer.py] Fix playlist file selection bug

### DIFF
--- a/lib/python/Components/MediaPlayer.py
+++ b/lib/python/Components/MediaPlayer.py
@@ -1,13 +1,12 @@
-from __future__ import absolute_import
+from os.path import split
+from random import shuffle
+
+from enigma import RT_VALIGN_CENTER, eListboxPythonMultiContent, eServiceCenter, gFont
+
+from skin import fonts, parameters
 from Components.MenuList import MenuList
-
 from Tools.Directories import SCOPE_GUISKIN, resolveFilename
-from os import path
-
-from enigma import eListboxPythonMultiContent, RT_VALIGN_CENTER, gFont, eServiceCenter
-
 from Tools.LoadPixmap import LoadPixmap
-import skin
 
 STATE_PLAY = 0
 STATE_PAUSE = 1
@@ -20,7 +19,7 @@ STATE_NONE = 5
 class PlayList(MenuList):
 	def __init__(self, enableWrapAround=False):
 		MenuList.__init__(self, [], enableWrapAround, eListboxPythonMultiContent)
-		font = skin.fonts.get("PlayList", ("Regular", 18, 23))
+		font = fonts.get("PlayList", ("Regular", 18, 23))
 		self.l.setFont(0, gFont(font[0], font[1]))
 		self.l.setItemHeight(font[2])
 		self.currPlaying = -1
@@ -32,22 +31,22 @@ class PlayList(MenuList):
 			LoadPixmap(resolveFilename(SCOPE_GUISKIN, "icons/ico_mp_pause.png")),
 			LoadPixmap(resolveFilename(SCOPE_GUISKIN, "icons/ico_mp_stop.png")),
 			LoadPixmap(resolveFilename(SCOPE_GUISKIN, "icons/ico_mp_rewind.png")),
-			LoadPixmap(path=resolveFilename(SCOPE_GUISKIN, "icons/ico_mp_forward.png")),
+			LoadPixmap(resolveFilename(SCOPE_GUISKIN, "icons/ico_mp_forward.png")),
 		]
 
-	def PlaylistEntryComponent(self, serviceref, state):
-		res = [serviceref]
-		text = serviceref.getName()
+	def PlaylistEntryComponent(self, serviceReference, state):
+		res = [serviceReference]
+		text = serviceReference.getName()
 		if text == "":
-			text = path.split(serviceref.getPath().split('/')[-1])[1]
-		x, y, w, h = skin.parameters.get("PlayListName", (25, 1, 470, 22))
+			text = split(serviceReference.getPath().split("/")[-1])[1]
+		x, y, w, h = parameters.get("PlayListName", (25, 1, 470, 22))
 		res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_VALIGN_CENTER, text))
 		try:
 			png = self.icons[state]
-			x, y, w, h = skin.parameters.get("PlayListIcon", (5, 3, 16, 16))
+			x, y, w, h = parameters.get("PlayListIcon", (5, 3, 16, 16))
 			res.append((eListboxPythonMultiContent.TYPE_PIXMAP_ALPHATEST, x, y, w, h, png))
-		except:
-				pass
+		except Exception:
+			pass
 		return res
 
 	def clear(self):
@@ -59,12 +58,12 @@ class PlayList(MenuList):
 	def getSelection(self):
 		return self.l.getCurrentSelection() and self.l.getCurrentSelection()[0]
 
-	def addFile(self, serviceref):
-		self.list.append(self.PlaylistEntryComponent(serviceref, STATE_NONE))
+	def addFile(self, serviceReference):
+		self.list.append(self.PlaylistEntryComponent(serviceReference, STATE_NONE))
 
-	def updateFile(self, index, newserviceref):
+	def updateFile(self, index, serviceReference):
 		if index < len(self.list):
-			self.list[index] = self.PlaylistEntryComponent(newserviceref, STATE_NONE)
+			self.list[index] = self.PlaylistEntryComponent(serviceReference, STATE_NONE)
 
 	def deleteFile(self, index):
 		if self.currPlaying >= index:
@@ -106,7 +105,8 @@ class PlayList(MenuList):
 		self.l.setList(self.list)
 
 	def getCurrentIndex(self):
-		return self.currPlaying
+		# return self.currPlaying
+		return MenuList.getCurrentIndex(self)
 
 	def getCurrentEvent(self):
 		l = self.l.getCurrentSelection()
@@ -118,6 +118,12 @@ class PlayList(MenuList):
 
 	def getServiceRefList(self):
 		return [x[0] for x in self.list]
+
+	def playlistShuffle(self):
+		shuffle(self.list)
+		self.l.setList(self.list)
+		self.currPlaying = -1
+		self.oldCurrPlaying = -1
 
 	def __len__(self):
 		return len(self.list)


### PR DESCRIPTION
This code is part of a bigger refactor of the FileCommander / MoviePlayer / FileList code.  This small section has been brought forward to address issues being raised in GitHub and the forum that the MediaPlayer is stuck playing the wrong files (typically is always plays the last file in the playlist no matter what file is selected) when OK is pressed.
