### PR TITLE
[AVSwitch.py] Prepare for a refactor

### DIFF
--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -1493,7 +1493,8 @@ def InitiVideomodeHotplug(**kwargs):
 	startHotplug()
 
 
-iAVSwitch = AVSwitchBase()  # This should be updated in Screens/InfoBarGenerics.py, Screens/VideoWizard.py and Screens/VideoMode.py.
+avSwitch = AVSwitchBase()
+iAVSwitch = avSwitch
 hotplug = None
 
 

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -16,7 +16,7 @@ from keyids import KEYFLAGS, KEYIDNAMES, KEYIDS
 from RecordTimer import AFTEREVENT, RecordTimer, RecordTimerEntry, findSafeRecordPath, parseEvent
 from ServiceReference import ServiceReference, getStreamRelayRef, hdmiInServiceRef, isPlayableForCur
 from Components.ActionMap import ActionMap, HelpableActionMap, HelpableNumberActionMap
-from Components.AVSwitch import iAVSwitch
+from Components.AVSwitch import avSwitch
 from Components.config import ConfigBoolean, ConfigClock, ConfigSelection, config, configfile
 from Components.Harddisk import findMountPoint, harddiskmanager
 from Components.Input import Input
@@ -4201,7 +4201,7 @@ class InfoBarAspectSelection:
 			aspectSwitchList = []
 			if config.av.aspectswitch.enabled.value:
 				for aspect in range(5):
