### PR TITLE
Show eg. `Wed 29 Nov` instead of `29 Nov 2023`

### DIFF
--- a/lib/python/Screens/EventView.py
+++ b/lib/python/Screens/EventView.py
@@ -224,7 +224,7 @@ class EventViewBase:
 		results = epgcache.search(("NB", 100, eEPGCache.SIMILAR_BROADCASTINGS_SEARCH, serviceRef, id))
 		if results:
 			similar = [_("Similar broadcasts:")]
-			timeFormat = "%s, %s" % (config.usage.date.long.value, config.usage.time.short.value)
+			timeFormat = "%s, %s" % (config.usage.date.dayshort.value, config.usage.time.short.value)
 			for result in sorted(results, key=lambda x: x[1]):
 				similar.append("%s  -  %s" % (strftime(timeFormat, localtime(result[1])), result[0]))
 			self["epg_description"].setText("%s\n\n%s" % (self["epg_description"].getText(), "\n".join(similar)))


### PR DESCRIPTION
This change uses `date.dayshort` instead of `date.long`.

EPG data is pretty much guaranteed to be less than a year ahead.  Even if further than a year away, that would be inferred by overlapping months.

### Before:
![datteefmt-20231129170220](https://github.com/openatv/enigma2/assets/9741693/c52e6d7e-c1d7-4612-b387-51ad5a8c2ea9)

### After:
![datefmt-20231129170609](https://github.com/openatv/enigma2/assets/9741693/67807206-77e8-44d0-a174-2644e94a6e63)



