### PR TITLE
Horizontal and Grid listbox layout

### DIFF
--- a/data/keymap.ntr
+++ b/data/keymap.ntr
@@ -426,8 +426,8 @@
 		<key id="KEY_PAGEDOWN" mapto="pageDown" flags="mr" />
 		<key id="KEY_CHANNELUP" mapto="pageUp" flags="mr" />
 		<key id="KEY_CHANNELDOWN" mapto="pageDown" flags="mr" />
-		<!--key id="KEY_LEFT" mapto="pageUp" flags="mr" />
-		<key id="KEY_RIGHT" mapto="pageDown" flags="mr" /-->
+		<key id="KEY_LEFT" mapto="moveLeft" flags="mr" />
+		<key id="KEY_RIGHT" mapto="moveRight" flags="mr" />
 		<key id="1" mapto="moveUp" flags="mr" />
 		<key id="2" mapto="moveDown" flags="mr" />
 	</map>

--- a/data/keymap.u80
+++ b/data/keymap.u80
@@ -198,8 +198,8 @@
 		<key id="KEY_END" mapto="moveEnd" flags="mr" />
 		<key id="KEY_PAGEUP" mapto="pageUp" flags="mr" />
 		<key id="KEY_PAGEDOWN" mapto="pageDown" flags="mr" />
-		<key id="KEY_LEFT" mapto="pageUp" flags="mr" />
-		<key id="KEY_RIGHT" mapto="pageDown" flags="mr" />
+		<key id="KEY_LEFT" mapto="moveLeft" flags="mr" />
+		<key id="KEY_RIGHT" mapto="moveRight" flags="mr" />
 		<key id="1" mapto="moveUp" flags="mr" />
 		<key id="2" mapto="moveDown" flags="mr" />
 	</map>

--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -424,8 +424,8 @@
 		<key id="KEY_END" mapto="moveEnd" flags="mr" />
 		<key id="KEY_PAGEUP" mapto="pageUp" flags="mr" />
 		<key id="KEY_PAGEDOWN" mapto="pageDown" flags="mr" />
-		<key id="KEY_LEFT" mapto="pageUp" flags="mr" />
-		<key id="KEY_RIGHT" mapto="pageDown" flags="mr" />
+		<key id="KEY_LEFT" mapto="moveLeft" flags="mr" />
+		<key id="KEY_RIGHT" mapto="moveRight" flags="mr" />
 		<key id="1" mapto="moveUp" flags="mr" />
 		<key id="2" mapto="moveDown" flags="mr" />
 	</map>

--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -976,9 +976,9 @@ void eListbox::moveSelection(int dir)
 	if (m_orientation == orVertical && m_native_keys_bound)
 	{
 		if (dir == moveLeft)
-			dir = movePageDown;
-		if (dir == moveRight)
 			dir = movePageUp;
+		if (dir == moveRight)
+			dir = movePageDown;
 	}
 
 	bool isGrid = m_orientation == orGrid;

--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -14,15 +14,16 @@ int eListbox::defaultScrollBarScroll = eListbox::DefaultScrollBarScroll;
 int eListbox::defaultScrollBarMode = eListbox::DefaultScrollBarMode;
 int eListbox::defaultPageSize = eListbox::DefaultPageSize;
 bool eListbox::defaultWrapAround = eListbox::DefaultWrapAround;
-eRect eListbox::defaultPadding = eRect(1,1,1,1);
+eRect eListbox::defaultPadding = eRect(1, 1, 1, 1);
 
-eListbox::eListbox(eWidget *parent) :
-	eWidget(parent), m_list_orientation(listVertical), m_scrollbar_mode(showNever), m_prev_scrollbar_page(-1), m_scrollbar_scroll(byPage),
-	m_content_changed(false), m_enabled_wrap_around(false), m_scrollbar_width(10),
-	m_top(0), m_selected(0), m_itemheight(25), m_itemwidth(25),
-	m_items_per_page(0), m_selection_enabled(1), m_page_size(0), m_native_keys_bound(false), m_first_selectable_item(-1),m_last_selectable_item(-1),m_scrollbar(nullptr)
+eListbox::eListbox(eWidget *parent) : eWidget(parent), m_scrollbar_mode(showNever), m_prev_scrollbar_page(-1),
+									  m_scrollbar_scroll(byPage), m_content_changed(false), m_enabled_wrap_around(false), m_scrollbar_width(10),
+									  m_scrollbar_height(10), m_top(0), m_left(0), m_selected(0), m_itemheight(25), m_itemwidth(25),
+									  m_orientation(orVertical), m_max_columns(0), m_max_rows(0), m_selection_enabled(1), m_page_size(0), m_item_alignment(0),
+									  m_native_keys_bound(false), m_first_selectable_item(-1), m_last_selectable_item(-1), m_scrollbar(nullptr)
 {
 	m_scrollbar_width = eListbox::defaultScrollBarWidth;
+	m_scrollbar_height = eListbox::defaultScrollBarWidth; // TODO
 	m_scrollbar_offset = eListbox::defaultScrollBarOffset;
 	m_scrollbar_border_width = eListbox::defaultScrollBarBorderWidth;
 	m_scrollbar_scroll = eListbox::defaultScrollBarScroll;
@@ -30,15 +31,14 @@ eListbox::eListbox(eWidget *parent) :
 	m_scrollbar_mode = eListbox::defaultScrollBarMode;
 	m_page_size = eListbox::defaultPageSize;
 
-	memset(static_cast<void*>(&m_style), 0, sizeof(m_style));
+	memset(static_cast<void *>(&m_style), 0, sizeof(m_style));
 	m_style.m_text_padding = eListbox::defaultPadding;
-//	setContent(new eListboxStringContent());
+	//	setContent(new eListboxStringContent());
 
 	allowNativeKeys(true);
 
-	if(m_scrollbar_mode != showNever)
+	if (m_scrollbar_mode != showNever)
 		setScrollbarMode(m_scrollbar_mode);
-
 }
 
 eListbox::~eListbox()
@@ -57,7 +57,7 @@ void eListbox::setScrollbarMode(int mode)
 		if (m_scrollbar_mode == showNever)
 		{
 			delete m_scrollbar;
-			m_scrollbar=0;
+			m_scrollbar = 0;
 		}
 	}
 	else
@@ -66,16 +66,20 @@ void eListbox::setScrollbarMode(int mode)
 		m_scrollbar->setIsScrollbar();
 		m_scrollbar->hide();
 		m_scrollbar->setBorderWidth(m_scrollbar_border_width);
-		m_scrollbar->setOrientation(eSlider::orVertical);
+		m_scrollbar->setOrientation(m_orientation == orHorizontal ? eSlider::orHorizontal : eSlider::orVertical);
 		m_scrollbar->setRange(0, 100);
-		if (m_scrollbarbackgroundpixmap) m_scrollbar->setBackgroundPixmap(m_scrollbarbackgroundpixmap);
-		if (m_scrollbarpixmap) m_scrollbar->setPixmap(m_scrollbarpixmap);
-		if (m_style.m_scollbarborder_color_set) m_scrollbar->setBorderColor(m_style.m_scollbarborder_color);
-		if (m_style.m_scrollbarforeground_color_set) m_scrollbar->setForegroundColor(m_style.m_scrollbarforeground_color);
-		if (m_style.m_scrollbarbackground_color_set) m_scrollbar->setBackgroundColor(m_style.m_scrollbarbackground_color);
+		if (m_scrollbarbackgroundpixmap)
+			m_scrollbar->setBackgroundPixmap(m_scrollbarbackgroundpixmap);
+		if (m_scrollbarpixmap)
+			m_scrollbar->setPixmap(m_scrollbarpixmap);
+		if (m_style.m_scollbarborder_color_set)
+			m_scrollbar->setBorderColor(m_style.m_scollbarborder_color);
+		if (m_style.m_scrollbarforeground_color_set)
+			m_scrollbar->setForegroundColor(m_style.m_scrollbarforeground_color);
+		if (m_style.m_scrollbarbackground_color_set)
+			m_scrollbar->setBackgroundColor(m_style.m_scrollbarbackground_color);
 	}
 }
-
 
 void eListbox::setScrollbarScroll(int scroll)
 {
@@ -86,11 +90,6 @@ void eListbox::setScrollbarScroll(int scroll)
 		return;
 	}
 	m_scrollbar_scroll = scroll;
-}
-
-void eListbox::setWrapAround(bool state)
-{
-	m_enabled_wrap_around = state;
 }
 
 void eListbox::setContent(iListboxContent *content)
@@ -124,7 +123,7 @@ bool eListbox::atBegin()
 
 bool eListbox::atEnd()
 {
-	if (m_content && m_content->size() == m_selected+1)
+	if (m_content && m_content->size() == m_selected + 1)
 		return true;
 	return false;
 }
@@ -136,18 +135,34 @@ void eListbox::moveToEnd()
 	if (!m_content)
 		return;
 	/* move to last existing one ("end" is already invalid) */
-	m_content->cursorEnd(); m_content->cursorMove(-1);
+	m_content->cursorEnd();
+	m_content->cursorMove(-1);
 	/* current selection invisible? */
-	if (m_top + m_items_per_page <= m_content->cursorGet())
+
+	int topLeft = m_top;
+	int maxItems = m_max_rows;
+
+	if (m_orientation == orHorizontal)
 	{
-		int rest = m_content->size() % m_items_per_page;
-		if (rest)
-			m_top = m_content->cursorGet() - rest + 1;
-		else
-			m_top = m_content->cursorGet() - m_items_per_page + 1;
-		if (m_top < 0)
-			m_top = 0;
+		topLeft = m_left;
+		maxItems = m_max_columns;
 	}
+
+	if (topLeft + maxItems <= m_content->cursorGet())
+	{
+		int rest = m_content->size() % maxItems;
+		if (rest)
+			topLeft = m_content->cursorGet() - rest + 1;
+		else
+			topLeft = m_content->cursorGet() - maxItems + 1;
+		if (topLeft < 0)
+			topLeft = 0;
+	}
+
+	if (m_orientation == orHorizontal)
+		m_left = topLeft;
+	else
+		m_top = topLeft;
 }
 
 void eListbox::moveSelectionTo(int index)