-					aspectSwitchList.append((iAVSwitch.ASPECT_SWITCH_MSG[aspect], str(aspect + 100)))
+					aspectSwitchList.append((avSwitch.ASPECT_SWITCH_MSG[aspect], str(aspect + 100)))
 				aspectSwitchList.append(("--", ""))
 			aspectList = [
 				(_("Resolution"), "resolution"),
@@ -4216,7 +4216,7 @@ class InfoBarAspectSelection:
 				(_("16:9 Letterbox"), "6")
 			]
 		keys = ["green", "", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
-		aspect = iAVSwitch.getAspectRatioSetting()
+		aspect = avSwitch.getAspectRatioSetting()
 		selection = 0
 		for item in range(len(aspectList)):
 			if aspectList[item][1] == aspect:
@@ -4232,7 +4232,7 @@ class InfoBarAspectSelection:
 				elif aspect[1] == "resolution":
 					self.ExGreen_toggleGreen()
 				else:
-					iAVSwitch.setAspectRatio(int(aspect[1]))
+					avSwitch.setAspectRatio(int(aspect[1]))
 					self.ExGreen_doHide()
 		else:
 			self.ExGreen_doHide()
@@ -4253,7 +4253,7 @@ class InfoBarResolutionSelection:
 		resList.append((_("Video: ") + "%dx%d@%gHz" % (xRes, yRes, fps), ""))
 		resList.append(("--", ""))
 		# Do we need a new sorting with this way here or should we disable some choices?
-		videoModes = iAVSwitch.readPreferredModes(readOnly=True)
+		videoModes = avSwitch.readPreferredModes(readOnly=True)
 		videoModes = [x.replace("pal ", "").replace("ntsc ", "") for x in videoModes]  # Do we need this?
 		for videoMode in videoModes:
 			video = videoMode
@@ -4278,7 +4278,7 @@ class InfoBarResolutionSelection:
 				if videoMode[1] == "exit" or videoMode[1] == "" or videoMode[1] == "auto":
 					self.ExGreen_toggleGreen()
 				if videoMode[1] != "auto":
-					iAVSwitch.setVideoModeDirect(videoMode[1])
+					avSwitch.setVideoModeDirect(videoMode[1])
 					self.ExGreen_doHide()
 		else:
 			self.ExGreen_doHide()

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -5,7 +5,7 @@ from enigma import eTimer
 
 from skin import findSkinScreen, menus
 from Components.ActionMap import HelpableNumberActionMap, HelpableActionMap
-from Components.AVSwitch import iAVSwitch
+from Components.AVSwitch import avSwitch
 from Components.config import ConfigDictionarySet, NoSave, config, configfile
 from Components.Pixmap import Pixmap
 from Components.PluginComponent import plugins
@@ -628,7 +628,7 @@ class Menu(Screen, HelpableScreen, ProtectedScreen):
 			self.moveAction()
 
 	def keyText(self):
-		iAVSwitch.setMode("HDMI", "720p", "50Hz")
+		avSwitch.setMode("HDMI", "720p", "50Hz")
 
 	def moveAction(self):
 		menuListCopy = list(self.menuList)

--- a/lib/python/Screens/StartWizard.py
+++ b/lib/python/Screens/StartWizard.py
@@ -4,7 +4,7 @@ from shlex import split
 
 from enigma import eTimer
 
-from Components.AVSwitch import iAVSwitch
+from Components.AVSwitch import avSwitch
 from Components.config import ConfigBoolean, config, configfile
 from Components.Console import Console
 from Components.Harddisk import harddiskmanager
@@ -183,18 +183,17 @@ class WizardLanguage(Wizard, ShowRemoteControl):
 		ShowRemoteControl.__init__(self)
 		self.skinName = ["WizardLanguage", "StartWizard"]
 		self.oldLanguage = config.osd.language.value
-		self.avSwitch = iAVSwitch
 		self.mode = "720p"
-		self.modeList = [(mode[0], mode[0]) for mode in self.avSwitch.getModeList("HDMI")]
+		self.modeList = [(mode[0], mode[0]) for mode in avSwitch.getModeList("HDMI")]
 		self["wizard"] = Pixmap()
 		self["HelpWindow"] = Pixmap()
 		self["HelpWindow"].hide()
 		self.setTitle(_("Start Wizard"))
 		self.resolutionTimer = eTimer()
 		self.resolutionTimer.callback.append(self.resolutionTimeout)
-		# preferred = self.avSwitch.readPreferredModes(saveMode=True)
+		# preferred = avSwitch.readPreferredModes(saveMode=True)
 		preferred = ["720p"]  # Use only 720p because some TV sends wrong edid info
-		available = self.avSwitch.readAvailableModes()
+		available = avSwitch.readAvailableModes()
 		preferred = list(set(preferred) & set(available))
 
 		if preferred:
@@ -208,7 +207,7 @@ class WizardLanguage(Wizard, ShowRemoteControl):
 		self.setMode()
 
 		if not preferred:
-			ports = [port for port in self.avSwitch.getPortList() if self.avSwitch.isPortUsed(port)]
+			ports = [port for port in avSwitch.getPortList() if avSwitch.isPortUsed(port)]
 			if len(ports) > 1:
 				self.resolutionTimer.start(20000)
 				print("[WizardLanguage] DEBUG start resolutionTimer")
@@ -219,7 +218,7 @@ class WizardLanguage(Wizard, ShowRemoteControl):
 			rate = "multi"
 		else:
 			rate = self.getVideoRate()
-		self.avSwitch.setMode(port="HDMI", mode=self.mode, rate=rate)
+		avSwitch.setMode(port="HDMI", mode=self.mode, rate=rate)
 
 	def getVideoRate(self):
 		def sortKey(name):
@@ -229,7 +228,7 @@ class WizardLanguage(Wizard, ShowRemoteControl):
 			}.get(name[0], 3)
 
 		rates = []
-		for modes in self.avSwitch.getModeList("HDMI"):
+		for modes in avSwitch.getModeList("HDMI"):
 			if modes[0] == self.mode:
 				for rate in modes[1]:
 					if rate == "auto" and not BoxInfo.getItem("have24hz"):

--- a/lib/python/Screens/VideoMode.py
+++ b/lib/python/Screens/VideoMode.py
@@ -3,7 +3,7 @@ from os.path import exists
 from enigma import eAVControl, iPlayableService, iServiceInformation, eTimer, eServiceCenter, eServiceReference, eDVBDB
 
 from Components.ActionMap import HelpableActionMap
-from Components.AVSwitch import iAVSwitch
+from Components.AVSwitch import avSwitch
 from Components.ConfigList import ConfigListScreen
 from Components.config import config, configfile, getConfigListEntry, ConfigNothing
 from Components.Label import Label
@@ -69,7 +69,6 @@ class VideoSetup(Screen, ConfigListScreen):
 		self["VKeyIcon"] = Boolean(False)
 		self["footnote"] = Label()
 
