### PR TITLE
[keymap.xml] Add new PreviousNext action map

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -231,6 +231,15 @@
 		<key id="KEY_F6" mapto="save" flags="m" />
 	</map>
 
+	<map context="PreviousNextActions">
+		<key id="KEY_PREVIOUS" mapto="previous" flags="mr" />
+		<!-- <key id="KEY_PREVIOUS" mapto="PREVIOUS" flags="b" /> -->
+		<!-- <key id="KEY_PREVIOUS" mapto="previousLong" flags="l" /> -->
+		<key id="KEY_NEXT" mapto="next" flags="mr" />
+		<!-- <key id="KEY_NEXT" mapto="NEXT" flags="b" /> -->
+		<!-- <key id="KEY_NEXT" mapto="nextLong" flags="l" /> -->
+	</map>
+
 	<map context="SelectCancelActions">
 		<key id="KEY_OK" mapto="select" flags="m" />
 		<key id="KEY_OK" mapto="SELECT" flags="b" />


### PR DESCRIPTION
This new action map will allow code to grab or reassign the PREV and NEXT buttons for other uses.

The original button usage design used these buttons for navigation but many users complained and wanted them reserved for editing.  This commit is a workaround to allow these buttons to be remapped back to navigation on a case by case basis.
