### PR TITLE
Major skin enhancement

### DIFF
--- a/lib/python/Components/Converter/XmlMultiContent.py
+++ b/lib/python/Components/Converter/XmlMultiContent.py
@@ -1,0 +1,201 @@
+from enigma import eListboxPythonMultiContent
+
+from skin import SkinContext, SkinContextStack, TemplateParser, parseFont
+from Components.Converter.StringList import StringList
+
+
+class MultiContentTemplateParser(TemplateParser):
+	def __init__(self, debug=False):
+		TemplateParser.__init__(self, debug=debug)
+		self.template = {}
+		self.indexNames = {}
+
+	def readTemplate(self, templateName):
+		def parseTemplateModes(template):
+			modes = {}
+			modesItems = {}
+			for mode in template.findall("mode"):
+				items = []
+				modeName = mode.get("name")
+				itemWidth = int(mode.get("itemWidth", self.itemWidth))  # Override from mode.
+				itemHeight = int(mode.get("itemHeight", self.itemHeight))  # Override from mode.
+				attibutes = {
+					"itemWidth": itemWidth,
+					"itemHeight": itemHeight
+				}
+				for name, value in mode.items():
+					attibutes[name] = value
+				modes[modeName] = attibutes
+				context = SkinContextStack()
+				context.x = 0
+				context.y = 0
+				context.w = itemWidth
+				context.h = itemHeight
+				context.scale = self.scale  # Set scale from the widget.
+				context = SkinContext(context, "0,0", f"{itemWidth},{itemHeight}")
+				for element in list(mode):
+					processor = self.processors.get(element.tag, self.processNone)
+					newItems = processor(element, context, excludeItemValues=[], includeItemValues=[])
+					if newItems:
+						items += newItems
+				newItems = []
+				for item in items:
+					itemsAttibutes = {}
+					for name, value in item.items():
+						itemsAttibutes[name] = int(value) if name in ("font", "index") else value
+					newItems.append(itemsAttibutes)
+				modesItems[modeName] = newItems
+				modes[modeName] = attibutes
+				if self.debug:
+					print(f"[MultiContentTemplateParser] DEBUG ITEMS {modeName}")
+					print(modesItems[modeName])
+			return modes, modesItems
+
+		self.template = {}
+		self.template["modes"] = {}
+		self.template["fonts"] = []
+		try:
+			for template in self.dom.findall("template"):
+				templateStyleName = template.get("name", "Default")
+				self.itemWidth = int(template.get("itemWidth", self.itemWidth))
+				self.itemHeight = int(template.get("itemHeight", self.itemHeight))
+				if templateStyleName == templateName:
+					templateModes, modesItems = parseTemplateModes(template)
+					for index, font in enumerate([x.strip() for x in template.get("fonts", "").split(",")]):
+						self.template["fonts"].append(parseFont(font, self.scale))
+					for modeName, modeProperties in templateModes.items():
+						modeItemWidth = modeProperties.get("itemWidth")
+						modeItemHeight = modeProperties.get("itemHeight")
+						modeData = []
+						for item in modesItems[modeName]:
+							index = item.get("index")
+							if index is None:
+								index = -1
+							elif isinstance(index, str) and self.indexNames:
+								index = self.indexNames.get(index, -1)
+								if index < 0 or index >= len(self.indexNames):
+									print(f"[XmlMultiContent] Error: Index must range from 0 to {len(self.indexNames) - 1}!")
+							elif not isinstance(index, int):
+								print("[XmlMultiContent] Error: Index must be a variable item number or variable name!")
+							else:
+								index = int(index)
+							pos = item.get("position")
+							size = item.get("size")
+							backgroundColor = item.get("backgroundColor")
+							backgroundColorSelected = item.get("backgroundColorSelected")
+							borderColor = item.get("borderColor")
+							borderWidth = int(item.get("borderWidth", "0"))
+							cornerRadius, cornerEdges = item.get("_radius", (0, 0))
+							flags = item.get("_flags", 0)
+							match item["type"]:
+								case "text":
+									foregroundColorSelected = item.get("foregroundColorSelected")
+									foregroundColor = item.get("foregroundColor")
+									font = int(item.get("font", 0))
+									if index == -1:
+										index = item.get("text", "")
+									modeData.append((eListboxPythonMultiContent.TYPE_TEXT, pos[0], pos[1], size[0], size[1], font or 0, flags, index, foregroundColor, foregroundColorSelected, backgroundColor, backgroundColorSelected, borderWidth, borderColor, cornerRadius, cornerEdges))
+								case "pixmap":
+									if index == -1:
+										index = item.get("pixmap", "")
+									pixmapType = item.get("pixmapType", eListboxPythonMultiContent.TYPE_PIXMAP)
+									pixmapFlags = item.get("pixmapFlags", 0)
+									modeData.append((pixmapType, pos[0], pos[1], size[0], size[1], self.resolvePixmap(index), backgroundColor, backgroundColorSelected, pixmapFlags, cornerRadius, cornerEdges))
+								case "rectangle":
+									gradientDirection, gradientAlpha, gradientStart, gradientEnd, gradientMid, gradientStartSelected, gradientEndSelected, gradientMidSelected = item.get("_gradient", (0, 0, None, None, None, None, None, None))
+									if gradientDirection:
+										if gradientAlpha:
+											modeData.append((eListboxPythonMultiContent.TYPE_LINEAR_GRADIENT_ALPHABLEND, pos[0], pos[1], size[0], size[1], gradientDirection, gradientStart, gradientMid, gradientEnd, gradientStartSelected, gradientMidSelected, gradientEndSelected, cornerRadius, cornerEdges))
+										else:
+											modeData.append((eListboxPythonMultiContent.TYPE_LINEAR_GRADIENT, pos[0], pos[1], size[0], size[1], gradientDirection, gradientStart, gradientMid, gradientEnd, gradientStartSelected, gradientMidSelected, gradientEndSelected, cornerRadius, cornerEdges))
+									else:
+										modeData.append((eListboxPythonMultiContent.TYPE_RECT, pos[0], pos[1], size[0], size[1], backgroundColor, backgroundColorSelected, borderWidth, borderColor, cornerRadius, cornerEdges))
+								case "progress":
+									if index == -1:
+										index = None
+									foregroundColorSelected = item.get("foregroundColorSelected", None)
+									foregroundColor = item.get("foregroundColor", None)
+									gradientDirection, gradientAlpha, gradientStart, gradientEnd, gradientMid, gradientStartSelected, gradientEndSelected, gradientMidSelected = item.get("_gradient", (0, 0, None, None, None, None, None, None))
+									modeData.append((eListboxPythonMultiContent.TYPE_PROGRESS, pos[0], pos[1], size[0], size[1], index, borderWidth, foregroundColor, foregroundColorSelected, borderColor, gradientStart, gradientMid, gradientEnd, gradientStartSelected, gradientMidSelected, gradientEndSelected, cornerRadius, cornerEdges))
+						self.template["modes"][modeName] = ((modeItemWidth, modeItemHeight), modeData)
+		except Exception as err:
+			# TODO: DEBUG: Remove the following two lines before publication.
+			import traceback
+			traceback.print_exc()
+			print(f"[TemplateParser] Error: Unable to parse XML template!  {str(err)})")
+
+
+class XmlMultiContent(StringList, MultiContentTemplateParser):
+	"""Turns a python tuple list into a multi-content list which can be used in a listbox renderer."""
+
+	def __init__(self, args):
+		StringList.__init__(self, args)
+		self.debug = True
+		MultiContentTemplateParser.__init__(self, self.debug)
+		self.activeStyle = None
+		self.activeTemplate = "Default"  # This value string is used in the UI.
+		self.dom = args.get("dom")
+		if self.dom is not None:
+			self.scale = args.get("scale")
+			self.widgetSize = (int(args.get("size")[0]), int(args.get("size")[1]))
+			scaleFactorVertical = self.scale[1][0] / self.scale[1][1]
+			scaleFactorHorizontal = self.scale[0][0] / self.scale[0][1]
+			self.itemWidth = int(self.widgetSize[0] * scaleFactorHorizontal)  # Set itemWidth to the widgetWidth.
+			self.itemHeight = int(self.widgetSize[1] * scaleFactorVertical)  # Set itemHeight to the widgetHeight.
+		else:
+			print("[XmlMultiContent] Error: This is for internal usage and not an argument for a 'converter' tag!")
+
+	def changed(self, what):
+		def setTemplate():
+			if self.source:
+				templateName = self.source.template
+				if templateName != self.activeTemplate:
+					self.activeTemplate = templateName
+					self.readTemplate(self.activeTemplate)
+				style = self.source.style
+				if style == self.activeStyle:
+					return
+				modes = self.template.get("modes")
+				if modes and modes[style]:
+					itemWidth = modes[style][0][0]
+					itemHeight = modes[style][0][1]
+					template = modes[style][1]
+					selectionEnabled = self.template.get("selectionEnabled")
+					scrollbarMode = self.template.get("scrollbarMode")
+					self.content.setTemplate(template)
+					self.content.setItemWidth(itemWidth)
+					self.content.setItemHeight(itemHeight)
+					if selectionEnabled is not None:
+						self.selectionEnabled = selectionEnabled
+					if scrollbarMode is not None:
+						self.scrollbarMode = scrollbarMode
+					self.activeStyle = style
+				else:
+					print("[XmlMultiContent] Error: All templates must include a 'mode' entry!")
+
+		if not self.content:
+			if self.dom is not None:
+				self.indexNames = self.source.indexNames
+				self.readTemplate(self.source.template)
+				if "fonts" not in self.template:
+					print("[XmlMultiContent] Error: All templates must include a 'fonts' entry!")
+				if "modes" not in self.template:
+					print("[XmlMultiContent] Error: All templates must include a 'mode' entry!")
+
+			self.content = eListboxPythonMultiContent()
+			for index, font in enumerate(self.template["fonts"]):  # Setup fonts (also given by source).
+				self.content.setFont(index, font)
+		if what[0] == self.CHANGED_SPECIFIC and what[1] in ("style", "template"):  # If only template changed, don't reload list.
+			pass
+		elif self.source:
+			try:
+				contentList = []
+				sourceList = self.source.list
+				for item in range(len(sourceList)):
+					contentList.append((sourceList[item],) if not isinstance(sourceList[item], (list, tuple)) else sourceList[item])
+			except Exception as error:
+				print(f"[XmlMultiContent] Error: {error}!")
+				contentList = self.source.list
+			self.content.setList(contentList)
+		setTemplate()
+		self.downstream_elements.changed(what)