-		self.avSwitch = iAVSwitch
 		self.onChangedEntry = []
 
 		# handle hotplug by re-creating setup
@@ -96,10 +95,10 @@ class VideoSetup(Screen, ConfigListScreen):
 		self["config"].onSelectionChanged.append(self.selectionChanged)
 
 	def startHotplug(self):
-		self.avSwitch.on_hotplug.append(self._createSetup)
+		avSwitch.on_hotplug.append(self._createSetup)
 
 	def stopHotplug(self):
-		self.avSwitch.on_hotplug.remove(self._createSetup)
+		avSwitch.on_hotplug.remove(self._createSetup)
 
 	# FIXME
 	def _createSetup(self, what):
@@ -125,7 +124,7 @@ class VideoSetup(Screen, ConfigListScreen):
 				self.list.append(getConfigListEntry(_("Show 1080p 24fps as"), config.av.autores_1080p24, _("This option allows you to choose how to display 1080p 24Hz on your TV. (as not all TV's support these resolutions)")))
 				self.list.append(getConfigListEntry(_("Show 1080p 25fps as"), config.av.autores_1080p25, _("This option allows you to choose how to display 1080p 25Hz on your TV. (as not all TV's support these resolutions)")))
 				self.list.append(getConfigListEntry(_("Show 1080p 30fps as"), config.av.autores_1080p30, _("This option allows you to choose how to display 1080p 30Hz on your TV. (as not all TV's support these resolutions)")))
-				if "2160p24" in iAVSwitch.readAvailableModes():
+				if "2160p24" in avSwitch.readAvailableModes():
 					self.list.append(getConfigListEntry(_("Show 2160p 24fps as"), config.av.autores_2160p24, _("This option allows you to choose how to display 2160p 24Hz on your TV. (as not all TV's support these resolutions)")))
 					self.list.append(getConfigListEntry(_("Show 2160p 25fps as"), config.av.autores_2160p25, _("This option allows you to choose how to display 2160p 25Hz on your TV. (as not all TV's support these resolutions)")))
 					self.list.append(getConfigListEntry(_("Show 2160p 30fps as"), config.av.autores_2160p30, _("This option allows you to choose how to display 2160p 30Hz on your TV. (as not all TV's support these resolutions)")))
@@ -154,20 +153,20 @@ class VideoSetup(Screen, ConfigListScreen):
 				self.getVerify_videomode(config.av.autores_mode_sd, config.av.autores_rate_sd)
 				self.list.append(getConfigListEntry(pgettext(_("Video output mode for SD"), _("%sMode for SD (up to 576p)") % self.prev_sd), config.av.autores_mode_sd[config.av.videoport.value], _("This option configures the video output mode (or resolution)."), "check_sd"))
 				self.list.append(getConfigListEntry(_("%sRefresh rate for SD") % self.prev_sd, config.av.autores_rate_sd[config.av.autores_mode_sd[config.av.videoport.value].value], _("Configure the refresh rate of the screen."), "check_sd"))
-				modelist = iAVSwitch.getModeList(config.av.videoport.value)
-				if "720p" in iAVSwitch.readAvailableModes():
+				modelist = avSwitch.getModeList(config.av.videoport.value)
+				if "720p" in avSwitch.readAvailableModes():
 					self.getVerify_videomode(config.av.autores_mode_hd, config.av.autores_rate_hd)
 					self.list.append(getConfigListEntry(pgettext(_("Video output mode for HD"), _("%sMode for HD (up to 720p)") % self.prev_hd), config.av.autores_mode_hd[config.av.videoport.value], _("This option configures the video output mode (or resolution)."), "check_hd"))
 					self.list.append(getConfigListEntry(_("%sRefresh rate for HD") % self.prev_hd, config.av.autores_rate_hd[config.av.autores_mode_hd[config.av.videoport.value].value], _("Configure the refresh rate of the screen."), "check_hd"))
