### PR TITLE
[Screen] Add integrated screen based images

### DIFF
--- a/lib/python/Screens/Information.py
+++ b/lib/python/Screens/Information.py
@@ -91,6 +91,7 @@ BoxInfo.setItem("InformationDistributionWelcome", welcome)
 class InformationBase(Screen, HelpableScreen):
 	skin = """
 	<screen name="Information" title="Information" position="center,center" size="1020,600" resolution="1280,720">
+		<widget name="Image" position="0,0" size="0,0" conditional="Image" />
 		<widget name="information" position="0,0" size="e,e-50" font="Regular;20" splitPosition="400" />
 		<widget source="key_red" render="Label" position="0,e-40" size="180,40" backgroundColor="key_red" conditional="key_red" font="Regular;20" foregroundColor="key_text" halign="center" valign="center">
 			<convert type="ConditionalShowHide" />
@@ -1222,6 +1223,7 @@ class NetworkInformation(InformationBase):
 class PictureInformation(Screen, HelpableScreen):
 	skin = """
 	<screen name="PictureInformation" title="Picture Information" position="center,center" size="950,560" resolution="1280,720">
+		<widget name="Image" position="0,0" size="0,0" conditional="Image" />
 		<widget name="name" position="0,0" size="e,25" font="Regular;20" halign="center" transparent="1" valign="center" />
 		<widget name="picture" position="0,35" size="e,e-85" alphatest="blend" scaleFlags="scaleCenter" transparent="1" />
 		<widget source="key_red" render="Label" position="0,e-40" size="180,40" backgroundColor="key_red" conditional="key_red" font="Regular;20" foregroundColor="key_text" halign="center" valign="center">

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -1,16 +1,18 @@
+from os.path import isdir, isfile
+
 from enigma import eRCInput, eTimer, eWindow, getDesktop
 
-from skin import GUI_SKIN_ID, applyAllAttributes
+from skin import GUI_SKIN_ID, applyAllAttributes, menus, screens, setups
 from Components.config import config
 from Components.GUIComponent import GUIComponent
+from Components.Pixmap import Pixmap
 from Components.Sources.Source import Source
 from Components.Sources.StaticText import StaticText
 from Tools.CList import CList
+from Tools.Directories import SCOPE_GUISKIN, resolveFilename
+from Tools.LoadPixmap import LoadPixmap
 
 
-# The lines marked DEBUG: are proposals for further fixes or improvements.
-# Other commented out code is historic and should probably be deleted if it is not going to be used.
-#
 class Screen(dict):
 	NO_SUSPEND, SUSPEND_STOPS, SUSPEND_PAUSES = list(range(3))
 	ALLOW_SUSPEND = NO_SUSPEND
@@ -18,143 +20,131 @@ class Screen(dict):
 
 	def __init__(self, session, parent=None, mandatoryWidgets=None):
 		dict.__init__(self)
-		self.skinName = self.__class__.__name__
 		self.session = session
 		self.parent = parent
 		self.mandatoryWidgets = mandatoryWidgets
-		self.onClose = []
+		className = self.__class__.__name__
+		self.skinName = className
 		self.onFirstExecBegin = []
 		self.onExecBegin = []
 		self.onExecEnd = []
+		self.onClose = []
 		self.onLayoutFinish = []
 		self.onShown = []
 		self.onShow = []
 		self.onHide = []
 		self.execing = False
 		self.shown = True
-		# DEBUG: Variable already_shown used in CutListEditor/ui.py...
-		# DEBUG: self.alreadyShown = False  # Already shown is false until the screen is really shown (after creation).
-		self.already_shown = False  # Already shown is false until the screen is really shown (after creation).
+		self.alreadyShown = False  # Already shown is false until the screen is really shown (after creation).
 		self.renderer = []
 		self.helpList = []  # In order to support screens *without* a help, we need the list in every screen. how ironic.
-		self.close_on_next_exec = None
-		# DEBUG: Variable already_shown used in webinterface/src/WebScreens.py...
-		# DEBUG: self.standAlone = False  # Stand alone screens (for example web screens) don't care about having or not having focus.
-		self.stand_alone = False  # Stand alone screens (for example web screens) don't care about having or not having focus.
+		self.closeOnNextExec = None
+		self.standAlone = False  # Stand alone screens (for example web screens) don't care about having or not having focus.
 		self.keyboardMode = None
 		self.desktop = None
 		self.instance = None
 		self.summaries = CList()
