### PR TITLE
[Setup] Add an option to reset all entries to default

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -331,6 +331,7 @@
 		<key id="KEY_MEDIA" mapto="menu" flags="m" />
 		<key id="KEY_PVR" mapto="menu" flags="m" />
 		<key id="KEY_VIDEO" mapto="menu" flags="m" />
+		<key id="KEY_AUDIO" mapto="default" flags="m" />
 		<!-- Keyboard specific buttons -->
 		<key id="KEY_F1" mapto="cancel" flags="m" />
 		<key id="KEY_F2" mapto="save" flags="m" />

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -50,7 +50,7 @@
 			<menu key="video_menu" level="0" text="Video" weight="0">
 				<item key="video_setup" level="0" text="Video Settings" weight="0"><screen module="VideoMode" screen="VideoSetup" /></item>
 				<item key="osdsetup" level="1" text="OSD Position Settings" weight="50" requires="OSDCalibration"><screen module="OSDCalibration" screen="OSDCalibration" /></item>
-				<item key="setup_osd3d" level="2" text="OSD 3D Settings" weight="60" requires="OSDCalibration"><screen module="OSDCalibration" screen="OSD3DCalibration" /></item>
+				<item key="setup_osd3d" level="2" text="OSD 3D Settings" weight="60" requires="OSDCalibration"><setup setupKey="OSD3DCalibration" /></item>
 			</menu>
 			<!-- Menu / Setup / Audio Menu -->
 			<menu key="audio_menu" level="1" text="Audio" weight="5">

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -500,7 +500,7 @@
 		<item level="0" text="Automatically update Client/Server View" description="Automatically update Client/Server View">config.oscaminfo.autoUpdate</item>
 		<item level="0" text="Automatically update Log-Fullscreen View" description="Automatically update Log-Fullscreen View">config.oscaminfo.autoUpdateLog</item>
 	</setup>
-	<setup key="OSD3DCalibration" title="OSD 3D Settings" showOpenWebif="1">
+	<setup key="OSD3DCalibration" title="OSD 3D Settings" showOpenWebif="1" allowDefault="1">
 		<item level="0" text="3D Mode" description="This option lets you choose the 3D mode.">config.osd.threeDmode</item>
 		<item level="0" text="Depth" description="This option lets you adjust the 3D depth.">config.osd.threeDznorm</item>
 		<item level="0" text="Show in Extension Menu" description="This option lets you show the option in the Extension Menu screen.">config.osd.show3dextensions</item>

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -169,7 +169,7 @@ class ConfigList(GUIComponent):
 
 
 class ConfigListScreen:
-	def __init__(self, list, session=None, on_change=None, fullUI=False):
+	def __init__(self, list, session=None, on_change=None, fullUI=False, allowDefault=False):
 		self.entryChanged = on_change if on_change is not None else lambda: None
 		if fullUI:
 			if "key_red" not in self:
@@ -182,6 +182,14 @@ class ConfigListScreen:
 				"save": (self.keySave, _("Save all changed settings and exit"))
 			}, prio=1, description=_("Common Setup Actions"))
 			self.actionMaps = ["fullUIActions"]
+			if allowDefault:
+				if "key_yellow" not in self:
+					self["key_yellow"] = StaticText(_("Default"))
+				self["defaultAction"] = HelpableActionMap(self, ["ConfigListActions", "ColorActions"], {
+					"default": (self.keyDefault, _("Reset entries to their default values")),
+					"yellow": (self.keyDefault, _("Reset entries to their default values"))
+				}, prio=1, description=_("Common Setup Actions"))
+				self.actionMaps.append("defaultAction")
 		else:
 			self.actionMaps = []
 		if "key_menu" not in self:
@@ -360,6 +368,11 @@ class ConfigListScreen:
 
 	def keyOK(self):  # This is the deprecated version of keySelect!
 		self.keySelect()
+
+	def keyDefault(self):  # This method should be replaced in sub-classes that need help to reset the defaults.
+		for item in self["config"].getList():
+			item[1].setValue(item[1].default)
+			self["config"].invalidate(item)
 
 	def keyText(self):
 		def keyTextCallback(callback=None):

--- a/lib/python/Screens/OSDCalibration.py
+++ b/lib/python/Screens/OSDCalibration.py
@@ -400,20 +400,3 @@ class OSDCalibration(Screen, ConfigListScreen):
 		config.osd.dst_height.save()
 		configfile.save()
 		self.close()
-
-
-class OSD3DCalibration(Setup):
-	def __init__(self, session):
-		Setup.__init__(self, session, "OSD3DCalibration")
-		self["key_yellow"] = StaticText(_("Defaults"))
-		self["actions"] = HelpableActionMap(self, ["ColorActions"], {
-			"yellow": (self.keyDefault, _("Reset all settings to the default values"))
-		}, prio=0, description=_("OSD 3D Calibration Setup Actions"))
-
-	def keyDefault(self):
-		config.osd.threeDmode.setValue(config.osd.threeDmode.default)
-		config.osd.threeDznorm.setValue(config.osd.threeDznorm.default)
-		config.osd.show3dextensions.setValue(config.osd.show3dextensions.default)
-		print("[OSDCalibration] OSD 3D settings restored to defaults.")
-		for entry in self["config"].getList():
-			self["config"].invalidate(entry)

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -70,7 +70,13 @@ class Setup(ConfigListScreen, Screen, HelpableScreen):
 			self.skinName.append("Setup%s" % setup)
 		self.skinName.append("Setup")
 		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry, fullUI=True)
+		xmlData = setupDom(self.setup, self.plugin)
+		allowDefault = False
+		for setup in xmlData.findall("setup"):
+			if setup.get("key") == self.setup:
+				allowDefault = setup.get("allowDefault", "") in ("1", "allowDefault", "enabled", "on", "true", "yes")
+				break
+		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry, fullUI=True, allowDefault=allowDefault)
 		self["footnote"] = Label()
 		self["footnote"].hide()
 		self["description"] = Label()


### PR DESCRIPTION
[Setup.py]
- Add code to check if the attribute "allowDefault" as been added to a "setup.xml" "setup" tag.  If so, tell "ConfigList.py" to allow the new "default" option.

[ConfigList.py]
- Add an optional calling argument that enables the new reset to default option.
- Create a method "keyDefault()" to implement the default action.  This can be redefined in sub-classes to implement custom default resets.
- Add a YELLOW button to the Setup screen that offers the "Default" action if the YELLOW button is available,
- Add the button AUDIO to trigger the default in all cases, even if the YELLOW button is otherwise allocated.

[OSDCalibration.py]
- Remove the custom screen for "OSD3DCalibration" as this can now be handled by the "Setup" class directly.

[menu.xml]
- Restore the "setup" tag to run the "OSD3DCalibration" code.

[setup.xml]
- Add the "allowDefault" attribute to the "setup" tag of "OSD3DCalibration" entry to enable the "Default" option for this "Setup" based screen.
