### PR TITLE
Small tweaks to BackupRestore.py

### DIFF
--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/BackupRestore.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/BackupRestore.py
@@ -43,7 +43,7 @@ def InitConfig():
 	BACKUPFILES = ["/etc/enigma2/", "/etc/CCcam.cfg", "/usr/keys/",
 		"/etc/davfs2/", "/etc/tuxbox/config/", "/etc/auto.network", "/etc/feeds.xml", "/etc/machine-id", "/etc/rc.local",
 		"/etc/openvpn/", "/etc/ipsec.conf", "/etc/ipsec.secrets", "/etc/ipsec.user", "/etc/strongswan.conf", "/etc/vtuner.conf",
-		"/etc/default/crond", "/etc/dropbear/", "/etc/default/dropbear", "/home/", "/etc/samba/", "/etc/fstab", "/etc/inadyn.conf",
+		"/etc/default/crond", "/etc/dropbear/", "/etc/default/dropbear", "/etc/sysctl.conf", "/etc/samba/", "/etc/fstab", "/etc/inadyn.conf",
 		"/etc/network/interfaces", "/etc/wpa_supplicant.conf", "/etc/wpa_supplicant.ath0.conf",
 		"/etc/wpa_supplicant.wlan0.conf", "/etc/wpa_supplicant.wlan1.conf", "/etc/resolv.conf", "/etc/enigma2/nameserversdns.conf", "/etc/default_gw", "/etc/hostname", "/etc/hosts", "/etc/epgimport/", "/etc/exports",
 		"/etc/enigmalight.conf", "/etc/enigma2/volume.xml", "/etc/enigma2/ci_auth_slot_0.bin", "/etc/enigma2/ci_auth_slot_1.bin",


### PR DESCRIPTION
Small tweaks to BackupRestore.py

Included for backup :

/etc/sysctl.conf
(for users who disable ipv6 its needed to backup.)

Removed for backup :

"/home/"
(Don't see a reason to include the main folder instead of individual files?)

Also settings-backup is getting pretty large over time. Main reason are the EPG cache files.

/etc/enigma2/epg.dat
/etc/enigma2/xstreamity/epg/

Do they really need to be backup'd by default for all users or better to exclude epg? Backup seize are then reduced from ~50mb to ~1mb and much quicker to make and restore backups. Big improvement.