--- a/lib/python/Components/Renderer/Listbox.py
+++ b/lib/python/Components/Renderer/Listbox.py
@@ -1,16 +1,13 @@
 from enigma import eListbox
+
 from Components.Renderer.Renderer import Renderer
 
-# the listbox renderer is the listbox, but no listbox content.
-# the content will be provided by the source (or converter).
-
-# the source should emit the 'changed' signal whenever
-# it has a new listbox content.
-
-# the source needs to have the 'content' property for the
-# used listbox content
-
-# it should expose exactly the non-content related functions
+# The listbox renderer is the listbox, but no listbox content. The content
+# will be provided by the source (or converter).
+#
+# The source should emit the 'changed' signal whenever it has new listbox
+# content. The source needs to have the 'content' property for the used
+# listbox content. It should expose exactly the non-content related functions
 # of the eListbox class. more or less.
 
 
@@ -23,16 +20,6 @@ class Listbox(Renderer):
 		self.__selectionEnabled = True  # FIXME: The default is true already.
 		self.scale = None
 
-	def contentChanged(self):
-		self.content = self.source.content
-
-	def setContent(self, content):
-		self.__content = content
-		if self.instance is not None:
-			self.instance.setContent(self.__content)
-
-	content = property(lambda self: self.__content, setContent)
-
 	def applySkin(self, desktop, parent):
 		self.scale = parent.scale
 		return Renderer.applySkin(self, desktop, parent)
@@ -41,8 +28,7 @@ class Listbox(Renderer):
 		if self.__content is not None:
 			instance.setContent(self.__content)
 		instance.selectionChanged.get().append(self.selectionChanged)
-		# Trigger property changes
-		self.setWrapAround(self.wrapAround)
+		self.setWrapAround(self.wrapAround)  # Trigger property changes.
 		self.setSelectionEnabled(self.selectionEnabled)
 		self.setScrollbarMode(self.scrollbarMode)
 
