### PR TITLE
[EventInfo.py] Ensure that times are an integer

### DIFF
--- a/lib/python/Components/Sources/EventInfo.py
+++ b/lib/python/Components/Sources/EventInfo.py
@@ -21,7 +21,7 @@ class pServiceEvent:
 		self.m_ShortDescriptionNext = ""
 		self.m_ExtendedDescriptionNow = ""
 		self.m_ExtendedDescriptionNext = ""
-		self.m_Begin = time()
+		self.m_Begin = int(time())
 		self.m_Duration = 0
 
 		sTagTitle = info.getInfoString(iServiceInformation.sTagTitle)


### PR DESCRIPTION
Enigma2 times used for displays, and most processing, are in whole seconds.
