### PR TITLE
[DVD] Fix infobar show / hide and introduce angle label text

### DIFF
--- a/lib/python/Screens/DVD.py
+++ b/lib/python/Screens/DVD.py
@@ -210,6 +210,7 @@ class DVDPlayer(Screen, InfoBarBase, InfoBarNotifications, InfoBarSeek, InfoBarP
 		self["OkCancelActions"] = ActionMap(["OkCancelActions"],
 			{
 				"ok": self.keyOk,
+				"OK": self.doNothing, # disable showing / toggle infobar in menu for key break event
 				"cancel": self.keyCancel,
 			}, -2)
 
@@ -411,7 +412,7 @@ class DVDPlayer(Screen, InfoBarBase, InfoBarNotifications, InfoBarSeek, InfoBarP
 		if angleTuple:
 			angleString = ""
 			if angleTuple[1] > 1:
-				angleString = "%d / %d" % (angleTuple[0], angleTuple[1])
+				angleString = "%s %d / %d" % (_("Angle"), angleTuple[0], angleTuple[1])
 				self["anglePix"].show()
 			else:
 				self["anglePix"].hide()
@@ -515,7 +516,9 @@ class DVDPlayer(Screen, InfoBarBase, InfoBarNotifications, InfoBarSeek, InfoBarP
 		self.sendKey(iServiceKeys.keyDown)
 
 	def keyOk(self):
+		self.skipToggleShow = True
 		if self.sendKey(iServiceKeys.keyOk) and not self.in_menu:
+			self.skipToggleShow = False
 			self.okButton()
 			print("[DVD] keyOk")
 			self.toggleInfo()
@@ -610,7 +613,7 @@ class DVDPlayer(Screen, InfoBarBase, InfoBarNotifications, InfoBarSeek, InfoBarP
 		except Exception as ex:
 #			If the service is an .iso or .img file we assume it is PAL
 #			Sorry we cannot open image files here.
-			print("[DVD] Cannot read file or is ISO/IMG :%s", ex)
+			print("[DVD] Cannot read file or is ISO/IMG: %s" % ex)
 		finally:
 			if ifofile is not None:
 				ifofile.close()


### PR DESCRIPTION
This fix tries to disable the InfoBar showing in DVD menues which is annoying because it allows actions in the menu only if the InfoBar is hidden.
Also a new text is added to show the camera perspective of DVDs that support it. MetrixHD does not have an Icon for it. So thus the textual description.
Furthermore there is a fix to a print statement for logging / debugging purpose.