### PR TITLE
PicturePlayer: use floor division to get integer

### DIFF
--- a/lib/python/Plugins/Extensions/PicturePlayer/ui.py
+++ b/lib/python/Plugins/Extensions/PicturePlayer/ui.py
@@ -216,7 +216,7 @@ class Pic_Thumb(Screen):
 
 		posX = -1
 		for x in range(self.thumbsC):
-			posY = x / self.thumbsX
+			posY = x // self.thumbsX
 			posX += 1
 			if posX >= self.thumbsX:
 				posX = 0


### PR DESCRIPTION
class Pic_Thumb
- Otherwise the presentation of thumbnail images (GREEN button) will appear descent.

before this commit:
<a href='https://postimg.cc/Jsdd9DxW' target='_blank'><img src='https://i.postimg.cc/SKyFYczj/antes.jpg' border='0' alt='antes'/></a>

with this commit:
<a href='https://postimg.cc/n9z3RnmL' target='_blank'><img src='https://i.postimg.cc/0jGhNQ27/despues.jpg' border='0' alt='despues'/></a>