@@ -164,7 +179,8 @@ void eListbox::setTopIndex(int index)
 {
 	if (m_content)
 	{
-		if (m_content->size() > index) {
+		if (m_content->size() > index)
+		{
 			m_top = index;
 			m_content_changed = true;
 			moveSelection(justCheck);
@@ -181,26 +197,32 @@ int eListbox::getCurrentIndex()
 
 void eListbox::updateScrollBar()
 {
-	if (!m_scrollbar || !m_content || m_scrollbar_mode == showNever )
+	if (!m_scrollbar || !m_content || m_scrollbar_mode == showNever)
 		return;
-	int entries = m_content->size();
+	int entries = (m_orientation == orGrid) ? (m_content->size() + m_max_columns - 1) / m_max_columns : m_content->size();
 	bool scrollbarvisible = m_scrollbar->isVisible();
+	int maxItems = (m_orientation == orHorizontal) ? m_max_columns : m_max_rows;
+
 	if (m_content_changed)
 	{
 		int width = size().width();
 		int height = size().height();
 
-		if (m_scrollbar_scroll == byLine) {
-			m_scrollbar->setRange(0,height-(m_scrollbar_border_width*2));
+		if (m_scrollbar_scroll == byLine)
+		{
+			if (m_orientation == orHorizontal)
+				m_scrollbar->setRange(0, width - (m_scrollbar_border_width * 2));
+			else
+				m_scrollbar->setRange(0, height - (m_scrollbar_border_width * 2));
 		}
 
 		m_content_changed = false;
-		if (m_scrollbar_mode == showLeftOnDemand || m_scrollbar_mode == showLeftAlways)
+		if (m_scrollbar_mode == showTopAlways || m_scrollbar_mode == showTopOnDemand)
 		{
-			m_content->setSize(eSize(width-m_scrollbar_width-m_scrollbar_offset, m_itemheight));
+			m_content->setSize(eSize(m_itemwidth, height - m_scrollbar_height - m_scrollbar_offset));
 			m_scrollbar->move(ePoint(0, 0));
-			m_scrollbar->resize(eSize(m_scrollbar_width, height));
-			if (entries > m_items_per_page || m_scrollbar_mode == showLeftAlways)
+			m_scrollbar->resize(eSize(width, m_scrollbar_height));
+			if (entries > m_max_columns || m_scrollbar_mode == showLeftAlways)
 			{
 				m_scrollbar->show();
 				scrollbarvisible = true;
@@ -211,77 +233,130 @@ void eListbox::updateScrollBar()
 				scrollbarvisible = false;
 			}
 		}
-		else if (entries > m_items_per_page || m_scrollbar_mode == showAlways)
+		else if (m_scrollbar_mode == showLeftOnDemand || m_scrollbar_mode == showLeftAlways)
 		{
-			m_scrollbar->move(ePoint(width-m_scrollbar_width, 0));
+			if (m_orientation == orVertical)
+				m_content->setSize(eSize(width - m_scrollbar_width - m_scrollbar_offset, m_itemheight));
+			else
+				m_content->setSize(eSize(m_itemwidth, m_itemheight));
+			m_scrollbar->move(ePoint(0, 0));
 			m_scrollbar->resize(eSize(m_scrollbar_width, height));
-			m_content->setSize(eSize(width-m_scrollbar_width-m_scrollbar_offset, m_itemheight));
+			if (entries > m_max_rows || m_scrollbar_mode == showLeftAlways)
+			{
+				m_scrollbar->show();
+				scrollbarvisible = true;
+			}
+			else
+			{
+				m_scrollbar->hide();
+				scrollbarvisible = false;
+			}
+		}
+		else if (entries > maxItems || m_scrollbar_mode == showAlways)
+		{
+			if (m_orientation == orHorizontal)
+			{
+				m_scrollbar->move(ePoint(0, height - m_scrollbar_height));
+				m_scrollbar->resize(eSize(width, m_scrollbar_height));
+				m_content->setSize(eSize(m_itemwidth, height - m_scrollbar_height - m_scrollbar_offset));
+			}
+			else if (m_orientation == orVertical)
+			{
+				m_scrollbar->move(ePoint(width - m_scrollbar_width, 0));
+				m_scrollbar->resize(eSize(m_scrollbar_width, height));
+				m_content->setSize(eSize(width - m_scrollbar_width - m_scrollbar_offset, m_itemheight));
+			}
+			else
+			{
+				m_scrollbar->move(ePoint(width - m_scrollbar_width, 0));
+				m_scrollbar->resize(eSize(m_scrollbar_width, height));
+				m_content->setSize(eSize(m_itemwidth, m_itemheight));
+			}
 			m_scrollbar->show();
 			scrollbarvisible = true;
 		}
 		else
 		{
-			m_content->setSize(eSize(width, m_itemheight));
+			if (m_orientation == orHorizontal)
+				m_content->setSize(eSize(m_itemwidth, height));
+			else if (m_orientation == orVertical)
+				m_content->setSize(eSize(width, m_itemheight));
+			else
+				m_content->setSize(eSize(m_itemwidth, m_itemheight));
 			m_scrollbar->hide();
 			scrollbarvisible = false;
 		}
 	}
 
-	// Don't set Start/End if scollbar not visible or entries/m_items_per_page = 0
-	if (m_items_per_page && entries && scrollbarvisible)
+	// Don't set Start/End if scollbar not visible or entries/maxItems = 0
+	if (maxItems && entries && scrollbarvisible)
 	{
 
-		if(m_scrollbar_scroll == byLine) {
+		if (m_scrollbar_scroll == byLine)
+		{
 
-			if(m_prev_scrollbar_page != m_selected) {
+			if (m_prev_scrollbar_page != m_selected)
+			{
 				m_prev_scrollbar_page = m_selected;
 
 				int start = 0;
+				int selected = (m_orientation == orGrid) ? m_selected / m_max_columns : m_selected;
 				int range = size().height() - (m_scrollbar_border_width * 2);
+				if (m_orientation == orHorizontal)
+					range = size().width() - (m_scrollbar_border_width * 2);
 				int end = range;
 				// calculate thumb only if needed
-				if (entries > 1 && entries > m_items_per_page)
+				if (entries > 1 && entries > maxItems)
 				{
-					float fthumb = (float)m_items_per_page / (float)entries * range;
+					float fthumb = (float)maxItems / (float)entries * range;
 					float fsteps = ((float)(range - fthumb) / (float)entries);
-					float fstart = (float)m_selected * fsteps;
+					float fstart = (float)selected * fsteps;
 					fthumb = (float)range - (fsteps * (float)(entries - 1));
 					int visblethumb = fthumb < 4 ? 4 : (int)(fthumb + 0.5);
 					start = (int)(fstart + 0.5);
 					end = start + visblethumb;
-					if (end > range) {
+					if (end > range)
+					{
 						end = range;
 						start = range - visblethumb;
 					}
-					//eDebug("[eListbox] updateScrollBar thumb=%d steps=%d start=%d end=%d range=%d m_items_per_page=%d entries=%d m_selected=%d", thumb, steps, start, end, range, m_items_per_page, entries, m_selected);
 				}
 
 				m_scrollbar->setStartEnd(start, end, true);
-
-			} 
+			}
 			return;
 		}
 
-		int curVisiblePage = m_top / m_items_per_page;
+		int topLeft = (m_orientation == orHorizontal) ? m_left : m_top;
+		int curVisiblePage = topLeft / maxItems;
 
 		if (m_prev_scrollbar_page != curVisiblePage)
 		{
 			m_prev_scrollbar_page = curVisiblePage;
-			int pages = entries / m_items_per_page;
-			if ((pages*m_items_per_page) < entries)
+			int pages = entries / maxItems;
+			if ((pages * maxItems) < entries)
 				++pages;
-			int start=(m_top*100)/(pages*m_items_per_page);
-			int vis=(m_items_per_page*100+pages*m_items_per_page-1)/(pages*m_items_per_page);
+			int start = (topLeft * 100) / (pages * maxItems);
+			int vis = (maxItems * 100 + pages * maxItems - 1) / (pages * maxItems);
 			if (vis < 3)
-				vis=3;
-			m_scrollbar->setStartEnd(start,start+vis);
+				vis = 3;
+			m_scrollbar->setStartEnd(start, start + vis);
 		}
 	}
 }
 
 int eListbox::getEntryTop()
 {
-	return (m_selected - m_top) * m_itemheight;
+	/*
+		Please Note! This will currently only work for verticial list box.
+		It's only used in eListboxPythonMultiContent::setSelectionClip.
+	*/
+	if (m_orientation == orHorizontal)
+		return (m_selected - m_left) * m_itemwidth;
+	else if (m_orientation == orVertical)
+		return (m_selected - m_top) * m_itemheight;
+	else
+		return (m_selected - m_top) * m_itemheight;
 }
 
 int eListbox::event(int event, void *data, void *data2)
@@ -301,52 +376,168 @@ int eListbox::event(int event, void *data, void *data2)
 		if (!m_content)
 			return 0;
 
-		gPainter &painter = *(gPainter*)data2;
+		gPainter &painter = *(gPainter *)data2;
 
 		m_content->cursorSave();
-		m_content->cursorMove(m_top - m_selected);
-
-		gRegion entryrect = eRect(0, 0, size().width(), m_itemheight);
-		const gRegion &paint_region = *(gRegion*)data;
-
-		int xoffset = 0;
-		if (m_scrollbar && (m_scrollbar_mode == showLeftOnDemand || m_scrollbar_mode == showLeftAlways))
+		gRegion entryRect = m_orientation == orVertical ? eRect(0, 0, size().width(), m_itemheight) : eRect(0, 0, m_itemwidth, size().height());
+		if (m_orientation == orVertical)
+			m_content->cursorMove(m_top - m_selected);
+		else if (m_orientation == orHorizontal)
+			m_content->cursorMove(m_left - m_selected);
+		else
 		{
-			xoffset = m_scrollbar->size().width() + m_scrollbar_offset;
+			m_content->cursorMove((m_max_columns * m_top) - m_selected);
+			entryRect = eRect(0, 0, m_itemwidth, m_itemheight);
+		}
+
+		const gRegion &paint_region = *(gRegion *)data;
+
+		int xOffset = 0;
+		int yOffset = 0;
+		if (m_scrollbar)
+		{
+			if (m_scrollbar_mode == showLeftOnDemand || m_scrollbar_mode == showLeftAlways)
+			{
+				xOffset = m_scrollbar->size().width() + m_scrollbar_offset;
+			}
+
+			if (m_scrollbar_mode == showTopOnDemand || m_scrollbar_mode == showTopAlways)
+			{
+				yOffset = m_scrollbar->size().height() + m_scrollbar_offset;
+			}
+		}
+
+		int itemOffset = 0;
+		if (m_orientation == orGrid)
+		{
+			if (!m_scrollbar || !m_scrollbar->isVisible() || m_item_alignment != itemAlignDefault)
+			{
+				style->setStyle(painter, eWindowStyle::styleListboxNormal);
+				painter.clear();
+			}
+
+			if (m_item_alignment != itemAlignDefault)
+			{
+				int fullSpace = size().width() - ((m_scrollbar) ? m_scrollbar->size().width() + m_scrollbar_offset : 0);
+				int itemSpace = m_max_columns * m_itemwidth;
+				if (fullSpace > itemSpace)
+				{
+					if (m_item_alignment == itemAlignCenter)
+					{
+						xOffset = (fullSpace - itemSpace) / 2;
+					}
+					else if (m_item_alignment == itemAlignJustify && m_max_columns > 1)
+					{
+						itemOffset = (fullSpace - itemSpace) / (m_max_columns - 1);
+					}
+				}
+			}
 		}
 
 		int line = 0;
 
-		for (int y = 0, i = 0; i <= m_items_per_page; y += m_itemheight, ++i)
+		if (m_orientation == orVertical)
 		{
-			gRegion entry_clip_rect = paint_region & entryrect;
 
-			bool sel = (m_selected == m_content->cursorGet() && m_content->size() && m_selection_enabled);
+			for (int y = 0, i = 0; i <= m_max_rows; y += m_itemheight, ++i)
+			{
+				gRegion entry_clip_rect = paint_region & entryRect;
 
-			if(sel)
-				line = i;
+				bool sel = (m_selected == m_content->cursorGet() && m_content->size() && m_selection_enabled);
 
-			if (!entry_clip_rect.empty())
-				m_content->paint(painter, *style, ePoint(xoffset, y), sel);
+				if (sel)
+					line = i;
+
+				if (!entry_clip_rect.empty())
+					m_content->paint(painter, *style, ePoint(xOffset, y), sel);
 #ifdef USE_LIBVUGLES2
-			if (sel) {
-				ePoint pos = getAbsolutePosition();
-				painter.sendShowItem(m_dir, ePoint(pos.x(), pos.y() + y), eSize(m_scrollbar && m_scrollbar->isVisible() ? size().width() - m_scrollbar->size().width() : size().width(), m_itemheight));
-				gles_set_animation_listbox_current(pos.x(), pos.y() + y, m_scrollbar && m_scrollbar->isVisible() ? size().width() - m_scrollbar->size().width() : size().width(), m_itemheight);
-				m_dir = justCheck;
-			}
+				if (sel)
+				{
+					ePoint pos = getAbsolutePosition();
+					painter.sendShowItem(m_dir, ePoint(pos.x(), pos.y() + y), eSize(m_scrollbar && m_scrollbar->isVisible() ? size().width() - m_scrollbar->size().width() : size().width(), m_itemheight));
+					gles_set_animation_listbox_current(pos.x(), pos.y() + y, m_scrollbar && m_scrollbar->isVisible() ? size().width() - m_scrollbar->size().width() : size().width(), m_itemheight);
+					m_dir = justCheck;
+				}
 #endif
 				/* (we could clip with entry_clip_rect, but
-				   this shouldn't change the behavior of any
-				   well behaving content, so it would just
-				   degrade performance without any gain.) */
+				this shouldn't change the behavior of any
+				well behaving content, so it would just
+				degrade performance without any gain.) */
 
-			m_content->cursorMove(+1);
-			entryrect.moveBy(ePoint(0, m_itemheight));
-
+				m_content->cursorMove(+1);
+				entryRect.moveBy(ePoint(0, m_itemheight));
+			}
 		}
 
-		// clear/repaint empty/unused space between scrollbar and listboxentrys
+		if (m_orientation == orHorizontal)
+		{
+
+			for (int x = 0, i = 0; i <= m_max_columns; x += m_itemwidth, ++i)
+			{
+				gRegion entry_clip_rect = paint_region & entryRect;
+
+				bool sel = (m_selected == m_content->cursorGet() && m_content->size() && m_selection_enabled);
+
+				if (sel)
+					line = i;
+
+				if (!entry_clip_rect.empty())
+					m_content->paint(painter, *style, ePoint(x, yOffset), sel);
+
+				/* (we could clip with entry_clip_rect, but
+				this shouldn't change the behavior of any
+				well behaving content, so it would just
+				degrade performance without any gain.) */
+
+				m_content->cursorMove(+1);
+				entryRect.moveBy(ePoint(m_itemwidth, 0));
+			}
+		}
+
+		if (m_orientation == orGrid)
+		{
+			int i = 0;
+			int l = 0;
+			int m_max_items = m_max_columns * m_max_rows;
+			for (int y = 0; y < m_max_rows; y++)
+			{
+				for (int x = 0; x < m_max_columns; x++)
+				{
+
+					int leftOffset = (itemOffset > 0) ? (itemOffset * x) : xOffset;
+
+					gRegion entry_clip_rect = paint_region & entryRect;
+
+					// This is a workaround because there is a bug in gRegion intersect
+					bool paint = !entry_clip_rect.empty();
+					if (!paint)
+					{
+						paint = (paint_region.extends.height() >= (entryRect.extends.y() + entryRect.extends.height()));
+					}
+
+					bool sel = (m_selected == m_content->cursorGet() && m_content->size() && m_selection_enabled);
+
+					if (sel)
+						line = l;
+
+					if (paint)
+						m_content->paint(painter, *style, ePoint(leftOffset + (x * m_itemwidth), y * m_itemheight), sel);
+
+					m_content->cursorMove(+1);
+					entryRect.moveBy(ePoint(m_itemwidth, 0));
+					++i;
+					if (i > m_max_items)
+						break;
+				}
+				l++;
+
+				entryRect.moveBy(ePoint(0, m_itemheight));
+				entryRect.extends.setX(0);
+				entryRect.extends.setWidth(m_itemwidth);
+			}
+		}
+
+		// clear/repaint empty/unused space between scrollbar and listbox entries
 		if (m_scrollbar)
 		{
 			if (m_scrollbar_mode == showLeftOnDemand || m_scrollbar_mode == showLeftAlways)
@@ -354,7 +545,7 @@ int eListbox::event(int event, void *data, void *data2)
 				style->setStyle(painter, eWindowStyle::styleListboxNormal);
 				if (m_scrollbar->isVisible())
 				{
-					painter.clip(eRect(m_scrollbar->position() + ePoint(m_scrollbar->size().width(), 0), eSize(m_scrollbar_offset,m_scrollbar->size().height())));
+					painter.clip(eRect(m_scrollbar->position() + ePoint(m_scrollbar->size().width(), 0), eSize(m_scrollbar_offset, m_scrollbar->size().height())));
 				}
 				else
 				{
@@ -363,14 +554,34 @@ int eListbox::event(int event, void *data, void *data2)
 				painter.clear();
 				painter.clippop();
 			}
-			else if (m_scrollbar->isVisible())
+			else if (m_scrollbar_mode == showTopOnDemand || m_scrollbar_mode == showTopAlways)
 			{
 				style->setStyle(painter, eWindowStyle::styleListboxNormal);
-				painter.clip(eRect(m_scrollbar->position() - ePoint(m_scrollbar_offset,0), eSize(m_scrollbar_offset,m_scrollbar->size().height())));
+				if (m_scrollbar->isVisible())
+				{
+					painter.clip(eRect(m_scrollbar->position() + ePoint(0, m_scrollbar->size().height()), eSize(m_scrollbar->size().width(), m_scrollbar_offset)));
+				}
+				else
+				{
+					painter.clip(eRect(m_scrollbar->position(), eSize(m_scrollbar->size().width(), m_scrollbar->size().height() + m_scrollbar_offset)));
+				}
 				painter.clear();
 				painter.clippop();
 			}
-
+			else if (m_scrollbar->isVisible())
+			{
+				style->setStyle(painter, eWindowStyle::styleListboxNormal);
+				if (m_orientation == orHorizontal)
+				{
+					painter.clip(eRect(m_scrollbar->position() - ePoint(0, m_scrollbar_offset), eSize(m_scrollbar->size().width(), m_scrollbar_offset)));
+				}
+				else
+				{
+					painter.clip(eRect(m_scrollbar->position() - ePoint(m_scrollbar_offset, 0), eSize(m_scrollbar_offset, m_scrollbar->size().height())));
+				}
+				painter.clear();
+				painter.clippop();
+			}
 		}
 
 		m_content->cursorSaveLine(line);
@@ -397,14 +608,34 @@ int eListbox::event(int event, void *data, void *data2)
 
 void eListbox::recalcSize()
 {
-	m_content_changed=true;
-	m_prev_scrollbar_page=-1;
-	if (m_content)
-		m_content->setSize(eSize(size().width(), m_itemheight));
-	m_items_per_page = size().height() / m_itemheight;
+	m_content_changed = true;
+	m_prev_scrollbar_page = -1;
+	if (m_orientation == orVertical)
+	{
+		if (m_content)
+			m_content->setSize(eSize(size().width(), m_itemheight));
+		m_max_rows = size().height() / m_itemheight;
+	}
+	else if (m_orientation == orHorizontal)
+	{
+		if (m_content)
+			m_content->setSize(eSize(m_itemwidth, size().height()));
+		m_max_columns = size().width() / m_itemwidth;
+	}
+	else
+	{
+		if (m_content)
+			m_content->setSize(eSize(m_itemwidth, m_itemheight));
 
-	if (m_items_per_page < 0) /* TODO: whyever - our size could be invalid, or itemheigh could be wrongly specified. */
- 		m_items_per_page = 0;
+		m_max_columns = size().width() / m_itemwidth;
+		m_max_rows = size().height() / m_itemheight;
+	}
+
+	/* TODO: whyever - our size could be invalid, or itemheigh could be wrongly specified. */
+	if (m_max_columns < 0)
+		m_max_columns = 0;
+	if (m_max_rows < 0)
+		m_max_rows = 0;
 
 	moveSelection(justCheck);
 }
@@ -415,6 +646,15 @@ void eListbox::setItemHeight(int h)
 		m_itemheight = h;
 	else
 		m_itemheight = 20; // TODO : why 20
+	recalcSize();
+}
+
+void eListbox::setItemWidth(int w)
+{
+	if (w)
+		m_itemwidth = w;
+	else
+		m_itemwidth = 20; // TODO : why 20
 	recalcSize();
 }
 
@@ -430,34 +670,83 @@ void eListbox::entryAdded(int index)
 {
 	m_first_selectable_item = -1;
 	m_last_selectable_item = -1;
-	if (m_content && (m_content->size() % m_items_per_page) == 1)
-		m_content_changed=true;
-	/* manage our local pointers. when the entry was added before the current position, we have to advance. */
+	if (m_content)
+	{
+		if (m_orientation == orVertical)
+		{
+			if ((m_content->size() % m_max_rows) == 1)
+				m_content_changed = true;
+		}
+		else if (m_orientation == orHorizontal)
+		{
+			if ((m_content->size() % m_max_columns) == 1)
+				m_content_changed = true;
+		}
+		else
+			m_content_changed = true;
+	}
 
-		/* we need to check <= - when the new entry has the (old) index of the cursor, the cursor was just moved down. */
+	/* manage our local pointers. when the entry was added before the current position, we have to advance. */
+	/* we need to check <= - when the new entry has the (old) index of the cursor, the cursor was just moved down. */
+
 	if (index <= m_selected)
 		++m_selected;
-	if (index <= m_top)
-		++m_top;
+	if (m_orientation == orVertical)
+	{
+		if (index <= m_top)
+			++m_top;
+	}
+	else
+	{
+		if (index <= m_left)
+			++m_left;
+	}
 
-		/* we have to check wether our current cursor is gone out of the screen. */
-		/* moveSelection will check for this case */
+	/* we have to check wether our current cursor is gone out of the screen. */
+	/* moveSelection will check for this case */
 	moveSelection(justCheck);
 
-		/* now, check if the new index is visible. */
-	if ((m_top <= index) && (index < (m_top + m_items_per_page)))
+	/* now, check if the new index is visible. */
+	if (m_orientation == orVertical)
 	{
+		if ((m_top <= index) && (index < (m_top + m_max_rows)))
+		{
 			/* todo, calc exact invalidation... */
-		invalidate();
+			invalidate();
+		}
 	}
+	else if (m_orientation == orHorizontal)
+	{
+		if ((m_left <= index) && (index < (m_left + m_max_columns)))
+		{
+			/* todo, calc exact invalidation... */
+			invalidate();
+		}
+	}
+	else
+		invalidate();
 }
 
 void eListbox::entryRemoved(int index)
 {
 	m_first_selectable_item = -1;
 	m_last_selectable_item = -1;
-	if (m_content && !(m_content->size() % m_items_per_page))
-		m_content_changed=true;
+
+	if (m_content)
+	{
+		if (m_orientation == orVertical)
+		{
+			if (!(m_content->size() % m_max_rows))
+				m_content_changed = true;
+		}
+		else if (m_orientation == orHorizontal)
+		{
+			if (!(m_content->size() % m_max_columns))
+				m_content_changed = true;
+		}
+		else
+			m_content_changed = true;
+	}
 
 	if (index == m_selected && m_content)
 		m_selected = m_content->cursorGet();
@@ -467,18 +756,49 @@ void eListbox::entryRemoved(int index)
 	else
 		moveSelection(justCheck);
 
-	if ((m_top <= index) && (index < (m_top + m_items_per_page)))
+	if (m_orientation == orVertical)
 	{
+		if ((m_top <= index) && (index < (m_top + m_max_rows)))
+		{
 			/* todo, calc exact invalidation... */
-		invalidate();
+			invalidate();
+		}
 	}
+	else if (m_orientation == orHorizontal)
+	{
+		if ((m_left <= index) && (index < (m_left + m_max_columns)))
+		{
+			/* todo, calc exact invalidation... */
+			invalidate();
+		}
+	}
+	else
+		invalidate();
 }
 
 void eListbox::entryChanged(int index)
 {
-	if ((m_top <= index) && (index < (m_top + m_items_per_page)))
+	if (m_orientation == orVertical)
 	{
-		gRegion inv = eRect(0, m_itemheight * (index-m_top), size().width(), m_itemheight);
+		if ((m_top <= index) && (index < (m_top + m_max_rows)))
+		{
+			gRegion inv = eRect(0, m_itemheight * (index - m_top), size().width(), m_itemheight);
+			invalidate(inv);
+		}
+	}
+	else if (m_orientation == orHorizontal)
+	{
+		if ((m_left <= index) && (index < (m_left + m_max_columns)))
+		{
+			gRegion inv = eRect(m_itemwidth * (index - m_left), 0, m_itemwidth, size().height());
+			invalidate(inv);
+		}
+	}
+	else
+	{
+		int col = index % m_max_columns;
+		int row = index / m_max_rows;
+		gRegion inv = eRect(col * m_itemwidth, row * m_itemheight, m_itemwidth, m_itemheight);
 		invalidate(inv);
 	}
 }
@@ -489,13 +809,14 @@ void eListbox::entryReset(bool selectionHome)
 	m_last_selectable_item = -1;
 	m_content_changed = true;
 	m_prev_scrollbar_page = -1;
-	int oldsel;
+	int oldSel;
 
 	if (selectionHome)
 	{
 		if (m_content)
 			m_content->cursorHome();
 		m_top = 0;
+		m_left = 0;
 		m_selected = 0;
 	}
 
@@ -508,49 +829,14 @@ void eListbox::entryReset(bool selectionHome)
 		m_content->cursorSet(m_selected);
 	}
 
-	oldsel = m_selected;
+	oldSel = m_selected;
 	moveSelection(justCheck);
-		/* if oldsel != m_selected, selectionChanged was already
-		   emitted in moveSelection. we want it in any case, so otherwise,
-		   emit it now. */
-	if (oldsel == m_selected)
+	/* if oldSel != m_selected, selectionChanged was already
+	   emitted in moveSelection. we want it in any case, so otherwise,
+	   emit it now. */
+	if (oldSel == m_selected)
 		/* emit */ selectionChanged();
 	invalidate();
-}
-
-void eListbox::setFont(gFont *font)
-{
-	m_style.m_font = font;
-}
-
-void eListbox::setEntryFont(gFont *font)
-{
-	m_style.m_font = font;
-}
-
-void eListbox::setValueFont(gFont *font)
-{
-	m_style.m_valuefont = font;
-}
-
-void eListbox::setVAlign(int align)
-{
-	m_style.m_valign = align;
-}
-
-void eListbox::setHAlign(int align)
-{
-	m_style.m_halign = align;
-}
-
-void eListbox::setTextPadding(const eRect &padding)
-{
-	m_style.m_text_padding = padding;
-}
-
-void eListbox::setUseVTIWorkaround(void)
-{
-	m_style.m_use_vti_workaround = 1;
 }
 
 void eListbox::setBackgroundColor(gRGB &col)
@@ -577,75 +863,66 @@ void eListbox::setForegroundColorSelected(gRGB &col)
 	m_style.m_foreground_color_selected_set = 1;
 }
 
-void eListbox::setBorderColor(const gRGB &col)
-{
-	m_style.m_border_color = col;
-}
-
 void eListbox::setBorderWidth(int size)
 {
 	m_style.m_border_size = size;
-	if (m_scrollbar) m_scrollbar->setBorderWidth(size);
+	if (m_scrollbar)
+		m_scrollbar->setBorderWidth(size);
 }
 
 void eListbox::setScrollbarBorderWidth(int width)
 {
 	m_style.m_scrollbarborder_width = width;
 	m_style.m_scrollbarborder_width_set = 1;
-	if (m_scrollbar) m_scrollbar->setBorderWidth(width);
-}
-
-void eListbox::setScrollbarWidth(int size)
-{
-	m_scrollbar_width = size;
-}
-
-void eListbox::setScrollbarOffset(int size)
-{
-	m_scrollbar_offset = size;
-}
-
-void eListbox::setBackgroundPixmap(ePtr<gPixmap> &pm)
-{
-	m_style.m_background = pm;
-}
-
-void eListbox::setSelectionPixmap(ePtr<gPixmap> &pm)
-{
-	m_style.m_selection = pm;
+	if (m_scrollbar)
+		m_scrollbar->setBorderWidth(width);
 }
 
 void eListbox::setScrollbarForegroundPixmap(ePtr<gPixmap> &pm)
 {
 	m_scrollbarpixmap = pm;
-	if (m_scrollbar && m_scrollbarpixmap) m_scrollbar->setPixmap(pm);
+	if (m_scrollbar && m_scrollbarpixmap)
+		m_scrollbar->setPixmap(pm);
 }
 
 void eListbox::setScrollbarBackgroundColor(gRGB &col)
 {
 	m_style.m_scrollbarbackground_color = col;
 	m_style.m_scrollbarbackground_color_set = 1;
-	if (m_scrollbar) m_scrollbar->setBackgroundColor(col);
+	if (m_scrollbar)
+		m_scrollbar->setBackgroundColor(col);
 }
 
 void eListbox::setScrollbarForegroundColor(gRGB &col)
 {
 	m_style.m_scrollbarforeground_color = col;
 	m_style.m_scrollbarforeground_color_set = 1;
-	if (m_scrollbar) m_scrollbar->setForegroundColor(col);
+	if (m_scrollbar)
+		m_scrollbar->setForegroundColor(col);
 }
 
 void eListbox::setScrollbarBorderColor(const gRGB &col)
 {
 	m_style.m_scollbarborder_color = col;
 	m_style.m_scollbarborder_color_set = 1;
-	if (m_scrollbar) m_scrollbar->setBorderColor(col);
+	if (m_scrollbar)
+		m_scrollbar->setBorderColor(col);
 }
 
 void eListbox::setScrollbarBackgroundPixmap(ePtr<gPixmap> &pm)
 {
 	m_scrollbarbackgroundpixmap = pm;
-	if (m_scrollbar && m_scrollbarbackgroundpixmap) m_scrollbar->setBackgroundPixmap(pm);
+	if (m_scrollbar && m_scrollbarbackgroundpixmap)
+		m_scrollbar->setBackgroundPixmap(pm);
+}
+
+void eListbox::setItemAlignment(int align)
+{
+	if (m_item_alignment != align)
+	{
+		m_item_alignment = align;
+		invalidate();
+	}
 }
 
 void eListbox::invalidate(const gRegion &region)
@@ -658,45 +935,64 @@ void eListbox::invalidate(const gRegion &region)
 
 struct eListboxStyle *eListbox::getLocalStyle(void)
 {
-		/* transparency is set directly in the widget */
+	/* transparency is set directly in the widget */
 	m_style.m_transparent_background = isTransparent();
 	return &m_style;
 }
 
-void eListbox::setItemWidth(int w)
+void eListbox::setOrientation(int newOrentation)
 {
-	if (w)
-		m_itemwidth = w;
-	else
-		m_itemwidth = 20; // TODO : why 20
-	recalcSize();
-}
-
-void eListbox::setOrientation(int o)
-{
-	m_list_orientation = o;
+	if (m_orientation != newOrentation && m_scrollbar)
+	{
+		if (newOrentation == orHorizontal)
+		{
+			m_scrollbar->setOrientation(eSlider::orHorizontal);
+		}
+		else
+		{
+			m_scrollbar->setOrientation(eSlider::orVertical);
+		}
+	}
+	m_orientation = newOrentation;
 	invalidate();
 }
 
-void eListbox::moveSelection(long dir)
+void eListbox::moveSelection(int dir)
 {
 	/* refuse to do anything without a valid list. */
 	if (!m_content)
 		return;
 	/* if our list does not have one entry, don't do anything. */
-	if (!m_items_per_page || !m_content->size())
+	int maxItems = (m_orientation == orVertical) ? m_max_rows : m_max_columns;
+	if (m_orientation == orGrid)
+	{
+		maxItems = m_max_rows * m_max_columns;
+	}
+
+	if (!maxItems || !m_content->size())
 		return;
 
-	/* we need the old top/sel to see what we have to redraw */
-	int oldtop = m_top;
-	int oldsel = m_selected;
-	int prevsel = oldsel;
-	int newsel;
-	int pageOffset = (m_page_size > 0 && m_scrollbar_scroll == byLine) ? m_page_size : m_items_per_page;
-	bool indexchanged = dir > 100;
-	if(indexchanged) {
-		dir -= 100;
+	// patch pageUp / pageDown for virtual listbox if native keys enabled
+	if (m_orientation == orVertical && m_native_keys_bound)
+	{
+		if (dir == moveLeft)
+			dir = movePageDown;
+		if (dir == moveRight)
+			dir = movePageUp;
 	}
+
+	bool isGrid = m_orientation == orGrid;
+
+	/* we need the old top/sel to see what we have to redraw */
+	int oldTop = m_top;
+	int oldLeft = m_left;
+	int oldSel = m_selected;
+	int prevSel = oldSel;
+	int newSel;
+	int pageOffset = (m_page_size > 0 && m_scrollbar_scroll == byLine) ? m_page_size : maxItems;
+	bool indexChanged = dir > 100;
+	if (indexChanged)
+		dir -= 100;
 
 #ifdef USE_LIBVUGLES2
 	m_dir = dir;
@@ -707,29 +1003,56 @@ void eListbox::moveSelection(long dir)
 		m_content->cursorEnd();
 		[[fallthrough]];
 	case moveUp:
+		if (isGrid)
+		{
+			do
+			{
+				m_content->cursorMove(-m_max_columns);
+				newSel = m_content->cursorGet();
+				if (newSel == prevSel)
+				{ // cursorMove reached top and left cursor position the same. Must wrap around ?
+					if (m_enabled_wrap_around)
+					{
+						m_content->cursorEnd();
+						m_content->cursorMove(-1);
+						newSel = m_content->cursorGet();
+					}
+					else
+					{
+						m_content->cursorSet(oldSel);
+						break;
+					}
+				}
+				prevSel = newSel;
+
+			} while (newSel != oldSel && !m_content->currentCursorSelectable());
+			break;
+		}
+		[[fallthrough]];
+	case moveLeft:
 		do
 		{
 			m_content->cursorMove(-1);
-			newsel = m_content->cursorGet();
-			if (newsel == prevsel) {  // cursorMove reached top and left cursor position the same. Must wrap around ?
+			newSel = m_content->cursorGet();
+			if (newSel == prevSel)
+			{ // cursorMove reached top and left cursor position the same. Must wrap around ?
 				if (m_enabled_wrap_around)
 				{
 					m_content->cursorEnd();
 					m_content->cursorMove(-1);
-					newsel = m_content->cursorGet();
+					newSel = m_content->cursorGet();
 				}
 				else
 				{
-					m_content->cursorSet(oldsel);
+					m_content->cursorSet(oldSel);
 					break;
 				}
 			}
-			prevsel = newsel;
-		}
-		while (newsel != oldsel && !m_content->currentCursorSelectable());
+			prevSel = newSel;
+		} while (newSel != oldSel && !m_content->currentCursorSelectable());
 		break;
 	case refresh:
-		oldsel = ~m_selected;
+		oldSel = ~m_selected;
 		break;
 	case moveTop:
 		m_content->cursorHome();
@@ -739,18 +1062,36 @@ void eListbox::moveSelection(long dir)
 			break;
 		[[fallthrough]];
 	case moveDown:
+		if (isGrid)
+		{
+			do
+			{
+				m_content->cursorMove(m_max_columns);
+				if (!m_content->cursorValid())
+				{ // cursorMove reached end and left cursor position past the list. Must wrap around ?
+					if (m_enabled_wrap_around)
+						m_content->cursorHome();
+					else
+						m_content->cursorSet(oldSel);
+				}
+				newSel = m_content->cursorGet();
+			} while (newSel != oldSel && !m_content->currentCursorSelectable());
+			break;
+		}
+		[[fallthrough]];
+	case moveRight:
 		do
 		{
 			m_content->cursorMove(1);
-			if (!m_content->cursorValid()) { //cursorMove reached end and left cursor position past the list. Must wrap around ?
+			if (!m_content->cursorValid())
+			{ // cursorMove reached end and left cursor position past the list. Must wrap around ?
 				if (m_enabled_wrap_around)
 					m_content->cursorHome();
 				else
-					m_content->cursorSet(oldsel);
+					m_content->cursorSet(oldSel);
 			}
-			newsel = m_content->cursorGet();
-		}
-		while (newsel != oldsel && !m_content->currentCursorSelectable());
+			newSel = m_content->cursorGet();
+		} while (newSel != oldSel && !m_content->currentCursorSelectable());
 		break;
 	case movePageUp:
 	{
@@ -758,38 +1099,37 @@ void eListbox::moveSelection(long dir)
 		do
 		{
 			m_content->cursorMove(-pageOffset);
-			newsel = m_content->cursorGet();
-			pageind = newsel % m_items_per_page; // rememer were we land in thsi page (could be different on topmost page)
-			prevsel = newsel - pageind; // get top of page index
+			newSel = m_content->cursorGet();
+			pageind = newSel % maxItems; // rememer were we land in thsi page (could be different on topmost page)
+			prevSel = newSel - pageind;	 // get top of page index
 			// find first selectable entry in new page. First check bottom part, than upper part
-			while (newsel != prevsel + m_items_per_page && m_content->cursorValid() && !m_content->currentCursorSelectable())
+			while (newSel != prevSel + maxItems && m_content->cursorValid() && !m_content->currentCursorSelectable())
 			{
 				m_content->cursorMove(1);
-				newsel = m_content->cursorGet();
+				newSel = m_content->cursorGet();
 			}
 			if (!m_content->currentCursorSelectable()) // no selectable found in bottom part of page
 			{
-				m_content->cursorSet(prevsel + pageind);
-				while (newsel != prevsel && !m_content->currentCursorSelectable())
+				m_content->cursorSet(prevSel + pageind);
+				while (newSel != prevSel && !m_content->currentCursorSelectable())
 				{
 					m_content->cursorMove(-1);
-					newsel = m_content->cursorGet();
+					newSel = m_content->cursorGet();
 				}
 			}
 			if (m_content->currentCursorSelectable())
 				break;
-			if (newsel == 0) // at top and nothing found . Go down till something selectable or old location
+			if (newSel == 0) // at top and nothing found . Go down till something selectable or old location
 			{
-				while (newsel != oldsel && !m_content->currentCursorSelectable())
+				while (newSel != oldSel && !m_content->currentCursorSelectable())
 				{
 					m_content->cursorMove(1);
-					newsel = m_content->cursorGet();
+					newSel = m_content->cursorGet();
 				}
 				break;
 			}
-			m_content->cursorSet(prevsel + pageind);
-		}
-		while (newsel == prevsel);
+			m_content->cursorSet(prevSel + pageind);
+		} while (newSel == prevSel);
 		break;
 	}
 	case movePageDown:
@@ -800,170 +1140,249 @@ void eListbox::moveSelection(long dir)
 			m_content->cursorMove(pageOffset);
 			if (!m_content->cursorValid())
 				m_content->cursorMove(-1);
-			newsel = m_content->cursorGet();
-			pageind = newsel % m_items_per_page;
-			prevsel = newsel - pageind; // get top of page index
+			newSel = m_content->cursorGet();
+			pageind = newSel % maxItems;
+			prevSel = newSel - pageind; // get top of page index
 			// find a selectable entry in the new page. first look up then down from current screenlocation on the page
-			while (newsel != prevsel && !m_content->currentCursorSelectable())
+			while (newSel != prevSel && !m_content->currentCursorSelectable())
 			{
 				m_content->cursorMove(-1);
-				newsel = m_content->cursorGet();
+				newSel = m_content->cursorGet();
 			}
 			if (!m_content->currentCursorSelectable()) // no selectable found in top part of page
 			{
-				m_content->cursorSet(prevsel + pageind);
-				do {
+				m_content->cursorSet(prevSel + pageind);
+				do
+				{
 					m_content->cursorMove(1);
-					newsel = m_content->cursorGet();
-				}
-			    while (newsel != prevsel + m_items_per_page && m_content->cursorValid() && !m_content->currentCursorSelectable());
+					newSel = m_content->cursorGet();
+				} while (newSel != prevSel + maxItems && m_content->cursorValid() && !m_content->currentCursorSelectable());
 			}
 			if (!m_content->cursorValid())
 			{
 				// we reached the end of the list
-				// Back up till something selectable or we reach oldsel again
+				// Back up till something selectable or we reach oldSel again
 				// E.g this should bring us back to the last selectable item on the original page
 				do
 				{
 					m_content->cursorMove(-1);
-					newsel = m_content->cursorGet();
-				}
-				while (newsel != oldsel && !m_content->currentCursorSelectable());
+					newSel = m_content->cursorGet();
+				} while (newSel != oldSel && !m_content->currentCursorSelectable());
 				break;
 			}
-			if (newsel != prevsel + m_items_per_page)
+			if (newSel != prevSel + maxItems)
 				break;
-			m_content->cursorSet(prevsel + pageind); // prepare for next page down
-		}
-		while (newsel == prevsel + m_items_per_page);
+			m_content->cursorSet(prevSel + pageind); // prepare for next page down
+		} while (newSel == prevSel + maxItems);
 		break;
 	}
 	}
 
 	/* now, look wether the current selection is out of screen */
 	m_selected = m_content->cursorGet();
