### PR TITLE
[TemplatedMulticontent] support the *f syntax

### DIFF
--- a/lib/python/Components/Converter/TemplatedMultiContent.py
+++ b/lib/python/Components/Converter/TemplatedMultiContent.py
@@ -1,5 +1,7 @@
 from Components.Converter.StringList import StringList
+import re
 
+pattern = re.compile(r"(\d+\*f)")
 
 class TemplatedMultiContent(StringList):
 	"""Turns a python tuple list into a multi-content list which can be used in a listbox renderer."""
@@ -14,6 +16,8 @@ class TemplatedMultiContent(StringList):
 		del loc["self"]  # Cleanup locals a bit.
 		del loc["args"]
 		self.active_style = None
+		for x in set(pattern.findall(args)):
+			args = args.replace(x, '%s'%int(eval(x.replace("f", '%s'%f))))
 		self.template = eval(args, {}, loc)
 		self.scale = None
 		assert "fonts" in self.template, "templates must include a 'fonts' entry"
@@ -66,6 +70,7 @@ class TemplatedMultiContent(StringList):
 		fonts = []
 		for font in self.template["fonts"]:
 			fonts.append(gFont(font.family, int(font.pointSize * scaleFactorVertical)))
+
 		for content in template:
 			elments = list(content)
 			elments[1] = int(elments[1] * scaleFactorVertical)


### PR DESCRIPTION
By @pepsik
The next bug is more serious and is related to the C implementation of the gFont method - it does not support the *f syntax in TemplatedMulticontent in OpenATV

For example, there is such a "skin"

```
     <widget source="forecast" render="Listbox" position="14*f,62*f" size="666*f,636*f" scrollbarMode="showOnDemand" scrollbarWidth="4*f" transparent="0"  zPosition="2" backgroundColor="#111111" backgroundColorSelected="#121212" foregroundColor="#F5aaa4" foregroundColorSelected="#aa2265"> 
      <convert type="TemplatedMultiContent">                                                                                                                                                              
          {"template": [                                                                                                                                                                                  
            MultiContentEntryText(pos=(6*f, 4*f), size=(66*f, 24*f), font=0, flags=RT_HALIGN_CENTER, text=0,  color="#4d94ff", color_sel="#FFF554"),                                                      
            MultiContentEntryText(pos=(6*f, 26*f), size=(66*f, 24*f), font=1, flags=RT_HALIGN_CENTER, text=1,  color="#58D68D", color_sel="#FFF554"),                                                     
            MultiContentEntryPixmapAlphaTest(pos = (80*f, 4*f), size = (46*f, 46*f), png = 2, flags=BT_SCALE),                                                                                            
            MultiContentEntryText(pos=(133*f, 6*f), size=(46*f, 26*f), font=0, flags=RT_HALIGN_RIGHT, text=3),                                                                                            
            MultiContentEntryText(pos=(173*f, 20*f), size=(34*f, 26*f), font=1, flags=RT_HALIGN_LEFT, text=4),                                                                                            
            MultiContentEntryText(pos=(214*f, 14*f), size=(366*f, 26*f), font=0, flags=RT_HALIGN_LEFT, text=5),                                                                                           
            MultiContentEntryText(pos=(613*f, 16*f), size=(46*f, 20*f), font=1, flags=RT_HALIGN_RIGHT, text=6,  color="#33ccff", color_sel="#FFF554"),                                                    
            MultiContentEntryPixmapAlphaTest(pos = (593*f, 16*f), size = (20*f, 20*f), png = 7, flags=BT_SCALE),                                                                                          
            ],                                                                                                                                                                                            
            "fonts": [gFont("Regular", 20*f), gFont("Regular", 16*f)],                                                                                                                                    
            "itemHeight": 53*f,                                                                                                                                                                           
          }                                                                                                                                                                                               
        </convert>                                                                                                                                                                                        
    </widget>
```

Based on the skin.py logic that supports "f*" scaling syntax... This skin variant should work ...But this will not work with the current implementation of the code.. We'll get a crash on

```
"fonts": [gFont("Regular", 20*f), gFont("Regular", 16*f)],
```

I haven't dug deep, but most likely the problem is in the c-code of gFont() ... Without much straining, I added two lines to the code  and now such skins work with "f*" syntax support for scaling any elements in TemplatedMultiContent .