### PR TITLE
Workaround for #3006 (pressing `0` no longer goes to first channel in Multi-channel EPG)

### DIFF
--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -692,6 +692,9 @@ class EPGSelection(Screen, HelpableScreen):
 
 	def toTop(self):
 		self["list"].moveTo(self["list"].instance.moveTop)
+		# dirty workaround for #3006 (pressing `0` no longer goes to first channel in bouquet)
+		self.nextBouquet()
+		self.prevBouquet()
 
 	def toEnd(self):
 		self["list"].moveTo(self["list"].instance.moveEnd)


### PR DESCRIPTION
This is a dirty workaround until the multi-channel EPG code can be reworked.