### PR TITLE
Add GT-S2dCSS24 - Italy

### DIFF
--- a/data/unicable.xml
+++ b/data/unicable.xml
@@ -126,6 +126,9 @@ unicable (version)
 					scr1="0975" scr2="1025" scr3="1075" scr4="1125" scr5="1175" scr6="1225" scr7="1275" scr8="1325"
 					scr9="1375" scr10="1425" scr11="1475" scr12="1525" scr13="1575" scr14="1625" scr15="1675" scr16="1725"
 					scr17="1775" scr18="1825" scr19="1875" scr20="1925" scr21="1975" scr22="2025" scr23="2075" scr24="2125"/>
+			<product name="GT-S2DCSS24 - Italy" format="EN50607" bootuptime="2500"
+					scr1 ="1210" scr2 ="1420" scr3 ="1680" scr4 ="2040" scr5 ="985"  scr6 ="1050" scr7 ="1115" scr8 ="1275"
+					scr9 ="1340" scr10="1485" scr11="1550" scr12="1615" scr13="1745" scr14="1810" scr15="1875" scr16="1940"/> <!-- Programmed for 16 SCR only for the Italian market -->
 			<product name="GT-S3DCSS24" format="EN50607" bootuptime="2500"
 					scr1="0975" scr2="1025" scr3="1075" scr4="1125" scr5="1175" scr6="1225" scr7="1275" scr8="1325"
 					scr9="1375" scr10="1425" scr11="1475" scr12="1525" scr13="1575" scr14="1625" scr15="1675" scr16="1725"


### PR DESCRIPTION
Programmed to use only 16 SCR for Italian market

![gt sat dcss 24](https://github.com/openatv/enigma2/assets/6644489/58b038cb-95ec-407d-a68c-48e98f3b5d92)
