### PR TITLE
Move "getChipSetString()" to a BoxInfo variable

### DIFF
--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -220,21 +220,7 @@ def getSystemTemperature():
 
 
 def getChipSetString():
-	if MODEL in ('dm7080', 'dm820'):
-		return "7435"
-	elif MODEL in ('dm520', 'dm525'):
-		return "73625"
-	elif MODEL in ('dm900', 'dm920', 'et13000', 'sf5008'):
-		return "7252S"
-	elif MODEL in ('hd51', 'vs1500', 'h7'):
-		return "7251S"
-	elif MODEL in ('alien5',):
-		return "S905D"
-	else:
-		chipset = fileReadLine("/proc/stb/info/chipset", source=MODULE_NAME)
-		if chipset is None:
-			return _("Undefined")
-		return str(chipset.lower().replace('\n', '').replace('bcm', '').replace('brcm', '').replace('sti', ''))
+	return str(BoxInfo.getItem("ChipsetString")
 
 
 def getCPUBrand():

--- a/lib/python/Components/About.py
+++ b/lib/python/Components/About.py
@@ -220,7 +220,7 @@ def getSystemTemperature():
 
 
 def getChipSetString():
-	return str(BoxInfo.getItem("ChipsetString")
+	return str(BoxInfo.getItem("ChipsetString"))
 
 
 def getCPUBrand():

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -215,6 +215,21 @@ def getRCFile(ext):
 	return filename
 
 
+def getChipsetString():
+	if MODEL in ("dm7080", "dm820"):
+		return "7435"
+	elif MODEL in ("dm520", "dm525"):
+		return "73625"
+	elif MODEL in ("dm900", "dm920", "et13000", "sf5008"):
+		return "7252S"
+	elif MODEL in ("hd51", "vs1500", "h7"):
+		return "7251S"
+	elif MODEL == "alien5":
+		return "S905D"
+	chipset = fileReadLine("/proc/stb/info/chipset", default=_("Undefined"), source=MODULE_NAME)
+	return str(chipset.lower().replace("\n", "").replace("bcm", "").replace("brcm", "").replace("sti", ""))
+
+
 def getModuleLayout():
 	modulePath = BoxInfo.getItem("enigmamodule")
 	if modulePath:
@@ -364,6 +379,7 @@ BoxInfo.setItem("cankexec", BoxInfo.getItem("kexecmb") and not BoxInfo.getItem("
 BoxInfo.setItem("CanNotDoSimultaneousTranscodeAndPIP", MODEL in ("vusolo4k", "gbquad4k", "gbue4k"))
 BoxInfo.setItem("canRecovery", MODEL in ("hd51", "vs1500", "h7", "8100s") and ("disk.img", "mmcblk0p1") or MODEL in ("xc7439", "osmio4k", "osmio4kplus", "osmini4k") and ("emmc.img", "mmcblk1p1") or MODEL in ("gbmv200", "cc1", "sf8008", "sf8008m", "sf8008opt", "sx988", "ip8", "ustym4kpro", "ustym4kottpremium", "ustym4ks2ottx", "beyonwizv2", "viper4k", "og2ott4k", "sx88v2", "sx888") and ("usb_update.bin", "none"))
 BoxInfo.setItem("CanUse3DModeChoices", fileExists("/proc/stb/fb/3dmode_choices") and True or False)
+BoxInfo.setItem("ChipsetString", getChipsetString(), immutable=True)
 BoxInfo.setItem("CIHelper", fileExists("/usr/bin/cihelper"))
 BoxInfo.setItem("DeepstandbySupport", MODEL != 'dm800')
 BoxInfo.setItem("DefaultDisplayBrightness", MACHINEBUILD in ("dm900", "dm920") and 8 or 5)

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/ImageBackup.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/ImageBackup.py
@@ -4,7 +4,7 @@ from os.path import exists, isdir, isfile, join as pathjoin
 from subprocess import getoutput
 from time import localtime, strftime, time
 
-from Components.About import getChipSetString, getCPUBrand, getCPUInfoString
+from Components.About import getCPUBrand, getCPUInfoString
 from Components.ActionMap import ActionMap
 from Components.ChoiceList import ChoiceList, ChoiceEntryComponent
 from Components.Harddisk import Freespace, getFolderSize
@@ -718,7 +718,7 @@ class ImageBackup(Screen):
 		AboutText += _("Backup Date: %s\n") % strftime("%Y-%m-%d", localtime(self.START))
 
 		if exists("/proc/stb/info/chipset"):
-			AboutText += _("Chipset: BCM%s") % getChipSetString().lower().replace("\n", "").replace("bcm", "") + "\n"
+			AboutText += _("Chipset: BCM%s") % BoxInfo.getItem("ChipsetString") + "\n"
 
 		cpu = getCPUInfoString()
 		AboutText += "%s: %s\n" % (_("CPU"), cpu[0])

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -3815,8 +3815,7 @@ class InfoBarInstantRecord:
 		elif answer[1] == "stop":
 			self.session.openWithCallback(self.stopCurrentRecording, TimerSelection, list)
 		elif answer[1] in ("indefinitely", "manualduration", "manualendtime", "event"):
-			from Components.About import about
-			if len(list) >= 2 and about.getChipSetString() in ('meson-6', 'meson-64'):
+			if len(list) >= 2 and BoxInfo.getItem("ChipsetString") in ('meson-6', 'meson-64'):
 				Notifications.AddNotification(MessageBox, _("Sorry only possible to record 2 channels at once"), MessageBox.TYPE_ERROR, timeout=5)
 				return
 			self.startInstantRecording(limitEvent=answer[1] in ("event", "manualendtime") or False)


### PR DESCRIPTION
This change moves the "getChipSetString()" method from the about.py module to a BoxInfo variable called "ChipsetString".  The variable is immutable as the box can't change its chipset during operation.  ;)

The new variable can be accessed with "BoxInfo.getItem("ChipsetString")".

A side benefit of this change is that the chipset is determined only once.  This can reduce file access and time taken to get the value for this variable.
