### PR TITLE
[YTDLPWrapper] Enable using netrc file

### DIFF
--- a/lib/python/Plugins/Extensions/YTDLPWrapper/plugin.py
+++ b/lib/python/Plugins/Extensions/YTDLPWrapper/plugin.py
@@ -17,7 +17,7 @@ def zap(session, service, **kwargs):
 				url = url.replace("YT-DLP%3a//", "")
 				url = url.replace("%3a", ":")
 				try:
-					ydl = YoutubeDL({"format": "b", "no_color": True})
+					ydl = YoutubeDL({"format": "b", "no_color": True, "netrc_cmd": "cat ~/.netrc"})
 					result = ydl.extract_info(url, download=False)
 					result = ydl.sanitize_info(result)
 					if result and result.get("url"):


### PR DESCRIPTION
Hi,
This change enables using netrc file in YTDLPWrapper plugin to allow yt-dlp to use authentication data stored in the netrc file.

The netrc file is a structured text file that - in principle - stores the credentials used during logging in to remote machines.
https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html

The yt-dlp can use the netrc file to store credentials data (logins, passwords) for websites that need logging in to make access its contents (videos, live transmissions, etc.).
Link to yt-dlp's documentation describing using the netrc file: https://github.com/yt-dlp/yt-dlp#authentication-with-netrc

For some reason enabling just the "--netrc" flag (in code - by inserting `"usenetrc": True` does not seem to work so I used a workaround with using "cat" on a file stored in the default location - user's home directory.

If the netrc file does not exist, a warning is displayed, but the link generation process is not interrupted so the change should be transparent for users that have not created the file.

I leave it open to consider using a different file location or adding the option to customize this option for example in the user interface, from the system settings. 

Nevertheless in my opinion it should be possible to use netrc file (or - possibly other way) to store credential data for yt-dlp used as a base mechanism of stream URL extraction in YTDLPWrapper plugin.

Best regards,
mp107