### PR TITLE
[config.py] Improve ConfigSelectionNumber

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -950,11 +950,20 @@ class ConfigSatlist(ConfigSatellite):
 # wraparound: Pressing RIGHT key at max value brings you to min value and vice versa
 # if set to True.
 #
+# units: This is a list or tuple with two strings that contain a "%d" formatting
+# element that will be used, via ngettext(), to display the numbers in a more
+# meaningful way.  The first string in the list/tuple is the singular string and
+# the second is the one for other numbers.
+#
+# NOTE: If the units argument is used please ensure that the text to be used is
+# 	already defined and translated elsewhere so that unit strings are properly
+# 	available for translation.
+#
 class ConfigSelectionNumber(ConfigSelection):
-	def __init__(self, min, max, stepwidth, default=None, wraparound=False):
+	def __init__(self, min, max, stepwidth, default=None, wraparound=False, units=None):
 		if default is None:
 			default = min
-		ConfigSelection.__init__(self, choices=[(x, str(x)) for x in range(min, max + 1, stepwidth)], default=default)
+		ConfigSelection.__init__(self, choices=[(x, (ngettext(units[0], units[1], x) % x if units and isinstance(units, (list, tuple)) else str(x))) for x in range(min, max + 1, stepwidth)], default=default)
 		self.wrapAround = wraparound
 
 	def handleKey(self, key, callback=None):


### PR DESCRIPTION
Allow for the number value to be displayed with units text if specified in the calling code.  This allows for the numbers to be displayed in a more meaningful way.  For example, instead of an option list of "1, 2, 3, 4, 5" you could display "1 Second, 2 Seconds, 3 Seconds, 4 Seconds, 5 Seconds".

NOTE: The unit strings used in the units list/tuple should be defined elsewhere for translation as this code can not translate variables!
