### PR TITLE
fix #3156

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -890,8 +890,8 @@
 		<item level="0" text="2nd InfoBar timeout" description="Set the time to hide the second infobar. The bar also disappears on pressing 'OK'.">config.usage.second_infobar_timeout</item>
 		<item level="0" text="Show InfoBar picons" description="Option to disable picons on the Infobar.">config.usage.showpicon</item>
 		<item level="0" text="Show InfoBar lite *" description="Set the screen type you get on pressing 'OK' when the info bar shows to 2nd infobar Lite or event info.">config.usage.show_infobar_lite</item>
-		<item level="0" text="Enable InfoBar fade-out" description="Fade the InfoBar on hide.">config.usage.show_infobar_do_dimming</item>
-		<item level="0" text="InfoBar fade-out speed" description="Control the InfoBar fading speed.">config.usage.show_infobar_dimming_speed</item>
+		<item level="0" text="Enable InfoBar fade-out" description="Fade the InfoBar on hide." requires="CanChangeOsdAlpha">config.usage.show_infobar_do_dimming</item>
+		<item level="0" text="InfoBar fade-out speed" description="Control the InfoBar fading speed." requires="CanChangeOsdAlpha">config.usage.show_infobar_dimming_speed</item>
 		<item level="0" text="InfoBar EPG mode" description="Select how to activate the Quick EPG mode." requires="InfoBarEpg">config.plisettings.InfoBarEpg_mode</item>
 		<item level="0" text="Time delay of the shutdown messages" description="Set the time to wait for execute the default action in shutdown, standby or restart messages, e.g. used in RecordTimer, PowerTimer, SleepTimer etc.">config.usage.shutdown_msgbox_timeout</item>
 		<item level="1" text="Show job tasks in Extension Menu" description="With this option you can hide Job Tasks from the Extension Menu screen (BLUE button press).">config.usage.jobtaksextensions</item>


### PR DESCRIPTION
Hide the menu items for "Fade the InfoBar" on "OSD Settings" if not available.
- Enable InfoBar fade-out
- InfoBar fade-out speed