-	m_top = m_selected - (m_selected % m_items_per_page);
+	if (m_orientation == orHorizontal)
+		m_left = m_selected - (m_selected % maxItems);
+	else
+		m_top = (m_scrollbar_scroll == byLine) ? m_selected / maxItems : (m_selected / maxItems) * m_max_rows;
 
-	/*  new scollmode by line if not on the first page */
-	if(m_scrollbar_scroll == byLine && m_content->size() > m_items_per_page)
+	/*  new scollmode by line if not on the first page .. only for vertical */
+	if (m_scrollbar_scroll == byLine && m_content->size() > maxItems)
 	{
-
-		int oldline = m_content->cursorRestoreLine();
-		int max = m_content->size() - m_items_per_page;
-		bool customPageSize = pageOffset != m_items_per_page;
-		//eDebug("[eListbox] moveSelection 1 dir=%d oldline=%d oldsel=%d m_selected=%d m_items_per_page=%d sz=%d max=%d", dir, oldline, oldsel, m_selected, m_items_per_page, m_content->size(), max);
-
-		bool jumpBottom = (dir == moveBottom);
-
-		if(dir == movePageDown && m_selected > max && !customPageSize) {
-			jumpBottom = true;
-		}
-
-		if(dir == moveUp || (customPageSize && dir == movePageUp) ) {
-			if(m_selected > oldsel) {
-				jumpBottom = true;
-			}
-			else if (oldline > 0)
-				oldline-= oldsel - m_selected;
-
-			if(oldline < 0 && m_selected > m_items_per_page)
-				oldline = 0;
-
-		}
-
-		if(m_last_selectable_item == -1 && dir == justCheck)
-		{
-			m_content->cursorEnd();
-			do
-			{
-				m_content->cursorMove(-1);
-				m_last_selectable_item = m_content->cursorGet();
-			}
-			while (!m_content->currentCursorSelectable());
-			m_content->cursorSet(m_selected);
-		}
-
-		if(dir == moveDown || (customPageSize && dir == movePageDown)) {
-
-			int newline = oldline + (m_selected - oldsel);
-			if(newline < m_items_per_page && newline > 0) {
-				m_top = oldsel - oldline;
-			}
-			else {
-				m_top = m_selected - (m_items_per_page - 1);
-				if(m_selected < m_items_per_page )
-					m_top=0;
-			}
-
-			if (m_last_selectable_item != m_content->size() - 1 && m_selected >= m_last_selectable_item)
-				jumpBottom = true;
-		}
-
-		if(jumpBottom) {
-			m_top = max;
-		}
-		else if (dir == justCheck)
-		{
-			if(m_first_selectable_item==-1)
-			{
-				m_first_selectable_item = 0;
-				if(m_selected>0)
-				{
-					m_content->cursorHome();
-					if (!m_content->currentCursorSelectable()) {
-						do
-						{
-							m_content->cursorMove(1);
-							m_first_selectable_item = m_content->cursorGet();
-						}
-						while (!m_content->currentCursorSelectable());
-					}
-					m_content->cursorSet(m_selected);
-					if(oldline==0)
-						oldline = m_selected;
-				}
-			}
-			if(indexchanged && m_selected < m_items_per_page) {
-				oldline = m_selected;
-			}
-
-			m_top = m_selected - oldline;
-		}
-		else if (dir == moveUp || (customPageSize && dir == movePageUp))
-		{
-			if(m_first_selectable_item > 0 && m_selected == m_first_selectable_item)
-			{
-				oldline = m_selected;
-			}
-			m_top = m_selected - oldline;
-		}
-
-		if(m_top < 0 || oldline < 0) {
-			m_top = 0;
-		}
-
-		//eDebug("[eListbox] moveSelection 2 dir=%d oldline=%d oldtop=%d m_top=%d m_selected=%d m_items_per_page=%d sz=%d jumpBottom=%d", dir, oldline, oldtop, m_top, m_selected, m_items_per_page, m_content->size(),jumpBottom);
-
+		if (m_orientation == orHorizontal)
+			m_left = moveSelectionLineMode((dir == moveLeft), (dir == moveRight), dir, oldSel, oldLeft, maxItems, indexChanged, pageOffset, m_left);
+		else
+			m_top = moveSelectionLineMode((dir == moveUp), (dir == moveDown), dir, oldSel, oldTop, maxItems, indexChanged, pageOffset, m_top);
 	}
 
 	// if it is, then the old selection clip is irrelevant, clear it or we'll get artifacts
