### PR TITLE
[Processing.py] Correct small visual anomaly

### DIFF
--- a/lib/python/Screens/Processing.py
+++ b/lib/python/Screens/Processing.py
@@ -64,6 +64,7 @@ class Processing:
 			title = _("Processing")
 		self.processingDialog.setTitle(title)
 		self.progress = progress
+		self.processingDialog.setProgress(progress)
 		self.processingDialog.show()
 		if endless:
 			self.timer.start(100)


### PR DESCRIPTION
This change corrects a small visual anomaly where the initial display of the ProcessingScreen does not start at the nominated progress position.  Users may not have noticed the issue as the first update corrected the display.