-		self["Title"] = StaticText()
-		self["ScreenPath"] = StaticText()
 		self.screenPath = ""  # This is the current screen path without the title.
 		self.screenTitle = ""  # This is the current screen title without the path.
+		self["ScreenPath"] = StaticText()
+		self["Title"] = StaticText()
+		self.screenImage = self.checkImage(className)  # This is the current screen image name.
+		if self.screenImage:
+			self["Image"] = Pixmap()
 
 	def __repr__(self):
 		return str(type(self))
 
 	def execBegin(self):
-		self.active_components = []
-		if self.close_on_next_exec is not None:
-			tmp = self.close_on_next_exec
-			self.close_on_next_exec = None
+		self.activeComponents = []
+		if self.closeOnNextExec is not None:
+			closeOnNextExec = self.closeOnNextExec
+			self.closeOnNextExec = None
 			self.execing = True
-			self.close(*tmp)
+			self.close(*closeOnNextExec)
 		else:
-			single = self.onFirstExecBegin
+			onFirstExecBegin = self.onFirstExecBegin
 			self.onFirstExecBegin = []
-			for x in self.onExecBegin + single:
-				x()
-				# DEBUG: if not self.standAlone and self.session.current_dialog != self:
-				if not self.stand_alone and self.session.current_dialog != self:
+			for method in self.onExecBegin + onFirstExecBegin:
+				method()
+				if not self.standAlone and self.session.current_dialog != self:
 					return
-			# assert self.session is None, "a screen can only exec once per time"
-			# self.session = session
-			for val in list(self.values()) + self.renderer:
-				val.execBegin()
-				# DEBUG: if not self.standAlone and self.session.current_dialog != self:
-				if not self.stand_alone and self.session.current_dialog != self:
+			for value in list(self.values()) + self.renderer:
+				value.execBegin()
+				if not self.standAlone and self.session.current_dialog != self:
 					return
-				self.active_components.append(val)
+				self.activeComponents.append(value)
 			self.execing = True
-			for x in self.onShown:
-				x()
+			for method in self.onShown:
+				method()
 
 	def execEnd(self):
-		active_components = self.active_components
-		# for (name, val) in self.items():
-		self.active_components = []
-		for val in active_components:
-			val.execEnd()
-		# assert self.session is not None, "execEnd on non-execing screen!"
-		# self.session = None
+		activeComponents = self.activeComponents
+		self.activeComponents = []
+		for component in activeComponents:
+			component.execEnd()
 		self.execing = False
-		for x in self.onExecEnd:
-			x()
+		for method in self.onExecEnd:
+			method()
 
-	def doClose(self):  # Never call this directly - it will be called from the session!
+	def doClose(self):  # Never call this directly - it will be called from session!
 		self.hide()
-		for x in self.onClose:
-			x()
-		del self.helpList  # Fixup circular references.
+		for method in self.onClose:
+			method()
+		del self.helpList  # Fix up circular references.
 		self.deleteGUIScreen()
-		# First disconnect all render from their sources. We might split this out into
+		# First disconnect all renderers from their sources. We might split this out into
 		# a "unskin"-call, but currently we destroy the screen afterwards anyway.
-		for val in self.renderer:
-			val.disconnectAll()  # Disconnect converter/sources and probably destroy them. Sources will not be destroyed.
+		for value in self.renderer:
+			value.disconnectAll()  # Disconnect converter/sources and probably destroy them. Sources will not be destroyed.
 		del self.session
-		for (name, val) in list(self.items()):
-			val.destroy()
+		for (name, value) in list(self.items()):  # Use a copy of the self dictionary as we are changing the dictionary as we go!
+			value.destroy()
 			del self[name]
 		self.renderer = []
 		self.__dict__.clear()  # Really delete all elements now.
 
-	def close(self, *retval):
+	def close(self, *retVal):
 		if not self.execing:
-			self.close_on_next_exec = retval
+			self.closeOnNextExec = retVal
 		else:
-			self.session.close(self, *retval)
+			self.session.close(self, *retVal)
 
 	def show(self):
