### PR TITLE
[ChoiceList.py] Make vertical alignment configurable

### DIFF
--- a/lib/python/Components/ChoiceList.py
+++ b/lib/python/Components/ChoiceList.py
@@ -1,21 +1,22 @@
-from enigma import RT_HALIGN_LEFT, RT_VALIGN_CENTER, eListboxPythonMultiContent, gFont
+from enigma import RT_HALIGN_LEFT, eListboxPythonMultiContent, gFont
 
-from skin import fonts, parameters
+from skin import fonts, parameters, parseVerticalAlignment
 from Components.MenuList import MenuList
 from Tools.Directories import SCOPE_GUISKIN, resolveFilename
 from Tools.LoadPixmap import LoadPixmap
 
 
 def ChoiceEntryComponent(key=None, text=None):
+	verticalAlignment = parseVerticalAlignment(parameters.get("ChoicelistVerticalAlignment", "top")) << 4  # This is a hack until other images fix their code.
 	text = ["--"] if text is None else text
 	res = [text]
 	if text[0] == "--":
 		x, y, w, h = parameters.get("ChoicelistDash", (0, 0, 1280, 25))
-		res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, "\u2014" * 200))
+		res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT | verticalAlignment, "\u2014" * 200))
 	else:
 		if key:
 			x, y, w, h = parameters.get("ChoicelistName", (45, 0, 1235, 25))
-			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, text[0]))
+			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT | verticalAlignment, text[0]))
 			if key in ("dummy", "none"):
 				png = None
 			elif key == "expandable":
@@ -37,7 +38,7 @@ def ChoiceEntryComponent(key=None, text=None):
 				res.append((eListboxPythonMultiContent.TYPE_PIXMAP_ALPHABLEND, x, y, w, h, png))
 		else:
 			x, y, w, h = parameters.get("ChoicelistNameSingle", (5, 0, 1275, 25))
-			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, text[0]))
+			res.append((eListboxPythonMultiContent.TYPE_TEXT, x, y, w, h, 0, RT_HALIGN_LEFT | verticalAlignment, text[0]))
 	return res
 
 


### PR DESCRIPTION
Add a new skin parameter called "ChoicelistVerticalAlignment", that takes a value from "*top", "*center", "*middle" or "*bottom", to specify the vertical alignment of all ChoiceList base widgets.  (NOTE: The "*" is required to tell the parameter processor that the data is actually a string value and to not try and process this value through the numeric parsers.)

This parameter is a temporary hack to allow skins from other distributions to work, unchanged, on openATV.  The other images should really fix the alignment issue in their code.  The issue in the other images is that the default alignment is "top" and skinners have been forced to manually calculate offsets of the text to cause the text to be centered vertically in the line.  In openATV we fixed this issue so that no such offset is required.  Manually calculating and maintaining centering offsets is a waste of time and code when Enigma2 is fully capable of centering text itself.  Most Enigma2 displays assume and expect text to be centered in the space allocated.  The opeATV change makes this automatic and consistent for all widgets.