@@ -59,24 +45,15 @@ class Listbox(Renderer):
 
 	wrapAround = property(getWrapAround, setWrapAround)
 
-	def selectionChanged(self):
-		self.source.selectionChanged(self.index)
-
-	def getIndex(self):
-		if self.instance is None:
-			return 0
-		return self.instance.getCurrentIndex()
-
-	def moveToIndex(self, index):
-		if self.instance is None:
-			return
-		self.instance.moveSelectionTo(index)
-
-	index = property(getIndex, moveToIndex)
-
-	def move(self, direction):
+	def setContent(self, content):
+		self.__content = content
 		if self.instance is not None:
-			self.instance.moveSelection(direction)
+			self.instance.setContent(self.__content)
+
+	content = property(lambda self: self.__content, setContent)
+
+	def contentChanged(self):
+		self.content = self.source.content
 
 	def setSelectionEnabled(self, enabled):
 		self.__selectionEnabled = enabled
@@ -85,28 +62,50 @@ class Listbox(Renderer):
 
 	selectionEnabled = property(lambda self: self.__selectionEnabled, setSelectionEnabled)
 
-	def setScrollbarMode(self, mode):
+	def selectionChanged(self):
+		self.source.selectionChanged(self.index)
+
+	def entryChanged(self, index):
 		if self.instance is not None:
-			self.instance.setScrollbarMode(
-				{
-					"showOnDemand": eListbox.showOnDemand,
-					"showAlways": eListbox.showAlways,
-					"showNever": eListbox.showNever,
-					"showLeft": eListbox.showLeftOnDemand,
-					"showLeftOnDemand": eListbox.showLeftOnDemand,
-					"showLeftAlways": eListbox.showLeftAlways,
-				}.get(mode, eListbox.showNever))
+			self.instance.entryChanged(index)
+
+	def entry_changed(self, index):  # Remove this method when it is no longer in use.
+		self.entryChanged(index)
+
+	def getIndex(self):
+		return 0 if self.instance is None else self.instance.getCurrentIndex()
+
+	def moveToIndex(self, index):
+		if self.instance is not None:
+			self.instance.moveSelectionTo(index)
+
+	index = property(getIndex, moveToIndex)
+
+	def move(self, direction):
+		if self.instance is not None:
+			self.instance.moveSelection(direction)
 
 	def getScrollbarMode(self):
 		mode = self.instance and self.instance.getScrollbarMode()
 		mode = {
-				eListbox.showOnDemand: "showOnDemand",
-				eListbox.showAlways: "showAlways",
-				eListbox.showNever: "showNever",
-				eListbox.showLeftOnDemand: "showLeftOnDemand",
-				eListbox.showLeftAlways: "showLeftAlways",
-			}.get(mode, "showNever")
+			eListbox.showOnDemand: "showOnDemand",
+			eListbox.showAlways: "showAlways",
+			eListbox.showNever: "showNever",
+			eListbox.showLeftOnDemand: "showLeftOnDemand",
+			eListbox.showLeftAlways: "showLeftAlways"
+		}.get(mode, "showNever")
 		return mode
+
+	def setScrollbarMode(self, mode):
+		if self.instance is not None:
+			self.instance.setScrollbarMode({
+				"showOnDemand": eListbox.showOnDemand,
+				"showAlways": eListbox.showAlways,
+				"showNever": eListbox.showNever,
+				"showLeft": eListbox.showLeftOnDemand,
+				"showLeftOnDemand": eListbox.showLeftOnDemand,
+				"showLeftAlways": eListbox.showLeftAlways
+			}.get(mode, eListbox.showNever))
 
 	scrollbarMode = property(getScrollbarMode, setScrollbarMode)
 
@@ -115,12 +114,6 @@ class Listbox(Renderer):
 			self.selectionEnabled = self.source.selectionEnabled
 		if hasattr(self.source, "scrollbarMode"):
 			self.scrollbarMode = self.source.scrollbarMode
-		if len(what) > 1 and isinstance(what[1], str) and what[1] == "style":
-			return
-		if self.content:
+		if len(what) > 1 and isinstance(what[1], str) and what[1] in ("style", "template") or self.content:
 			return
 		self.content = self.source.content
-
-	def entry_changed(self, index):
-		if self.instance is not None:
-			self.instance.entryChanged(index)

--- a/lib/python/Components/Sources/List.py
+++ b/lib/python/Components/Sources/List.py
@@ -17,10 +17,12 @@ to generate HTML."""
 	# use of the enableWrapAround="1" attribute in the skin. Similarly the
 	# itemHeight and font specifications are handled by the skin.
 	#
-	def __init__(self, list=None, enableWrapAround=None, item_height=0, fonts=None):
+	def __init__(self, list=None, enableWrapAround=None, item_height=0, fonts=None, templateName=None, indexNames=None):
 		Source.__init__(self)
 		self.listData = list or []
+		self.listTemplate = templateName or "Default"  # Style might be an optional string which can be used to define different visualizations in the skin.
 		self.listStyle = "default"  # Style might be an optional string which can be used to define different visualizations in the skin.
+		self.listIndexNames = indexNames or {}
 		self.onSelectionChanged = []
 		self.disableCallbacks = False
 
@@ -29,7 +31,7 @@ to generate HTML."""
 			instance = self.master.master.instance
 			instance.enableAutoNavigation(enabled)
 		except AttributeError:
-			return
+			pass
 
 	def getList(self):
 		return self.listData
@@ -40,6 +42,9 @@ to generate HTML."""
 
 	list = property(getList, setList)
 
+	def count(self):
+		return len(self.listData)
+
 	def updateList(self, listData):
 		"""Changes the list without changing the selection or emitting changed Events"""
 		maxIndex = len(listData) - 1
@@ -49,32 +54,28 @@ to generate HTML."""
 		self.index = oldIndex
 		self.disableCallbacks = False
 
-	def count(self):
-		return len(self.listData)
-
-	def selectionChanged(self, index):
-		if self.disableCallbacks:
-			return
-		for element in self.downstream_elements:  # Update all non-master targets.
-			if element is not self.master:
-				element.index = index
-		for callback in self.onSelectionChanged:
-			callback()
+	def updateEntry(self, index, data):
+		self.listData[index] = data
+		self.entryChanged(index)
 
 	def selectionEnabled(self, enabled):
 		try:
 			instance = self.master.master.instance
 			instance.selectionEnabled(enabled)
 		except AttributeError:
