### PR TITLE
[TimeDateInput]

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -797,6 +797,10 @@
 		<item level="0" text="Date style" description="Choose the display formatting style for dates. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin." requires="config.usage.date.enabled">config.usage.date.dayfull</item>
 		<item level="0" text="Time style" description="Choose the display formatting style for times. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes and 'ss' is the seconds.  ('HH' and 'hh' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin." requires="config.usage.time.enabled">config.usage.time.long</item>
 	</setup>
+	<setup key="TimeDateInput" title="Date/time input">
+		<item level="0" text="Date" description="Select the date.">self.timeInputDate</item>
+		<item level="0" text="Time" description="Select the time.">self.timeInputTime</item>
+	</setup>
 	<setup key="Timeshift" title="Time Shift Settings" level="1" showOpenWebif="1">
 		<item level="2" text="Time shift buffer location" description="Set the default location to store your time shift buffer files. Press 'OK' to add new locations, press 'LEFT'/'RIGHT' to select from previously defined locations.">config.timeshift.path</item>
 		<item level="1" text="Automatically start time shift after" description="When enabled, time shift starts automatically in background after specified time.">config.timeshift.startDelay</item>

--- a/po/enigma2.pot
+++ b/po/enigma2.pot
@@ -15595,6 +15595,9 @@ msgstr ""
 msgid "Select the currently highlighted service"
 msgstr ""
 
+msgid "Select the date."
+msgstr ""
+
 msgid "Select the date from which this timer will become active."
 msgstr ""
 
@@ -15759,6 +15762,9 @@ msgid "Select the starting/initial column to be activated on File Commander star
 msgstr ""
 
 msgid "Select the tags that should be used for this recording."
+msgstr ""
+
+msgid "Select the time."
 msgstr ""
 
 msgid "Select the time after which this timer can start."


### PR DESCRIPTION
[TimeDateInput] Refactory, config_date lost regression
- `class TimeDateInput(Screen, ConfigListScreen):` --> `class TimeDateInput(Setup):`
- camel case vars
- remove config_date
- remove unused save_mask
- add init with timestamp, default
- add getTimestamp without parameter
- add TimeDateInput to setup.xml

Please feel free to help me proper the commit documetaion

Additional:
- MetrixHD https://github.com/openatv/MetrixHD/commit/f40149c8f4cd715d759633f0694f4e71b3d1a33b