-				if "1080i" in iAVSwitch.readAvailableModes() or "1080p" in iAVSwitch.readAvailableModes():
+				if "1080i" in avSwitch.readAvailableModes() or "1080p" in avSwitch.readAvailableModes():
 					self.getVerify_videomode(config.av.autores_mode_fhd, config.av.autores_rate_fhd)
 					self.list.append(getConfigListEntry(pgettext(_("Video output mode for FHD"), _("%sMode for FHD (up to 1080p)") % self.prev_fhd), config.av.autores_mode_fhd[config.av.videoport.value], _("This option configures the video output mode (or resolution)."), "check_fhd"))
 					self.list.append(getConfigListEntry(_("%sRefresh rate for FHD") % self.prev_fhd, config.av.autores_rate_fhd[config.av.autores_mode_fhd[config.av.videoport.value].value], _("Configure the refresh rate of the screen."), "check_fhd"))
-					if config.av.autores_mode_fhd[config.av.videoport.value].value == '1080p' and ('1080p' in iAVSwitch.readAvailableModes() or "1080p50" in iAVSwitch.readAvailableModes()):
+					if config.av.autores_mode_fhd[config.av.videoport.value].value == '1080p' and ('1080p' in avSwitch.readAvailableModes() or "1080p50" in avSwitch.readAvailableModes()):
 						self.list.append(getConfigListEntry(_("%sShow 1080i as 1080p") % self.prev_fhd, config.av.autores_1080i_deinterlace, _("Use Deinterlacing for 1080i Videosignal?"), "check_fhd"))
-					elif "1080p" not in iAVSwitch.readAvailableModes() and "1080p50" not in iAVSwitch.readAvailableModes():
+					elif "1080p" not in avSwitch.readAvailableModes() and "1080p50" not in avSwitch.readAvailableModes():
 						config.av.autores_1080i_deinterlace.value = False
-				if "2160p" in iAVSwitch.readAvailableModes() or "2160p30" in iAVSwitch.readAvailableModes():
+				if "2160p" in avSwitch.readAvailableModes() or "2160p30" in avSwitch.readAvailableModes():
 					self.getVerify_videomode(config.av.autores_mode_uhd, config.av.autores_rate_uhd)
 					self.list.append(getConfigListEntry(pgettext(_("Video output mode for UHD"), _("%sMode for UHD (up to 2160p)") % self.prev_uhd), config.av.autores_mode_uhd[config.av.videoport.value], _("This option configures the video output mode (or resolution)."), "check_uhd"))
 					self.list.append(getConfigListEntry(_("%sRefresh rate for UHD") % self.prev_uhd, config.av.autores_rate_uhd[config.av.autores_mode_uhd[config.av.videoport.value].value], _("Configure the refresh rate of the screen."), "check_uhd"))
@@ -198,7 +197,7 @@ class VideoSetup(Screen, ConfigListScreen):
 		mode = config.av.videomode[port].value if port in config.av.videomode else None
 
 		# some modes (720p, 1080i) are always widescreen. Don't let the user select something here, "auto" is not what he wants.
-		force_wide = self.avSwitch.isWidescreenMode(port, mode)
+		force_wide = avSwitch.isWidescreenMode(port, mode)
 
 		if not force_wide:
 			self.list.append(getConfigListEntry(_("Aspect ratio"), config.av.aspect, _("Configure the aspect ratio of the screen.")))
@@ -216,7 +215,7 @@ class VideoSetup(Screen, ConfigListScreen):
 				self.list.append(getConfigListEntry(_("Aspect switch"), config.av.aspectswitch.enabled, _("This option allows you to set offset values for different Letterbox resolutions.")))
 				if config.av.aspectswitch.enabled.value:
 					for aspect in range(5):
-						self.list.append(getConfigListEntry(f" -> {iAVSwitch.ASPECT_SWITCH_MSG[aspect]}", config.av.aspectswitch.offsets[str(aspect)]))
+						self.list.append(getConfigListEntry(f" -> {avSwitch.ASPECT_SWITCH_MSG[aspect]}", config.av.aspectswitch.offsets[str(aspect)]))
 
 			self.list.append(getConfigListEntry(_("Allow unsupported modes"), config.av.edid_override, _("This option allows you to use all HDMI Modes")))
 
@@ -294,7 +293,7 @@ class VideoSetup(Screen, ConfigListScreen):
 				config.av.videorate[self.last_good[1]].value = self.last_good[2]
 				config.av.autores_sd.value = self.last_good_extra[0]
 				config.av.smart1080p.value = self.last_good_extra[1]