-			return
+			pass
 
-	def entryChanged(self, index):
+	def selectionChanged(self, index):
+		if not self.disableCallbacks:
+			for element in self.downstream_elements:  # Update all non-master targets.
+				if element is not self.master:
+					element.index = index
+			for callback in self.onSelectionChanged:
+				callback()
+
+	def entryChanged(self, index):  # Only used in CutListEditor.
 		if not self.disableCallbacks:
 			self.downstream_elements.entry_changed(index)
-
-	def modifyEntry(self, index, data):
-		self.listData[index] = data
-		self.entryChanged(index)
 
 	@cached
 	def getCurrent(self):
@@ -91,24 +92,42 @@ to generate HTML."""
 			self.master.index = index
 			self.selectionChanged(index)
 
-	def setIndex(self, index):  # This method should be found and removed from all code.
-		return self.setCurrentIndex(index)
-
 	index = property(getCurrentIndex, setCurrentIndex)
 
 	def getTopIndex(self):
 		try:
 			instance = self.master.master.instance
-			return instance.getTopIndex()
+			result = instance.getTopIndex()
 		except AttributeError:
-			return -1
+			result = -1
+		return result
 
 	def setTopIndex(self, index):
 		try:
 			instance = self.master.master.instance
 			instance.setTopIndex(index)
 		except AttributeError:
-			return
+			pass
+
+	@cached
+	def getTemplate(self):
+		return self.listTemplate
+
+	def setTemplate(self, template):
+		if self.listTemplate != template:
+			self.listTemplate = template
+			self.changed((self.CHANGED_SPECIFIC, "template"))
+
+	template = property(getTemplate, setTemplate)
+
+	@cached
+	def getMode(self):
+		return self.listStyle
+
+	def setMode(self, mode):
+		self.setStyle(mode)
+
+	mode = property(getMode, setMode)
 
 	@cached
 	def getStyle(self):
@@ -121,19 +140,11 @@ to generate HTML."""
 
 	style = property(getStyle, setStyle)
 
-	def show(self):
-		try:
-			instance = self.master.master.instance
-			instance.show()
-		except AttributeError:
-			return
+	@cached
+	def getIndexNames(self):
+		return self.listIndexNames
 
-	def hide(self):
-		try:
-			instance = self.master.master.instance
-			instance.hide()
-		except AttributeError:
-			return
+	indexNames = property(getIndexNames)
 
 	def setVisible(self, visble):
 		if visble:
@@ -144,83 +155,105 @@ to generate HTML."""
 	def getVisible(self):
 		try:
 			instance = self.master.master.instance
-			return instance.isVisible()
+			result = instance.isVisible()
 		except AttributeError:
-			return False
+			result = False
+		return result
 
 	visible = property(getVisible, setVisible)
+
+	def show(self):
+		try:
+			instance = self.master.master.instance
+			instance.show()
+		except AttributeError:
+			pass
+
+	def hide(self):
+		try:
+			instance = self.master.master.instance
+			instance.hide()
+		except AttributeError:
+			pass
+
+	def enableAutoNavigation(self, value):
+		try:
+			instance = self.master.master.instance
+			instance.enableAutoNavigation(value)
+		except AttributeError:
+			pass
 
 	def goTop(self):
 		try:
 			instance = self.master.master.instance
 			instance.goTop()
 		except AttributeError:
-			return
+			pass
 
 	def goPageUp(self):
 		try:
 			instance = self.master.master.instance
 			instance.goPageUp()
 		except AttributeError:
-			return
+			pass
 
 	def goLineUp(self):
 		try:
 			instance = self.master.master.instance
 			instance.goLineUp()
 		except AttributeError:
-			return
+			pass
 
 	def goFirst(self):
 		try:
 			instance = self.master.master.instance
 			instance.goFirst()
 		except AttributeError:
-			return
+			pass
 
 	def goLeft(self):
 		try:
 			instance = self.master.master.instance
 			instance.goLeft()
 		except AttributeError:
-			return
+			pass
 
 	def goRight(self):
 		try:
 			instance = self.master.master.instance
 			instance.goRight()
 		except AttributeError:
-			return
+			pass
 
 	def goLast(self):
 		try:
 			instance = self.master.master.instance
 			instance.goLast()
 		except AttributeError:
-			return
+			pass
 
 	def goLineDown(self):
 		try:
 			instance = self.master.master.instance
 			instance.goLineDown()
 		except AttributeError:
-			return
+			pass
 
 	def goPageDown(self):
 		try:
 			instance = self.master.master.instance
 			instance.goPageDown()
 		except AttributeError:
-			return
+			pass
 
 	def goBottom(self):
 		try:
 			instance = self.master.master.instance
 			instance.goBottom()
 		except AttributeError:
-			return
+			pass
 
-	# These hacks protect code that was modified to use the previous up/down hack!   This methods should be found and removed from all code.
+	# These hacks protect code that was modified to use the previous up/down hack!   These methods should be found and removed from all code.
 	#
 	def selectPrevious(self):
 		self.goLineUp()
@@ -228,13 +261,22 @@ to generate HTML."""
 	def selectNext(self):
 		self.goLineDown()
 
-	# Old method names. This methods should be found and removed from all code.
+	# Old method names. These methods should be found and removed from all code.
 	#
+	def entry_changed(self, index):
+		self.entryChanged(index)
+
+	def modifyEntry(self, index, data):  # This is only used by CutListEditor.
+		self.updateEntry(index, data)
+
 	def getSelectedIndex(self):
 		return self.getCurrentIndex()
 
 	def getIndex(self):
 		return self.getCurrentIndex()
+
+	def setIndex(self, index):
+		self.setCurrentIndex(index)
 
 	def top(self):
 		self.goTop()

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -4,7 +4,7 @@ from os import listdir, unlink
 from traceback import print_exc
 from xml.etree.ElementTree import Element, ElementTree, fromstring
 