-		print("[Screen] Showing screen '%s'." % self.skinName)  # To ease identification of screens.
-		# DEBUG: if (self.shown and self.alreadyShown) or not self.instance:
-		if (self.shown and self.already_shown) or not self.instance:
-			return
-		self.shown = True
-		# DEBUG: self.alreadyShown = True
-		self.already_shown = True
-		self.instance.show()
-		for x in self.onShow:
-			x()
-		for val in list(self.values()) + self.renderer:
-			if isinstance(val, GUIComponent) or isinstance(val, Source):
-				val.onShow()
+		if not (self.shown and self.alreadyShown) and self.instance:
+			self.shown = True
+			self.alreadyShown = True
+			self.instance.show()
+			for method in self.onShow:
+				method()
+			for value in list(self.values()) + self.renderer:
+				if isinstance(value, GUIComponent) or isinstance(value, Source):
+					value.onShow()
 
 	def hide(self):
-		if not self.shown or not self.instance:
-			return
-		self.shown = False
-		self.instance.hide()
-		for x in self.onHide:
-			x()
-		for val in list(self.values()) + self.renderer:
-			if isinstance(val, GUIComponent) or isinstance(val, Source):
-				val.onHide()
+		if self.shown and self.instance:
+			self.shown = False
+			self.instance.hide()
+			for method in self.onHide:
+				method()
+			for value in list(self.values()) + self.renderer:
+				if isinstance(value, GUIComponent) or isinstance(value, Source):
+					value.onHide()
 
 	def isAlreadyShown(self):  # Already shown is false until the screen is really shown (after creation).
-		return self.already_shown
+		return self.alreadyShown
 
-	def isStandAlone(self):  # Stand alone screens (for example web screens) don't care about having or not having focus.
-		return self.stand_alone
+	def getStandAlone(self):  # Stand alone screens (for example web screens) don't care about having or not having focus.
+		return self.standAlone
 
-	def getScreenPath(self):
-		return self.screenPath
+	def setStandAlone(self, value):  # Stand alone screens (for example web screens) don't care about having or not having focus.
+		self.standAlone = value
 
 	def setTitle(self, title, showPath=True):
-		try:  # This protects against calls to setTitle() before being fully initialised like self.session is accessed *before* being defined.
+		try:  # This protects against calls to setTitle() before being fully initialized like self.session is accessed *before* being defined.
 			self.screenPath = ""
 			if self.session and len(self.session.dialog_stack) > 1:
-				self.screenPath = " > ".join(ds[0].getTitle() for ds in self.session.dialog_stack[1:])
+				self.screenPath = " > ".join(x[0].getTitle() for x in self.session.dialog_stack[1:])
 			if self.instance:
 				self.instance.setTitle(title)
 			self.summaries.setTitle(title)
@@ -163,23 +153,56 @@ class Screen(dict):
 		self.screenTitle = title
 		if showPath and config.usage.showScreenPath.value == "large" and title:
 			screenPath = ""
-			screenTitle = "%s > %s" % (self.screenPath, title) if self.screenPath else title
+			screenTitle = f"{self.screenPath} > {title}" if self.screenPath else title
 		elif showPath and config.usage.showScreenPath.value == "small":
-			screenPath = "%s >" % self.screenPath if self.screenPath else ""
+			screenPath = f"{self.screenPath} >" if self.screenPath else ""
 			screenTitle = title
 		else:
 			screenPath = ""
 			screenTitle = title
-		self["ScreenPath"].text = screenPath
-		self["Title"].text = screenTitle
+		self["ScreenPath"].setText(screenPath)
+		self["Title"].setText(screenTitle)
 
 	def getTitle(self):
 		return self.screenTitle
 
 	title = property(getTitle, setTitle)
 
-	def setFocus(self, o):
-		self.instance.setFocus(o.instance)
+	def getScreenPath(self):
+		return self.screenPath
+
+	def checkImage(self, image, source=None):
+		screenImage = None
+		if image:
+			images = {
+				# "screen": screens,
+				"menu": menus,
+				"setup": setups
+			}.get(source, screens)
+			defaultImage = images.get("default", "")
+			screenImage = images.get(image, defaultImage)
+			if screenImage:
+				screenImage = resolveFilename(SCOPE_GUISKIN, screenImage)
+				msg = f"{'Default' if screenImage == defaultImage and image != 'default' else 'Specified'} {source if source else 'screen'} image for '{image}' is '{screenImage}'"
+				if isfile(screenImage):
+					print(f"[Screen] {msg}.")
+				else:
+					print(f"[Screen] Error: {msg} but this is not a file!")
+					screenImage = None
+		return screenImage
+
+	def setImage(self, image, source=None):
+		self.screenImage = self.checkImage(image, source=source)
+		if self.screenImage and "Image" not in self:
+			self["Image"] = Pixmap()
+
+	def getImage(self):
+		return self.screenImage
+
+	image = property(getImage, setImage)
+
+	def setFocus(self, item):
+		self.instance.setFocus(item.instance)
 
 	def setKeyboardModeNone(self):
 		rcinput = eRCInput.getInstance()