-	if (m_top != oldtop && m_content)
-		m_content->resetClip();
+	if (m_orientation == orHorizontal)
+	{
+		if (m_left != oldLeft && m_content)
+			m_content->resetClip();
+	}
+	else
+	{
+		if (m_top != oldTop && m_content)
+			m_content->resetClip();
+	}
 
-	if (oldsel != m_selected)
-		/* emit */ selectionChanged();
+	if (oldSel != m_selected) /* emit */
+		selectionChanged();
 
 	updateScrollBar();
 
-	if (m_top != oldtop) {
-		invalidate();
-	}
-	else if (m_selected != oldsel)
+	if (m_orientation == orHorizontal)
 	{
-		/* redraw the old and newly selected */
-		gRegion inv = eRect(0, m_itemheight * (m_selected-m_top), size().width(), m_itemheight);
-		inv |= eRect(0, m_itemheight * (oldsel-m_top), size().width(), m_itemheight);
-		invalidate(inv);
+		if (m_left != oldLeft)
+		{
+			invalidate();
+		}
+		else if (m_selected != oldSel)
+		{
+			/* redraw the old and newly selected */
+			gRegion inv = eRect(m_itemwidth * (m_selected - m_left), 0, m_itemwidth, size().height());
+			inv |= eRect(m_itemwidth * (oldSel - m_left), 0, m_itemwidth, size().height());
+			invalidate(inv);
+		}
+	}
+	else
+	{
+		if (m_top != oldTop)
+		{
+			invalidate();
+		}
+		else if (m_selected != oldSel)
+		{
+			if (m_orientation == orGrid)
+			{
+				// TODO:
+				// gRegion inv = eRect(0, m_itemheight * m_top, m_itemwidth, m_itemheight);
+				// inv |= eRect(0, m_itemheight * (oldSel - m_top), m_itemwidth, m_itemheight);
+				// invalidate(inv);
+				invalidate();
+			}
+			else
+			{
+				/* redraw the old and newly selected */
+				gRegion inv = eRect(0, m_itemheight * (m_selected - m_top), size().width(), m_itemheight);
+				inv |= eRect(0, m_itemheight * (oldSel - m_top), size().width(), m_itemheight);
+				invalidate(inv);
+			}
+		}
+	}
+}
+
+int eListbox::moveSelectionLineMode(bool doUp, bool doDown, int dir, int oldSel, int oldTopLeft, int maxItems, bool indexChanged, int pageOffset, int topLeft)
+{
+	int oldLine = m_content->cursorRestoreLine();
+	int max = m_content->size() - maxItems;
+	bool customPageSize = pageOffset != maxItems;
+	if (m_orientation == orGrid)
+	{
+		int newline = (m_selected / m_max_columns);
+		if (newline < m_max_rows)
+		{
+			return 0;
+		}
+		int newlinecalc = (m_selected / m_max_columns) - oldTopLeft;
+		if (doUp)
+		{
+			if ((oldLine > 0 && oldTopLeft > 0) || (newlinecalc > 0))
+			{
+				return oldTopLeft;
+			}
+		}
+		if (newlinecalc == oldLine)
+			return oldTopLeft;
+		if (m_max_rows < newline)
+		{
+			return newline - m_max_rows + 1;
+		}
+		return topLeft;
 	}
 
+	bool jumpBottom = (dir == moveBottom);
+
+	if (dir == movePageDown && m_selected > max && !customPageSize)
+	{
+		jumpBottom = true;
+	}
+
+	if (doUp || (customPageSize && dir == movePageUp))
+	{
+		if (m_selected > oldSel)
+		{
+			jumpBottom = true;
+		}
+		else if (oldLine > 0)
+			oldLine -= oldSel - m_selected;
+
+		if (oldLine < 0 && m_selected > maxItems)
+			oldLine = 0;
+	}
+
+	if (m_last_selectable_item == -1 && dir == justCheck)
+	{
+		m_content->cursorEnd();
+		do
+		{
+			m_content->cursorMove(-1);
+			m_last_selectable_item = m_content->cursorGet();
+		} while (!m_content->currentCursorSelectable());
+		m_content->cursorSet(m_selected);
+	}
+
+	if (doDown || (customPageSize && dir == movePageDown))
+	{
+
+		int newline = oldLine + (m_selected - oldSel);
+		if (newline < maxItems && newline > 0)
+		{
+			topLeft = oldSel - oldLine;
+		}
+		else
+		{
+			topLeft = m_selected - (maxItems - 1);
+			if (m_selected < maxItems)
+			{
+				topLeft = 0;
+			}
+		}
+
+		if (m_last_selectable_item != m_content->size() - 1 && m_selected >= m_last_selectable_item)
+			jumpBottom = true;
+	}
+
+	if (jumpBottom)
+	{
+		topLeft = max;
+	}
+	else if (dir == justCheck)
+	{
+		if (m_first_selectable_item == -1)
+		{
+			m_first_selectable_item = 0;
+			if (m_selected > 0)
+			{
+				m_content->cursorHome();
+				if (!m_content->currentCursorSelectable())
+				{
+					do
+					{
+						m_content->cursorMove(1);
+						m_first_selectable_item = m_content->cursorGet();
+					} while (!m_content->currentCursorSelectable());
+				}
+				m_content->cursorSet(m_selected);
+				if (oldLine == 0)
+					oldLine = m_selected;
+			}
+		}
+		if (indexChanged && m_selected < maxItems)
+		{
+			oldLine = m_selected;
+		}
+
+		// special case for initial draw
+		topLeft = m_selected - oldLine;
+		if (topLeft == 0 && m_selected > maxItems)
+		{
+			topLeft = m_selected - (maxItems / 2);
+		}
+	}
+	else if (doUp || (customPageSize && dir == movePageUp))
+	{
+		if (m_first_selectable_item > 0 && m_selected == m_first_selectable_item)
+		{
+			oldLine = m_selected;
+		}
+		topLeft = m_selected - oldLine;
+	}
+
+	if (topLeft < 0 || oldLine < 0)
+	{
+		topLeft = 0;
+	}
+
+	return topLeft;
 }

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -207,6 +207,11 @@ public:
 	void setForegroundColor(gRGB &col);
 	void setForegroundColorSelected(gRGB &col);
 
+	void clearBackgroundColor() { m_style.m_background_color_set = 0; }
+	void clearBackgroundColorSelected() { m_style.m_background_color_selected_set = 0; }
+	void clearForegroundColor() { m_style.m_foreground_color_set = 0; }
+	void clearForegroundColorSelected() { m_style.m_foreground_color_selected_set = 0; }
+
 	void setBorderColor(const gRGB &col) { m_style.m_border_color = col; }
 	void setBorderWidth(int size);
 
@@ -258,7 +263,7 @@ public:
 	int getScrollbarHeight() { return m_scrollbar_height; }
 	int getScrollbarOffset() { return m_scrollbar_offset; }
 	int getScrollbarBorderWidth() { return m_scrollbar_border_width; }
-	int getItemAlignment() {return m_item_alignment; }
+	int getItemAlignment() { return m_item_alignment; }
 	int getPageSize() { return m_page_size; }
 	int getItemHeight() { return m_itemheight; }
 	int getItemWidth() { return m_itemwidth; }

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -7,52 +7,54 @@
 class eListbox;
 class eSlider;
 
-class iListboxContent: public iObject
+class iListboxContent : public iObject
 {
 public:
-	virtual ~iListboxContent()=0;
+	virtual ~iListboxContent() = 0;
 
-		/* indices go from 0 to size().
-		   the end is reached when the cursor is on size(),
-		   i.e. one after the last entry (this mimics
-		   stl behavior)
+	/* indices go from 0 to size().
+	   the end is reached when the cursor is on size(),
+	   i.e. one after the last entry (this mimics
+	   stl behavior)
 
-		   cursors never invalidate - they can become invalid
-		   when stuff is removed. Cursors will always try
-		   to stay on the same data, however when the current
-		   item is removed, this won't work. you'll be notified
-		   anyway. */
+	   cursors never invalidate - they can become invalid
+	   when stuff is removed. Cursors will always try
+	   to stay on the same data, however when the current
+	   item is removed, this won't work. you'll be notified
+	   anyway. */
 #ifndef SWIG
 protected:
 	iListboxContent();
 	friend class eListbox;
-	virtual void updateClip(gRegion &){ };
-	virtual void resetClip(){ };
-	virtual void cursorHome()=0;
-	virtual void cursorEnd()=0;
-	virtual int cursorMove(int count=1)=0;
-	virtual int cursorValid()=0;
-	virtual int cursorSet(int n)=0;
-	virtual int cursorGet()=0;
+	virtual void updateClip(gRegion &){};
+	virtual void resetClip(){};
+	virtual void cursorHome() = 0;
+	virtual void cursorEnd() = 0;
+	virtual int cursorMove(int count = 1) = 0;
+	virtual int cursorValid() = 0;
+	virtual int cursorSet(int n) = 0;
+	virtual int cursorGet() = 0;
 
-	virtual void cursorSave()=0;
-	virtual void cursorRestore()=0;
-	virtual void cursorSaveLine(int n)=0;
-	virtual int cursorRestoreLine()=0;
+	virtual void cursorSave() = 0;
+	virtual void cursorRestore() = 0;
+	virtual void cursorSaveLine(int n) = 0;
+	virtual int cursorRestoreLine() = 0;
 
-	virtual int size()=0;
+	virtual int size() = 0;
 
 	virtual int currentCursorSelectable();
 
 	void setListbox(eListbox *lb);
 
 	// void setOutputDevice ? (for allocating colors, ...) .. requires some work, though
-	virtual void setSize(const eSize &size)=0;
+	virtual void setSize(const eSize &size) = 0;
 
-		/* the following functions always refer to the selected item */
-	virtual void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected)=0;
+	/* the following functions always refer to the selected item */
+	virtual void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected) = 0;
 
-	virtual int getItemHeight()=0;
+	virtual int getItemHeight() = 0;
+	virtual int getItemWidth() { return -1; }
+	virtual int getOrientation() { return 1; }
 
 	eListbox *m_listbox;
 #endif
@@ -63,25 +65,26 @@ struct eListboxStyle
 {
 	ePtr<gPixmap> m_background, m_selection;
 	int m_transparent_background;
+	int m_border_set;
 	gRGB m_background_color, m_background_color_selected,
-	m_foreground_color, m_foreground_color_selected, m_border_color, m_scollbarborder_color, m_scrollbarforeground_color, m_scrollbarbackground_color;
+		m_foreground_color, m_foreground_color_selected, m_border_color, m_scollbarborder_color, m_scrollbarforeground_color, m_scrollbarbackground_color;
 	int m_background_color_set, m_foreground_color_set, m_background_color_selected_set, m_foreground_color_selected_set, m_scrollbarforeground_color_set, m_scrollbarbackground_color_set, m_scollbarborder_color_set, m_scrollbarborder_width_set;
-		/*
-			{m_transparent_background m_background_color_set m_background}
-			{0 0 0} use global background color
-			{0 1 x} use background color
-			{0 0 p} use background picture
-			{1 x 0} use transparent background
-			{1 x p} use transparent background picture
-		*/
+	/*
+		{m_transparent_background m_background_color_set m_background}
+		{0 0 0} use global background color
+		{0 1 x} use background color
+		{0 0 p} use background picture
+		{1 x 0} use transparent background
+		{1 x p} use transparent background picture
+	*/
 
 	enum
 	{
 		alignLeft,
-		alignTop=alignLeft,
+		alignTop = alignLeft,
 		alignCenter,
 		alignRight,
-		alignBottom=alignRight,
+		alignBottom = alignRight,
 		alignBlock
 	};
 	int m_valign, m_halign, m_border_size, m_scrollbarborder_width;
@@ -91,35 +94,35 @@ struct eListboxStyle
 };
 #endif
 
