### PR TITLE
[Input.py] Remove Python 2 code options

### DIFF
--- a/lib/python/Components/Input.py
+++ b/lib/python/Components/Input.py
@@ -206,12 +206,12 @@ class Input(VariableText, GUIComponent, NumericalTextInput):
 
 	def deleteChar(self, pos):
 		if not self.maxSize:
-			format = "%s%s"
+			layout = "%s%s"
 		elif self.overwrite:
-			format = "%s %s"
+			layout = "%s %s"
 		else:
-			format = "%s%s "
-		self.textBuffer = format % (self.textBuffer[0:pos], self.textBuffer[pos + 1:])
+			layout = "%s%s "
+		self.textBuffer = layout % (self.textBuffer[0:pos], self.textBuffer[pos + 1:])
 
 	def toggleOverwrite(self):
 		if self.type == self.TEXT:


### PR DESCRIPTION
- Remove all the Python 2 code.
- Add comments to explain where self.text is defined and used.
- Rename self.textU to self.textBuffer to remove potential confusion with Unicode text.
- Reorder some of the methods to keep related functions together.
