### PR TITLE
Fix SubservicesQuickzap Selected

### DIFF
--- a/lib/python/Screens/SubservicesQuickzap.py
+++ b/lib/python/Screens/SubservicesQuickzap.py
@@ -82,7 +82,9 @@ class SubservicesQuickzap(InfoBarBase, InfoBarShowHide, InfoBarMenu,
 
 	def subserviceSelected(self, service):
 		if service:
-			self.playSubservice(service[1])
+			index = self.getSubserviceIndex(eServiceReference(service[1]))
+			if index != self.__lastservice:
+				self.playSubservice(index)
 
 	def keyOK(self):
 		self.doShow()


### PR DESCRIPTION
Old Bug

PS: Another thing: The Index on init is the bouquet service number!? Not the SubserviceIndex.