### PR TITLE
StreamRelay

### DIFF
--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -969,13 +969,16 @@ int eDVBServicePMTHandler::getChannel(eUsePtr<iDVBChannel> &channel)
 			std::list<eDVBResourceManager::active_channel> list;
 			res_mgr->getActiveChannels(list);
 			if(list.size()) {
+
+				eServiceReferenceDVB m_alternative_ref = eServiceReferenceDVB(m_reference.alternativeurl);
+				char buf[30];
+				sprintf(buf, "%x:%x:%x", m_alternative_ref.getTransportStreamID().get(), m_alternative_ref.getOriginalNetworkID().get(), m_alternative_ref.getDVBNamespace().get());
+				std::string alternativeChannelID = std::string(buf);
+
 				for (std::list<eDVBResourceManager::active_channel>::iterator i(list.begin()); i != list.end(); ++i)
 				{
 					std::string channelid = i->m_channel_id.toString();
-					eServiceReferenceDVB m_alternative_ref = eServiceReferenceDVB(m_reference.alternativeurl);
-					char buf[30];
-					sprintf(buf, "%x:%x:%x", m_alternative_ref.getTransportStreamID().get(), m_alternative_ref.getOriginalNetworkID().get(), m_alternative_ref.getDVBNamespace().get());
-					if (channelid == std::string(buf))
+					if (channelid == alternativeChannelID)
 					{
 						m_sr_channel = i->m_channel;
 						break;

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -960,7 +960,33 @@ int eDVBServicePMTHandler::compareAudioSubtitleCode(const std::string &subtitleT
 
 int eDVBServicePMTHandler::getChannel(eUsePtr<iDVBChannel> &channel)
 {
-	channel = m_channel;
+	if (!m_sr_channel && !m_reference.alternativeurl.empty())
+	{
+
+		ePtr<eDVBResourceManager> res_mgr;
+		if ( !eDVBResourceManager::getInstance( res_mgr ) )
+		{
+			std::list<eDVBResourceManager::active_channel> list;
+			res_mgr->getActiveChannels(list);
+			if(list.size()) {
+				for (std::list<eDVBResourceManager::active_channel>::iterator i(list.begin()); i != list.end(); ++i)
+				{
+					std::string channelid = i->m_channel_id.toString();
+					eServiceReferenceDVB m_alternative_ref = eServiceReferenceDVB(m_reference.alternativeurl);
+					char buf[30];
+					sprintf(buf, "%x:%x:%x", m_alternative_ref.getTransportStreamID().get(), m_alternative_ref.getOriginalNetworkID().get(), m_alternative_ref.getDVBNamespace().get());
+					if (channelid == std::string(buf))
+					{
+						m_sr_channel = i->m_channel;
+						break;
+					}
+				}
+
+			}
+		}
+	}
+
+	channel = (m_sr_channel) ? m_sr_channel : m_channel;
 	if (channel)
 		return 0;
 	else

--- a/lib/dvb/pmt.h
+++ b/lib/dvb/pmt.h
@@ -78,7 +78,7 @@ class eDVBServicePMTHandler: public eDVBPMTParser
 	eAUTable<eTable<ApplicationInformationSection> > m_AIT;
 	eAUTable<eTable<OCSection> > m_OC;
 
-	eUsePtr<iDVBChannel> m_channel;
+	eUsePtr<iDVBChannel> m_channel, m_sr_channel;
 	eUsePtr<iDVBPVRChannel> m_pvr_channel;
 	ePtr<eDVBResourceManager> m_resourceManager;
 	ePtr<iDVBDemux> m_demux, m_pvr_demux_tmp;

--- a/lib/python/Navigation.py
+++ b/lib/python/Navigation.py
@@ -348,6 +348,7 @@ class Navigation:
 				self.currentlyPlayingServiceReference = playref
 				if not ignoreStreamRelay:
 					playref = streamrelay.streamrelayChecker(playref)
+				print("[Navigation] playref", playref.toString())
 				self.currentlyPlayingServiceOrGroup = ref
 				if InfoBarInstance and InfoBarInstance.servicelist.servicelist.setCurrent(ref, adjust):
 					self.currentlyPlayingServiceOrGroup = InfoBarInstance.servicelist.servicelist.getCurrent()

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -280,6 +280,7 @@ class InfoBarStreamRelay:
 				playrefmod = playrefstring
 			playref = eServiceReference("%s%s%s:%s" % (playrefmod, url.replace(":", "%3a"), playrefstring.replace(":", "%3a"), ServiceReference(playref).getServiceName()))
 			print(f"[{self.__class__.__name__} Play service {playref.toString()} via streamrelay")
+			playref.setAlternativeUrl(playrefstring)
 		return playref
 
 	def checkService(self, service):

--- a/lib/service/elistboxservicecontent.cpp
+++ b/lib/service/elistboxservicecontent.cpp
@@ -530,6 +530,10 @@ eListboxPythonServiceContent::eListboxPythonServiceContent()
 	m_servicelist = true;
 }
 
+inline bool compareServices(const eServiceReference &src, const eServiceReference &trg) {
+	return (src.toString() == trg.alternativeurl);
+}
+
 bool eListboxPythonServiceContent::checkServiceIsRecorded(eServiceReference ref,pNavigation::RecordType type)
 {
 	std::map<ePtr<iRecordableService>, eServiceReference, std::less<iRecordableService*> > recordedServices;
@@ -545,10 +549,10 @@ bool eListboxPythonServiceContent::checkServiceIsRecorded(eServiceReference ref,
 			eBouquet *bouquet=0;
 			db->getBouquet(ref, bouquet);
 			for (std::list<eServiceReference>::iterator i(bouquet->m_services.begin()); i != bouquet->m_services.end(); ++i)
-				if (*i == it->second)
+				if (*i == it->second || compareServices(*i, it->second))
 					return true;
 		}
-		else if (ref == it->second)
+		else if (ref == it->second || compareServices(ref, it->second))
 			return true;
 	}
 	return false;

--- a/lib/service/listboxservice.cpp
+++ b/lib/service/listboxservice.cpp
@@ -621,6 +621,10 @@ void eListboxServiceContent::setItemHeight(int height)
 		m_listbox->setItemHeight(height);
 }
 
+inline bool compareServices(const eServiceReference &src, const eServiceReference &trg) {
+	return (src.toString() == trg.alternativeurl);
+}
+
 bool eListboxServiceContent::checkServiceIsRecorded(eServiceReference ref,pNavigation::RecordType type)
 {
 	std::map<ePtr<iRecordableService>, eServiceReference, std::less<iRecordableService*> > recordedServices;
@@ -636,10 +640,10 @@ bool eListboxServiceContent::checkServiceIsRecorded(eServiceReference ref,pNavig
 			eBouquet *bouquet=0;
 			db->getBouquet(ref, bouquet);
 			for (std::list<eServiceReference>::iterator i(bouquet->m_services.begin()); i != bouquet->m_services.end(); ++i)
-				if (*i == it->second)
+				if (*i == it->second || compareServices(*i, it->second))
 					return true;
 		}
-		else if (ref == it->second)
+		else if (ref == it->second || compareServices(ref, it->second))
 			return true;
 	}
 	return false;

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2030,6 +2030,10 @@ int eDVBServicePlay::getInfo(int w)
 	case sTSID:
 		return ((const eServiceReferenceDVB&)m_reference).getTransportStreamID().get();
 	case sNamespace:
+		// use origiginal namespace
+		if (!m_reference.alternativeurl.empty()){
+			return ((const eServiceReferenceDVB&)eServiceReferenceDVB(m_reference.alternativeurl)).getDVBNamespace().get();
+		}
 		return ((const eServiceReferenceDVB&)m_reference).getDVBNamespace().get();
 	case sProvider:
 		if (!m_dvb_service)
@@ -2051,6 +2055,12 @@ std::string eDVBServicePlay::getInfoString(int w)
 	{
 	case sProvider:
 		if (!m_dvb_service) return "";
+		if(m_dvb_service->m_provider_name.empty() && !m_reference.alternativeurl.empty())
+		{
+			ePtr<eDVBService> sRelayServiceOrigSref;
+			eDVBDB::getInstance()->getService(eServiceReferenceDVB(m_reference.alternativeurl), sRelayServiceOrigSref);
+			m_dvb_service->m_provider_name = std::string(sRelayServiceOrigSref->m_provider_name);
+		}
 		return m_dvb_service->m_provider_name;
 	case sServiceref:
 		return m_reference.toString();
@@ -2076,6 +2086,10 @@ std::string eDVBServicePlay::getInfoString(int w)
 
 ePtr<iDVBTransponderData> eDVBServicePlay::getTransponderData()
 {
+	if(!m_reference.alternativeurl.empty())
+	{
+		return eStaticServiceDVBInformation().getTransponderData(eServiceReferenceDVB(m_reference.alternativeurl));
+	}
 	return eStaticServiceDVBInformation().getTransponderData(m_reference);
 }
 


### PR DESCRIPTION
* add zap delay if stream relay active to prevent "no free tuner".
* show correct provider, namespace, transponder and frontend info for stream relay services
* show recording indicator in channel selection for stream relay services

PLEASE NOTE!!
All of this will only work if you use whitelist_streamrelay.

Some parts are taken from openVix.
Thanks to @DimitarCC