### PR TITLE
[HarddiskSetup] Change "Initialize" to "Format"

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -186,7 +186,7 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 				<!-- Menu / Setup / System / Storage devices -->
 				<menu key="harddisk" level="0" text="Storage Devices" weight="45" requires="Harddisk">
 					<item key="harddisk_setup" level="1" text="Hard Disk Settings" weight="0"><setup setupKey="HardDisk" /></item>
-					<item key="harddisk_init" level="0" text="Initialization" weight="5"><screen module="HarddiskSetup" screen="HarddiskSelection" /></item>
+					<item key="harddisk_init" level="0" text="Format Storage Device" weight="5"><screen module="HarddiskSetup" screen="HarddiskSelection" /></item>
 					<item key="harddisk_check" level="0" text="File System Check" weight="10"><screen module="HarddiskSetup" screen="HarddiskFsckSelection" /></item>
 					<item key="harddisk_convert" level="0" text="Convert EXT3 File System to EXT4" weight="15" requires="ext4"><screen module="HarddiskSetup" screen="HarddiskConvertExt4Selection" /></item>
 					<item key="mount_manager" level="0" text="Mount Manager" weight="20"><screen module="MountManager" screen="HddMount" /></item>

--- a/lib/python/Screens/HarddiskSetup.py
+++ b/lib/python/Screens/HarddiskSetup.py
@@ -76,7 +76,7 @@ class HarddiskSetup(Screen):
 class HarddiskSelection(Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
-		self.setTitle(_("Initialization"))
+		self.setTitle(_("Format Storage Device"))
 		self.skinName = "HarddiskSelection"  # For derived classes
 		if harddiskmanager.HDDCount() == 0:
 			tlist = [(_("no storage devices found"), 0)]
@@ -93,8 +93,8 @@ class HarddiskSelection(Screen):
 	def doIt(self, selection):
 		self.session.openWithCallback(self.close, HarddiskSetup, selection,
 			action=selection.createInitializeJob,
-			text=_("Initialize"),
-			question=_("Do you really want to initialize the device?\nAll data on the disk will be lost!"))
+			text=_("Format"),
+			question=_("Do you really want to format the device in the Linux file system?\nAll data on the device will be lost!"))
 
 	def okbuttonClick(self):
 		selection = self["hddlist"].getCurrent()


### PR DESCRIPTION
A storage device is initialised automatically when you record, go to flash online etc without any user intervention. 
The context of the menu/ question is that it is asking if we want to format the device, not if we want to initialise it. (initial setup for use). Most E2 users are from a Windows background and "Format" in this context reflects the function in a more user friendly term.