@@ -189,14 +212,14 @@ class Screen(dict):
 		rcinput = eRCInput.getInstance()
 		rcinput.setKeyboardMode(rcinput.kmAscii)
 
+	def saveKeyboardMode(self):
+		rcinput = eRCInput.getInstance()
+		self.keyboardMode = rcinput.getKeyboardMode()
+
 	def restoreKeyboardMode(self):
 		rcinput = eRCInput.getInstance()
 		if self.keyboardMode is not None:
 			rcinput.setKeyboardMode(self.keyboardMode)
-
-	def saveKeyboardMode(self):
-		rcinput = eRCInput.getInstance()
-		self.keyboardMode = rcinput.getKeyboardMode()
 
 	def setDesktop(self, desktop):
 		self.desktop = desktop
@@ -206,30 +229,32 @@ class Screen(dict):
 			self.instance.setAnimationMode(mode)
 
 	def getRelatedScreen(self, name):
-		if name == "session":
-			return self.session.screen
-		elif name == "parent":
-			return self.parent
-		elif name == "global":
-			return self.globalScreen
-		return None
+		match name:
+			case "session":
+				related = self.session.screen
+			case "parent":
+				related = self.parent
+			case "global":
+				related = self.globalScreen
+			case _:
+				related = None
+		return related
 
-	def callLater(self, function):
+	def callLater(self, method):
 		self.__callLaterTimer = eTimer()
-		self.__callLaterTimer.callback.append(function)
+		self.__callLaterTimer.callback.append(method)
 		self.__callLaterTimer.start(0, True)
 
 	def applySkin(self):
 		bounds = (getDesktop(GUI_SKIN_ID).size().width(), getDesktop(GUI_SKIN_ID).size().height())
 		resolution = bounds
 		zPosition = 0
-		# DEBUG: baseRes = (getDesktop(GUI_SKIN_ID).size().width(), getDesktop(GUI_SKIN_ID).size().height())
-		# baseRes = (720, 576)  # FIXME: A skin might have set another resolution, which should be the base res.
 		for (key, value) in self.skinAttributes:
-			if key == "resolution" or key == "baseResolution":
-				resolution = tuple([int(x.strip()) for x in value.split(",")])
-			elif key == "zPosition":
-				zPosition = int(value)
+			match key:
+				case "resolution" | "baseResolution":
+					resolution = tuple([int(x.strip()) for x in value.split(",")])
+				case "zPosition":
+					zPosition = int(value)
 		if not self.instance:
 			self.instance = eWindow(self.desktop, zPosition)
 		if "title" not in self.skinAttributes and self.screenTitle:
@@ -237,43 +262,46 @@ class Screen(dict):
 		else:
 			for attribute in self.skinAttributes:
 				if attribute[0] == "title":
-					self.setTitle(_(attribute[1]))
+					self.setTitle(_(attribute[1]))  # This translation harvest is handled by the XML scanner.
 		self.scale = ((bounds[0], resolution[0]), (bounds[1], resolution[1]))
 		self.skinAttributes.sort(key=lambda a: {"position": 1}.get(a[0], 0))  # We need to make sure that certain attributes come last.
 		applyAllAttributes(self.instance, self.desktop, self.skinAttributes, self.scale)
 		self.createGUIScreen(self.instance, self.desktop)
 
 	def createGUIScreen(self, parent, desktop, updateonly=False):
-		for val in self.renderer:
-			if isinstance(val, GUIComponent):
+		for value in self.renderer:
+			if isinstance(value, GUIComponent):
 				if not updateonly:
