### PR TITLE
[VfdDisplay] Show channel number and clock for some streams

### DIFF
--- a/lib/python/Components/Converter/VfdDisplay.py
+++ b/lib/python/Components/Converter/VfdDisplay.py
@@ -1,3 +1,5 @@
+from enigma import iPlayableService
+
 from datetime import datetime
 from Components.Converter.Poll import Poll
 from Components.Converter.Converter import Converter
@@ -74,7 +76,7 @@ class VfdDisplay(Poll, Converter):
 	text = property(getText)
 
 	def changed(self, what):
-		if what[0] is self.CHANGED_SPECIFIC and self.delay >= 0:
+		if what[0] is self.CHANGED_SPECIFIC and (what[1] in (iPlayableService.evStart, iPlayableService.evEnd, iPlayableService.evNewProgramInfo)) and self.delay >= 0:
 			self.showclock = 0
 			if self.loop != -1:
 				self.loop = self.delay


### PR DESCRIPTION
The source CurrentService fires too often for some streams as to display the clock. Thus only the channel number is shown. The event in question is evUpdatedInfo that fires in less than a second really often for some streams. This patch filters the event received by VfdDisplay converter from CurrentService source and thus allows to display the channel number and after a delay the clock. This may also affect dvb services where evUpdatedInfo is also received but quiet less often.