### PR TITLE
Fix some recording issues

### DIFF
--- a/lib/dvb/pvrparse.cpp
+++ b/lib/dvb/pvrparse.cpp
@@ -652,7 +652,7 @@ int eMPEGStreamInformationWriter::stopSave(void)
 		return 1;
 
 	// do not create access points if there is no recording file
-	if (::access(filename.c_str(), R_OK) < 0)
+	if (::access(m_filename.c_str(), R_OK) < 0)
 		return 1;
 
 	std::string ap_filename(m_filename);

--- a/lib/dvb/pvrparse.cpp
+++ b/lib/dvb/pvrparse.cpp
@@ -650,6 +650,11 @@ int eMPEGStreamInformationWriter::stopSave(void)
 	if (m_access_points.empty() && (m_streamtime_access_points.size() <= 1))
 		// Nothing to save, don't create an ap file at all
 		return 1;
+
+	// do not create access points if there is no recording file
+	if (::access(filename.c_str(), R_OK) < 0)
+		return 1;
+
 	std::string ap_filename(m_filename);
 	ap_filename += ".ap";
 	{

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -1745,6 +1745,8 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 				rec_filename = split(current.getPath())[1]
 				if rec_filename.endswith(".ts"):
 					rec_filename = rec_filename[:-3]
+				if rec_filename.endswith(".stream"):
+					rec_filename = rec_filename[:-7]
 				for timer in NavigationInstance.instance.RecordTimer.timer_list:
 					if timer.isRunning() and not timer.justplay and rec_filename in timer.Filename:
 						choices = [

--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -594,7 +594,7 @@ void eDVBServiceRecord::saveCutlist()
 	/* XXX: dupe of eDVBServicePlay::saveCuesheet, refactor plz */
 	
 	/* save cuesheet only when main file is accessible. */
-	if (::access(filename.c_str(), R_OK) < 0)
+	if (::access(m_filename.c_str(), R_OK) < 0)
 		return;
 
 	std::string filename = m_filename + ".cuts";

--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -591,7 +591,12 @@ void eDVBServiceRecord::gotNewEvent(int /*error*/)
 
 void eDVBServiceRecord::saveCutlist()
 {
-			/* XXX: dupe of eDVBServicePlay::saveCuesheet, refactor plz */
+	/* XXX: dupe of eDVBServicePlay::saveCuesheet, refactor plz */
+	
+	/* save cuesheet only when main file is accessible. */
+	if (::access(filename.c_str(), R_OK) < 0)
+		return;
+
 	std::string filename = m_filename + ".cuts";
 
 	eDVBTSTools tstools;

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -323,7 +323,7 @@ RESULT eStaticServiceMP3Info::getName(const eServiceReference &ref, std::string 
 		name = ref.name;
 	else
 	{
-		if (endsWith(ref.path, ".stream") && !m_parser.parseMeta(ref.path))
+		if (endsWith(ref.path, ".stream") && !m_parser.parseMeta(ref.path)) {
 			name = m_parser.m_name;
 			return 0;
 		}

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -280,10 +280,11 @@ RESULT eMP3ServiceOfflineOperations::getListOfFilenames(std::list<std::string> &
 	res.push_back(m_ref.path + ".meta");
 	res.push_back(m_ref.path + ".cuts");
 	std::string filename = m_ref.path;
+	size_t pos;
 	if ( (pos = filename.rfind('.')) != std::string::npos)
 	{
 		filename.erase(pos + 1);
-		res.push_back(tmp + ".eit");
+		res.push_back(filename + ".eit");
 	}
 	return 0;
 }
@@ -318,23 +319,21 @@ eStaticServiceMP3Info::eStaticServiceMP3Info()
 
 RESULT eStaticServiceMP3Info::getName(const eServiceReference &ref, std::string &name)
 {
-	if ( ref.name.length() )
+	if (ref.name.length())
 		name = ref.name;
 	else
 	{
-
-		if(ref.path.rfind('.stream') != std::string::npos)
+		if (endsWith(ref.path, ".stream"))
 		{
-			if(!m_parser.parseMeta(ref.path))
+			if (!m_parser.parseMeta(ref.path))
 			{
 				name = m_parser.m_name;
 				return 0;
 			}
 		}
-
 		size_t last = ref.path.rfind('/');
 		if (last != std::string::npos)
-			name = ref.path.substr(last+1);
+			name = ref.path.substr(last + 1);
 		else
 			name = ref.path;
 	}

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -323,13 +323,9 @@ RESULT eStaticServiceMP3Info::getName(const eServiceReference &ref, std::string 
 		name = ref.name;
 	else
 	{
-		if (endsWith(ref.path, ".stream"))
-		{
-			if (!m_parser.parseMeta(ref.path))
-			{
-				name = m_parser.m_name;
-				return 0;
-			}
+		if (endsWith(ref.path, ".stream") && !m_parser.parseMeta(ref.path))
+			name = m_parser.m_name;
+			return 0;
 		}
 		size_t last = ref.path.rfind('/');
 		if (last != std::string::npos)

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -314,6 +314,16 @@ RESULT eStaticServiceMP3Info::getName(const eServiceReference &ref, std::string 
 		name = ref.name;
 	else
 	{
+
+		if(ref.path.rfind('.stream') != std::string::npos)
+		{
+			if(!m_parser.parseMeta(ref.path))
+			{
+				name = m_parser.m_name;
+				return 0;
+			}
+		}
+
 		size_t last = ref.path.rfind('/');
 		if (last != std::string::npos)
 			name = ref.path.substr(last+1);

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -277,6 +277,14 @@ RESULT eMP3ServiceOfflineOperations::getListOfFilenames(std::list<std::string> &
 {
 	res.clear();
 	res.push_back(m_ref.path);
+	res.push_back(m_ref.path + ".meta");
+	res.push_back(m_ref.path + ".cuts");
+	std::string filename = m_ref.path;
+	if ( (pos = filename.rfind('.')) != std::string::npos)
+	{
+		filename.erase(pos + 1);
+		res.push_back(tmp + ".eit");
+	}
 	return 0;
 }
 

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -6,6 +6,7 @@
 #include <lib/dvb/pmt.h>
 #include <lib/dvb/subtitle.h>
 #include <lib/dvb/teletext.h>
+#include <lib/dvb/metaparser.h>
 #include <gst/gst.h>
 /* for subtitles */
 #include <lib/gui/esubtitle.h>
@@ -36,6 +37,7 @@ class eStaticServiceMP3Info: public iStaticServiceInformation
 	DECLARE_REF(eStaticServiceMP3Info);
 	friend class eServiceFactoryMP3;
 	eStaticServiceMP3Info();
+	eDVBMetaParser m_parser;
 public:
 	RESULT getName(const eServiceReference &ref, std::string &name);
 	int getLength(const eServiceReference &ref);


### PR DESCRIPTION
[eStaticServiceMP3Info]
* get name from meta for ".stream" recordings

[eMP3ServiceOfflineOperations]
* add cuts, meta and eit for stream recordings to delete list

[MovieSelection]
* handle .streams recording filenames like .ts in case of deletion

[eDVBServiceRecord]
* do not create cuts file if there is no recording

[eMPEGStreamInformationWriter]
* do not create access points if there is no recording file

Close #2864
Close #754