-				self.avSwitch.setMode(*self.last_good)
+				avSwitch.setMode(*self.last_good)
 			elif self.reset_mode == 2:
 				config.av.autores_mode_sd[self.last_good_autores_sd[0]].value = self.last_good_autores_sd[1]
 				config.av.autores_rate_sd[self.last_good_autores_sd[1]].value = self.last_good_autores_sd[2]
@@ -307,10 +306,10 @@ class VideoSetup(Screen, ConfigListScreen):
 				config.av.autores_24p.value = self.last_good_autores_extra[0]
 				config.av.autores_1080i_deinterlace.value = self.last_good_autores_extra[1]
 				config.av.autores_unknownres.value = self.last_good_autores_unknownres
-				if self.current_mode in iAVSwitch.readAvailableModes():
-					self.avSwitch.setVideoModeDirect(self.current_mode)
+				if self.current_mode in avSwitch.readAvailableModes():
+					avSwitch.setVideoModeDirect(self.current_mode)
 				else:
-					self.avSwitch.setMode(*self.last_good)
+					avSwitch.setMode(*self.last_good)
 			self.createSetup()
 		else:
 			self.keySave()
@@ -371,20 +370,20 @@ class VideoSetup(Screen, ConfigListScreen):
 		if config.av.autores.value in ("all", "hd") and ((port, mode, rate) != self.last_good or (autores_sd, smart1080p) != self.last_good_extra):
 			self.reset_mode = 1
 			if autores_sd.find("1080") >= 0:
-				self.avSwitch.setMode(port, "1080p", "50Hz")
+				avSwitch.setMode(port, "1080p", "50Hz")
 			elif (smart1080p == "1080p50") or (smart1080p == "true"):  # for compatibility with old ConfigEnableDisable
-				self.avSwitch.setMode(port, "1080p", "50Hz")
+				avSwitch.setMode(port, "1080p", "50Hz")
 			elif smart1080p == "2160p50":
-				self.avSwitch.setMode(port, "2160p", "50Hz")
+				avSwitch.setMode(port, "2160p", "50Hz")
 			elif smart1080p == "1080i50":
-				self.avSwitch.setMode(port, "1080i", "50Hz")
+				avSwitch.setMode(port, "1080i", "50Hz")
 			elif smart1080p == "720p50":
-				self.avSwitch.setMode(port, "720p", "50Hz")
+				avSwitch.setMode(port, "720p", "50Hz")
 			else:
-				self.avSwitch.setMode(port, mode, rate)
+				avSwitch.setMode(port, mode, rate)
 		elif (port, mode, rate) != self.last_good or (config.av.autores.value == "disabled" and self.last_good_autores != "disabled"):
 			self.reset_mode = 1
-			self.avSwitch.setMode(port, mode, rate)
+			avSwitch.setMode(port, mode, rate)
 		elif config.av.autores.value in ("native", "simple") and ((port, mode_sd, rate_sd) != self.last_good_autores_sd or (port, mode_hd, rate_hd) != self.last_good_autores_hd or (port, mode_fhd, rate_fhd) != self.last_good_autores_fhd
 			or (port, mode_uhd, rate_uhd) != self.last_good_autores_uhd or (autores_24p, autores_1080i) != self.last_good_autores_extra or self.last_good_autores != config.av.autores.value or self.reset_mode == 1
 			or (self.last_good_autores_unknownres != config.av.autores_unknownres.value and config.av.autores.value == "native")):
