### PR TITLE
[Screens/FlashManager]

### DIFF
--- a/lib/python/Screens/FlashManager.py
+++ b/lib/python/Screens/FlashManager.py
@@ -557,7 +557,7 @@ class FlashImage(Screen, HelpableScreen):
 				self["header"].setText(_("Downloading Image"))
 				self["info"].setText(self.imageName)
 				self["summary_header"].setText(self["header"].getText())
-				self.downloader = DownloadWithProgress(self.source, self.zippedImage)
+				self.downloader = DownloadWithProgress(self.source.replace(" ", "%20"), self.zippedImage)
 				self.downloader.addProgress(self.downloadProgress)
 				self.downloader.addEnd(self.downloadEnd)
 				self.downloader.addError(self.downloadError)


### PR DESCRIPTION
Fix URL can't contain control characters
* As in the case of OpenSPA "/Descarga%20de%20Im%C3%A1genes/AirDigital/Zgemma H9.2H SE/"