### PR TITLE
[config.py] Ad new ConfigSelection methods

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -879,7 +879,10 @@ class ConfigSelection(ConfigElement):
 	def getDescriptions(self):
 		return self.description.__list__()
 
-	def setChoices(self, choices, default=None):
+	def getSelectionList(self):
+		return list(zip(self.choices.__list__(), self.description.__list__()))
+
+	def setSelectionList(self, choices, default=None):
 		value = self.value
 		self.choices = choicesList(choices)
 		if default is None:
@@ -889,6 +892,9 @@ class ConfigSelection(ConfigElement):
 			self.value = default
 		if self.value != value:
 			self.changed()
+
+	def setChoices(self, choices, default=None):
+		return self.setSelectionList(choices, default=default)
 
 	def getValue(self):
 		return self._value


### PR DESCRIPTION
- Add a new "getSelectionList()" method to return a list of tuples that are the current contents of the ConfigSelection list.
- Add a new "setSelectionList()" method to set the list of tuples that will be the current contents of the ConfigSelection list.
- The existing "setChoices()" method remains as a synonym of the "setSelectionList()".
