### PR TITLE
[MessageBox.py] Restore unused widget definitions

### DIFF
--- a/lib/python/Screens/MessageBox.py
+++ b/lib/python/Screens/MessageBox.py
@@ -47,6 +47,8 @@ class MessageBox(Screen, HelpableScreen):
 			else:
 				print(f"[MessageBox] Error: The context of the default ({default}) can't be determined!")
 		else:
+			self["list"] = MenuList([])
+			self["list"].hide()
 			self.list = None
 		self.timeout = timeout
 		if close_on_any_key is True:  # Process legacy close_on_any_key argument.


### PR DESCRIPTION
The dummy widget has been restored as some skins do not check if the "list" widget actually exists before manipulating it.  The widget is optional and code should be checking that the widget is available *BEFORE* trying to manipulate it.  This hack has been restored to give skinners more time to correctly fix their skins!