-from enigma import BT_ALPHABLEND, BT_ALPHATEST, BT_HALIGN_CENTER, BT_HALIGN_LEFT, BT_HALIGN_RIGHT, BT_KEEP_ASPECT_RATIO, BT_SCALE, BT_VALIGN_BOTTOM, BT_VALIGN_CENTER, BT_VALIGN_TOP, addFont, eLabel, eListbox, ePixmap, ePoint, eRect, eRectangle, eSize, eSlider, eSubtitleWidget, eWidget, eWindow, eWindowStyleManager, eWindowStyleSkinned, getDesktop, gFont, getFontFaces, gMainDC, gRGB
+from enigma import BT_ALPHABLEND, BT_ALPHATEST, BT_HALIGN_CENTER, BT_HALIGN_LEFT, BT_HALIGN_RIGHT, BT_KEEP_ASPECT_RATIO, BT_SCALE, BT_VALIGN_BOTTOM, BT_VALIGN_CENTER, BT_VALIGN_TOP, addFont, eLabel, eListbox, eListboxPythonMultiContent, ePixmap, ePoint, eRect, eRectangle, eSize, eSlider, eSubtitleWidget, eWidget, eWindow, eWindowStyleManager, eWindowStyleSkinned, getDesktop, gFont, getFontFaces, gMainDC, gRGB
 
 from Components.config import ConfigSubsection, ConfigText, config
 from Components.SystemInfo import BoxInfo
@@ -151,10 +151,10 @@ def InitSkins():
 		gMainDC.getInstance().setResolution(resolution[0], resolution[1])
 		getDesktop(GUI_SKIN_ID).resize(eSize(resolution[0], resolution[1]))
 	runCallbacks = True
-	# Load all XML template styles.
-	styleFileName = resolveFilename(SCOPE_SKINS, pathjoin(dirname(currentPrimarySkin), "styles.xml"))
-	if isfile(styleFileName):
-		loadStyles(styleFileName)
+	# Load all XML templates.
+	skinTemplatesFileName = resolveFilename(SCOPE_SKINS, pathjoin(dirname(currentPrimarySkin), "skinTemplates.xml"))
+	if isfile(skinTemplatesFileName):
+		loadSkinTemplates(skinTemplatesFileName)
 
 
 # Method to load a skin XML file into the skin data structures.