-class eListbox: public eWidget
+class eListbox : public eWidget
 {
 	void updateScrollBar();
+
 public:
 	eListbox(eWidget *parent);
 	~eListbox();
 
 	PSignal0<void> selectionChanged;
 
-	enum {
+	enum
+	{
 		showOnDemand,
 		showAlways,
 		showNever,
 		showLeftOnDemand,
-		showLeftAlways
+		showLeftAlways,
+		showTopOnDemand,
+		showTopAlways
 	};
 
-	enum {
+	enum
+	{
 		byPage,
 		byLine
 	};
 
-	enum {
-		listVertical,
-		listHorizontal,
-		listGrid
-	};
-
-	enum {
+	enum
+	{
 		DefaultScrollBarWidth = 10,
 		DefaultScrollBarOffset = 5,
 		DefaultScrollBarBorderWidth = 1,
@@ -128,18 +131,32 @@ public:
 		DefaultWrapAround = true,
 		DefaultPageSize = 0
 	};
+	enum
+	{
+		orVertical = 1,
+		orHorizontal = 2,
+		orGrid = 3
+	};
+	enum
+	{
+		itemAlignDefault,
+		itemAlignCenter,
+		itemAlignJustify
+	};
 
+	void setItemAlignment(int align);
 	void setScrollbarScroll(int scroll);
 	void setScrollbarMode(int mode);
-	void setWrapAround(bool);
+	void setWrapAround(bool state) { m_enabled_wrap_around = state; }
 
+	void setOrientation(int orientation);
 	void setContent(iListboxContent *content);
 
 	void allowNativeKeys(bool allow);
 	void enableAutoNavigation(bool allow) { allowNativeKeys(allow); }
 
 	int getCurrentIndex();
-	void moveSelection(long how);
+	void moveSelection(int how);
 	void moveSelectionTo(int index);
 	void moveToEnd(); // Deprecated
 	bool atBegin();
@@ -160,7 +177,8 @@ public:
 	void goFirst() { moveSelection(moveFirst); }
 	void goLast() { moveSelection(moveLast); }
 
-	enum ListboxActions {
+	enum ListboxActions
+	{
 		moveUp,
 		moveDown,
 		moveTop,
@@ -171,13 +189,13 @@ public:
 		refresh,
 		moveLeft,
 		moveRight,
-		moveFirst, // for future use
-		moveLast, // for future use
-		movePageLeft, // for future use
-		movePageRight, // for future use
-		moveEnd = moveBottom, // deprecated
-		pageUp = movePageUp,  // deprecated
-		pageDown = movePageDown  // deprecated
+		moveFirst,				// for future use
+		moveLast,				// for future use
+		movePageLeft,			// for future use
+		movePageRight,			// for future use
+		moveEnd = moveBottom,	// deprecated
+		pageUp = movePageUp,	// deprecated
+		pageDown = movePageDown // deprecated
 	};
 
 	void setItemHeight(int h);
@@ -188,24 +206,29 @@ public:
 	void setBackgroundColorSelected(gRGB &col);
 	void setForegroundColor(gRGB &col);
 	void setForegroundColorSelected(gRGB &col);
-	void setBorderColor(const gRGB &col);
+
+	void setBorderColor(const gRGB &col) { m_style.m_border_color = col; }
 	void setBorderWidth(int size);
-	void setBackgroundPixmap(ePtr<gPixmap> &pixmap);
-	void setSelectionPixmap(ePtr<gPixmap> &pixmap);
+
+	void setBackgroundPixmap(ePtr<gPixmap> &pm) { m_style.m_background = pm; }
+	void setSelectionPixmap(ePtr<gPixmap> &pm) { m_style.m_selection = pm; }
+	void setSelectionBorderHidden() { m_style.m_border_set = 1; }
 
 	void setScrollbarForegroundPixmap(ePtr<gPixmap> &pm);
 	void setScrollbarBackgroundPixmap(ePtr<gPixmap> &pm);
 	void setScrollbarBorderWidth(int width);
-	void setScrollbarWidth(int size);
-	void setScrollbarOffset(int size);
 
-	void setFont(gFont *font);
-	void setEntryFont(gFont *font);
-	void setValueFont(gFont *font);
-	void setVAlign(int align);
-	void setHAlign(int align);
-	void setTextPadding(const eRect &padding);
-	void setUseVTIWorkaround(void);
+	void setScrollbarWidth(int size) { m_scrollbar_width = size; }
+	void setScrollbarHeight(int size) { m_scrollbar_height = size; }
+	void setScrollbarOffset(int size) { m_scrollbar_offset = size; }
+
+	void setFont(gFont *font) { m_style.m_font = font; }
+	void setEntryFont(gFont *font) { m_style.m_font = font; }
+	void setValueFont(gFont *font) { m_style.m_valuefont = font; }
+	void setVAlign(int align) { m_style.m_valign = align; }
+	void setHAlign(int align) { m_style.m_halign = align; }
+	void setTextPadding(const eRect &padding) { m_style.m_text_padding = padding; }
+	void setUseVTIWorkaround(void) { m_style.m_use_vti_workaround = 1; }
 
 	void setScrollbarBorderColor(const gRGB &col);
 	void setScrollbarForegroundColor(gRGB &col);
@@ -213,58 +236,60 @@ public:
 
 	void setPageSize(int size) { m_page_size = size; }
 
-	static void setDefaultScrollbarStyle(int width, int offset, int borderwidth, int scroll, int mode, bool enablewraparound, int pageSize) { 
-			defaultScrollBarWidth = width; 
-			defaultScrollBarOffset = offset; 
-			defaultScrollBarBorderWidth = borderwidth; 
-			defaultScrollBarScroll = scroll; 
-			defaultWrapAround = enablewraparound;
-			defaultScrollBarMode = mode;
-			defaultPageSize = pageSize;
-		}
+	static void setDefaultScrollbarStyle(int width, int offset, int borderwidth, int scroll, int mode, bool enablewraparound, int pageSize)
+	{
+		defaultScrollBarWidth = width;
+		defaultScrollBarOffset = offset;
+		defaultScrollBarBorderWidth = borderwidth;
+		defaultScrollBarScroll = scroll;
+		defaultWrapAround = enablewraparound;
+		defaultScrollBarMode = mode;
+		defaultPageSize = pageSize;
+	}
 
 	static void setDefaultPadding(const eRect &padding) { defaultPadding = padding; }
 
-	void setOrientation(int o);
 	void setTopIndex(int idx);
 
 	bool getWrapAround() { return m_enabled_wrap_around; }
 	int getScrollbarScroll() { return m_scrollbar_scroll; }
 	int getScrollbarMode() { return m_scrollbar_mode; }
 	int getScrollbarWidth() { return m_scrollbar_width; }
+	int getScrollbarHeight() { return m_scrollbar_height; }
 	int getScrollbarOffset() { return m_scrollbar_offset; }
 	int getScrollbarBorderWidth() { return m_scrollbar_border_width; }
+	int getItemAlignment() {return m_item_alignment; }
 	int getPageSize() { return m_page_size; }
 	int getItemHeight() { return m_itemheight; }
 	int getItemWidth() { return m_itemwidth; }
-	int getOrientation() { return m_list_orientation; }
+	int getOrientation() { return m_orientation; }
 	int getTopIndex() { return m_top; }
-	bool getSelectionEnable() {return m_selection_enabled; }
-	gFont* getFont() {return m_style.m_font; }
-	gFont* getEntryFont() {return m_style.m_font; }
-	gFont* getValueFont() {return m_style.m_valuefont; }
-
+	bool getSelectionEnable() { return m_selection_enabled; }
+	gFont *getFont() { return m_style.m_font; }
+	gFont *getEntryFont() { return m_style.m_font; }
+	gFont *getValueFont() { return m_style.m_valuefont; }
 
 #ifndef SWIG
 	struct eListboxStyle *getLocalStyle(void);
 
-		/* entryAdded: an entry was added *before* the given index. it's index is the given number. */
+	/* entryAdded: an entry was added *before* the given index. it's index is the given number. */
 	void entryAdded(int index);
-		/* entryRemoved: an entry with the given index was removed. */
+	/* entryRemoved: an entry with the given index was removed. */
 	void entryRemoved(int index);
-		/* entryChanged: the entry with the given index was changed and should be redrawn. */
+	/* entryChanged: the entry with the given index was changed and should be redrawn. */
 	void entryChanged(int index);
-		/* the complete list changed. you should not attemp to keep the current index. */
-	void entryReset(bool cursorHome=true);
+	/* the complete list changed. you should not attemp to keep the current index. */
+	void entryReset(bool cursorHome = true);
 
 	int getEntryTop();
 	void invalidate(const gRegion &region = gRegion::invalidRegion());
 
 protected:
-	int event(int event, void *data=0, void *data2=0);
+	int event(int event, void *data = 0, void *data2 = 0);
 	void recalcSize();
 
 private:
+	int moveSelectionLineMode(bool doUp, bool doDown, int dir, int oldSel, int oldTopLeft, int maxItems, bool indexChanged, int pageOffset, int topLeft);
 	static int defaultScrollBarWidth;
 	static int defaultScrollBarOffset;
 	static int defaultScrollBarBorderWidth;
@@ -274,19 +299,23 @@ private:
 	static bool defaultWrapAround;
 	static eRect defaultPadding;
 
-	int m_list_orientation,m_scrollbar_mode, m_prev_scrollbar_page, m_scrollbar_scroll;
+	int m_scrollbar_mode, m_prev_scrollbar_page, m_scrollbar_scroll;
 	bool m_content_changed;
 	bool m_enabled_wrap_around;
 
 	int m_scrollbar_width;
+	int m_scrollbar_height;
 	int m_scrollbar_offset;
 	int m_scrollbar_border_width;
-	int m_top, m_selected;
+	int m_top, m_left, m_selected;
 	int m_itemheight;
 	int m_itemwidth;
-	int m_items_per_page;
+	int m_orientation;
+	int m_max_columns;
+	int m_max_rows;
 	int m_selection_enabled;
 	int m_page_size;
+	int m_item_alignment;
 
 	bool m_native_keys_bound;
 	int m_first_selectable_item;

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -10,33 +10,33 @@
 using namespace std;
 
 /*
-    The basic idea is to have an interface which gives all relevant list
-    processing functions, and can be used by the listbox to browse trough
-    the list.
+	The basic idea is to have an interface which gives all relevant list
+	processing functions, and can be used by the listbox to browse trough
+	the list.
 
-    The listbox directly uses the implemented cursor. It tries hard to avoid
-    iterating trough the (possibly very large) list, so it should be O(1),
-    i.e. the performance should not be influenced by the size of the list.
+	The listbox directly uses the implemented cursor. It tries hard to avoid
+	iterating trough the (possibly very large) list, so it should be O(1),
+	i.e. the performance should not be influenced by the size of the list.
 
-    The list interface knows how to draw the current entry to a specified
-    offset. Different interfaces can be used to adapt different lists,
-    pre-filter lists on the fly etc.
+	The list interface knows how to draw the current entry to a specified
+	offset. Different interfaces can be used to adapt different lists,
+	pre-filter lists on the fly etc.
 
 		cursorSave/Restore is used to avoid re-iterating the list on redraw.
 		The current selection is always selected as cursor position, the
-    cursor is then positioned to the start, and then iterated. This gives
-    at most 2x m_items_per_page cursor movements per redraw, indepenent
-    of the size of the list.
+	cursor is then positioned to the start, and then iterated. This gives
+	at most 2x m_items_per_page cursor movements per redraw, indepenent
+	of the size of the list.
 
-    Although cursorSet is provided, it should be only used when there is no
-    other way, as it involves iterating trough the list.
+	Although cursorSet is provided, it should be only used when there is no
+	other way, as it involves iterating trough the list.
  */
 
 iListboxContent::~iListboxContent()
 {
 }
 
-iListboxContent::iListboxContent(): m_listbox(0)
+iListboxContent::iListboxContent() : m_listbox(0)
 {
 }
 
@@ -44,6 +44,8 @@ void iListboxContent::setListbox(eListbox *lb)
 {
 	m_listbox = lb;
 	m_listbox->setItemHeight(getItemHeight());
+	m_listbox->setItemWidth(getItemWidth());
+	m_listbox->setOrientation(getOrientation());
 }
 
 int iListboxContent::currentCursorSelectable()
@@ -56,7 +58,7 @@ int iListboxContent::currentCursorSelectable()
 DEFINE_REF(eListboxPythonStringContent);
 
 eListboxPythonStringContent::eListboxPythonStringContent()
-	:m_cursor(0), m_saved_cursor(0), m_saved_cursor_line(0), m_itemheight(25)
+	: m_cursor(0), m_saved_cursor(0), m_saved_cursor_line(0), m_itemheight(25), m_itemwidth(25), m_orientation(1)
 {
 }
 
@@ -163,7 +165,7 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 	gRGB border_color;
 	int border_size = 0;
 
-		/* get local listbox style, if present */
+	/* get local listbox style, if present */
 	if (m_listbox)
 		local_style = m_listbox->getLocalStyle();
 
@@ -191,29 +193,50 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 				painter.setForegroundColor(local_style->m_foreground_color);
 		}
 	}
-	if (!fnt) {
+	if (!fnt)
+	{
 		style.getFont(eWindowStyle::fontListbox, fnt);
 	}
+
+	int orientation = m_listbox->getOrientation();
 
 	/* if we have no transparent background */
 	if (!local_style || !local_style->m_transparent_background)
 	{
-			/* blit background picture, if available (otherwise, clear only) */
+		/* blit background picture, if available (otherwise, clear only) */
 		if (local_style && local_style->m_background && cursorValid)
 		{
-			if (validitem) painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			if (validitem)
+			{
+				int x = offset.x();
+				int y = offset.y();
+				x += (orientation & 2) ? (m_itemsize.width() - local_style->m_background->size().width()) / 2 : 0;	 // vertical
+				y += (orientation & 1) ? (m_itemsize.height() - local_style->m_background->size().height()) / 2 : 0; // horizontal
+				painter.blit(local_style->m_background, ePoint(x, y), eRect(), 0);
+			}
 		}
 		else
 			painter.clear();
-	} else
+	}
+	else
 	{
 		if (local_style->m_background && cursorValid)
 		{
-			if (validitem) painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+			if (validitem)
+			{
+				int x = offset.x();
+				int y = offset.y();
+				x += (orientation & 2) ? (m_itemsize.width() - local_style->m_background->size().width()) / 2 : 0;	 // vertical
+				y += (orientation & 1) ? (m_itemsize.height() - local_style->m_background->size().height()) / 2 : 0; // horizontal
+				painter.blit(local_style->m_background, ePoint(x, y), eRect(), gPainter::BT_ALPHATEST);
+			}
 		}
 		else if (selected && !local_style->m_selection)
 			painter.clear();
 	}
+	// Draw frame here so to be under the content
+	if (selected && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
+		style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 
 	if (validitem)
 	{
@@ -221,7 +244,7 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 		ePyObject item = PyList_GET_ITEM(m_list, m_cursor); // borrowed reference!
 		painter.setFont(fnt);
 
-			/* the user can supply tuples, in this case the first one will be displayed. */
+		/* the user can supply tuples, in this case the first one will be displayed. */
 		if (PyTuple_Check(item))
 		{
 			if (PyTuple_Size(item) == 1)
@@ -230,14 +253,25 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 		}
 
 		if (selected && local_style && local_style->m_selection)
-			painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+		{
+			int x = offset.x();
+			int y = offset.y();
+			x += (orientation & 2) ? (m_itemsize.width() - local_style->m_selection->size().width()) / 2 : 0;	// vertical
+			y += (orientation & 1) ? (m_itemsize.height() - local_style->m_selection->size().height()) / 2 : 0; // horizontal
+			painter.blit(local_style->m_selection, ePoint(x, y), eRect(), gPainter::BT_ALPHATEST);
+		}
 
 		if (!item || item == Py_None)
 		{
-				/* seperator */
+			/* Please Note .. this needs to fixed in the navigation code because this separator can be selected as an active element*/
+			/* seperator */
 			int half_height = m_itemsize.height() / 2;
-			painter.fill(eRect(offset.x() + half_height, offset.y() + half_height - 2, m_itemsize.width() - m_itemsize.height(), 4));
-		} 
+			int half_width = m_itemsize.width() / 2;
+			if (orientation == 1)
+				painter.fill(eRect(offset.x() + half_height, offset.y() + half_height - 2, m_itemsize.width() - m_itemsize.height(), 4));
+			if (orientation == 2)
+				painter.fill(eRect(offset.x() + half_width, offset.y() + half_width - 2, m_itemsize.width() - m_itemsize.height(), 4));
+		}
 		else
 		{
 			const char *string = PyUnicode_Check(item) ? PyUnicode_AsUTF8(item) : "<not-a-string>";
@@ -249,7 +283,7 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 			if (local_style)
 			{
 				text_offset += local_style->m_text_padding.topLeft();
-//HACK VTI hat hier scheinbar einen Fehler und addiert den Textoffset zweimal auf, also machen wir das hier auch so
+				// HACK VTI hat hier scheinbar einen Fehler und addiert den Textoffset zweimal auf, also machen wir das hier auch so
 				if (local_style->m_use_vti_workaround)
 					text_offset += local_style->m_text_padding.topLeft();
 
@@ -275,17 +309,14 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 				int paddingh = local_style->m_text_padding.height();
 
 				auto position = eRect(text_offset.x(), text_offset.y(), m_itemsize.width() - (paddingx * 2) - paddingw, m_itemsize.height() - (paddingy * 2) - paddingh);
-				painter.renderText(position, string, flags, border_color, border_size);
 
+				painter.renderText(position, string, flags, border_color, border_size);
 			}
-			else {
+			else
+			{
 				painter.renderText(eRect(text_offset, m_itemsize), string, flags, border_color, border_size);
 			}
-			
 		}
-
-		if (selected && (!local_style || !local_style->m_selection))
-			style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 	}
 
 	painter.clippop();
@@ -297,7 +328,8 @@ void eListboxPythonStringContent::setList(ePyObject list)
 	if (!PyList_Check(list))
 	{
 		m_list = ePyObject();
-	} else
+	}
+	else
 	{
 		m_list = list;
 		Py_INCREF(m_list);
@@ -307,11 +339,27 @@ void eListboxPythonStringContent::setList(ePyObject list)
 		m_listbox->entryReset(false);
 }
 
+void eListboxPythonStringContent::setOrientation(int orientation)
+{
+	m_orientation = orientation;
+	if (m_listbox)
+	{
+		m_listbox->setOrientation(orientation);
+	}
+}
+
 void eListboxPythonStringContent::setItemHeight(int height)
 {
 	m_itemheight = height;
 	if (m_listbox)
 		m_listbox->setItemHeight(height);
+}
+
+void eListboxPythonStringContent::setItemWidth(int width)
+{
+	m_itemwidth = width;
+	if (m_listbox)
+		m_listbox->setItemWidth(width);
 }
 
 PyObject *eListboxPythonStringContent::getCurrentSelection()
@@ -335,8 +383,8 @@ void eListboxPythonStringContent::invalidate()
 	if (m_listbox)
 	{
 		int s = size();
-		if ( m_cursor >= s )
-			m_listbox->moveSelectionTo(s?s-1:0);
+		if (m_cursor >= s)
+			m_listbox->moveSelectionTo(s ? s - 1 : 0);
 		else
 			m_listbox->invalidate();
 	}
@@ -359,7 +407,7 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 	painter.clip(itemrect);
 	style.setStyle(painter, selected ? eWindowStyle::styleListboxSelected : eWindowStyle::styleListboxNormal);
 
-		/* get local listbox style, if present */
+	/* get local listbox style, if present */
 	if (m_listbox)
 		local_style = m_listbox->getLocalStyle();
 
@@ -395,76 +443,100 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 	if (!fnt2)
 		style.getFont(eWindowStyle::fontValue, fnt2);
 
+	int orientation = m_listbox->getOrientation();
+
 	if (!local_style || !local_style->m_transparent_background)
-		/* if we have no transparent background */
+	/* if we have no transparent background */
 	{
 		/* blit background picture, if available (otherwise, clear only) */
 		if (local_style && local_style->m_background && cursorValid)
-			painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+		{
+			int x = offset.x();
+			int y = offset.y();
+			x += (orientation & 2) ? (m_itemsize.width() - local_style->m_background->size().width()) / 2 : 0;	 // vertical
+			y += (orientation & 1) ? (m_itemsize.height() - local_style->m_background->size().height()) / 2 : 0; // horizontal
+			painter.blit(local_style->m_background, ePoint(x, y), eRect(), 0);
+		}
 		else
 			painter.clear();
-	} else
+	}
+	else
 	{
 		if (local_style->m_background && cursorValid)
-			painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+		{
+			int x = offset.x();
+			int y = offset.y();
+			x += (orientation & 2) ? (m_itemsize.width() - local_style->m_background->size().width()) / 2 : 0;	 // vertical
+			y += (orientation & 1) ? (m_itemsize.height() - local_style->m_background->size().height()) / 2 : 0; // horizontal
+			painter.blit(local_style->m_background, ePoint(x, y), eRect(), gPainter::BT_ALPHATEST);
+		}
 		else if (selected && !local_style->m_selection)
 			painter.clear();
 	}
 
+	// Draw frame here so to be drawn under icons
+	if (selected && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
+		style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 	if (m_list && cursorValid)
 	{
-			/* get current list item */
+		/* get current list item */
 		ePyObject item = PyList_GET_ITEM(m_list, cursorGet()); // borrowed reference!
 		ePyObject text, value;
 		painter.setFont(fnt);
 
 		if (selected && local_style && local_style->m_selection)
-			painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (m_itemsize.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+		{
+			int x = offset.x();
+			int y = offset.y();
+			x += (orientation & 2) ? (m_itemsize.width() - local_style->m_selection->size().width()) / 2 : 0;	// vertical
+			y += (orientation & 1) ? (m_itemsize.height() - local_style->m_selection->size().height()) / 2 : 0; // horizontal
+			painter.blit(local_style->m_selection, ePoint(x, y), eRect(), gPainter::BT_ALPHATEST);
+		}
 
-			/* the first tuple element is a string for the left side.
-			   the second one will be called, and the result shall be an tuple.
+		/* the first tuple element is a string for the left side.
+		   the second one will be called, and the result shall be an tuple.
 
-			   of this tuple,
-			   the first one is the type (string).
-			   the second one is the value. */
+		   of this tuple,
+		   the first one is the type (string).
+		   the second one is the value. */
 		if (PyTuple_Check(item))
 		{
-				/* handle left part. get item from tuple, convert to string, display. */
+			/* handle left part. get item from tuple, convert to string, display. */
 			text = PyTuple_GET_ITEM(item, 0);
 			text = PyObject_Str(text); /* creates a new object - old object was borrowed! */
 			const char *string = (text && PyUnicode_Check(text)) ? PyUnicode_AsUTF8(text) : "<not-a-string>";
-			eRect labelrect(ePoint(offset.x()+15, offset.y()), m_itemsize);
+			eRect labelrect(ePoint(offset.x() + 15, offset.y()), m_itemsize);
 			painter.renderText(labelrect, string,
-				gPainter::RT_HALIGN_LEFT | gPainter::RT_VALIGN_CENTER, border_color, border_size);
+							   gPainter::RT_HALIGN_LEFT | gPainter::RT_VALIGN_CENTER, border_color, border_size);
 			Py_XDECREF(text);
 
-				/* when we have no label, align value to the left. (FIXME:
-				   don't we want to specifiy this individually?) */
+			/* when we have no label, align value to the left. (FIXME:
+			   don't we want to specifiy this individually?) */
 			int value_alignment_left = !*string;
 
-				/* now, handle the value. get 2nd part from tuple*/
+			/* now, handle the value. get 2nd part from tuple*/
 			if (PyTuple_Size(item) >= 2) // when no 2nd entry is in tuple this is a non selectable entry without config part
 				value = PyTuple_GET_ITEM(item, 1);
 
 			if (value)
 			{
 				ePyObject args = PyTuple_New(1);
-				PyTuple_SET_ITEM(args, 0, PyInt_FromLong(selected));
+				PyTuple_SET_ITEM(args, 0, PyLong_FromLong(selected));
 
-					/* CallObject will call __call__ which should return the value tuple */
+				/* CallObject will call __call__ which should return the value tuple */
 				value = PyObject_CallObject(value, args);
 
 				if (PyErr_Occurred())
 					PyErr_Print();
 
 				Py_DECREF(args);
-					/* the PyInt was stolen. */
+				/* the PyInt was stolen. */
 			}
 
-				/*  check if this is really a tuple */
+			/*  check if this is really a tuple */
 			if (value && PyTuple_Check(value))
 			{
-					/* convert type to string */
+				/* convert type to string */
 				ePyObject type = PyTuple_GET_ITEM(value, 0);
 				const char *atype = (type && PyUnicode_Check(type)) ? PyUnicode_AsUTF8(type) : 0;
 
@@ -504,7 +576,7 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 								/* plist is 0 or borrowed */
 							}
 						}
-							/* find the width of the label, to prevent the value overwriting it. */
+						/* find the width of the label, to prevent the value overwriting it. */
 						ePoint valueoffset = offset;
 						eSize valuesize = m_itemsize;
 						int labelwidth = 0;
@@ -518,8 +590,10 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 						valueoffset.setX(valueoffset.x() + 15 + labelwidth);
 						valuesize.setWidth(valuesize.width() - 15 - labelwidth - 15);
 						painter.renderText(eRect(valueoffset, valuesize), text, flags | gPainter::RT_VALIGN_CENTER, border_color, border_size, markedpos, &m_text_offset[cursor]);
-					/* pvalue is borrowed */
-					} else if (!strcmp(atype, "slider")) {
+						/* pvalue is borrowed */
+					}
+					else if (!strcmp(atype, "slider"))
+					{
 
 						ePyObject pvalue = PyTuple_GET_ITEM(value, 1);
 						ePyObject pmin = PyTuple_GET_ITEM(value, 2);
@@ -530,13 +604,14 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 						int max = (pmax && PyLong_Check(pmax)) ? PyLong_AsLong(pmax) : 100;
 
 						// if min < 0 and max < min -> replace min,max
-						if(min < 0 && max < min) {
+						if (min < 0 && max < min)
+						{
 							int newmax = min;
 							min = max;
 							max = newmax;
 						}
 
-//OLD					int size = (psize && PyLong_Check(psize)) ? PyLong_AsLong(psize) : 100;
+						// OLD					int size = (psize && PyLong_Check(psize)) ? PyLong_AsLong(psize) : 100;
 						int value_area = 0;
 
 						/* draw value at the end of the slider */
@@ -544,18 +619,18 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 						{
 							value_area = 100;
 							painter.setFont(fnt2);
-							painter.renderText(eRect(ePoint(offset.x()-15, offset.y()), m_itemsize), std::to_string(value), gPainter::RT_HALIGN_RIGHT| gPainter::RT_VALIGN_CENTER, border_color, border_size);
+							painter.renderText(eRect(ePoint(offset.x() - 15, offset.y()), m_itemsize), std::to_string(value), gPainter::RT_HALIGN_RIGHT | gPainter::RT_VALIGN_CENTER, border_color, border_size);
 						}
 						/* calc. slider length */
-					    int width = (m_itemsize.width() - m_seperation - 15 - value_area) * (value - min) / (max - min);
-//OLD					int width = (m_itemsize.width() - m_seperation - 15 - value_area) * value / size;
+						int width = (m_itemsize.width() - m_seperation - 15 - value_area) * (value - min) / (max - min);
+						// OLD					int width = (m_itemsize.width() - m_seperation - 15 - value_area) * value / size;
 						int height = m_itemsize.height();
 
 						/* draw slider */
-						//painter.fill(eRect(offset.x() + m_seperation, offset.y(), width, height));
+						// painter.fill(eRect(offset.x() + m_seperation, offset.y(), width, height));
 						if (m_slider_height % 2 != height % 2)
 							m_slider_height -= 1;
-						if(m_slider_height + 2*m_slider_space >= height) // frame out of selector = without frame
+						if (m_slider_height + 2 * m_slider_space >= height) // frame out of selector = without frame
 							m_slider_space = 0;
 						int slider_y_offset = (height - m_slider_height) / 2;
 						if (m_slider_space)
@@ -568,7 +643,7 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 							painter.line(tr, br);
 							painter.line(br, bl);
 							painter.line(bl, tl);
-							painter.fill(eRect(offset.x() + m_seperation + m_slider_space + 1, offset.y() + slider_y_offset, width - 2*(m_slider_space + 1), m_slider_height));
+							painter.fill(eRect(offset.x() + m_seperation + m_slider_space + 1, offset.y() + slider_y_offset, width - 2 * (m_slider_space + 1), m_slider_height));
 						}
 						else
 						{
@@ -591,9 +666,9 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 							const char *value = (ppixmap && PyUnicode_Check(ppixmap)) ? PyUnicode_AsUTF8(ppixmap) : "<not-a-string>";
 							painter.setFont(fnt2);
 							if (value_alignment_left)
-								painter.renderText(eRect(ePoint(offset.x()-15, offset.y()), m_itemsize), value, gPainter::RT_HALIGN_LEFT | gPainter::RT_VALIGN_CENTER, border_color, border_size);
+								painter.renderText(eRect(ePoint(offset.x() - 15, offset.y()), m_itemsize), value, gPainter::RT_HALIGN_LEFT | gPainter::RT_VALIGN_CENTER, border_color, border_size);
 							else
-								painter.renderText(eRect(ePoint(offset.x()-15, offset.y()), m_itemsize), value, gPainter::RT_HALIGN_RIGHT| gPainter::RT_VALIGN_CENTER, border_color, border_size);
+								painter.renderText(eRect(ePoint(offset.x() - 15, offset.y()), m_itemsize), value, gPainter::RT_HALIGN_RIGHT | gPainter::RT_VALIGN_CENTER, border_color, border_size);
 						}
 						else
 						{
@@ -605,14 +680,12 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 					}
 				}
 				/* type is borrowed */
-			} else if (value)
+			}
+			else if (value)
 				eWarning("[eListboxPythonConfigContent] second value of tuple is not a tuple.");
 			if (value)
 				Py_DECREF(value);
 		}