-					val.GUIcreate(parent)
-				if not val.applySkin(desktop, self):
-					print("[Screen] Warning: Skin is missing renderer '%s' in %s." % (val, str(self)))
+					value.GUIcreate(parent)
+				if not value.applySkin(desktop, self):
+					print(f"[Screen] Warning: Skin is missing renderer '{value}' in {str(self)}.")
 		for key in self:
-			val = self[key]
-			if isinstance(val, GUIComponent):
+			value = self[key]
+			if isinstance(value, GUIComponent):
 				if not updateonly:
-					val.GUIcreate(parent)
-				depr = val.deprecationInfo
-				if val.applySkin(desktop, self):
-					if depr:
-						print("[Screen] WARNING: OBSOLETE COMPONENT '%s' USED IN SKIN. USE '%s' INSTEAD!" % (key, depr[0]))
-						print("[Screen] OBSOLETE COMPONENT WILL BE REMOVED %s, PLEASE UPDATE!" % depr[1])
-				elif not depr:
-					print("[Screen] Warning: Skin is missing element '%s' in %s." % (key, str(self)))
-		for w in self.additionalWidgets:
+					value.GUIcreate(parent)
+				deprecated = value.deprecationInfo
+				if value.applySkin(desktop, self):
+					if deprecated:
+						print(f"[Screen] WARNING: OBSOLETE COMPONENT '{key}' USED IN SKIN. USE '{deprecated[0]}' INSTEAD!")
+						print(f"[Screen] OBSOLETE COMPONENT WILL BE REMOVED {deprecated[1]}, PLEASE UPDATE!")
+				elif not deprecated:
+					try:
+						print(f"[Screen] Warning: Skin is missing element '{key}' in {str(self)} item {str(self[key])}.")
+					except Exception:
+						print(f"[Screen] Warning: Skin is missing element '{key}'.")
+		for widget in self.additionalWidgets:
 			if not updateonly:
-				w.instance = w.widget(parent)
-				# w.instance.thisown = 0
-			applyAllAttributes(w.instance, desktop, w.skinAttributes, self.scale)
-		for f in self.onLayoutFinish:
-			# DEBUG: if type(f) is not type(self.close):  # Is this the best way to do this?
-			# DEBUG: Is the following an acceptable fix?
-			if not isinstance(f, type(self.close)):
-				exec(f, globals(), locals())
+				widget.instance = widget.widget(parent)
+			applyAllAttributes(widget.instance, desktop, widget.skinAttributes, self.scale)
+		if self.screenImage:
+			screenImage = LoadPixmap(self.screenImage)
+			self["Image"].instance.setPixmap(screenImage)
+		for method in self.onLayoutFinish:
+			if not isinstance(method, type(self.close)):
+				exec(method, globals(), locals())
 			else:
-				f()
+				method()
 
 	def deleteGUIScreen(self):
 		for (name, val) in list(self.items()):
@@ -291,6 +319,11 @@ class Screen(dict):
 		if summary is not None:
 			self.summaries.remove(summary)
 
