### PR TITLE
[FileCommander] Fix Crash

### DIFF
--- a/lib/python/Plugins/Extensions/FileCommander/plugin.py
+++ b/lib/python/Plugins/Extensions/FileCommander/plugin.py
@@ -765,10 +765,10 @@ class FileCommander(Screen, HelpableScreen, NumericalTextInput, StatInfo):
 						symbolicMode,  # 1
 						_("%s (%s)") % (octalMode, symbolicMode)  # 2
 					)
+					size = pathStat.st_size
 					if S_ISCHR(pathStat.st_mode) or S_ISBLK(pathStat.st_mode):
 						sizes = ("", "", "")
 					else:
-						size = pathStat.st_size
 						scaledSize = NumberScaler().scale(size, maxNumLen=3, decimals=3)
 						formattedSize = "{:n}".format(size)
 						sizes = (


### PR DESCRIPTION
UnboundLocalError: cannot access local variable 'size' where it is not associated with a value
Sorry again 3 PR. You close the [Updates Branch](https://github.com/openatv/enigma2/tree/FileCommanderUpdates) and haven't visit my [suggestion](https://github.com/openatv/enigma2/issues/2649#issuecomment-1339725166).