### PR TITLE
[OSDCalibration.py] Prepare for a major refactor

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -11,7 +11,7 @@ dist_pkgdata_DATA = \
 	setup.xml \
 	skin_subtitles.xml \
 	startwizard.xml \
-	userinterfacepositionerwizard.xml \
+	wizardosdcalibration.xml \
 	videowizard.xml \
 	wizardlanguage.xml \
 	freesat.t1 \

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -49,8 +49,8 @@
 			<!-- Menu / Setup / Video Menu -->
 			<menu key="video_menu" level="0" text="Video" weight="0">
 				<item key="video_setup" level="0" text="Video Settings" weight="0"><screen module="VideoMode" screen="VideoSetup" /></item>
-				<item key="osdsetup" level="1" text="OSD Position Settings" weight="50" requires="OsdMenu"><screen module="UserInterfacePositioner" screen="UserInterfacePositioner2" /></item>
-				<item key="setup_osd3d" level="2" text="OSD 3D Settings" weight="60" requires="CanChange3DOsd"><setup setupKey="OSD3D" /></item>
+				<item key="osdsetup" level="1" text="OSD Position Settings" weight="50" requires="OSDCalibration"><screen module="OSDCalibration" screen="OSDCalibration" /></item>
+				<item key="setup_osd3d" level="2" text="OSD 3D Settings" weight="60" requires="OSDCalibration"><screen module="OSDCalibration" screen="OSD3DCalibration" /></item>
 			</menu>
 			<!-- Menu / Setup / Audio Menu -->
 			<menu key="audio_menu" level="1" text="Audio" weight="5">

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -500,7 +500,7 @@
 		<item level="0" text="Automatically update Client/Server View" description="Automatically update Client/Server View">config.oscaminfo.autoUpdate</item>
 		<item level="0" text="Automatically update Log-Fullscreen View" description="Automatically update Log-Fullscreen View">config.oscaminfo.autoUpdateLog</item>
 	</setup>
-	<setup key="OSD3D" title="OSD 3D Settings" showOpenWebif="1">
+	<setup key="OSD3DCalibration" title="OSD 3D Settings" showOpenWebif="1">
 		<item level="0" text="3D Mode" description="This option lets you choose the 3D mode.">config.osd.threeDmode</item>
 		<item level="0" text="Depth" description="This option lets you adjust the 3D depth.">config.osd.threeDznorm</item>
 		<item level="0" text="Show in Extension Menu" description="This option lets you show the option in the Extension Menu screen.">config.osd.show3dextensions</item>

--- a/data/wizardosdcalibration.xml
+++ b/data/wizardosdcalibration.xml
@@ -3,7 +3,7 @@
 	   <step id="start" nextstep="end">
 				<text value="Please setup your user interface by adjusting the values till the edges of the red box are touching the edges of your TV.\nWhen you are ready press OK to continue." />
 				<displaytext value="Configure interface" />
-				<config screen="UserInterfacePositioner" module="UserInterfacePositioner" type="ConfigList" />
+				<config screen="OSDCalibration" module="OSDCalibration" type="ConfigList" />
 				<code>
 self.clearSelectedKeys()
 self.selectKey("OK")

--- a/lib/python/Screens/WizardOSDCalibration.py
+++ b/lib/python/Screens/WizardOSDCalibration.py
@@ -7,9 +7,9 @@ from Tools.Directories import resolveFilename, SCOPE_SKINS
 from Components.Console import Console
 
 
-class UserInterfacePositionerWizard(Wizard, ShowRemoteControl):
+class WizardOSDCalibration(Wizard, ShowRemoteControl):
 	def __init__(self, session, interface=None):
-		self.xmlfile = resolveFilename(SCOPE_SKINS, "userinterfacepositionerwizard.xml")
+		self.xmlfile = resolveFilename(SCOPE_SKINS, "wizardosdcalibration.xml")
 		Wizard.__init__(self, session, showSteps=False, showStepSlider=False)
 		ShowRemoteControl.__init__(self)
 		self.skinName = "StartWizard"
@@ -20,15 +20,8 @@ class UserInterfacePositionerWizard(Wizard, ShowRemoteControl):
 		self["HelpWindow"] = Pixmap()
 		self["HelpWindow"].hide()
 		self["VKeyIcon"] = Boolean(False)
-
 		self.NextStep = None
 		self.Text = None
-
-		self.onLayoutFinish.append(self.layoutFinished)
-		self.onClose.append(self.__onClose)
-
-	def layoutFinished(self):
-		self.Console.ePopen('/usr/bin/showiframe /usr/share/enigma2/hd-testcard.mvi')
 
 	def exitWizardQuestion(self, ret=False):
 		if ret:
@@ -40,6 +33,3 @@ class UserInterfacePositionerWizard(Wizard, ShowRemoteControl):
 
 	def back(self):
 		Wizard.back(self)
-
-	def __onClose(self):
-		self.Console.ePopen('/usr/bin/showiframe /usr/share/backdrop.mvi')

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -900,9 +900,9 @@ if BOX_TYPE in ("uniboxhd1", "uniboxhd2", "uniboxhd3", "sezam5000hd", "mbtwin", 
 
 enigma.eAVControl.getInstance().disableHDMIIn()
 
-enigma.eProfileWrite("InitOSD")
-from Screens.UserInterfacePositioner import InitOsd
-InitOsd()
+enigma.eProfileWrite("InitOSDCalibration")
+from Screens.OSDCalibration import InitOSDCalibration
+InitOSDCalibration()
 
 enigma.eProfileWrite("EPGCacheCheck")
 from Components.EpgLoadSave import EpgCacheLoadCheck, EpgCacheSaveCheck


### PR DESCRIPTION
This change is in preparation of a major refactor of the "UserInterfacePositioner.py" code and its associated Wizard "WizardUserInterfacePositioner.py".  This commit has minimal code changes and is focused on introducing the new module names and new classes.  This will give skinners time to prepare skins for the code changes when they are committed.

At this time skinners should be aware that the new screen name for "UserInterfacePositioner2" will be "OSDCalibration".  When this commit is merged skinners should add a conditional widget "description" that will replace the current widget "status".  The "conditional" attribute should be used on the "description" widget to suppress skin errors until the new OSDCalibration code based on "Setup" is published.  Skinners should also add the following widget to their skins:
        <widget name="footnote" position="0,0" size="0,0" conditional="footnote" />

The "status" widget should also be made "conditional" to suppress skin errors when the new OSDCalibration code based on "Setup" is published.  The new "description" widget is identically functional to the "description" widget in "Setup" based screens.  This change is required because the new "OSDCalibration" screen will be a sub-class of the current "Setup" class.  When the new code is activated the "status" widget and the conditional="footnote" (from the line added above) can be removed from the "OSDCalibration" screen.
