### PR TITLE
[Plugin] Move the REASON definitions

### DIFF
--- a/lib/python/Components/PluginComponent.py
+++ b/lib/python/Components/PluginComponent.py
@@ -10,9 +10,6 @@ from Tools.Directories import SCOPE_PLUGINS, fileExists, resolveFilename
 from Tools.Import import my_import
 from Tools.Profile import profile
 
-REASON_START = 0
-REASON_STOP = 1
-
 
 class PluginComponent:
 	firstRun = True
@@ -34,7 +31,7 @@ class PluginComponent:
 			for where in plugin.where:
 				insort(self.plugins.setdefault(where, []), plugin)
 				if where == PluginDescriptor.WHERE_AUTOSTART:
-					plugin(reason=REASON_START)
+					plugin(reason=PluginDescriptor.REASON_START)
 		else:
 			self.restartRequired = True
 
@@ -44,7 +41,7 @@ class PluginComponent:
 		for where in plugin.where:
 			self.plugins[where].remove(plugin)
 			if where == PluginDescriptor.WHERE_AUTOSTART:
-				plugin(reason=REASON_STOP)
+				plugin(reason=PluginDescriptor.REASON_STOP)
 
 	def readPluginList(self, directory):
 		"""Enumerates plugins."""

--- a/lib/python/Plugins/Plugin.py
+++ b/lib/python/Plugins/Plugin.py
@@ -6,6 +6,9 @@ from Tools.LoadPixmap import LoadPixmap
 
 class PluginDescriptor(object):
 	"""An object to describe a plugin."""
+	# Rather than using magic numbers plugins can use these definitions to signify the Enigma2 starting or stopping status.
+	REASON_START = 0
+	REASON_STOP = 1
 	# Where to list the plugin. Note that there are different call arguments,
 	# so you might not be able to combine them.
 	# Common arguments are:


### PR DESCRIPTION
The REASON definitions created in the last commit required the inclusion of PluginComponent as an additional include into plugins.  As all plugins already import the PluginDescriptor class from Plugin.py it makes more sense to define the REASONs here.
