### PR TITLE
[Setup.py] Correct a potential crash

### DIFF
--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -88,6 +88,7 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 					print("[Setup] Error: Unable to load image '%s'!" % setupImage)
 			else:
 				print("[Setup] Error: Setup image '%s' is not a file!" % setupImage)
+				self.setupImage = None
 		else:
 			self.setupImage = None
 		self["config"].onSelectionChanged.append(self.selectionChanged)


### PR DESCRIPTION
This change resolves a potential crash if a setup image is defined but the image file is missing or invalid.