@@ -684,14 +683,14 @@ class AutoVideoMode(Screen):
 				if new_mode[-1:] == "p":
 					new_rate = setProgressiveRate((video_rate + 500) // 1000 * (int(video_pol == "i") + 1), new_rate, new_mode[:-1], config_res, config_rate)
 
-				if new_mode + new_rate in iAVSwitch.readAvailableModes():
+				if new_mode + new_rate in avSwitch.readAvailableModes():
 					write_mode = new_mode + new_rate
-				elif new_mode in iAVSwitch.readAvailableModes():
+				elif new_mode in avSwitch.readAvailableModes():
 					write_mode = new_mode
 				else:
 					if config_rate not in ("auto", "multi") and int(new_rate) > int(config_rate):
 						new_rate = config_rate
-					if config_mode + new_rate in iAVSwitch.readAvailableModes():
+					if config_mode + new_rate in avSwitch.readAvailableModes():
 						write_mode = config_mode + new_rate
 					else:
 						write_mode = config_mode
@@ -723,13 +722,13 @@ class AutoVideoMode(Screen):
 				if new_pol == "p":
 					new_rate = setProgressiveRate((video_rate + 500) // 1000 * (int(video_pol == "i") + 1), new_rate, new_res, config_res, config_rate)
 
-				if new_res + new_pol + new_rate in iAVSwitch.readAvailableModes():
+				if new_res + new_pol + new_rate in avSwitch.readAvailableModes():
 					write_mode = new_res + new_pol + new_rate
-				elif new_res + new_pol in iAVSwitch.readAvailableModes():
+				elif new_res + new_pol in avSwitch.readAvailableModes():
 					write_mode = new_res + new_pol
-				elif new_res + min_pol + new_rate in iAVSwitch.readAvailableModes():
+				elif new_res + min_pol + new_rate in avSwitch.readAvailableModes():
 					write_mode = new_res + min_pol + new_rate
-				elif new_res + min_pol in iAVSwitch.readAvailableModes():
+				elif new_res + min_pol in avSwitch.readAvailableModes():
 					write_mode = new_res + min_pol
 				else:
 					if config.av.autores_unknownres.value == "next":
@@ -745,18 +744,18 @@ class AutoVideoMode(Screen):
 						new_res = config_res
 					if new_pol == "p":
 						new_rate = setProgressiveRate((video_rate + 500) // 1000 * (int(video_pol == "i") + 1), new_rate, new_res, config_res, config_rate)
-					if new_res + new_pol + new_rate in iAVSwitch.readAvailableModes():
+					if new_res + new_pol + new_rate in avSwitch.readAvailableModes():
 						write_mode = new_res + new_pol + new_rate
-					elif new_res + new_pol in iAVSwitch.readAvailableModes():
+					elif new_res + new_pol in avSwitch.readAvailableModes():
 						write_mode = new_res + new_pol
-					elif new_res + min_pol + new_rate in iAVSwitch.readAvailableModes():
+					elif new_res + min_pol + new_rate in avSwitch.readAvailableModes():
 						write_mode = new_res + min_pol + new_rate
-					elif new_res + min_pol in iAVSwitch.readAvailableModes():
+					elif new_res + min_pol in avSwitch.readAvailableModes():
 						write_mode = new_res + min_pol
 					else:
 						if config_rate not in ("auto", "multi") and int(new_rate) > int(config_rate):
 							new_rate = config_rate
-						if config_mode + new_rate in iAVSwitch.readAvailableModes():
+						if config_mode + new_rate in avSwitch.readAvailableModes():
 							write_mode = config_mode + new_rate
 						else:
 							write_mode = config_mode
@@ -765,7 +764,7 @@ class AutoVideoMode(Screen):
 				autorestyp = "all or hd"
 				if config.av.autores_deinterlace.value:
 					new_pol = new_pol.replace("i", "p")
-				if new_res + new_pol + new_rate in iAVSwitch.readAvailableModes():
+				if new_res + new_pol + new_rate in avSwitch.readAvailableModes():
 					new_mode = new_res + new_pol + new_rate
 					if new_mode == "480p24" or new_mode == "576p24":
 						new_mode = config.av.autores_480p24.value
@@ -783,7 +782,7 @@ class AutoVideoMode(Screen):
 						new_mode = config.av.autores_2160p25.value
 					if new_mode == "2160p30" or new_mode == "2160p60" or new_mode == "2160p":
 						new_mode = config.av.autores_2160p30.value
-				elif new_res + new_pol in iAVSwitch.readAvailableModes():
+				elif new_res + new_pol in avSwitch.readAvailableModes():
 					new_mode = new_res + new_pol
 					if new_mode == "2160p30" or new_mode == "2160p60" or new_mode == "2160p":
 						new_mode = config.av.autores_2160p30.value
@@ -799,7 +798,7 @@ class AutoVideoMode(Screen):
 					new_mode = config.av.autores_sd.value + new_rate
 					if config.av.autores_deinterlace.value:
 						test_new_mode = config.av.autores_sd.value.replace("i", "p") + new_rate
-						if test_new_mode in iAVSwitch.readAvailableModes():
+						if test_new_mode in avSwitch.readAvailableModes():
 							new_mode = test_new_mode
 
 				if new_mode == "720p24":
@@ -886,7 +885,7 @@ class AutoVideoMode(Screen):
 				#print("[VideoMode] smart1080p mode, selecting %s" % write_mode)
 
 			if write_mode and current_mode != write_mode and self.bufferfull or self.firstrun:
-				values = iAVSwitch.readAvailableModes()
+				values = avSwitch.readAvailableModes()
 				if write_mode not in values:
 					if write_mode in ("1080p24", "1080p30", "1080p60"):
 						write_mode = "1080p"
@@ -898,7 +897,7 @@ class AutoVideoMode(Screen):
 					else:
 						write_mode += "hz"
 				if write_mode in values:
-					iAVSwitch.setVideoModeDirect(write_mode)
+					avSwitch.setVideoModeDirect(write_mode)
 					print(f"[VideoMode] setMode - port: {config_port}, mode: {write_mode} (autoresTyp: '{autorestyp}')")
 					resolutionlabel["restxt"].setText(_("Video mode: %s") % write_mode)
 				else:
@@ -913,10 +912,10 @@ class AutoVideoMode(Screen):
 				print(f"[VideoMode] not changing from {current_mode} to {write_mode} as self.bufferfull is {self.bufferfull}")
 
 		if write_mode and write_mode != current_mode or self.firstrun:
-			iAVSwitch.setAspect(config.av.aspect)
-			iAVSwitch.setWss(config.av.wss)
-			iAVSwitch.setPolicy43(config.av.policy_43)
-			iAVSwitch.setPolicy169(config.av.policy_169)
+			avSwitch.setAspect(config.av.aspect)
+			avSwitch.setWss(config.av.wss)
+			avSwitch.setPolicy43(config.av.policy_43)
+			avSwitch.setPolicy169(config.av.policy_169)
 
 		self.firstrun = False
 		self.delay = False

--- a/lib/python/Screens/VideoWizard.py
+++ b/lib/python/Screens/VideoWizard.py
@@ -1,4 +1,4 @@
-from Components.AVSwitch import iAVSwitch as avSwitch
+from Components.AVSwitch import avSwitch
 from Components.config import config, configfile
 from Components.SystemInfo import BoxInfo
 from Screens.HelpMenu import ShowRemoteControl
@@ -12,7 +12,6 @@ class VideoWizard(Wizard, ShowRemoteControl):
 		Wizard.__init__(self, session, showSteps=False, showStepSlider=False)
 		ShowRemoteControl.__init__(self)
 		self.setTitle(_("Video Wizard"))
-		self.avSwitch = avSwitch
 		self.hasDVI = BoxInfo.getItem("dvi", False)
 		self.hasJack = BoxInfo.getItem("avjack", False)
 		self.hasRCA = BoxInfo.getItem("rca", False)
@@ -24,8 +23,8 @@ class VideoWizard(Wizard, ShowRemoteControl):
 
 	def listPorts(self):  # Called by wizardvideo.xml.
 		ports = []
-		for port in self.avSwitch.getPortList():
-			if self.avSwitch.isPortUsed(port):
+		for port in avSwitch.getPortList():
+			if avSwitch.isPortUsed(port):
 				descr = port
 				if descr == "HDMI" and self.hasDVI:
 					descr = "DVI"
@@ -43,7 +42,7 @@ class VideoWizard(Wizard, ShowRemoteControl):
 		def sortKey(name):
 			return sortKeys.get(name[0], 6)
 
-		modes = [(mode[0], mode[0]) for mode in self.avSwitch.getModeList(self.port)]
+		modes = [(mode[0], mode[0]) for mode in avSwitch.getModeList(self.port)]
 
 		sortKeys = {
 			"720p": 1,
@@ -54,7 +53,7 @@ class VideoWizard(Wizard, ShowRemoteControl):
 			"smpte": 20
 		}
 
-		# preferred = self.avSwitch.readPreferredModes(saveMode=True)
+		# preferred = avSwitch.readPreferredModes(saveMode=True)
 		preferred = []  # Don't resort because some TV sends wrong edid info
 		if preferred:
 			if "2160p" in preferred:
@@ -81,7 +80,7 @@ class VideoWizard(Wizard, ShowRemoteControl):
 		if mode is None:
 			mode = self.mode
 		rates = []
-		for modes in self.avSwitch.getModeList(self.port):
+		for modes in avSwitch.getModeList(self.port):
 			if modes[0] == mode:
 				for rate in modes[1]:
 					if rate == "auto" and not BoxInfo.getItem("have24hz"):
@@ -106,12 +105,12 @@ class VideoWizard(Wizard, ShowRemoteControl):
 		self.portSelect(self.selection)
 
 	def portSelect(self, port):
-		modeList = self.avSwitch.getModeList(self.selection)
+		modeList = avSwitch.getModeList(self.selection)
 		# print("[WizardVideo] inputSelect DEBUG: port='%s', modeList=%s." % (port, modeList))
 		self.port = port
 		if modeList:
 			ratesList = self.listRates(modeList[0][0])
-			self.avSwitch.setMode(port=port, mode=modeList[0][0], rate=ratesList[0][0])
+			avSwitch.setMode(port=port, mode=modeList[0][0], rate=ratesList[0][0])
 
 	def modeSelectionMade(self, index):  # Called by wizardvideo.xml.
 		# print("[WizardVideo] modeSelectionMade DEBUG: index='%s'." % index)
@@ -127,9 +126,9 @@ class VideoWizard(Wizard, ShowRemoteControl):
 		# print("[WizardVideo] modeSelect DEBUG: rates=%s." % rates)
 		if self.port == "HDMI" and mode in ("720p", "1080i", "1080p") and not BoxInfo.getItem("AmlogicFamily"):
 			self.rate = "multi"
-			self.avSwitch.setMode(port=self.port, mode=mode, rate="multi")
+			avSwitch.setMode(port=self.port, mode=mode, rate="multi")
 		else:
-			self.avSwitch.setMode(port=self.port, mode=mode, rate=rates[0][0])
+			avSwitch.setMode(port=self.port, mode=mode, rate=rates[0][0])
 
 	def rateSelectionMade(self, index):  # Called by wizardvideo.xml.
 		# print("[WizardVideo] rateSelectionMade DEBUG: index='%s'." % index)
@@ -141,22 +140,22 @@ class VideoWizard(Wizard, ShowRemoteControl):
 		self.rateSelect(self.selection)
 
 	def rateSelect(self, rate):
-		self.avSwitch.setMode(port=self.port, mode=self.mode, rate=rate)
+		avSwitch.setMode(port=self.port, mode=self.mode, rate=rate)
 
 	def keyNumberGlobal(self, number):
 		if number in (1, 2, 3):
 			if number == 1:
-				self.avSwitch.saveMode("HDMI", "720p", "multi")
+				avSwitch.saveMode("HDMI", "720p", "multi")
 			elif number == 2:
-				self.avSwitch.saveMode("HDMI", "1080i", "multi")
+				avSwitch.saveMode("HDMI", "1080i", "multi")
 			elif number == 3:
-				self.avSwitch.saveMode("Scart", "Multi", "multi")
-			self.avSwitch.setConfiguredMode()
+				avSwitch.saveMode("Scart", "Multi", "multi")
+			avSwitch.setConfiguredMode()
 			self.close()
 		Wizard.keyNumberGlobal(self, number)
 
 	def saveWizardChanges(self):  # Called by wizardvideo.xml.
-		self.avSwitch.saveMode(self.port, self.mode, self.rate)
+		avSwitch.saveMode(self.port, self.mode, self.rate)
 		# config.misc.wizardVideoEnabled.value = 0
 		# config.misc.wizardVideoEnabled.save()
 		config.misc.videowizardenabled.value = 0


### PR DESCRIPTION
This code is about to be refactored as well as some associated configuration code related to the GUI position and 3D settings. This name change brings this mechanism into line with similar instances.

[InfoBarGenerics.py]
- Use the new avSwitch class instantiation pointer.

[Menu.py]
- Use the new avSwitch class instantiation pointer.

[StartWizard.py]
- Use the new avSwitch class instantiation pointer.

[VideoMode.py]
- Use the new avSwitch class instantiation pointer.

[VideoWizard.py]
- Use the new avSwitch class instantiation pointer.
