### PR TITLE
[Wizard] Change default option for channel list installation to "none"

### DIFF
--- a/lib/python/Screens/InstallWizard.py
+++ b/lib/python/Screens/InstallWizard.py
@@ -57,7 +57,7 @@ class InstallWizard(Screen, ConfigListScreen):
 					self.createMenu()
 			case self.STATE_CHANNELLIST:
 				self.enabled = ConfigYesNo(default=True)
-				self.channellist_type = ConfigSelection(default="default", choices={
+				self.channellist_type = ConfigSelection(default="none", choices={
 					"default": _("Default Astra (13e-19e)"),
 					"none": _("None")
 				})


### PR DESCRIPTION
Do not install defaultsat (13e/19e) channel lists unless user asks for it.