### PR TITLE
[ChannelSelection] Subservices

### DIFF
--- a/lib/python/Screens/ButtonSetup.py
+++ b/lib/python/Screens/ButtonSetup.py
@@ -234,6 +234,7 @@ def getButtonSetupFunctions():
 	ButtonSetupFunctions.append((_("Start time shift"), "Infobar/startTimeshift", textInfoBar))
 	ButtonSetupFunctions.append((_("Stop time shift"), "Infobar/stopTimeshift", textInfoBar))
 	ButtonSetupFunctions.append((_("Start teletext"), "Infobar/startTeletext", textInfoBar))
+	ButtonSetupFunctions.append((_("Show subservices"), "Infobar/openSubservices", textInfoBar))
 	ButtonSetupFunctions.append((_("Show subservice selection"), "Infobar/subserviceSelection", textInfoBar))
 	ButtonSetupFunctions.append((_("Show subtitle selection"), "Infobar/subtitleSelection", textInfoBar))
 	ButtonSetupFunctions.append((_("Show subtitle quick menu"), "Infobar/subtitleQuickMenu", textInfoBar))

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -18,6 +18,7 @@ from Screens.ChoiceBox import ChoiceBox
 from Screens.DateTimeInput import EPGJumpTime
 from Screens.EventView import EventViewEPGSelect, EventViewSimple
 from Screens.HelpMenu import HelpableScreen
+from Screens.InfoBar import InfoBar
 from Screens.MessageBox import MessageBox
 from Screens.PictureInPicture import PictureInPicture
 from Screens.Screen import Screen
@@ -398,6 +399,8 @@ class EPGSelection(Screen, HelpableScreen):
 
 	def getBouquetServices(self, bouquet):
 		services = []
+		if InfoBar.instance.servicelist.isSubservices(bouquet):
+			return [ServiceReference(ref) for ref in InfoBar.instance.servicelist.getSubservices()]
 		servicelist = eServiceCenter.getInstance().list(bouquet)
 		if servicelist is not None:
 			while True:

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -1707,6 +1707,10 @@ class InfoBarChannelSelection:
 		self.servicelist.showFavourites()
 		self.session.execDialog(self.servicelist)
 
+	def openSubservices(self):
+		self.servicelist.enterSubservices()
+		self.session.execDialog(self.servicelist)
+
 	def zapUp(self):
 		if not self.LongButtonPressed or BoxInfo.getItem("NumVideoDecoders", 1) <= 1:
 			if self.pts_blockZap_timer.isActive():


### PR DESCRIPTION
- create, fill and refill a virtual (groupedservices.virtualsubservices.tv) bouquet
- if subservices available, they can be entered via
  - "Reception Lists"
  - ChannelContextMenu new item added
  - Hotkey

[InfoBarGenerics]
- add method for ButtonSetup

[ButtonSetup]
- append "Show subservices"

[EpgSelection]
- provide a subservicelist for all EPG's