### PR TITLE
[keymap.xml] Add new ShowVirtualKeyboardActions action map

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -266,6 +266,10 @@
 		<key id="\x1b" mapto="cancel" flags="m" />
 	</map>
 
+	<map context="ShowVirtualKeyboardActions">
+		<key id="KEY_TEXT" mapto="showVirtualKeyboard" flags="m" />
+	</map>
+
 	<map context="TextEditActions">
 		<key id="KEY_BACK" mapto="backspace" flags="mr" />
 		<key id="KEY_LAST" mapto="backspace" flags="mr" />


### PR DESCRIPTION
This is a new action map to allow for a future clarification that will make all VirtualKeyboard actions use a standardised case.

Having two separate action maps that differ by the case of one letter that do very different things is not a good idea and can cause confusion.
