### PR TITLE
fix GS in Timers.py

### DIFF
--- a/lib/python/Screens/Timers.py
+++ b/lib/python/Screens/Timers.py
@@ -1679,7 +1679,7 @@ class RecordTimerEdit(Setup):
 		locations = config.movielist.videodirs.value
 		return (default, locations)
 
-	def getLocation(self):
+	def getLocation(self, retVal = None):
 		def getLocationCallback(result):
 			if result:
 				if config.movielist.videodirs.value != self.timerLocation.choices:


### PR DESCRIPTION
This change fixes GS when getLocation() invoked from line 1524 "self.session.openWithCallback(self.getLocation, MessageBox, _("Error: A location to save the recording has not been selected!"), MessageBox.TYPE_ERROR)"