### PR TITLE
[StartEnigma.py] More clean up and simplification of the code

### DIFF
--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -430,12 +430,7 @@ def runScreenTest():
 	profile("RunReactor")
 	profile_final()
 	if BOX_TYPE in ("sf8", "classm", "axodin", "axodinc", "starsatlx", "genius", "evo"):
-		filename = "/dev/dbox/oled0"
-		try:
-			with open(filename, "w") as fd:
-				fd.write("-E2-")
-		except OSError as err:
-			print("[StartEnigma] Error %d: Unable to write a line to file '%s'!  (%s)" % (err.errno, filename, err.strerror))
+		fileUpdateLine("/dev/dbox/oled0", conditionValue=None, replacementValue="-E2-", create=True, source=MODULE_NAME)
 	print("[StartEnigma] Last shutdown=%s.  (True = last shutdown was OK.)" % config.usage.shutdownOK.value)
 	print("[StartEnigma] NOK shutdown action=%s." % config.usage.shutdownNOK_action.value)
 	print("[StartEnigma] Boot action=%s." % config.usage.boot_action.value)
@@ -699,14 +694,11 @@ from Components.International import international
 
 config.osd = ConfigSubsection()
 
-if DISPLAYBRAND == "Atto.TV":
-	defaultLocale = "pt_BR"
-elif DISPLAYBRAND == "Zgemma":
-	defaultLocale = "en_US"
-elif DISPLAYBRAND == "Beyonwiz":
-	defaultLocale = "en_AU"
-else:
-	defaultLocale = "de_DE"
+defaultLocale = {
+	"Atto.TV": "pt_BR",
+	"Zgemma": "en_US",
+	"Beyonwiz": "en_AU"
+}.get(DISPLAYBRAND, "de_DE")
 config.misc.locale = ConfigText(default=defaultLocale)
 config.misc.language = ConfigText(default=international.getLanguage(defaultLocale))
 config.misc.country = ConfigText(default=international.getCountry(defaultLocale))

--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -250,6 +250,12 @@ def fileWriteLine(filename, line, source=DEFAULT_MODULE_NAME, debug=False):
 	return result
 
 
+def fileUpdateLine(filename, conditionValue, replacementValue, create=False, source=DEFAULT_MODULE_NAME, debug=False):
+	line = fileReadLine(filename, default="", source=source, debug=debug)
+	create = False if conditionValue and not line.startswith(conditionValue) else create
+	return fileWriteLine(filename, replacementValue, source=source, debug=debug) if create or (conditionValue and line.startswith(conditionValue)) else 0
+
+
 def fileReadLines(filename, default=None, source=DEFAULT_MODULE_NAME, debug=False):
 	lines = None
 	try:


### PR DESCRIPTION
- Revert the sys import change as it breaks the twisted redirection of stderr and stdout.
- Remove use of the system() system call.
- Move autorestoreLoop() into runScreenTest() where is is actually used.
- Change all file processing code to use with blocks and add error logging.
- Remove the "killall -9 showiframe" code as it is no longer required.
- Add the new fileUpdateLine() method to Directories.py and use it to simplify some status file updates.
- Replace locale if block with a dictionary lookup.
