### PR TITLE
[NetworkSetup] Add Quad9 DNS service

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -142,6 +142,7 @@ def InitUsageConfig():
 		("custom", _("Static IP / Custom")),
 		("google", _("Google DNS")),
 		("cloudflare", _("Cloudflare DNS")),
+		("quad9", _("Quad9 DNS")),
 		("opendns-familyshield", _("OpenDNS FamilyShield")),
 		("opendns-home", _("OpenDNS Home"))
 	])

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -241,6 +241,7 @@ class DNSSettings(Setup):
 			"dhcp-router": [list(x[1]) for x in self.getNetworkRoutes()],
 			"google": [[8, 8, 8, 8], [8, 8, 4, 4]],
 			"cloudflare": [[1, 1, 1, 1], [1, 0, 0, 1]],
+			"quad9": [[9, 9, 9, 9], [149, 112, 112, 10]],
 			"opendns-familyshield": [[208, 67, 222, 123], [208, 67, 220, 123]],
 			"opendns-home": [[208, 67, 222, 222], [208, 67, 220, 220]]
 		}


### PR DESCRIPTION
This change add the Quad9 DNS servers to the list of available DNS providers.
