### PR TITLE
[Setup.py] Update comments to warn of pending change

### DIFF
--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -259,11 +259,11 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 class SetupSummary(ScreenSummary):
 	def __init__(self, session, parent):
 		ScreenSummary.__init__(self, session, parent=parent)
-		self["entry"] = StaticText("")  # DEBUG: Proposed for new summary screens.
-		self["value"] = StaticText("")  # DEBUG: Proposed for new summary screens.
-		self["SetupTitle"] = StaticText(parent.getTitle())
-		self["SetupEntry"] = StaticText("")
-		self["SetupValue"] = StaticText("")
+		self["entry"] = StaticText("")
+		self["value"] = StaticText("")
+		self["SetupTitle"] = StaticText(parent.getTitle())  # DEBUG: Deprecated widget name, this will be removed soon.
+		self["SetupEntry"] = StaticText("")  # DEBUG: Deprecated widget name, this will be removed soon.
+		self["SetupValue"] = StaticText("")  # DEBUG: Deprecated widget name, this will be removed soon.
 		if self.addWatcher not in self.onShow:
 			self.onShow.append(self.addWatcher)
 		if self.removeWatcher not in self.onHide:
@@ -283,10 +283,10 @@ class SetupSummary(ScreenSummary):
 			self.parent["config"].onSelectionChanged.remove(self.selectionChanged)
 
 	def selectionChanged(self):
-		self["entry"].text = self.parent.getCurrentEntry()  # DEBUG: Proposed for new summary screens.
-		self["value"].text = self.parent.getCurrentValue()  # DEBUG: Proposed for new summary screens.
-		self["SetupEntry"].text = self.parent.getCurrentEntry()
-		self["SetupValue"].text = self.parent.getCurrentValue()
+		self["entry"].text = self.parent.getCurrentEntry()
+		self["value"].text = self.parent.getCurrentValue()
+		self["SetupEntry"].text = self.parent.getCurrentEntry()  # DEBUG: Deprecated widget name, this will be removed soon.
+		self["SetupValue"].text = self.parent.getCurrentValue()  # DEBUG: Deprecated widget name, this will be removed soon.
 
 
 # Read the setup XML file.

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -213,9 +213,9 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 	def selectionChanged(self):
 		if self["config"]:
 			self.setFootnote(None)
-			self["description"].text = self.getCurrentDescription()
+			self["description"].setText(self.getCurrentDescription())
 		else:
-			self["description"].text = _("There are no items currently available for this screen.")
+			self["description"].setText(_("There are no items currently available for this screen."))
 
 	def layoutFinished(self):
 		if self.setupImage:
@@ -226,13 +226,13 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 	def setFootnote(self, footnote):
 		if footnote is None:
 			if self.getCurrentEntry().endswith("*"):
-				self["footnote"].text = _("* = Restart Required")
+				self["footnote"].setText(_("* = Restart Required"))
 				self["footnote"].show()
 			else:
-				self["footnote"].text = ""
+				self["footnote"].setText("")
 				self["footnote"].hide()
 		else:
-			self["footnote"].text = footnote
+			self["footnote"].setText(footnote)
 			self["footnote"].show()
 
 	def getFootnote(self):
@@ -283,10 +283,10 @@ class SetupSummary(ScreenSummary):
 			self.parent["config"].onSelectionChanged.remove(self.selectionChanged)
 
 	def selectionChanged(self):
-		self["entry"].text = self.parent.getCurrentEntry()
-		self["value"].text = self.parent.getCurrentValue()
-		self["SetupEntry"].text = self.parent.getCurrentEntry()  # DEBUG: Deprecated widget name, this will be removed soon.
-		self["SetupValue"].text = self.parent.getCurrentValue()  # DEBUG: Deprecated widget name, this will be removed soon.
+		self["entry"].setText(self.parent.getCurrentEntry())
+		self["value"].setText(self.parent.getCurrentValue())
+		self["SetupEntry"].setText(self.parent.getCurrentEntry())  # DEBUG: Deprecated widget name, this will be removed soon.
+		self["SetupValue"].setText(self.parent.getCurrentValue())  # DEBUG: Deprecated widget name, this will be removed soon.
 
 
 # Read the setup XML file.


### PR DESCRIPTION
This update changes the comments for the Summary screen to advise coders and skinners that the proposed widget name changes are now available and should be used.  The old widgets "SetupTitle", "SetupEntry" and "SetupValue" are now deprecated and will be removed soon.

All openATV display skins will be updated to use the new widget names.
