### PR TITLE
Update VWatches.py

### DIFF
--- a/lib/python/Components/Renderer/VWatches.py
+++ b/lib/python/Components/Renderer/VWatches.py
@@ -73,7 +73,7 @@ class VWatches(Renderer):
 		deltay = abs(y1 - y0)
 		error = -deltax / 2
 		y = y0
-		for x in range(x0, x1 + 1):
+		for x in range(int(x0), int(x1 + 1)):
 			if steep:
 				self.instance.fillRect(eRect(y, x, 1, 3), self.fColor)
 			else:


### PR DESCRIPTION
resolves the following:
17:13:21.9586   File "/usr/lib/enigma2/python/Components/Renderer/VWatches.py", line 95, in changed
    self.hand()
17:13:21.9586   File "/usr/lib/enigma2/python/Components/Renderer/VWatches.py", line 58, in hand
    self.draw_line(r, r, endX, endY)
17:13:21.9587   File "/usr/lib/enigma2/python/Components/Renderer/VWatches.py", line 76, in draw_line
    for x in range(x0, x1 + 1):
             ^^^^^^^^^^^^^^^^^
17:13:21.9588 TypeError: 'float' object cannot be interpreted as an integer