-
-		if (selected && (!local_style || !local_style->m_selection))
-			style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 	}
 
 	painter.clippop();
@@ -625,11 +698,11 @@ int eListboxPythonConfigContent::currentCursorSelectable()
 
 //////////////////////////////////////
 
-	/* todo: make a real infrastructure here! */
+/* todo: make a real infrastructure here! */
 RESULT SwigFromPython(ePtr<gPixmap> &res, PyObject *obj);
 
 eListboxPythonMultiContent::eListboxPythonMultiContent()
-	:m_clip(gRegion::invalidRegion()), m_old_clip(gRegion::invalidRegion())
+	: m_clip(gRegion::invalidRegion()), m_old_clip(gRegion::invalidRegion())
 {
 }
 
@@ -642,6 +715,7 @@ eListboxPythonMultiContent::~eListboxPythonMultiContent()
 
 void eListboxPythonMultiContent::setSelectionClip(eRect &rect, bool update)
 {
+	/* Please Note! This will currently only work for verticial list box */
 	m_selection_clip = rect;
 	if (m_listbox)
 		rect.moveBy(ePoint(0, m_listbox->getEntryTop()));
@@ -653,7 +727,7 @@ void eListboxPythonMultiContent::setSelectionClip(eRect &rect, bool update)
 		m_listbox->entryChanged(cursorGet());
 }
 
