### PR TITLE
Add dayname to Date selection

### DIFF
--- a/lib/python/Screens/TimeDateInput.py
+++ b/lib/python/Screens/TimeDateInput.py
@@ -38,7 +38,7 @@ class TimeDateInput(Screen, ConfigListScreen):
 		if conf_date:
 			self.save_mask |= 2
 		else:
-			conf_date = ConfigDateTime(default=time.time(), formatstring=config.usage.date.full.value, increment=86400)
+			conf_date = ConfigDateTime(default=time.time(), formatstring=config.usage.date.dayfull.value, increment=86400)
 		self.timeinput_date = conf_date
 		self.timeinput_time = conf_time
 


### PR DESCRIPTION
Date/time Input screen doesn't show day name. This fixes that.

![20231006223719](https://github.com/openatv/enigma2/assets/9741693/168cc2a8-fb21-4f05-b2bd-bddfdaf90af4)
