### PR TITLE
[Multiboot.py] "revision" is a string, not a number

### DIFF
--- a/lib/python/Tools/MultiBoot.py
+++ b/lib/python/Tools/MultiBoot.py
@@ -373,10 +373,7 @@ class MultiBootClass():
 				info = self.readSlotInfo(infoFile)
 				compileDate = str(info.get("compiledate"))
 				revision = info.get("imgrevision")
-				if info.get("distro") == "openvix":
-					revision = ".%03d" % revision if revision else ""
-				else:
-					revision = " %s" % revision
+				revision = " %s" % revision
 				revision = "" if revision.strip() == compileDate else revision
 				compileDate = "%s-%s-%s" % (compileDate[0:4], compileDate[4:6], compileDate[6:8])
 				self.imageList[self.slotCode]["detection"] = "Found an enigma information file"


### PR DESCRIPTION
Also, "revision" is not always numeric. It can be alpha, as it often is in homebuilds.

14:02:49.3718 Traceback (most recent call last):
14:02:49.3719   File "/usr/lib/enigma2/python/Components/Console.py", line 52, in finishedCB
14:02:49.3723   File "/usr/lib/enigma2/python/Tools/MultiBoot.py", line 377, in analyzeSlot
14:02:49.3727 TypeError: %d format: a real number is required, not str
14:02:49.3728 PC: b64bdcd0
14:02:49.3728 Fault Address: 338709f9
14:02:49.3728 Error Code:: 518
14:02:49.3732 Backtrace:
14:02:49.3734 /usr/bin/enigma2(_Z17handleFatalSignaliP9siginfo_tPv) [0x75CA4]
14:02:49.3735 /lib/libc.so.6(__default_rt_sa_restorer) [0xB6074D30]
14:02:49.3735 -------FATAL SIGNAL