-static void clearRegionHelper(gPainter &painter, eListboxStyle *local_style, const ePoint &offset, const eSize &size, ePyObject &pbackColor, bool cursorValid, bool clear=true)
+static void clearRegionHelper(gPainter &painter, eListboxStyle *local_style, const ePoint &offset, const eSize &size, ePyObject &pbackColor, bool cursorValid, bool clear, int orientation)
 {
 	if (pbackColor)
 	{
@@ -666,10 +740,11 @@ static void clearRegionHelper(gPainter &painter, eListboxStyle *local_style, con
 			painter.setBackgroundColor(local_style->m_background_color);
 		if (local_style->m_background && cursorValid)
 		{
-			if (local_style->m_transparent_background)
-				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
-			else
-				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			int x = offset.x();
+			int y = offset.y();
+			x += (orientation & 2) ? (size.width() - local_style->m_background->size().width()) / 2 : 0;   // vertical
+			y += (orientation & 1) ? (size.height() - local_style->m_background->size().height()) / 2 : 0; // horizontal
+			painter.blit(local_style->m_background, ePoint(x, y), eRect(), local_style->m_transparent_background ? gPainter::BT_ALPHATEST : 0);
 			return;
 		}
 		else if (local_style->m_transparent_background)
@@ -679,7 +754,7 @@ static void clearRegionHelper(gPainter &painter, eListboxStyle *local_style, con
 		painter.clear();
 }
 
-static void clearRegionSelectedHelper(gPainter &painter, eListboxStyle *local_style, const ePoint &offset, const eSize &size, ePyObject &pbackColorSelected, bool cursorValid, bool clear=true)
+static void clearRegionSelectedHelper(gPainter &painter, eListboxStyle *local_style, const ePoint &offset, const eSize &size, ePyObject &pbackColorSelected, bool cursorValid, bool clear, int orientation)
 {
 	if (pbackColorSelected)
 	{
@@ -692,10 +767,11 @@ static void clearRegionSelectedHelper(gPainter &painter, eListboxStyle *local_st
 			painter.setBackgroundColor(local_style->m_background_color_selected);
 		if (local_style->m_background && cursorValid)
 		{
-			if (local_style->m_transparent_background)
-				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
-			else
-				painter.blit(local_style->m_background, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_background->size().height()) / 2), eRect(), 0);
+			int x = offset.x();
+			int y = offset.y();
+			x += (orientation & 2) ? (size.width() - local_style->m_background->size().width()) / 2 : 0;   // vertical
+			y += (orientation & 1) ? (size.height() - local_style->m_background->size().height()) / 2 : 0; // horizontal
+			painter.blit(local_style->m_background, ePoint(x, y), eRect(), local_style->m_transparent_background ? gPainter::BT_ALPHATEST : 0);
 			return;
 		}
 	}
@@ -703,7 +779,7 @@ static void clearRegionSelectedHelper(gPainter &painter, eListboxStyle *local_st
 		painter.clear();
 }
 
-static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *local_style, ePyObject pforeColor, ePyObject pforeColorSelected, ePyObject pbackColor, ePyObject pbackColorSelected, int selected, gRegion &rc, eRect &sel_clip, const ePoint &offset, const eSize &size, bool cursorValid, bool clear=true)
+static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *local_style, ePyObject pforeColor, ePyObject pforeColorSelected, ePyObject pbackColor, ePyObject pbackColorSelected, int selected, gRegion &rc, eRect &sel_clip, const ePoint &offset, const eSize &size, bool cursorValid, bool clear, int orientation)
 {
 	if (selected && sel_clip.valid())
 	{
@@ -712,7 +788,7 @@ static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *l
 		{
 			painter.clip(part);
 			style.setStyle(painter, eWindowStyle::styleListboxNormal);
-			clearRegionHelper(painter, local_style, offset, size, pbackColor, cursorValid, clear);
+			clearRegionHelper(painter, local_style, offset, size, pbackColor, cursorValid, clear, orientation);
 			painter.clippop();
 			selected = 0;
 		}
@@ -721,7 +797,7 @@ static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *l
 		{
 			painter.clip(part);
 			style.setStyle(painter, eWindowStyle::styleListboxSelected);
-			clearRegionSelectedHelper(painter, local_style, offset, size, pbackColorSelected, cursorValid, clear);
+			clearRegionSelectedHelper(painter, local_style, offset, size, pbackColorSelected, cursorValid, clear, orientation);
 			painter.clippop();
 			selected = 1;
 		}
@@ -729,14 +805,20 @@ static void clearRegion(gPainter &painter, eWindowStyle &style, eListboxStyle *l
 	else if (selected)
 	{
 		style.setStyle(painter, eWindowStyle::styleListboxSelected);
-		clearRegionSelectedHelper(painter, local_style, offset, size, pbackColorSelected, cursorValid, clear);
+		clearRegionSelectedHelper(painter, local_style, offset, size, pbackColorSelected, cursorValid, clear, orientation);
 		if (local_style && local_style->m_selection)
-			painter.blit(local_style->m_selection, ePoint(offset.x(), offset.y() + (size.height() - local_style->m_selection->size().height()) / 2), eRect(), gPainter::BT_ALPHATEST);
+		{
+			int x = offset.x();
+			int y = offset.y();
+			x += (orientation & 2) ? (size.width() - local_style->m_selection->size().width()) / 2 : 0;	  // vertical
+			y += (orientation & 1) ? (size.height() - local_style->m_selection->size().height()) / 2 : 0; // horizontal
+			painter.blit(local_style->m_selection, ePoint(x, y), eRect(), gPainter::BT_ALPHATEST);
+		}
 	}
 	else
 	{
 		style.setStyle(painter, eWindowStyle::styleListboxNormal);
-		clearRegionHelper(painter, local_style, offset, size, pbackColor, cursorValid, clear);
+		clearRegionHelper(painter, local_style, offset, size, pbackColor, cursorValid, clear, orientation);
 	}
 
 	if (selected)
@@ -773,7 +855,7 @@ static ePyObject lookupColor(ePyObject color, ePyObject data)
 
 	unsigned int icolor = PyLong_AsUnsignedLongMask(color);
 
-		/* check if we have the "magic" template color */
+	/* check if we have the "magic" template color */
 	if (data && (icolor & 0xFF000000) == 0xFF000000)
 	{
 		int index = icolor & 0xFFFFFF;
@@ -796,36 +878,41 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 	bool cursorValid = this->cursorValid();
 	gRGB border_color;
 	int border_size = 0;
+	int orientation = 0;
 
 	if (sel_clip.valid())
 		sel_clip.moveBy(offset);
 
-		/* get local listbox style, if present */
+	/* get local listbox style, if present */
 	if (m_listbox)
 	{
 		local_style = m_listbox->getLocalStyle();
 		border_size = local_style->m_border_size;
 		border_color = local_style->m_border_color;
+		orientation = m_listbox->getOrientation();
 	}
 
 	painter.clip(itemregion);
-	clearRegion(painter, style, local_style, ePyObject(), ePyObject(), ePyObject(), ePyObject(), selected, itemregion, sel_clip, offset, m_itemsize, cursorValid);
+	clearRegion(painter, style, local_style, ePyObject(), ePyObject(), ePyObject(), ePyObject(), selected, itemregion, sel_clip, offset, m_itemsize, cursorValid, true, orientation);
+	// Draw frame here so to be under the content
+	if (selected && !sel_clip.valid() && (!local_style || !local_style->m_selection) && (!local_style || !local_style->m_border_set))
+		style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
 
 	ePyObject items, buildfunc_ret;
 
 	if (m_list && cursorValid)
 	{
-			/* a multicontent list can be used in two ways:
-				either each item is a list of (TYPE,...)-tuples,
-				or there is a template defined, which is a list of (TYPE,...)-tuples,
-				and the list is an unformatted tuple. The template then references items from the list.
-			*/
+		/* a multicontent list can be used in two ways:
+			either each item is a list of (TYPE,...)-tuples,
+			or there is a template defined, which is a list of (TYPE,...)-tuples,
+			and the list is an unformatted tuple. The template then references items from the list.
+		*/
 		int cursor = cursorGet();
 		items = PyList_GET_ITEM(m_list, cursor); // borrowed reference!
 
 		if (m_buildFunc)
 		{
-			if (PyCallable_Check(m_buildFunc))  // when we have a buildFunc then call it
+			if (PyCallable_Check(m_buildFunc)) // when we have a buildFunc then call it
 			{
 				if (PyTuple_Check(items))
 					buildfunc_ret = items = PyObject_CallObject(m_buildFunc, items);
@@ -849,7 +936,8 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				eDebug("[eListboxPythonMultiContent] list entry %d is not a list (non-templated)", cursor);
 				goto error_out;
 			}
-		} else
+		}
+		else
 		{
 			if (!PyTuple_Check(items))
 			{
@@ -860,9 +948,9 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 
 		ePyObject data;
 
-			/* if we have a template, use the template for the actual formatting.
-				we will later detect that "data" is present, and refer to that, instead
-				of the immediate value. */
+		/* if we have a template, use the template for the actual formatting.
+			we will later detect that "data" is present, and refer to that, instead
+			of the immediate value. */
 		int start = 1;
 		if (m_template)
 		{
@@ -902,17 +990,17 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 			{
 			case TYPE_TEXT: // text
 			{
-			/*
-				(0, x, y, width, height, fnt, flags, "bla" [, color, colorSelected, backColor, backColorSelected, borderWidth, borderColor] )
-			*/
+				/*
+					(0, x, y, width, height, fnt, flags, "bla" [, color, colorSelected, backColor, backColorSelected, borderWidth, borderColor] )
+				*/
 				ePyObject px = PyTuple_GET_ITEM(item, 1),
-							py = PyTuple_GET_ITEM(item, 2),
-							pwidth = PyTuple_GET_ITEM(item, 3),
-							pheight = PyTuple_GET_ITEM(item, 4),
-							pfnt = PyTuple_GET_ITEM(item, 5),
-							pflags = PyTuple_GET_ITEM(item, 6),
-							pstring = PyTuple_GET_ITEM(item, 7),
-							pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, pborderWidth, pborderColor;
+						  py = PyTuple_GET_ITEM(item, 2),
+						  pwidth = PyTuple_GET_ITEM(item, 3),
+						  pheight = PyTuple_GET_ITEM(item, 4),
+						  pfnt = PyTuple_GET_ITEM(item, 5),
+						  pflags = PyTuple_GET_ITEM(item, 6),
+						  pstring = PyTuple_GET_ITEM(item, 7),
+						  pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, pborderWidth, pborderColor;
 
 				if (!(px && py && pwidth && pheight && pfnt && pflags && pstring))
 				{
@@ -936,7 +1024,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				{
 					pborderWidth = PyTuple_GET_ITEM(item, 12);
 					if (!pborderWidth || pborderWidth == Py_None)
-						pborderWidth=ePyObject();
+						pborderWidth = ePyObject();
 				}
 				if (size > 13)
 					pborderColor = lookupColor(PyTuple_GET_ITEM(item, 13), data);
@@ -944,31 +1032,20 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				if (PyLong_Check(pstring) && data) /* if the string is in fact a number, it refers to the 'data' list. */
 					pstring = PyTuple_GetItem(data, PyLong_AsLong(pstring));
 
-							/* don't do anything if we have 'None' as string */
+				/* don't do anything if we have 'None' as string */
 				if (!pstring || pstring == Py_None)
 					continue;
 
 				const char *string = (PyUnicode_Check(pstring)) ? PyUnicode_AsUTF8(pstring) : "<not-a-string>";
 
-				#if PY_VERSION_HEX >= 0x030a0000
+				int x = PyFloat_Check(px) ? (int)PyFloat_AsDouble(px) : PyLong_AsLong(px);
+				x += offset.x();
 
-					int x = PyFloat_Check(px) ? (int)PyFloat_AsDouble(px) : PyLong_AsLong(px); 
-					x += offset.x();
+				int y = PyFloat_Check(py) ? (int)PyFloat_AsDouble(py) : PyLong_AsLong(py);
+				y += offset.y();
 
-					int y = PyFloat_Check(py) ? (int)PyFloat_AsDouble(py) : PyLong_AsLong(py); 
-					y += offset.y();
-
-					int width = PyFloat_Check(pwidth) ? (int)PyFloat_AsDouble(pwidth) : PyLong_AsLong(pwidth); 
-					int height = PyFloat_Check(pheight) ? (int)PyFloat_AsDouble(pheight) : PyLong_AsLong(pheight); 
-
-				#else
-
-					int x = PyLong_AsLong(px) + offset.x();
-					int y = PyLong_AsLong(py) + offset.y();
-					int width = PyLong_AsLong(pwidth);
-					int height = PyLong_AsLong(pheight);
-
-				#endif
+				int width = PyFloat_Check(pwidth) ? (int)PyFloat_AsDouble(pwidth) : PyLong_AsLong(pwidth);
+				int height = PyFloat_Check(pheight) ? (int)PyFloat_AsDouble(pheight) : PyLong_AsLong(pheight);
 
 				int flags = PyLong_AsLong(pflags);
 				int fnt = PyLong_AsLong(pfnt);
@@ -980,13 +1057,13 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 					goto error_out;
 				}
 
-				eRect rect(x+bwidth, y+bwidth, width-bwidth*2, height-bwidth*2);
+				eRect rect(x + bwidth, y + bwidth, width - bwidth * 2, height - bwidth * 2);
 				painter.clip(rect);
 
 				{
 					gRegion rc(rect);
 					bool mustClear = (selected && pbackColorSelected) || (!selected && pbackColor);
-					clearRegion(painter, style, local_style, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear);
+					clearRegion(painter, style, local_style, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear, orientation);
 				}
 
 				painter.setFont(m_fonts[fnt]);
@@ -1007,13 +1084,13 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 					rect.setRect(x, y, width, bwidth);
 					painter.fill(rect);
 
-					rect.setRect(x, y+bwidth, bwidth, height-bwidth);
+					rect.setRect(x, y + bwidth, bwidth, height - bwidth);
 					painter.fill(rect);
 
-					rect.setRect(x+bwidth, y+height-bwidth, width-bwidth, bwidth);
+					rect.setRect(x + bwidth, y + height - bwidth, width - bwidth, bwidth);
 					painter.fill(rect);
 
-					rect.setRect(x+width-bwidth, y+bwidth, bwidth, height-bwidth);
+					rect.setRect(x + width - bwidth, y + bwidth, bwidth, height - bwidth);
 					painter.fill(rect);
 
 					painter.clippop();
@@ -1026,15 +1103,15 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 			*/
 			case TYPE_PROGRESS: // Progress
 			{
-			/*
-				(1, x, y, width, height, filled_percent [, borderWidth, foreColor, foreColorSelected, backColor, backColorSelected] )
-			*/
+				/*
+					(1, x, y, width, height, filled_percent [, borderWidth, foreColor, foreColorSelected, backColor, backColorSelected] )
+				*/
 				ePyObject px = PyTuple_GET_ITEM(item, 1),
-							py = PyTuple_GET_ITEM(item, 2),
-							pwidth = PyTuple_GET_ITEM(item, 3),
-							pheight = PyTuple_GET_ITEM(item, 4),
-							pfilled_perc = PyTuple_GET_ITEM(item, 5),
-							ppixmap, pborderWidth, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected;
+						  py = PyTuple_GET_ITEM(item, 2),
+						  pwidth = PyTuple_GET_ITEM(item, 3),
+						  pheight = PyTuple_GET_ITEM(item, 4),
+						  pfilled_perc = PyTuple_GET_ITEM(item, 5),
+						  ppixmap, pborderWidth, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected;
 				int idx = 6;
 				if (type == TYPE_PROGRESS)
 				{
@@ -1072,49 +1149,35 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				{
 					pforeColorSelected = PyTuple_GET_ITEM(item, idx++);
 					if (!pforeColorSelected || pforeColorSelected == Py_None)
-						pforeColorSelected=ePyObject();
+						pforeColorSelected = ePyObject();
 				}
 				if (size > idx)
 				{
 					pbackColor = PyTuple_GET_ITEM(item, idx++);
 					if (!pbackColor || pbackColor == Py_None)
-						pbackColor=ePyObject();
+						pbackColor = ePyObject();
 				}
 				if (size > idx)
 				{
 					pbackColorSelected = PyTuple_GET_ITEM(item, idx++);
 					if (!pbackColorSelected || pbackColorSelected == Py_None)
-						pbackColorSelected=ePyObject();
+						pbackColorSelected = ePyObject();
 				}
 
+				int x = PyFloat_Check(px) ? (int)PyFloat_AsDouble(px) : PyLong_AsLong(px);
+				x += offset.x();
 
-				#if PY_VERSION_HEX >= 0x030a0000
+				int y = PyFloat_Check(py) ? (int)PyFloat_AsDouble(py) : PyLong_AsLong(py);
+				y += offset.y();
 
-					int x = PyFloat_Check(px) ? (int)PyFloat_AsDouble(px) : PyLong_AsLong(px); 
-					x += offset.x();
-
-					int y = PyFloat_Check(py) ? (int)PyFloat_AsDouble(py) : PyLong_AsLong(py); 
-					y += offset.y();
-
-					int width = PyFloat_Check(pwidth) ? (int)PyFloat_AsDouble(pwidth) : PyLong_AsLong(pwidth); 
-					int height = PyFloat_Check(pheight) ? (int)PyFloat_AsDouble(pheight) : PyLong_AsLong(pheight); 
-					int filled = PyFloat_Check(pfilled_perc) ? (int)PyFloat_AsDouble(pfilled_perc) : PyLong_AsLong(pfilled_perc); 
-
-				#else
-
-					int x = PyLong_AsLong(px) + offset.x();
-					int y = PyLong_AsLong(py) + offset.y();
-					int width = PyLong_AsLong(pwidth);
-					int height = PyLong_AsLong(pheight);
-					int filled = PyLong_AsLong(pfilled_perc);
-
-				#endif
-
+				int width = PyFloat_Check(pwidth) ? (int)PyFloat_AsDouble(pwidth) : PyLong_AsLong(pwidth);
+				int height = PyFloat_Check(pheight) ? (int)PyFloat_AsDouble(pheight) : PyLong_AsLong(pheight);
+				int filled = PyFloat_Check(pfilled_perc) ? (int)PyFloat_AsDouble(pfilled_perc) : PyLong_AsLong(pfilled_perc);
 
 				if ((filled < 0) && data) /* if the string is in a negative number, it refers to the 'data' list. */
 					filled = PyLong_AsLong(PyTuple_GetItem(data, -filled));
 
-							/* don't do anything if percent out of range */
+				/* don't do anything if percent out of range */
 				if ((filled < 0) || (filled > 100))
 					continue;
 
@@ -1126,25 +1189,26 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				{
 					gRegion rc(rect);
 					bool mustClear = (selected && pbackColorSelected) || (!selected && pbackColor);
-					clearRegion(painter, style, local_style, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear);
+					clearRegion(painter, style, local_style, pforeColor, pforeColorSelected, pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear, orientation);
 				}
 
 				// border
-				if (bwidth) {
+				if (bwidth)
+				{
 					rect.setRect(x, y, width, bwidth);
 					painter.fill(rect);
 
-					rect.setRect(x, y+bwidth, bwidth, height-bwidth);
+					rect.setRect(x, y + bwidth, bwidth, height - bwidth);
 					painter.fill(rect);
 
-					rect.setRect(x+bwidth, y+height-bwidth, width-bwidth, bwidth);
+					rect.setRect(x + bwidth, y + height - bwidth, width - bwidth, bwidth);
 					painter.fill(rect);
 
-					rect.setRect(x+width-bwidth, y+bwidth, bwidth, height-bwidth);
+					rect.setRect(x + width - bwidth, y + bwidth, bwidth, height - bwidth);
 					painter.fill(rect);
 				}
 
-				rect.setRect(x+bwidth, y+bwidth, (width-bwidth*2) * filled / 100, height-bwidth*2);
+				rect.setRect(x + bwidth, y + bwidth, (width - bwidth * 2) * filled / 100, height - bwidth * 2);
 
 				// progress
 				if (ppixmap)
@@ -1171,16 +1235,16 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 			case TYPE_PIXMAP_ALPHATEST:
 			case TYPE_PIXMAP: // pixmap
 			{
-			/*
-				(2, x, y, width, height, pixmap [, backColor, backColorSelected, flags] )
-			*/
+				/*
+					(2, x, y, width, height, pixmap [, backColor, backColorSelected, flags] )
+				*/
 
 				ePyObject px = PyTuple_GET_ITEM(item, 1),
-							py = PyTuple_GET_ITEM(item, 2),
-							pwidth = PyTuple_GET_ITEM(item, 3),
-							pheight = PyTuple_GET_ITEM(item, 4),
-							ppixmap = PyTuple_GET_ITEM(item, 5),
-							pbackColor, pbackColorSelected;
+						  py = PyTuple_GET_ITEM(item, 2),
+						  pwidth = PyTuple_GET_ITEM(item, 3),
+						  pheight = PyTuple_GET_ITEM(item, 4),
+						  ppixmap = PyTuple_GET_ITEM(item, 5),
+						  pbackColor, pbackColorSelected;
 
 				if (!(px && py && pwidth && pheight && ppixmap))
 				{
@@ -1191,30 +1255,18 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				if (PyLong_Check(ppixmap) && data) /* if the pixmap is in fact a number, it refers to the 'data' list. */
 					ppixmap = PyTuple_GetItem(data, PyLong_AsLong(ppixmap));
 
-							/* don't do anything if we have 'None' as pixmap */
+				/* don't do anything if we have 'None' as pixmap */
 				if (!ppixmap || ppixmap == Py_None)
 					continue;
 
-				#if PY_VERSION_HEX >= 0x030a0000
+				int x = PyFloat_Check(px) ? (int)PyFloat_AsDouble(px) : PyLong_AsLong(px);
+				x += offset.x();
 
-					int x = PyFloat_Check(px) ? (int)PyFloat_AsDouble(px) : PyLong_AsLong(px); 
-					x += offset.x();
+				int y = PyFloat_Check(py) ? (int)PyFloat_AsDouble(py) : PyLong_AsLong(py);
+				y += offset.y();
 
-					int y = PyFloat_Check(py) ? (int)PyFloat_AsDouble(py) : PyLong_AsLong(py); 
-					y += offset.y();
-
-					int width = PyFloat_Check(pwidth) ? (int)PyFloat_AsDouble(pwidth) : PyLong_AsLong(pwidth); 
-					int height = PyFloat_Check(pheight) ? (int)PyFloat_AsDouble(pheight) : PyLong_AsLong(pheight); 
-
-				#else
-
-					int x = PyLong_AsLong(px) + offset.x();
-					int y = PyLong_AsLong(py) + offset.y();
-					int width = PyLong_AsLong(pwidth);
-					int height = PyLong_AsLong(pheight);
-
-				#endif
-
+				int width = PyFloat_Check(pwidth) ? (int)PyFloat_AsDouble(pwidth) : PyLong_AsLong(pwidth);
+				int height = PyFloat_Check(pheight) ? (int)PyFloat_AsDouble(pheight) : PyLong_AsLong(pheight);
 
 				int flags = 0;
 				ePtr<gPixmap> pixmap;
@@ -1239,9 +1291,11 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 				{
 					gRegion rc(rect);
 					bool mustClear = (selected && pbackColorSelected) || (!selected && pbackColor);
-					clearRegion(painter, style, local_style, ePyObject(), ePyObject(), pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear);
+					clearRegion(painter, style, local_style, ePyObject(), ePyObject(), pbackColor, pbackColorSelected, selected, rc, sel_clip, offset, m_itemsize, cursorValid, mustClear, orientation);
 				}
-				flags |= (type == TYPE_PIXMAP_ALPHATEST) ? gPainter::BT_ALPHATEST : (type == TYPE_PIXMAP_ALPHABLEND) ? gPainter::BT_ALPHABLEND : 0;
+
+				flags |= (type == TYPE_PIXMAP_ALPHATEST) ? gPainter::BT_ALPHATEST : (type == TYPE_PIXMAP_ALPHABLEND) ? gPainter::BT_ALPHABLEND
+																													 : 0;
 				painter.blit(pixmap, rect, rect, flags);
 				painter.clippop();
 				break;
@@ -1253,9 +1307,6 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 		}
 	}
 
-	if (selected && !sel_clip.valid() && (!local_style || !local_style->m_selection))
-		style.drawFrame(painter, eRect(offset, m_itemsize), eWindowStyle::frameListboxEntry);
-
 error_out:
 	if (buildfunc_ret)
 		Py_DECREF(buildfunc_ret);
@@ -1266,14 +1317,14 @@ error_out:
 void eListboxPythonMultiContent::setBuildFunc(ePyObject cb)
 {
 	Py_XDECREF(m_buildFunc);
-	m_buildFunc=cb;
+	m_buildFunc = cb;
 	Py_XINCREF(m_buildFunc);
 }
 
 void eListboxPythonMultiContent::setSelectableFunc(ePyObject cb)
 {
 	Py_XDECREF(m_selectableFunc);
-	m_selectableFunc=cb;
+	m_selectableFunc = cb;
 	Py_XINCREF(m_selectableFunc);
 }
 
@@ -1307,7 +1358,8 @@ int eListboxPythonMultiContent::currentCursorSelectable()
 				item = PyList_GET_ITEM(item, 0);
 				if (item != Py_None)
 					return 1;
-			} else if (PyTuple_Check(item))
+			}
+			else if (PyTuple_Check(item))
 			{
 				item = PyTuple_GET_ITEM(item, 0);
 				if (item != Py_None)
@@ -1328,13 +1380,6 @@ void eListboxPythonMultiContent::setFont(int fnt, gFont *font)
 		m_fonts.erase(fnt);
 }
 
-void eListboxPythonMultiContent::setItemHeight(int height)
-{
-	m_itemheight = height;
-	if (m_listbox)
-		m_listbox->setItemHeight(height);
-}
-
 void eListboxPythonMultiContent::setList(ePyObject list)
 {
 	m_old_clip = m_clip = gRegion::invalidRegion();
@@ -1351,7 +1396,7 @@ void eListboxPythonMultiContent::updateClip(gRegion &clip)
 	if (m_clip.valid())
 	{
 		clip &= m_clip;
-		if (m_old_clip.valid() && !(m_clip-m_old_clip).empty())
+		if (m_old_clip.valid() && !(m_clip - m_old_clip).empty())
 			m_clip -= m_old_clip;
 		m_old_clip = m_clip;
 	}

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -198,7 +198,7 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 		style.getFont(eWindowStyle::fontListbox, fnt);
 	}
 
-	int orientation = (m_listbox) ? m_listbox->getOrientation() : 0;
+	int orientation = (m_listbox) ? m_listbox->getOrientation() : 1;
 
 	/* if we have no transparent background */
 	if (!local_style || !local_style->m_transparent_background)
@@ -443,7 +443,7 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 	if (!fnt2)
 		style.getFont(eWindowStyle::fontValue, fnt2);
 
-	int orientation = (m_listbox) ? m_listbox->getOrientation() : 0;
+	int orientation = (m_listbox) ? m_listbox->getOrientation() : 1;
 
 	if (!local_style || !local_style->m_transparent_background)
 	/* if we have no transparent background */

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -198,7 +198,7 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 		style.getFont(eWindowStyle::fontListbox, fnt);
 	}
 
-	int orientation = m_listbox->getOrientation();
+	int orientation = (m_listbox) ? m_listbox->getOrientation() : 0;
 
 	/* if we have no transparent background */
 	if (!local_style || !local_style->m_transparent_background)
@@ -443,7 +443,7 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 	if (!fnt2)
 		style.getFont(eWindowStyle::fontValue, fnt2);
 
-	int orientation = m_listbox->getOrientation();
+	int orientation = (m_listbox) ? m_listbox->getOrientation() : 0;
 
 	if (!local_style || !local_style->m_transparent_background)
 	/* if we have no transparent background */

--- a/lib/gui/elistboxcontent.h
+++ b/lib/gui/elistboxcontent.h
@@ -4,15 +4,18 @@
 #include <lib/python/python.h>
 #include <lib/gui/elistbox.h>
 
-class eListboxPythonStringContent: public virtual iListboxContent
+class eListboxPythonStringContent : public virtual iListboxContent
 {
 	DECLARE_REF(eListboxPythonStringContent);
+
 public:
 	eListboxPythonStringContent();
 	~eListboxPythonStringContent();
 
 	void setList(SWIG_PYOBJECT(ePyObject) list);
+	void setOrientation(int orientation);
 	void setItemHeight(int height);
+	void setItemWidth(int width);
 	PyObject *getCurrentSelection();
 	int getCurrentSelectionIndex() { return m_cursor; }
 	void invalidateEntry(int index);
@@ -22,7 +25,7 @@ public:
 protected:
 	void cursorHome();
 	void cursorEnd();
-	int cursorMove(int count=1);
+	int cursorMove(int count = 1);
 	int cursorValid();
 	int cursorSet(int n);
 	int cursorGet();
@@ -39,10 +42,12 @@ protected:
 	// void setOutputDevice ? (for allocating colors, ...) .. requires some work, though
 	void setSize(const eSize &size);
 
-		/* the following functions always refer to the selected item */
+	/* the following functions always refer to the selected item */
 	virtual void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected);
 
 	int getItemHeight() { return m_itemheight; }
+	int getItemWidth() { return m_itemwidth; }
+	int getOrientation() { return m_orientation; }
 
 private:
 	int m_cursor;
@@ -53,46 +58,62 @@ protected:
 	ePyObject m_list;
 	eSize m_itemsize;
 	int m_itemheight;
+	int m_itemwidth;
+	int m_orientation;
 #endif
 };
 
-class eListboxPythonConfigContent: public eListboxPythonStringContent
+class eListboxPythonConfigContent : public eListboxPythonStringContent
 {
 public:
 	void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected);
 	void setSeperation(int sep) { m_seperation = sep; }
 	int currentCursorSelectable();
-	void setSlider(int height, int space) { m_slider_height = height; m_slider_space = space; }
+	void setSlider(int height, int space)
+	{
+		m_slider_height = height;
+		m_slider_space = space;
+	}
+
 private:
 	int m_seperation, m_slider_height, m_slider_space;
 	std::map<int, int> m_text_offset;
 };
 
-class eListboxPythonMultiContent: public eListboxPythonStringContent
+class eListboxPythonMultiContent : public eListboxPythonStringContent
 {
 	ePyObject m_buildFunc;
 	ePyObject m_selectableFunc;
 	ePyObject m_template;
 	eRect m_selection_clip;
 	gRegion m_clip, m_old_clip;
+
 public:
 	eListboxPythonMultiContent();
 	~eListboxPythonMultiContent();
-	enum { TYPE_TEXT, TYPE_PROGRESS, TYPE_PIXMAP, TYPE_PIXMAP_ALPHATEST, TYPE_PIXMAP_ALPHABLEND, TYPE_PROGRESS_PIXMAP };
+	enum
+	{
+		TYPE_TEXT,
+		TYPE_PROGRESS,
+		TYPE_PIXMAP,
+		TYPE_PIXMAP_ALPHATEST,
+		TYPE_PIXMAP_ALPHABLEND,
+		TYPE_PROGRESS_PIXMAP
+	};
 	void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected);
 	int currentCursorSelectable();
 	void setList(SWIG_PYOBJECT(ePyObject) list);
 	void setFont(int fnt, gFont *font);
 	void setBuildFunc(SWIG_PYOBJECT(ePyObject) func);
 	void setSelectableFunc(SWIG_PYOBJECT(ePyObject) func);
-	void setItemHeight(int height);
-	void setSelectionClip(eRect &rect, bool update=false);
+	void setSelectionClip(eRect &rect, bool update = false);
 	void updateClip(gRegion &);
 	void resetClip();
 	void entryRemoved(int idx);
 	void setTemplate(SWIG_PYOBJECT(ePyObject) tmplate);
+
 private:
-	std::map<int, ePtr<gFont> > m_fonts;
+	std::map<int, ePtr<gFont>> m_fonts;
 };
 
 #ifdef SWIG

--- a/lib/python/Components/Converter/TemplatedMultiContent.py
+++ b/lib/python/Components/Converter/TemplatedMultiContent.py
@@ -17,12 +17,12 @@ class TemplatedMultiContent(StringList):
 		self.template = eval(args, {}, loc)
 		self.scale = None
 		assert "fonts" in self.template, "templates must include a 'fonts' entry"
-		assert "itemHeight" in self.template, "templates must include an 'itemHeight' entry"
+		assert "itemHeight" in self.template or "itemSize" in self.template, "templates must include an 'itemHeight' or 'itemSize' entry"
 		assert "template" in self.template or "templates" in self.template, "templates must include a 'template' or 'templates' entry"
 		assert "template" in self.template or "default" in self.template["templates"], "templates must include a 'default' template"  # We need to have a default template.
 		if "template" not in self.template:  # Default template can be ["template"] or ["templates"]["default"].
 			self.template["template"] = self.template["templates"]["default"][1]
-			self.template["itemHeight"] = self.template["template"][0]
+			self.template["itemSize"] = self.template["template"][0]
 
 	def changed(self, what):
 		if not self.content:
@@ -56,48 +56,64 @@ class TemplatedMultiContent(StringList):
 		self.setTemplate()
 		self.downstream_elements.changed(what)
 
-	def scaleTemplate(self, template, itemheight):
+	def scaleTemplate(self, template, itemWidth, itemHeight):
 		from enigma import gFont
-		print("[TemplatedMultiContent] Scale template")
+		print("[TemplatedMultiContent] DEBUG: Scale template.")
 		scaleFactorVertical = self.scale[1][0] / self.scale[1][1]
 		scaleFactorHorizontal = self.scale[0][0] / self.scale[0][1]
-		itemheight = int(itemheight * scaleFactorVertical)
-		scaledtemplate = []
+		itemWidth = int(itemWidth * scaleFactorHorizontal)
+		itemHeight = int(itemHeight * scaleFactorVertical)
+		scaledTemplate = []
 		fonts = []
 		for font in self.template["fonts"]:
 			fonts.append(gFont(font.family, int(font.pointSize * scaleFactorVertical)))
 		for content in template:
-			elments = list(content)
-			elments[1] = int(elments[1] * scaleFactorVertical)
-			elments[2] = int(elments[2] * scaleFactorHorizontal)
-			elments[3] = int(elments[3] * scaleFactorVertical)
-			elments[4] = int(elments[4] * scaleFactorHorizontal)
-			scaledtemplate.append(tuple(elments))
-		return scaledtemplate, itemheight, fonts
+			elements = list(content)
+			elements[1] = int(elements[1] * scaleFactorVertical)
+			elements[2] = int(elements[2] * scaleFactorHorizontal)
+			elements[3] = int(elements[3] * scaleFactorVertical)
+			elements[4] = int(elements[4] * scaleFactorHorizontal)
+			scaledTemplate.append(tuple(elements))
+		return scaledTemplate, itemHeight, itemWidth, fonts
 
 	def setTemplate(self):
 		if self.source:
 			style = self.source.style
 			if style == self.active_style:
 				return
-			templates = self.template.get("templates")  # If skin defined "templates", that means that it defines multiple styles in a dict. template should still be a default.
+			templates = self.template.get("templates")  # If skin defined "templates", that means that it defines multiple styles in a dictionary but template should still be a default.
 			template = self.template.get("template")
-			itemheight = self.template["itemHeight"]
-			selectionEnabled = self.template.get("selectionEnabled", True)
-			scrollbarMode = self.template.get("scrollbarMode", "showOnDemand")
-			if templates and style and style in templates:  # If we have a custom style defined in the source, and different templates in the skin, look it up
+			if "itemHeight" in self.template:
+				itemHeight = self.template["itemHeight"]
+				itemWidth = itemHeight
+			if "itemWidth" in self.template:
+				itemWidth = self.template["itemWidth"]
+			if "itemSize" in self.template:
+				itemWidth = self.template["itemSize"]
+				itemHeight = itemWidth
+			selectionEnabled = self.template.get("selectionEnabled", None)
+			scrollbarMode = self.template.get("scrollbarMode", None)
+			if templates and style and style in templates:  # If we have a custom style defined in the source, and different templates in the skin, look the template up.
 				template = templates[style][1]
-				itemheight = templates[style][0]
+				if isinstance(templates[style][0], tuple):
+					itemWidth = templates[style][0][0]
+					itemHeight = templates[style][0][1]
+				else:
+					itemWidth = templates[style][0]
+					itemHeight = itemWidth
 				if len(templates[style]) > 2:
 					selectionEnabled = templates[style][2]
 				if len(templates[style]) > 3:
 					scrollbarMode = templates[style][3]
 			if self.scale:
-				template, itemheight, fonts = self.scaleTemplate(template, itemheight)
+				template, itemWidth, itemHeight, fonts = self.scaleTemplate(template, itemWidth, itemHeight)
 				for index, font in enumerate(fonts):
 					self.content.setFont(index, font)
 			self.content.setTemplate(template)
-			self.content.setItemHeight(int(itemheight))
-			self.selectionEnabled = selectionEnabled
-			self.scrollbarMode = scrollbarMode
+			self.content.setItemWidth(int(itemWidth))
+			self.content.setItemHeight(int(itemHeight))
+			if selectionEnabled is not None:
+				self.selectionEnabled = selectionEnabled
+			if scrollbarMode is not None:
+				self.scrollbarMode = scrollbarMode
 			self.active_style = style

--- a/lib/python/Components/Sources/List.py
+++ b/lib/python/Components/Sources/List.py
@@ -3,7 +3,7 @@ from Components.Sources.Source import Source
 
 
 class List(Source):
-	"""The datasource of a listbox. Currently, the format depends on the used converter. So
+	"""The data source of a listbox. Currently, the format depends on the used converter. So
 if you put a simple string list in here, you need to use a StringList converter, if you are
 using a "multi content list styled"-list, you need to use the StaticMultiList converter, and
 setup the "fonts".
@@ -13,8 +13,8 @@ to generate HTML."""
 
 	# NOTE: The calling arguments enableWraparound, item_height and fonts are not
 	# used but remain here so that calling code does not need to be modified.
-	# The enableWrapAround function is correctly handles by the C++ code and the 
-	# use of the enableWrapAround="1" attribute in the skin. Similarly the 
+	# The enableWrapAround function is correctly handled by the C++ code and the
+	# use of the enableWrapAround="1" attribute in the skin. Similarly the
 	# itemHeight and font specifications are handled by the skin.
 	#
 	def __init__(self, list=[], enableWrapAround=None, item_height=0, fonts=[]):
@@ -39,13 +39,16 @@ to generate HTML."""
 		self.index = oldIndex
 		self.disableCallbacks = False
 
-	def entry_changed(self, index):
+	def entryChanged(self, index):
 		if not self.disableCallbacks:
 			self.downstream_elements.entry_changed(index)
 
+	def entry_changed(self, index):  # IanSav: Is this old name really required?
+		return self.entryChanged(index)
+
 	def modifyEntry(self, index, data):
 		self.listData[index] = data
-		self.entry_changed(index)
+		self.entryChanged(index)
 
 	def selectionChanged(self, index):
 		if self.disableCallbacks:
@@ -73,6 +76,8 @@ to generate HTML."""
 
 	index = property(getCurrentIndex, setCurrentIndex)
 
+	# Old index method names.
+	#
 	def getSelectedIndex(self):
 		return self.getCurrentIndex()
 
@@ -96,6 +101,27 @@ to generate HTML."""
 	def count(self):
 		return len(self.listData)
 
+	def enableAutoNavigation(self, value):
+		try:
+			instance = self.master.master.instance
+			instance.enableAutoNavigation(value)
+		except AttributeError:
+			return
+
+	def show(self):
+		try:
+			instance = self.master.master.instance
+			instance.show()
+		except AttributeError:
+			return
+
+	def hide(self):
+		try:
+			instance = self.master.master.instance
+			instance.hide()
+		except AttributeError:
+			return
+
 	def goTop(self):
 		try:
 			instance = self.master.master.instance
@@ -114,6 +140,20 @@ to generate HTML."""
 		try:
 			instance = self.master.master.instance
 			instance.goLineUp()
+		except AttributeError:
+			return
+
+	def goLeft(self):
+		try:
+			instance = self.master.master.instance
+			instance.goLeft()
+		except AttributeError:
+			return
+
+	def goRight(self):
+		try:
+			instance = self.master.master.instance
+			instance.goRight()
 		except AttributeError:
 			return
 

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -441,6 +441,24 @@ def parseInteger(value, default=0):
 	return value
 
 
+def parseItemAlignment(value):
+	options = {
+		"default": eListbox.itemAlignDefault,
+		"center": eListbox.itemAlignCenter,
+		"justify": eListbox.itemAlignJustify,
+	}
+	return parseOptions(options, "scrollbarItemAlignment", value, eListbox.itemAlignDefault)
+
+
+def parseListOrientation(value):
+	options = {
+		"vertical": 0b01,
+		"horizontal": 0b10,
+		"grid": 0b11
+	}
+	return options.get(value, 0b01)
+
+
 def parseOrientation(value):
 	options = {
 		"orHorizontal": 0x00,
@@ -575,7 +593,9 @@ def parseScrollbarMode(value):
 		"showNever": eListbox.showNever,
 		"showLeft": eListbox.showLeftOnDemand,  # This value is deprecated to better allow option symmetry, use "showLeftOnDemand" instead.
 		"showLeftOnDemand": eListbox.showLeftOnDemand,
-		"showLeftAlways": eListbox.showLeftAlways
+		"showLeftAlways": eListbox.showLeftAlways,
+		"showTopOnDemand": eListbox.showTopOnDemand,
+		"showTopAlways": eListbox.showTopAlways
 	}
 	return parseOptions(options, "scrollbarMode", value, eListbox.showOnDemand)
 
@@ -771,6 +791,13 @@ class AttributeParser:
 		# print("[Skin] DEBUG: Scale itemHeight %d -> %d." % (int(value), self.applyVerticalScale(value)))
 		self.guiObject.setItemHeight(self.applyVerticalScale(value))
 
+	def itemWidth(self, value):
+		# print("[Skin] DEBUG: Scale itemWidth %d -> %d." % (int(value), self.applyHorizontalScale(value)))
+		self.guiObject.setItemWidth(self.applyHorizontalScale(value))
+
+	def listOrientation(self, value):  # Used by eListBox.
+		self.guiObject.setOrientation(parseListOrientation(value))
+
 	def noWrap(self, value):
 		self.guiObject.setNoWrap(1 if parseBoolean("nowrap", value) else 0)
 		# attribDeprecationWarning("noWrap", "wrap")
@@ -819,6 +846,9 @@ class AttributeParser:
 	def scrollbarbackgroundPixmap(self, value):  # This legacy definition uses an inconsistent name, use'scrollbarBackgroundPixmap' instead!
 		self.scrollbarBackgroundPixmap(value)
 		attribDeprecationWarning("scrollbarbackgroundPixmap", "scrollbarBackgroundPixmap")
+
+	def scrollbarItemAlignment(self, value):
+		self.guiObject.setItemAlignment(parseItemAlignment(value))
 
 	def scrollbarMode(self, value):
 		self.guiObject.setScrollbarMode(parseScrollbarMode(value))


### PR DESCRIPTION
[eListBox.cpp]
* Add horizontal and grid orientation layouts.
* Optimize rendering to reduce code and improve performance.
* Reformat code to reflect common styling and improve readability.

[eListBoxContent.cpp]
* Add support for horizontal and grid layouts.
* Optimize rendering to reduce code and improve performance.
* Reformat code to reflect common styling and improve readability.

[TemplatedMultiContent.py]
* Add support for new orientations.

[Skin.py]
* Add orientation and item alignment parsers for new horizontal and grid orientation layouts.

[keymap.xml]
* Update "ListboxActions" to separate LEFT/RIGHT for horizontal and grid layouts.

The UI designs that intended to stop using LEFT and RIGHT as the page up/down functions were proposed in the light of this new navigational functionality.  Users are warned that in some cases LEFT and RIGHT need to be reassigned to support these new display layouts.  It is hoped that users will now reconsider their desire to retain LEFT and RIGHT as vertical navigation options as this will allow for the original design of direction buttons becoming more natural and predictable in the actions that they will perform.

The horizontal layout is partial taken from these commits by @DimitarCC and @Huevos. https://github.com/OpenPLi/enigma2/commit/0726a1ac6f6f871590d07f81a292352b7b3f02cc https://github.com/OpenPLi/enigma2/commit/1364533ac1cc660b7822f37fec775cd84397e1e3 https://github.com/OpenPLi/enigma2/commit/32320c853f39d3c9ef849a578fcceadd86c39a01