### PR TITLE
Unicable connected

### DIFF
--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -519,7 +519,7 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					if isFBCLink(self.nim.slot):
 						if nimConfig_advanced.unicableconnected.value != True:
 							nimConfig_advanced.unicableconnected.value = True
-					self.advancedConnected = getConfigListEntry(_("connected through another tuner"), nimConfig_advanced.unicableconnected, _("Select 'yes' if this tuner is connected to the SCR device through another tuner, otherwise select 'no'."))
+					self.advancedConnected = getConfigListEntry(_("Connected through another tuner"), nimConfig_advanced.unicableconnected, _("Select 'yes' if this tuner is connected to the SCR device through another tuner, otherwise select 'no'."))
 					self.list.append(self.advancedConnected)
 					if nimConfig_advanced.unicableconnected.value:
 						nimConfig_advanced.unicableconnectedTo.setChoices(choices)

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -519,7 +519,7 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					if isFBCLink(self.nim.slot):
 						if nimConfig_advanced.unicableconnected.value != True:
 							nimConfig_advanced.unicableconnected.value = True
-					self.advancedConnected = getConfigListEntry(_("connected"), nimConfig_advanced.unicableconnected, _("Select 'yes' if this tuner is connected to the SCR device through another tuner, otherwise select 'no'."))
+					self.advancedConnected = getConfigListEntry(_("connected through another tuner"), nimConfig_advanced.unicableconnected, _("Select 'yes' if this tuner is connected to the SCR device through another tuner, otherwise select 'no'."))
 					self.list.append(self.advancedConnected)
 					if nimConfig_advanced.unicableconnected.value:
 						nimConfig_advanced.unicableconnectedTo.setChoices(choices)


### PR DESCRIPTION
Include wording that is in hint text. It is not asking if you have a signal wire `connected` to the tuner, it is as asking if you are `connected through another tuner`.  Make text reflect the question better.

Before:
![ATV- Connnected-orig](https://github.com/openatv/enigma2/assets/6644489/6c5edfa2-22c7-4e49-941c-6c1c5bb4612c)

After:
![ATV- Connnected-modded](https://github.com/openatv/enigma2/assets/6644489/3fab12ca-ed9b-4c2e-a5f8-cd86fb76614f)
