### PR TITLE
[MessageBox.py] Correct summary display

### DIFF
--- a/lib/python/Screens/MessageBox.py
+++ b/lib/python/Screens/MessageBox.py
@@ -45,7 +45,7 @@ class MessageBox(Screen, HelpableScreen):
 			elif isinstance(default, int):
 				self.startIndex = default
 			else:
-				print("[MessageBox] Error: The context of the default (%s) can't be determined!" % default)
+				print(f"[MessageBox] Error: The context of the default ({default}) can't be determined!")
 		else:
 			self["list"] = MenuList([])
 			self["list"].hide()
@@ -108,7 +108,7 @@ class MessageBox(Screen, HelpableScreen):
 		self.onLayoutFinish.append(self.layoutFinished)
 
 	def __repr__(self):
-		return "%s(%s)" % (str(type(self)), self.text)
+		return f"{str(type(self))}({self.text})"
 
 	def layoutFinished(self):
 		if self.list:
@@ -127,7 +127,7 @@ class MessageBox(Screen, HelpableScreen):
 			self.baseTitle = self.baseTitle % prefix
 		self.setTitle(self.baseTitle, showPath=False)
 		if self.timeout > 0:
-			print("[MessageBox] Timeout set to %d seconds." % self.timeout)
+			print(f"[MessageBox] Timeout set to {self.timeout} seconds.")
 			self.timer.start(25)
 
 	def processTimer(self):
@@ -139,7 +139,7 @@ class MessageBox(Screen, HelpableScreen):
 			self.baseTitle = self.activeTitle
 		if self.timeout > 0:
 			if self.baseTitle:
-				self.setTitle("%s (%d)" % (self.baseTitle, self.timeout), showPath=False)
+				self.setTitle(f"{self.baseTitle} ({self.timeout})", showPath=False)
 			self.timer.start(1000)
 			self.timeout -= 1
 		else:
@@ -150,7 +150,7 @@ class MessageBox(Screen, HelpableScreen):
 				self.select()
 
 	def stopTimer(self, reason):
-		print("[MessageBox] %s" % reason)
+		print(f"[MessageBox] {reason}")
 		self.timer.stop()
 		self.timeout = 0
 		if self.baseTitle is not None:
@@ -205,7 +205,7 @@ class MessageBoxSummary(ScreenSummary):
 		ScreenSummary.__init__(self, session, parent=parent)
 		self["text"] = StaticText(parent.text)
 		self["option"] = StaticText("")
-		if hasattr(self, "list"):
+		if hasattr(parent, "list"):
 			if self.addWatcher not in self.onShow:
 				self.onShow.append(self.addWatcher)
 			if self.removeWatcher not in self.onHide:


### PR DESCRIPTION
- The summary screen was looking at itself rather than the parent to see if the "list" widget exists.  It now correctly looks at the parent.
- Use f-strings.