@@ -181,9 +181,7 @@ def loadSkin(filename, scope=SCOPE_SKINS, desktop=getDesktop(GUI_SKIN_ID), scree
 							element.attrib["resolution"] = res
 						if config.crash.debugScreens.value:
 							res = [parseInteger(x.strip()) for x in res.split(",")]
-							msg = f", resolution {res[0]}x{res[1]}," if len(res) == 2 and res[0] and res[1] else ""
-							print(f"[Skin] Loading screen '{name}'{msg} from '{filename}'.  (scope={scope})")
-							# print(f"[Skin] Loading screen '{name}'{f", resolution {res[0]}x{res[1]}," if len(res) == 2 and res[0] and res[1] else ""} from '{filename}'.  (scope={scope})")
+							print(f"[Skin] Loading screen '{name}'{f", resolution {res[0]}x{res[1]}," if len(res) == 2 and res[0] and res[1] else ""} from '{filename}'.  (scope={scope})")
 						domScreens[name] = (element, f"{dirname(filename)}/")
 			elif element.tag == "windowstyle":  # Process the windowstyle element.
 				scrnID = element.attrib.get("id")
@@ -204,11 +202,11 @@ def loadSkin(filename, scope=SCOPE_SKINS, desktop=getDesktop(GUI_SKIN_ID), scree
 	return False
 
 
-# Method to load a styles.xml if exists.
+# Method to load a skinTemplates.xml if exists.
 #
-def loadStyles(styleFileName):
-	print(f"[Skin] Loading XML templates from '{styleFileName}'.")
-	domStyles = fileReadXML(styleFileName, source=MODULE_NAME)
+def loadSkinTemplates(skinTemplatesFileName):
+	print(f"[Skin] Loading XML templates from '{skinTemplatesFileName}'.")
+	domStyles = fileReadXML(skinTemplatesFileName, source=MODULE_NAME)
 	if domStyles is not None:
 		for template in domStyles.findall("template"):
 			component = template.get("component")
@@ -219,7 +217,7 @@ def loadStyles(styleFileName):
 				else:
 					componentTemplates[component] = {name: template}
 		if config.crash.debugScreens.value:
-			print(f"[Skin] DEBUG componentTemplates '{componentTemplates}'.")
+			print(f"[Skin] DEBUG: componentTemplates '{componentTemplates}'.")
 
 
 def reloadSkins():
@@ -290,9 +288,7 @@ def parseOptions(options, attribute, value, default):
 		if value in options.keys():
 			value = options[value]
 		else:
-			optionList = "', '".join(options.keys())
-			skinError(f"The '{attribute}' value '{value}' is invalid, acceptable options are '{optionList}'")
-			# skinError(f"The '{attribute}' value '{value}' is invalid, acceptable options are '{"', '".join(options.keys())}'")
+			skinError(f"The '{attribute}' value '{value}' is invalid, acceptable options are '{"', '".join(options.keys())}'")
 			value = default
 	else:
 		skinError(f"The '{attribute}' parser is not correctly initialized")
@@ -876,34 +872,46 @@ class AttributeParser:
 		pass
 
 	def backgroundColor(self, value):
-		self.guiObject.setBackgroundColor(parseColor(value, 0x00000000))
+		if "," in value:
+			self.guiObject.setBackgroundGradient(*parseGradient(value))
+		else:
+			self.guiObject.setBackgroundColor(parseColor(value, 0x00000000))
 
-	def backgroundColorEven(self, value):
+	def backgroundColorEven(self, value):  # Gradient not available here.
 		self.guiObject.setBackgroundColorRows(parseColor(value, 0x00000000))
 
-	def backgroundColorOdd(self, value):
+	def backgroundColorOdd(self, value):  # Gradient not available here.
 		self.guiObject.setBackgroundColor(parseColor(value, 0x00000000))
 
-	def backgroundColorRows(self, value):
+	def backgroundColorRows(self, value):  # Gradient not available here.
 		self.guiObject.setBackgroundColorRows(parseColor(value, 0x00000000))
+		attribDeprecationWarning("backgroundColorRows", "backgroundColorEven")
 
 	def backgroundColorSelected(self, value):
-		self.guiObject.setBackgroundColorSelected(parseColor(value, 0x00000000))
+		if "," in value:
+			self.guiObject.setBackgroundGradientSelected(*parseGradient(value))
+		else:
+			self.guiObject.setBackgroundColorSelected(parseColor(value, 0x00000000))
 
-	def backgroundCrypted(self, value):
-		self.guiObject.setBackgroundColor(parseColor(value, 0x00000000))
+	# def backgroundCrypted(self, value):  # This appears to be unused.
+	# 	self.guiObject.setBackgroundColor(parseColor(value, 0x00000000))
+	# 	attribDeprecationWarning("backgroundCrypted", "backgroundColor")
 
-	def backgroundEncrypted(self, value):
-		self.guiObject.setBackgroundColor(parseColor(value, 0x00000000))
+	# def backgroundEncrypted(self, value):  # This appears to be unused.
+	# 	self.guiObject.setBackgroundColor(parseColor(value, 0x00000000))
+	# 	attribDeprecationWarning("backgroundEncrypted", "backgroundColor")
 
 	def backgroundGradient(self, value):
 		self.guiObject.setBackgroundGradient(*parseGradient(value))
+		attribDeprecationWarning("backgroundGradient", "backgroundColor")
 
 	def backgroundGradientSelected(self, value):
 		self.guiObject.setBackgroundGradientSelected(*parseGradient(value))
+		attribDeprecationWarning("backgroundGradientSelected", "backgroundColorSelected")
 
-	def backgroundNotCrypted(self, value):
-		self.guiObject.setBackgroundColor(parseColor(value, 0x00000000))
+	# def backgroundNotCrypted(self, value):  # This appears to be unused.
+	# 	self.guiObject.setBackgroundColor(parseColor(value, 0x00000000))
+	# 	attribDeprecationWarning("backgroundNotCrypted", "backgroundColor")
 
 	def backgroundPixmap(self, value):
 		self.guiObject.setBackgroundPixmap(parsePixmap(value, self.desktop))
@@ -941,30 +949,35 @@ class AttributeParser:
 			except KeyError:
 				errors.append(flag)
 		if errors:
-			errorList = "', '".join(errors)
-			print(f"[Skin] Error: Attribute 'flags' with value '{value}' has invalid element(s) '{errorList}'!")
-			# print(f"[Skin] Error: Attribute 'flags' with value '{value}' has invalid element(s) '{"', '".join(errors)}'!")
+			print(f"[Skin] Error: Attribute 'flags' with value '{value}' has invalid element(s) '{"', '".join(errors)}'!")
 
 	def font(self, value):
 		self.guiObject.setFont(parseFont(value, self.scaleTuple))
 
 	def foregroundColor(self, value):
-		self.guiObject.setForegroundColor(parseColor(value, 0x00FFFFFF))
+		if "," in value:
+			self.guiObject.setForegroundGradient(*parseGradient(value))  # Only for eSlider.
+		else:
+			self.guiObject.setForegroundColor(parseColor(value, 0x00FFFFFF))
 
 	def foregroundColorSelected(self, value):
 		self.guiObject.setForegroundColorSelected(parseColor(value, 0x00FFFFFF))
 
-	def foregroundCrypted(self, value):
-		self.guiObject.setForegroundColor(parseColor(value, 0x00FFFFFF))
+	# def foregroundCrypted(self, value):  # This appears to be unused.
+	# 	self.guiObject.setForegroundColor(parseColor(value, 0x00FFFFFF))
+	# 	attribDeprecationWarning("foregroundCrypted", "foregroundColor")
 
-	def foregroundEncrypted(self, value):
-		self.guiObject.setForegroundColor(parseColor(value, 0x00FFFFFF))
+	# def foregroundEncrypted(self, value):  # This appears to be unused.
+	# 	self.guiObject.setForegroundColor(parseColor(value, 0x00FFFFFF))
+	# 	attribDeprecationWarning("foregroundEncrypted", "foregroundColor")
 
 	def foregroundGradient(self, value):
 		self.guiObject.setForegroundGradient(*parseGradient(value))
+		attribDeprecationWarning("foregroundGradient", "foregroundColor")
 
-	def foregroundNotCrypted(self, value):
-		self.guiObject.setForegroundColor(parseColor(value, 0x00FFFFFF))
+	# def foregroundNotCrypted(self, value):  # This appears to be unused.
+	# 	self.guiObject.setForegroundColor(parseColor(value, 0x00FFFFFF))
+	# 	attribDeprecationWarning("foregroundNotCrypted", "foregroundColor")
 
 	def hAlign(self, value):  # This typo catcher definition uses an inconsistent name, use 'horizontalAlignment' instead!
 		self.horizontalAlignment(value)
@@ -1280,7 +1293,7 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_GUISKIN
 				bpp = parseInteger(res.attrib.get("bpp", 32), 32)
 				resolutions[scrnID] = (xres, yres, bpp)
 				if bpp != 32:
-					pass  # Load palette (Not yet implemented!)
+					pass  # Load palette. (Not yet implemented!)
 	for tag in domSkin.findall("include"):
 		filename = tag.attrib.get("filename")
 		if filename:
@@ -1733,6 +1746,185 @@ class SkinContextHorizontal(SkinContext):
 		return (SizeTuple(pos), SizeTuple(size))
 
 
+class TemplateParser():
+	def __init__(self, debug=False):
+		self.debug = debug
+		self.processors = {
+			None: self.processNone,
+			"text": self.collectAttributes,
+			"pixmap": self.collectAttributes,
+			"progress": self.collectAttributes,
+			"rectangle": self.collectAttributes,
+			"panel": self.processPanel
+		}
+
+	def resolvePixmap(self, pixmap):
+		if isinstance(pixmap, str):
+			try:
+				return LoadPixmap(resolveFilename(SCOPE_GUISKIN, pixmap))
+			except Exception as err:
+				print(f"[MultiContent] Error: Invalid image extension!  ({str(err)})")
+			return None
+		return pixmap
+
+	def resolveColor(self, color):
+		if isinstance(color, str):
+			try:
+				if color and color[0] == "=":  # Index color for MultiContent.
+					return 0xff000000 | int(color[1:])
+				return parseColor(color).argb()
+			except Exception as err:
+				print("[MultiContent] Error: Resolve color '{str(err)}'!")
+			return None
+		return color
+
+	def readTemplate(self, templateName):  # Override in child class.
+		pass
+
+	def getGradient(self, foregroundGradient, foregroundGradientSelected):
+		gradientStart = None
+		gradientMid = None
+		gradientEnd = None
+		gradientStartSelected = None
+		gradientMidSelected = None
+		gradientEndSelected = None
+		direction = 0
+		alphaBlend = 0
+		if foregroundGradient:
+			gradientData = parseGradient(foregroundGradient)
+			gradientStart = gradientData[0].argb()
+			gradientMid = gradientData[1].argb()
+			gradientEnd = gradientData[2].argb()
+			direction = gradientData[3]
+			alphaBlend = gradientData[4]
+		if foregroundGradientSelected:
+			gradientData = parseGradient(foregroundGradientSelected)
+			gradientStartSelected = gradientData[0].argb()
+			gradientMidSelected = gradientData[1].argb()
+			gradientEndSelected = gradientData[2].argb()
+			direction = gradientData[3]
+			alphaBlend = gradientData[4]
+		return direction, alphaBlend, gradientStart, gradientEnd, gradientMid, gradientStartSelected, gradientEndSelected, gradientMidSelected
+
+	def collectColors(self, attributes):
+		for color in ("backgroundColor", "backgroundColorMarked", "backgroundColorMarkedAndSelected", "backgroundColorSelected", "borderColor", "foregroundColor", "foregroundColorMarked", "foregroundColorMarkedAndSelected", "foregroundColorSelected"):
+			translatedColor = self.resolveColor(attributes.get(color))
+			if translatedColor is not None:
+				attributes[color] = translatedColor
+		return attributes
+
+	def collectAttributes(self, node, context, ignore=(), excludeItemValues=None, includeItemValues=None):
+		horizontalAlignments = {
+			"left": 1,
+			"center": 4,
+			"right": 2,
+			"block": 8
+		}
+		verticalAlignments = {
+			"top": 0,
+			"center": 16,
+			"middle": 16,
+			"bottom": 32
+		}
+		wraps = {
+			"noWrap": 0,
+			"off": 0,
+			"0": 0,
+			"wrap": 64,
+			"on": 64,
+			"1": 64,
+			"ellipsis": 128
+		}
+		pixmapTypes = {
+			"blend": eListboxPythonMultiContent.TYPE_PIXMAP_ALPHABLEND,
+			"test": eListboxPythonMultiContent.TYPE_PIXMAP_ALPHATEST
+		}
+		pos = None
+		size = None
+		skinAttributes = []
+		itemValue = ""
+		for attrib, value in node.items():  # Walk all attributes.
+			if attrib not in ignore:
+				newValue = value
+				match attrib:
+					case "position":
+						pos = newValue
+					case "size":
+						size = newValue
+					case _:
+						skinAttributes.append((attrib, newValue))
+				if attrib == "value":
+					itemValue = value
+		if itemValue and includeItemValues and itemValue not in includeItemValues:
+			return []
+		if itemValue and excludeItemValues and itemValue in excludeItemValues:
+			return []
+		if pos is not None:
+			pos, size = context.parse(pos, size, None)
+			skinAttributes.append(("position", pos))
+		if size is not None:
+			skinAttributes.append(("size", size))
+		attributes = {"type": node.tag}
+		for attrib, value in skinAttributes:
+			attributes[attrib] = value
+		attributes["_flags"] = horizontalAlignments.get(attributes.get("horizontalAlignment"), 1) + verticalAlignments.get(attributes.get("verticalAlignment"), 0) + wraps.get(attributes.get("wrap"), 0)
+		if attributes["type"] == "pixmap":
+			attributes["pixmapType"] = pixmapTypes.get(attributes.get("alpha", ""), eListboxPythonMultiContent.TYPE_PIXMAP)
+			attributes["pixmapFlags"] = parseScale(attributes.get("scale", "off"))
+		if "cornerRadius" in attributes:
+			attributes["_radius"] = parseRadius(attributes.get("cornerRadius"))
+		foregroundGradient = attributes.get("foregroundGradient")
+		foregroundGradientSelected = attributes.get("foregroundGradientSelected", foregroundGradient)
+		if foregroundGradient or foregroundGradientSelected:
+			attributes["_gradient"] = self.getGradient(foregroundGradient, foregroundGradientSelected)
+		attributes = self.collectColors(attributes)
+		return [attributes]
+
+	def processPanel(self, widget, context, excludeItemValues=None, includeItemValues=None):
+		if self.debug:
+			print(f"[TemplateParser] processPanel DEBUG: Position={widget.attrib.get("position")}, Size={ widget.attrib.get("size")}.")
+			print(f"[TemplateParser] processPanel DEBUG: Parent x={context.x}, width={context.w}.")
+		pos = [int(x.strip()) for x in widget.attrib.get("position").split(",")]
+		layout = widget.attrib.get("layout")
+		classes = {
+			"stack": SkinContextStack,
+			"vertical": SkinContextVertical,
+			"horizontal": SkinContextHorizontal,
+		}
+		contextClass = classes.get(layout, SkinContext)
+		newContext = contextClass(context, widget.attrib.get("position"), widget.attrib.get("size"), widget.attrib.get("font"))
+		newContext.spacing = int(widget.attrib.get("spacing", "0"))
+		if self.debug:
+			print(f"[TemplateParser] processPanel DEBUG: Parent x={newContext.x}, width={newContext.w}.")
+		newContext.x = pos[0]
+		newContext.y = pos[1]
+		if layout == "horizontal":
+			newContext.w -= newContext.x  # I have no idea why this is needed!
+		if self.debug:
+			print(f"[TemplateParser] processPanel DEBUG: context='{str(newContext)}'.")
+		items = []
+		for element in list(widget):
+			processor = self.processors.get(element.tag, self.processNone)
+			newItems = processor(element, newContext, excludeItemValues=excludeItemValues, includeItemValues=includeItemValues)
+			if newItems:
+				items += newItems
+		if layout == "horizontal" and newContext.w > 0:
+			for item in items:
+				if item.get("autoGrow", ""):
+					oldSize = [int(x.strip()) for x in item["size"].split(",")]
+					width = oldSize[0] + newContext.w
+					item["size"] = f"{width},{oldSize[1]}"
+					if self.debug:
+						print(f"[TemplateParser] DEBUG: autoGrow context={newContext.w}, oldSize={oldSize}, newsize={item["size"]}.")
+					break
+		if self.debug:
+			print(items)
+		return items
+
+	def processNone(self, widget, context):
+		pass
+
+
 class SkinError(Exception):
 	def __init__(self, errorMessage):
 		self.errorMessage = errorMessage
@@ -1755,9 +1947,7 @@ def readSkin(screen, skin, names, desktop):
 				myName = name  # Use this name for debug output.
 				break
 			else:
-				widgetList = "', '".join(screen.mandatoryWidgets)
-				print(f"[Skin] Warning: Skin screen '{name}' rejected as it does not offer all the mandatory widgets '{widgetList}'!")
-				# print(f"[Skin] Warning: Skin screen '{name}' rejected as it does not offer all the mandatory widgets '{"', '".join(screen.mandatoryWidgets)}'!")
+				print(f"[Skin] Warning: Skin screen '{name}' rejected as it does not offer all the mandatory widgets '{"', '".join(screen.mandatoryWidgets)}'!")
 				myScreen = None
 	else:
 		myName = f"<embedded-in-{screen.__class__.__name__}>"
@@ -1844,7 +2034,6 @@ def readSkin(screen, skin, names, desktop):
 		widgetSource = widget.attrib.get("source")
 		if widgetName is None and widgetSource is None:
 			raise SkinError("The widget has no name and no source")
-			return
 		if widgetName:
 			# print(f"[Skin] DEBUG: Widget name='{widgetName}'.")
 			usedComponents.add(widgetName)
@@ -1889,6 +2078,25 @@ def readSkin(screen, skin, names, desktop):
 			widgetRenderer = widget.attrib.get("render")
 			if not widgetRenderer:
 				raise SkinError(f"For source '{widgetSource}' a renderer must be defined with a 'render=' attribute")
+			for widgetTemplates in widget.findall("templates"):
+				try:
+					converterClass = my_import(".".join(("Components", "Converter", "XmlMultiContent"))).__dict__.get("XmlMultiContent")
+				except ImportError:
+					raise SkinError(f"Converter XmlMultiContent not found")
+				connection = None
+				for element in source.downstream_elements:
+					if isinstance(element, converterClass):  # and element.converter_arguments == "widgetTemplates":
+						connection = element
+				if connection is None:
+					args = {
+						"scale": context.scale,
+						"dom": widgetTemplates,
+						"size": widget.attrib.get("size")
+					}
+					connection = converterClass(args)
+					connection.connect(source)
+				source = connection
+				break  # There can be only one XmlMultiContent converter.
 			for converter in widget.findall("convert"):
 				converterType = converter.get("type")
 				assert converterType, "[Skin] The 'convert' tag needs a 'type' attribute!"
@@ -2017,13 +2225,11 @@ def readSkin(screen, skin, names, desktop):
 	}
 
 	try:
-		msg = f", from list '{', '.join(names)}'," if len(names) > 1 else ""
 		posX = "?" if context.x is None else str(context.x)
 		posY = "?" if context.y is None else str(context.y)
 		sizeW = "?" if context.w is None else str(context.w)
 		sizeH = "?" if context.h is None else str(context.h)
-		print(f"[Skin] Processing screen '{myName}'{msg} position=({posX},{posY}), size=({sizeW},{sizeH}) for module '{screen.__class__.__name__}'.")
-		# print(f"[Skin] Processing screen '{myName}'{f", from list '{", ".join(names)}'," if len(names) > 1 else ""} position=({posX},{posY}), size=({sizeW},{sizeH}) for module '{screen.__class__.__name__}'.")
+		print(f"[Skin] Processing screen '{myName}'{f", from list '{", ".join(names)}'," if len(names) > 1 else ""} position=({posX},{posY}), size=({sizeW},{sizeH}) for module '{screen.__class__.__name__}'.")
 		context.x = 0  # Reset offsets, all components are relative to screen coordinates.
 		context.y = 0
 		processScreen(myScreen, context)

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1921,8 +1921,8 @@ class TemplateParser():
 			print(items)
 		return items
 
-	def processNone(self, widget, context):
-		pass
+	def processNone(self, widget, context):  # This is a dummy method for the XML template tag parser.
+		pass  # There is nothing to do in this case.
 
 
 class SkinError(Exception):
@@ -2082,7 +2082,7 @@ def readSkin(screen, skin, names, desktop):
 				try:
 					converterClass = my_import(".".join(("Components", "Converter", "XmlMultiContent"))).__dict__.get("XmlMultiContent")
 				except ImportError:
-					raise SkinError(f"Converter XmlMultiContent not found")
+					raise SkinError("Converter XmlMultiContent not found")
 				connection = None
 				for element in source.downstream_elements:
 					if isinstance(element, converterClass):  # and element.converter_arguments == "widgetTemplates":


### PR DESCRIPTION
- This change introduces XML based skin templates.  The old Python based templates are now deprecated.  When they are no longer needed all code that supports them will be removed.
- The new XML templates now use standard skin based attributes rather than Python code fragments and Python variable names.
- The index into the data tuples with the data to be formatted can now be specified by index number into the tuple and by a new variable name mechanism. This now means that as long as the code behind the skin keeps the same variable name the actual tuple order can now be changed without requiring a skin change.
- The templates can be defined in-line within a screen definition or they can be collected into a separate "skinTemplates.xml" file.

[skin.py]
- Add new XML based multi-content parser.
- Update f-strings to Python 3.12 format.
- Remove the recently added gradient attributes and replace them with smarter color attributes.  If the color attribute includes a comma "," then the color is a gradient.
- Note that the "backgroundColorEven", "backgroundColorOdd", and "backgroundColorRows" can not be gradients.
- Remove the unused "backgroundCrypted", "backgroundEncrypted", "backgroundNotCrypted", "foregroundCrypted", "foregroundEncrypted", "foregroundNotCrypted" attributes. If these attributes are used in a skin then please create an issue to discuss the problem.

[List.py]
- Add support for the new XML templates via the "template", "mode", and "indexName" methods.
- Optimize some of the code.
- Tidy up the code and move all deprecated methods to the end of the module.

[Listbox.py]
- Add support for the new XML templates.
- Optimize some of the code.
- Tidy up the code and move all deprecated methods to the end of the module.
- Improve some of the comments.

[XmlMultiContent.py]
- This is a new converter that supports the processing of XML templates for source based widgets.
- This is a special internal converter that does not need to be specified in a "converter" tag. The presence of a "templates" tag in the screen will automatically invoke this converter.