### PR TITLE
Fix subservices for iptv channels.

### DIFF
--- a/lib/python/Components/Converter/ServiceInfo.py
+++ b/lib/python/Components/Converter/ServiceInfo.py
@@ -257,7 +257,7 @@ class ServiceInfo(Poll, Converter):
 		elif self.type == self.IS_NOT_WIDESCREEN:
 			return video_aspect not in WIDESCREEN
 		elif self.type == self.SUBSERVICES_AVAILABLE:
-			return hasActiveSubservicesForCurrentChannel(':'.join(info.getInfoString(iServiceInformation.sServiceref).split(':')[:11]))
+			return hasActiveSubservicesForCurrentChannel(info.getInfoString(iServiceInformation.sServiceref))
 		elif self.type == self.HAS_HBBTV:
 			return info.getInfoString(iServiceInformation.sHBBTVUrl) != ""
 		elif self.type == self.AUDIOTRACKS_AVAILABLE:

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -221,6 +221,8 @@ def getActiveSubservicesForCurrentChannel(current_service):
 
 
 def hasActiveSubservicesForCurrentChannel(current_service):
+	if current_service and "%3a" not in current_service:
+		current_service = ':'.join(current_service.split(':')[:11])
 	activeSubservices = getActiveSubservicesForCurrentChannel(current_service)
 	return bool(activeSubservices and len(activeSubservices) > 1)
 
@@ -4033,7 +4035,7 @@ class InfoBarSubserviceSelection:
 		self.session.nav.event.remove(self.checkSubservicesAvail)
 
 	def checkSubservicesAvail(self):
-		refstr = self.session.nav.getCurrentlyPlayingServiceReference() and self.session.nav.getCurrentlyPlayingServiceReference().toCompareString()
+		refstr = self.session.nav.getCurrentlyPlayingServiceReference() and self.session.nav.getCurrentlyPlayingServiceReference().toString()
 		if not refstr or not hasActiveSubservicesForCurrentChannel(refstr):
 			self["SubserviceQuickzapAction"].setEnabled(False)
 			self.bouquets = self.bsel = self.selectedSubservice = None
@@ -4045,13 +4047,15 @@ class InfoBarSubserviceSelection:
 		self.changeSubservice(-1)
 
 	def playSubservice(self, ref):
-		if ref.getUnsignedData(6) == 0:
+		if ref.getUnsignedData(6) == 0 and "%3a" not in ref.toString():
 			ref.setName("")
 		self.session.nav.playService(ref, checkParentalControl=False, adjust=False)
 
 	def changeSubservice(self, direction):
 		refstr = self.session.nav.getCurrentlyPlayingServiceReference() and self.session.nav.getCurrentlyPlayingServiceReference().toCompareString()
 		if refstr:
+			if "%3a" in refstr:
+				refstr = self.session.nav.getCurrentlyPlayingServiceReference().toString()
 			subservices = getActiveSubservicesForCurrentChannel(refstr)
 			if subservices and len(subservices) > 1 and refstr in [x[1] for x in subservices]:
 				selection = [x[1] for x in subservices].index(refstr)
@@ -4066,6 +4070,8 @@ class InfoBarSubserviceSelection:
 	def subserviceSelection(self):
 		refstr = self.session.nav.getCurrentlyPlayingServiceReference() and self.session.nav.getCurrentlyPlayingServiceReference().toCompareString()
 		if refstr:
+			if "%3a" in refstr:
+				refstr = self.session.nav.getCurrentlyPlayingServiceReference().toString()
 			subservices = getActiveSubservicesForCurrentChannel(refstr)
 			if subservices and len(subservices) > 1 and refstr in [x[1] for x in subservices]:
 				selection = [x[1] for x in subservices].index(refstr)
@@ -4134,6 +4140,8 @@ class InfoBarSubserviceSelection:
 		else:
 			refstr = self.session.nav.getCurrentlyPlayingServiceReference() and self.session.nav.getCurrentlyPlayingServiceReference().toCompareString()
 			if refstr:
+				if "%3a" in refstr:
+					refstr = self.session.nav.getCurrentlyPlayingServiceReference().toString()
 				subservices = getActiveSubservicesForCurrentChannel(refstr)
 				if subservices and len(subservices) > 1 and refstr in [x[1] for x in subservices]:
 					self.subserviceSelection()

--- a/lib/python/Screens/SubservicesQuickzap.py
+++ b/lib/python/Screens/SubservicesQuickzap.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from Screens.Screen import Screen
 from Components.ActionMap import NumberActionMap
 from Components.Label import Label
@@ -66,8 +65,11 @@ class SubservicesQuickzap(InfoBarBase, InfoBarShowHide, InfoBarMenu,
 			self.playSubservice((self.currentlyPlayingSubservice - 1) % len(self.subservices))
 
 	def getSubserviceIndex(self, service):
-		if self.subservices and service and service.toCompareString() in [x[1] for x in self.subservices]:
-			return [x[1] for x in self.subservices].index(service.toCompareString())
+		if self.subservices and service:
+			if service.toCompareString() in [x[1] for x in self.subservices]:
+				return [x[1] for x in self.subservices].index(service.toCompareString())
+			elif service.toString() in [x[1] for x in self.subservices]:
+				return [x[1] for x in self.subservices].index(service.toString())
 
 	def keyNumberGlobal(self, number):
 		if number == 0:


### PR DESCRIPTION
Please note.
The sref for iptv channels must have ":" + name at the end in bouquet file to define the channel name. The sref in groupservice file must be identical like in bouquet file. (case sensitive) Subservice functionality for non iptv channels is untouched.

Close #1889