+	# These properties support legacy code that reaches into the internal variables of this class!
+	#
+	already_shown = property(isAlreadyShown)  # Used in CutListEditor/ui.py.
+	stand_alone = property(getStandAlone, setStandAlone)  # Used in webinterface/src/WebScreens.py.
+
 
 class ScreenSummary(Screen):
 	skin = """
@@ -304,14 +337,16 @@ class ScreenSummary(Screen):
 	def __init__(self, session, parent):
 		Screen.__init__(self, session, parent=parent)
 		self["Title"] = StaticText(parent.getTitle())
-		skinNames = parent.skinName
-		if not isinstance(skinNames, list):
-			skinNames = [skinNames]
-		self.skinName = ["%sSummary" % x for x in skinNames]
-		self.skinName += ["%s_summary" % x for x in skinNames]  # DEBUG: Old summary screens currently kept for compatibility.
+		skinName = parent.skinName
+		if not isinstance(skinName, list):
+			skinName = [skinName]
+		self.skinName = [f"{x}Summary" for x in skinName]
 		className = self.__class__.__name__
-		if className != "ScreenSummary" and className not in self.skinName: # When using a summary class that does not have the same name as the parent class
+		if className != "ScreenSummary" and className not in self.skinName:  # When a summary screen does not have the same name as the parent then add it to the list.
 			self.skinName.append(className)
+		self.skinName += [f"{x}_summary" for x in skinName]  # DEBUG: Old summary screens currently kept for compatibility.
 		self.skinName.append("ScreenSummary")
-		self.skinName.append("SimpleSummary")  # DEBUG: Old summary screens currently kept for compatibility.
 		self.skin = parent.__dict__.get("skinSummary", self.skin)  # If parent has a "skinSummary" defined, use that as default.
+		# skins = "', '".join(self.skinName)
+		# print(f"[Screen] DEBUG: Skin names: '{skins}'.")
+		# print(f"[Screen] DEBUG: Skin:\n{self.skin}")

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -38,8 +38,9 @@ fonts = {  # Dictionary of predefined and skin defined font aliases.
 	"Body": ("Regular", 18, 22, 16),
 	"ChoiceList": ("Regular", 20, 24, 18)
 }
-menus = {}  # Dictionary of images associated with menu entries.
 parameters = {}  # Dictionary of skin parameters used to modify code behavior.
+screens = {}  # Dictionary of images associated with screen entries.
+menus = {}  # Dictionary of images associated with menu entries.
 setups = {}  # Dictionary of images associated with setup menus.
 switchPixmap = {}  # Dictionary of switch images.
 windowStyles = {}  # Dictionary of window styles for each screen ID.
@@ -1283,10 +1284,19 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_GUISKIN
 				parameters[name] = list(map(parseParameter, [x.strip() for x in value.split(",")])) if "," in value else parseParameter(value)
 			else:
 				skinError(f"Tag 'parameter' needs a name and value, got name='{name}' and size='{value}'")
+	for tag in domSkin.findall("screens"):
+		for screen in tag.findall("screen"):
+			key = screen.attrib.get("key")
+			image = screen.attrib.get("image")
+			if key and image:
+				screens[key] = image
+				# print(f"[Skin] DEBUG: Screen key='{key}', image='{image}'.")
+			else:
+				skinError(f"Tag 'screen' needs key and image, got key='{key}' and image='{image}'")
 	for tag in domSkin.findall("menus"):
-		for setup in tag.findall("menu"):
-			key = setup.attrib.get("key")
-			image = setup.attrib.get("image")
+		for menu in tag.findall("menu"):
+			key = menu.attrib.get("key")
+			image = menu.attrib.get("image")
 			if key and image:
 				menus[key] = image
 				# print(f"[Skin] DEBUG: Menu key='{key}', image='{image}'.")
@@ -1665,7 +1675,7 @@ def readSkin(screen, skin, names, desktop):
 				myName = name  # Use this name for debug output.
 				break
 			else:
-				widgetList = ", ".join(screen.mandatoryWidgets)
+				widgetList = "', '".join(screen.mandatoryWidgets)
 				print(f"[Skin] Warning: Skin screen '{name}' rejected as it does not offer all the mandatory widgets '{widgetList}'!")
 				myScreen = None
 	else:
@@ -1673,7 +1683,7 @@ def readSkin(screen, skin, names, desktop):
 	if myScreen is None:  # Otherwise try embedded skin.
 		myScreen = getattr(screen, "parsedSkin", None)
 	if myScreen is None and getattr(screen, "skin", None):  # Try uncompiled embedded skin.
-		if isinstance(screen.skin, list):
+		if isinstance(screen.skin, list):  # This mode of skin scaling is deprecated!
 			print(f"[Skin] Resizable embedded skin template found in '{myName}'.")
 			skin = screen.skin[0] % tuple([int(x * getSkinFactor()) for x in screen.skin[1:]])
 		else:
@@ -1917,12 +1927,12 @@ def readSkin(screen, skin, names, desktop):
 	}
 
 	try:
-		msg = f" from list '{', '.join(names)}'" if len(names) > 1 else ""
+		msg = f", from list '{', '.join(names)}'," if len(names) > 1 else ""
 		posX = "?" if context.x is None else str(context.x)
 		posY = "?" if context.y is None else str(context.y)
 		sizeW = "?" if context.w is None else str(context.w)
 		sizeH = "?" if context.h is None else str(context.h)
-		print(f"[Skin] Processing screen '{myName}'{msg}, position=({posX}, {posY}), size=({sizeW}x{sizeH}) for module '{screen.__class__.__name__}'.")
+		print(f"[Skin] Processing screen '{myName}'{msg} position=({posX},{posY}), size=({sizeW},{sizeH}) for module '{screen.__class__.__name__}'.")
 		context.x = 0  # Reset offsets, all components are relative to screen coordinates.
 		context.y = 0
 		processScreen(myScreen, context)
@@ -1939,6 +1949,21 @@ def readSkin(screen, skin, names, desktop):
 	usedComponents = None
 
 
+# Search the domScreens dictionary to see if any of the screen names provided
+# have a skin based screen.  This will allow coders to know if the named
+# screen will be skinned by the skin code.  A return of None implies that the
+# code must provide its own skin for the screen to be displayed to the user.
+#
+def findSkinScreen(names):
+	if not isinstance(names, list):
+		names = [names]
+	for name in names:  # Try all names given, the first one found is the one that will be used by the skin engine.
+		screen, path = domScreens.get(name, (None, None))
+		if screen:  # is not None:
+			return name
+	return None
+
+
 # Return a set of all the widgets found in a screen. Panels will be expanded
 # recursively until all referenced widgets are captured. This code only performs
 # a simple scan of the XML and no skin processing is performed.
@@ -1946,20 +1971,20 @@ def readSkin(screen, skin, names, desktop):
 def findWidgets(name):
 	widgetSet = set()
 	element, path = domScreens.get(name, (None, None))
-	if element is not None:
+	if element:
 		widgets = element.findall("widget")
-		if widgets is not None:
+		if widgets:
 			for widget in widgets:
-				name = widget.get("name", None)
-				if name is not None:
+				name = widget.get("name")
+				if name:
 					widgetSet.add(name)
-				source = widget.get("source", None)
-				if source is not None:
+				source = widget.get("source")
+				if source:
 					widgetSet.add(source)
 		panels = element.findall("panel")
-		if panels is not None:
+		if panels:
 			for panel in panels:
-				name = panel.get("name", None)
+				name = panel.get("name")
 				if name:
 					widgetSet.update(findWidgets(name))
 	return widgetSet
@@ -1976,32 +2001,10 @@ def getScrollLabelStyle(element):
 # default screen resolution of HD (720p).  That is the scale factor for a HD
 # screen will be 1.
 #
+# NOTE: This function is deprecated for openATV!
+#
 def getSkinFactor(screen=GUI_SKIN_ID):
 	skinfactor = getDesktop(screen).size().height() / 720.0
 	# if skinfactor not in [0.8, 1, 1.5, 3, 6]:
 	# 	print(f"[Skin] Warning: Unexpected result for getSkinFactor '{skinfactor:.4f}'!")
 	return skinfactor
-
-
-# Search the domScreens dictionary to see if any of the screen names provided
-# have a skin based screen.  This will allow coders to know if the named
-# screen will be skinned by the skin code.  A return of None implies that the
-# code must provide its own skin for the screen to be displayed to the user.
-#
-def findSkinScreen(names):
-	if not isinstance(names, list):
-		names = [names]
-	for name in names:  # Try all names given, the first one found is the one that will be used by the skin engine.
-		screen, path = domScreens.get(name, (None, None))
-		if screen is not None:
-			return name
-	return None
-
-
-def dump(x, i=0):
-	print(" " * i + str(x))
-	try:
-		for node in x.childNodes:
-			dump(node, i + 1)
-	except Exception:
-		pass


### PR DESCRIPTION
[Screen.py]
- Add facility to have a screen based image based on the class name of the screen.
- Add new methods "isAlreadyShown()", "setStandAlone()" and "getStandAlone()" to replace direct access to the "self.already_shown" and "self.stand_alone" variables.
- Add "already_shown" and "stand_alone" properties to support legacy code that is manipulating the old internal variables.
- Add new methods "setImage()" and "getImage()" to fine control the new screen based image facility.
- Remove logging of the screen names as this is already done in "skin.py".
- Improve variable names.

[skin.py]
- Add new "screens" dictionary for the new screen based image system.
- Add code to read the "screens" tag block from the skin.
- Correct the variable name in the "menu" tab block reader.
- Improve some of the logging messages.
- Add comment that openATV will be deprecating skin list based scaling.
- Add comment that openATV will has deprecating "getSkinFactor()" skin list based scaling.
- Optimize some of the code.
- Remove long dead code.

[Information.py]
- Add new "Image" widget to support the new screen based images.
