### PR TITLE
AVSwitch and related code refactor

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -505,6 +505,25 @@
 		<item level="0" text="Depth" description="This option lets you adjust the 3D depth of the OSD.">config.osd.threeDznorm</item>
 		<item level="0" text="Show in Extension Menu" description="This option lets you show the 3D OSD menu option in the Extension Menu screen.">config.osd.show3dextensions</item>
 	</setup>
+	<setup key="OSDCalibration" title="OSD Calibration Settings" showOpenWebif="1" allowDefault="1">
+		<if requires="CanChangeOsdPositionAML">
+			<item level="0" text="Left" description="Use the LEFT/RIGHT buttons on your remote to move the OSD left.">config.osd.dst_left</item>
+			<item level="0" text="Top" description="Use the LEFT/RIGHT buttons on your remote to move the OSD top.">config.osd.dst_top</item>
+			<item level="0" text="Right" description="Use the LEFT/RIGHT buttons on your remote to move the OSD right.">config.osd.dst_width</item>
+			<item level="0" text="Bottom" description="Use the LEFT/RIGHT buttons on your remote to move the OSD bottom.">config.osd.dst_height</item>
+		</if>
+		<if requires="CanChangeOsdPosition">
+			<item level="0" text="Move Left/Right" description="Use the LEFT/RIGHT buttons on your remote to move the OSD left/right.">config.osd.dst_left</item>
+			<item level="0" text="Move Up/Down" description="Use the LEFT/RIGHT buttons on your remote to move the OSD up/down.">config.osd.dst_top</item>
+			<item level="0" text="Width" description="Use the LEFT/RIGHT buttons on your remote to adjust the width of the OSD. LEFT button decreases the width, RIGHT increases the width.">config.osd.dst_width</item>
+			<item level="0" text="Height" description="Use the LEFT/RIGHT buttons on your remote to adjust the height of the OSD. LEFT button decreases the height, RIGHT increases the height.">config.osd.dst_height</item>
+		</if>
+		<if requires="CanChangeOsdAlpha">
+			<item level="0" text="OSD visibility" description="This option lets you adjust the transparency of the OSD.">config.osd.alpha</item>
+			<item level="0" text="Teletext base visibility" description="Base transparency for teletext, more options are available within teletext screen.">config.osd.alpha_teletext</item>
+			<item level="0" text="Web browser base visibility" description="Base transparency for OpenOpera web browser.">config.osd.alpha_webbrowser</item>
+		</if>
+	</setup>
 	<setup key="Password" title="Password Settings">
 		<item level="0" text="New password" description="Setting a password is strongly advised if your STB is open to the Internet. You must set a password in order to be able to use network services like FTP, Telnet or SSH.">config.network.password</item>
 	</setup>

--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -861,7 +861,7 @@ void eDVBCIInterfaces::gotPMT(eDVBServicePMTHandler *pmthandler)
 {
 	// language config can only be accessed by e2 mainloop
 	if (m_language == "")
-		m_language = eConfigManager::getConfigValue("config.osd.language");
+		m_language = eConfigManager::getConfigValue("config.misc.locale");
 
 	singleLock s1(m_pmt_handler_lock);
 	singleLock s2(m_slot_lock);

--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -1,19 +1,856 @@
 from os.path import exists
 from os import W_OK, access, system
 from time import sleep
+
 from enigma import eAVControl, eDVBVolumecontrol, getDesktop
-from Components.config import ConfigBoolean, ConfigEnableDisable, ConfigInteger, ConfigNothing, ConfigOnOff, ConfigSelection, ConfigSelectionNumber, ConfigSlider, ConfigSubDict, ConfigSubsection, ConfigYesNo, NoSave, config
+
+from Components.config import ConfigBoolean, ConfigEnableDisable, ConfigInteger, ConfigNothing, ConfigOnOff, ConfigSelection, ConfigSelectionInteger, ConfigSelectionNumber, ConfigSlider, ConfigSubDict, ConfigSubsection, ConfigText, ConfigYesNo, NoSave, config
 from Components.About import about
 from Components.SystemInfo import BoxInfo
 from Tools.CList import CList
 from Tools.Directories import fileReadLine, fileWriteLine
 
 MODULE_NAME = __name__.split(".")[-1]
+AMLOGIC = BoxInfo.getItem("AmlogicFamily")
 BRAND = BoxInfo.getItem("brand")
 MACHINEBUILD = BoxInfo.getItem("machinebuild")
 
 config.av = ConfigSubsection()
 config.av.edid_override = ConfigYesNo(default=False)
+
+
+def InitAVSwitch():
+	def setUnsupportModes(configElement):
+		avSwitch.readPreferredModes()
+		avSwitch.createConfig()
+		print(f"[AVSwitch] Setting EDID override to '{configElement.value}'.")
+
+	config.av.edid_override.addNotifier(setUnsupportModes)
+	config.av.yuvenabled = ConfigBoolean(default=MACHINEBUILD != "vuduo")
+	config.av.osd_alpha = ConfigSlider(default=255, increment=5, limits=(20, 255))  # Make openATV compatible with some plugins who still use config.av.osd_alpha.
+	config.av.autores = ConfigSelection(default="disabled", choices=[
+		("disabled", _("Disabled")),
+		("simple", _("Simple")),
+		("native", _("Native")),
+		("all", _("All resolutions")),
+		("hd", _("Only HD"))
+	])
+	config.av.autores_preview = NoSave(ConfigYesNo(default=False))
+	config.av.autores_1080i_deinterlace = ConfigYesNo(default=False)
+	choiceList = [  # First value <= 720p, second value > 720p.
+		("24,24", "24p/24p"),  # These display values do not require translation.
+		("24,25", "24p/25p"),
+		("24,30", "24p/30p"),
+		("24,50", "24p/50p"),
+		("24,60", "24p/60p"),
+		("25,24", "25p/24p"),
+		("30,24", "30p/24p"),
+		("50,24", "50p/24p"),
+		("60,24", "60p/24p"),
+		("25,25", "25p/25p"),
+		("25,30", "25p/30p"),
+		("25,50", "25p/50p"),
+		("25,60", "25p/60p"),
+		("30,25", "30p/25p"),
+		("50,25", "50p/25p"),
+		("60,25", "60p/25p"),
+		("30,30", "30p/30p"),
+		("30,50", "30p/50p"),
+		("30,60", "30p/60p"),
+		("50,30", "50p/30p"),
+		("60,30", "60p/30p"),
+		("50,50", "50p/50p"),
+		("50,60", "50p/60p"),
+		("60,50", "60p/50p"),
+		("60,60", "60p/60p")
+	]
+	config.av.autores_24p = ConfigSelection(default="50,24", choices=choiceList)
+	config.av.autores_25p = ConfigSelection(default="50,25", choices=choiceList)
+	config.av.autores_30p = ConfigSelection(default="60,30", choices=choiceList)
+	config.av.autores_unknownres = ConfigSelection(default="next", choices=[
+		("next", _("Next higher resolution")),
+		("highest", _("Highest resolution"))
+	])
+	choiceList = []
+	for timeout in range(5, 16):
+		choiceList.append((timeout, ngettext("%d Second", "%d Seconds", timeout) % timeout))
+	config.av.autores_label_timeout = ConfigSelection(default=5, choices=[(0, _("Not Shown"))] + choiceList)
+	config.av.autores_delay = ConfigSelectionNumber(min=0, max=3000, stepwidth=50, default=400, wraparound=True)
+	config.av.autores_deinterlace = ConfigYesNo(default=False)
+	hertz = _("Hz")
+	if AMLOGIC:
+		config.av.autores_sd = ConfigSelection(default="720p50hz", choices=[
+			("720p50hz", f"720p50{hertz}"),
+			("720p", "720p"),
+			("1080i50hz", f"1080i50{hertz}"),
+			("1080i", "1080i")
+		])
+		config.av.autores_480p24 = ConfigSelection(default="1080p24hz", choices=[
+			("480p24", f"480p 24{hertz}"),
+			("720p24hz", f"720p 24{hertz}"),
+			("1080p24hz", f"1080p 24{hertz}")
+		])
+		config.av.autores_720p24 = ConfigSelection(default="720p24hz", choices=[
+			("720p24hz", f"720p 24{hertz}"),
+			("1080p24hz", f"1080p 24{hertz}"),
+			("1080i50hz", f"1080i 50{hertz}"),
+			("1080i", f"1080i 60{hertz}")
+		])
+		config.av.autores_1080p24 = ConfigSelection(default="1080p24hz", choices=[
+			("1080p24hz", f"1080p 24{hertz}"),
+			("1080p25hz", f"1080p 25{hertz}"),
+			("1080i50hz", f"1080p 50{hertz}"),
+			("1080i", f"1080i 60{hertz}")
+		])
+		config.av.autores_1080p25 = ConfigSelection(default="1080p25hz", choices=[
+			("1080p25hz", f"1080p 25{hertz}"),
+			("1080p50hz", f"1080p 50{hertz}"),
+			("1080i50hz", f"1080i 50{hertz}")
+		])
+		config.av.autores_1080p30 = ConfigSelection(default="1080p30hz", choices=[
+			("1080p30hz", f"1080p 30{hertz}"),
+			("1080p60hz", f"1080p 60{hertz}"),
+			("1080i", f"1080i 60{hertz}")
+		])
+		config.av.autores_2160p24 = ConfigSelection(default="2160p24hz", choices=[
+			("2160p24hz", f"2160p 24{hertz}"),
+			("2160p25hz", f"2160p 25{hertz}"),
+			("2160p30hz", f"2160p 30{hertz}")
+		])
+		config.av.autores_2160p25 = ConfigSelection(default="2160p25hz", choices=[
+			("2160p25hz", f"2160p 25{hertz}"),
+			("2160p50hz", f"2160p 50{hertz}")
+		])
+		config.av.autores_2160p30 = ConfigSelection(default="2160p30hz", choices=[
+			("2160p30hz", f"2160p 30{hertz}"),
+			("2160p60hz", f"2160p 60{hertz}")
+		])
+		config.av.policy_169 = ConfigSelection(default="11", choices=[
+			("4", _("Stretch nonlinear")),
+			("3", _("Stretch linear")),
+			("1", _("Stretch full")),
+			("10", _("Ignore")),
+			("11", _("Letterbox")),
+			("12", _("Pan&scan")),  # Should be "PanScan" or "Pan & Scan".
+			("13", _("Combined")),
+			("0", _("Pillarbox")),
+		])
+		config.av.policy_43 = ConfigSelection(default="8", choices=[
+			("2", _("Pillarbox")),
+			("6", _("Ignore")),
+			("7", _("Letterbox")),
+			("8", _("Pan&scan")),  # Should be "PanScan" or "Pan & Scan".
+			("9", _("Combined")),
+		])
+	else:
+		config.av.autores_sd = ConfigSelection(default="720p50", choices=[
+			("720p50", "720p50"),
+			("720p", "720p"),
+			("1080i50", "1080i50"),
+			("1080i", "1080i")
+		])
+		config.av.autores_480p24 = ConfigSelection(default="1080p24", choices=[
+			("480p24", f"480p 24{hertz}"),
+			("720p24", f"720p 24{hertz}"),
+			("1080p24", f"1080p 24{hertz}")
+		])
+		config.av.autores_720p24 = ConfigSelection(default="720p24", choices=[
+			("720p24", f"720p 24{hertz}"),
+			("1080p24", f"1080p 24{hertz}"),
+			("1080i50", f"1080i 50{hertz}"),
+			("1080i", f"1080i 60{hertz}")
+		])
+		config.av.autores_1080p24 = ConfigSelection(default="1080p24", choices=[
+			("1080p24", f"1080p 24{hertz}"),
+			("1080p25", f"1080p 25{hertz}"),
+			("1080i50", f"1080p 50{hertz}"),
+			("1080i", f"1080i 60{hertz}")
+		])
+		config.av.autores_1080p25 = ConfigSelection(default="1080p25", choices=[
+			("1080p25", f"1080p 25{hertz}"),
+			("1080p50", f"1080p 50{hertz}"),
+			("1080i50", f"1080i 50{hertz}")
+		])
+		config.av.autores_1080p30 = ConfigSelection(default="1080p30", choices=[
+			("1080p30", f"1080p 30{hertz}"),
+			("1080p60", f"1080p 60{hertz}"),
+			("1080i", f"1080i 60{hertz}")
+		])
+		config.av.autores_2160p24 = ConfigSelection(default="2160p24", choices=[
+			("2160p24", f"2160p 24{hertz}"),
+			("2160p25", f"2160p 25{hertz}"),
+			("2160p30", f"2160p 30{hertz}")
+		])
+		config.av.autores_2160p25 = ConfigSelection(default="2160p25", choices=[
+			("2160p25", f"2160p 25{hertz}"),
+			("2160p50", f"2160p 50{hertz}")
+		])
+		config.av.autores_2160p30 = ConfigSelection(default="2160p30", choices=[
+			("2160p30", f"2160p 30{hertz}"),
+			("2160p60", f"2160p 60{hertz}")
+		])
+		# Some boxes have a redundant proc entry for policy2 choices, but some don't (The choices are from a 16:9 point of view anyways)
+		policy2ChoicesProc = "/proc/stb/video/policy2_choices"
+		if not exists(policy2ChoicesProc):
+			policy2ChoicesProc = "/proc/stb/video/policy_choices"
+		policy2ChoicesRaw = fileReadLine(policy2ChoicesProc, default="letterbox", source=MODULE_NAME)
+		choiceList = {}
+		if "letterbox" in policy2ChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Black bars on top/bottom in doubt, keep English term.
+			choiceList.update({"letterbox": _("Letterbox")})
+		if "panscan" in policy2ChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Cropped content on left/right in doubt, keep English term.
+			choiceList.update({"panscan": _("Pan&scan")})  # Should be "PanScan" or "Pan & Scan".
+		if "nonliner" in policy2ChoicesRaw and "nonlinear" not in policy2ChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching the top/bottom. Center of picture maintains aspect, top/bottom lose aspect heaver than on linear stretch.
+			choiceList.update({"nonliner": _("Stretch nonlinear")})
+		if "nonlinear" in policy2ChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching the top/bottom. Center of picture maintains aspect, top/bottom lose aspect heaver than on linear stretch.
+			choiceList.update({"nonlinear": _("Stretch nonlinear")})
+		if "scale" in policy2ChoicesRaw and "auto" not in policy2ChoicesRaw and "bestfit" not in policy2ChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching all parts of the picture with the same factor (all parts lose aspect).
+			choiceList.update({"scale": _("Stretch linear")})
+		if "auto" in policy2ChoicesRaw and "bestfit" not in policy2ChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching all parts of the picture with the same factor (all parts lose aspect).
+			choiceList.update({"auto": _("Stretch linear")})  # IanSav: This is duplicated!
+		if "bestfit" in policy2ChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching all parts of the picture with the same factor (all parts lose aspect).
+			choiceList.update({"bestfit": _("Stretch linear")})
+		if "full" in policy2ChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching all parts of the picture with the same factor (force aspect).
+			choiceList.update({"full": _("Stretch full")})
+		config.av.policy_169 = ConfigSelection(default="letterbox", choices=choiceList)
+		policyChoicesRaw = fileReadLine("/proc/stb/video/policy_choices", default="panscan", source=MODULE_NAME)
+		choiceList = {}
+		if "pillarbox" in policyChoicesRaw and "panscan" not in policyChoicesRaw:
+			# Very few boxes support "pillarbox" as an alias for "panscan" (Which in fact does pillarbox) so only add "pillarbox" if "panscan" is not listed in choices.
+			#
+			# TRANSLATORS: Aspect ratio policy: Black bars on left/right in doubt, keep English term.
+			choiceList.update({"pillarbox": _("Pillarbox")})
+		if "panscan" in policyChoicesRaw:
+			# DRIVER BUG:	"panscan" in /proc actually does "pillarbox" (That's probably why an alias to it named "pillarbox" existed)!
+			#		Interpret "panscan" setting with a "Pillarbox" text in order to show the correct value in GUI.
+			#
+			# TRANSLATORS: Aspect ratio policy: Black bars on left/right in doubt, keep English term.
+			choiceList.update({"panscan": _("Pillarbox")})
+		if "letterbox" in policyChoicesRaw:
+			# DRIVER BUG:	"letterbox" in /proc actually does pan&scan.
+			#		"letterbox" and 4:3 content on 16:9 TVs is mutually exclusive, as "letterbox" is the method to show wide content on narrow TVs.
+			#		Probably the bug arose as the driver actually does the same here as it would for wide content on narrow TVs (it stretches the picture to fit width).
+			#
+			# TRANSLATORS: Aspect ratio policy: Fit width, cut/crop top and bottom (maintain aspect ratio).
+			choiceList.update({"letterbox": _("Pan&scan")})  # Should be "PanScan" or "Pan & Scan".
+		if "nonliner" in policyChoicesRaw and "nonlinear" not in policyChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching the left/right. Center 50% of picture maintain aspect, left/right 25% lose aspect heaver than on linear stretch.
+			choiceList.update({"nonliner": _("Stretch nonlinear")})
+		if "nonlinear" in policyChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching the left/right. Center 50% of picture maintain aspect, left/right 25% lose aspect heaver than on linear stretch.
+			choiceList.update({"nonlinear": _("Stretch nonlinear")})
+		# "auto", "bestfit" and "scale" are aliases for the same "Stretch linear".
+		if "scale" in policyChoicesRaw and "auto" not in policyChoicesRaw and "bestfit" not in policyChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching all parts of the picture with the same factor (all parts lose aspect).
+			choiceList.update({"scale": _("Stretch linear")})
+		if "auto" in policyChoicesRaw and "bestfit" not in policyChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching all parts of the picture with the same factor (all parts lose aspect).
+			choiceList.update({"auto": _("Stretch linear")})
+		if "bestfit" in policyChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching all parts of the picture with the same factor (all parts lose aspect).
+			choiceList.update({"bestfit": _("Stretch linear")})
+		if "full" in policyChoicesRaw:
+			# TRANSLATORS: Aspect ratio policy: Display as fullscreen, with stretching all parts of the picture with the same factor (force aspect).
+			choiceList.update({"full": _("Stretch full")})
+		config.av.policy_43 = ConfigSelection(default="panscan", choices=choiceList)
+	config.av.smart1080p = ConfigSelection(default="false", choices=[
+		("false", _("Off")),
+		("true", "1080p50: 24p/50p/60p"),
+		("2160p50", "2160p50: 24p/50p/60p"),
+		("1080i50", "1080i50: 24p/50i/60i"),
+		("720p50", "720p50: 24p/50p/60p")
+	])
+	choiceList = [
+		("cvbs", "CVBS"),
+		("rgb", "RGB"),
+		("svideo", "S-Video")
+	]
+	if config.av.yuvenabled.value:  # When YUV is not enabled, don't let the user select it.
+		choiceList.append(("yuv", "YPbPr"))
+	config.av.colorformat = ConfigSelection(default="rgb", choices=choiceList)
+	config.av.aspectratio = ConfigSelection(default="16_9", choices=[
+		("4_3_letterbox", _("4:3 Letterbox")),
+		("4_3_panscan", _("4:3 PanScan")),
+		("16_9", "16:9"),
+		("16_9_always", _("16:9 Always")),
+		("16_10_letterbox", _("16:10 Letterbox")),
+		("16_10_panscan", _("16:10 PanScan")),
+		("16_9_letterbox", _("16:9 Letterbox"))
+	])
+	config.av.aspect = ConfigSelection(default="16:9", choices=[
+		("4:3", "4:3"),
+		("16:9", "16:9"),
+		("16:10", "16:10"),
+		("auto", _("Automatic"))
+	])
+	config.av.tvsystem = ConfigSelection(default="pal", choices=[
+		("pal", "PAL"),
+		("ntsc", "NTSC"),
+		("multinorm", _("Multi"))
+	])
+	config.av.wss = ConfigEnableDisable(default=True)
+	config.av.generalAC3delay = ConfigSelectionNumber(-1000, 1000, 5, default=0)
+	config.av.generalPCMdelay = ConfigSelectionNumber(-1000, 1000, 5, default=0)
+	config.av.vcrswitch = ConfigEnableDisable(default=False)
+	config.av.aspect.addNotifier(avSwitch.setAspect)
+	config.av.wss.addNotifier(avSwitch.setWss)
+	config.av.policy_43.addNotifier(avSwitch.setPolicy43)
+	config.av.policy_169.addNotifier(avSwitch.setPolicy169)
+	config.osd = ConfigSubsection()
+	config.osd.language = ConfigText(default=config.misc.locale.value)
+	if BoxInfo.getItem("AmlogicFamily"):
+		limits = [int(x) for x in avSwitch.getWindowsAxis().split()]
+		config.osd.dst_left = ConfigSelectionInteger(default=limits[0], first=limits[0] - 255, last=limits[0] + 255, step=1, wrap=False)
+		config.osd.dst_top = ConfigSelectionInteger(default=limits[1], first=limits[1] - 255, last=limits[1] + 255, step=1, wrap=False)
+		config.osd.dst_width = ConfigSelectionInteger(default=limits[2], first=limits[2] - 255, last=limits[2] + 255, step=1, wrap=False)
+		config.osd.dst_height = ConfigSelectionInteger(default=limits[3], first=limits[3] - 255, last=limits[3] + 255, step=1, wrap=False)
+	else:
+		config.osd.dst_left = ConfigSelectionInteger(default=0, first=0, last=720, step=1, wrap=False)
+		config.osd.dst_top = ConfigSelectionInteger(default=0, first=0, last=576, step=1, wrap=False)
+		config.osd.dst_width = ConfigSelectionInteger(default=720, first=0, last=720, step=1, wrap=False)
+		config.osd.dst_height = ConfigSelectionInteger(default=576, first=0, last=576, step=1, wrap=False)
+	config.osd.alpha = ConfigSelectionInteger(default=255, first=0, last=255, step=1, wrap=False)
+	config.osd.alpha_teletext = ConfigSelectionInteger(default=255, first=0, last=255, step=1, wrap=False)
+	config.osd.alpha_webbrowser = ConfigSelectionInteger(default=255, first=0, last=255, step=1, wrap=False)
+	config.osd.threeDmode = ConfigSelection(default="auto", choices=[
+		("off", _("Off")),
+		("auto", _("Auto")),
+		("sidebyside", _("Side by Side")),
+		("topandbottom", _("Top and Bottom"))
+	])
+	config.osd.threeDznorm = ConfigSlider(default=0, increment=1, limits=(-50, 50))
+	config.osd.show3dextensions = ConfigYesNo(default=False)
+
+	def setColorFormat(configElement):
+		if config.av.videoport and config.av.videoport.value in ("YPbPr", "Scart-YPbPr"):
+			avSwitch.setColorFormat("yuv")
+		elif config.av.videoport and config.av.videoport.value in ("RCA"):
+			avSwitch.setColorFormat("cvbs")
+		else:
+			avSwitch.setColorFormat(configElement.value)
+
+	config.av.colorformat.addNotifier(setColorFormat)
+	avSwitch.setInput("encoder")  # Initialize on startup.
+	BoxInfo.setItem("ScartSwitch", eAVControl.getInstance().hasScartSwitch())
+	bypassEDID = fileReadLine("/proc/stb/hdmi/bypass_edid_checking", default=None, source=MODULE_NAME)
+	bypassEDID = bypassEDID.split() if bypassEDID else False
+	BoxInfo.setItem("Canedidchecking", bypassEDID)
+	if bypassEDID:
+		def setEDIDBypass(configElement):
+			if configElement.value:
+				value = "00000001" if configElement.value else "00000000"
+				fileWriteLine("/proc/stb/hdmi/bypass_edid_checking", value, source=MODULE_NAME)
+
+		config.av.bypass_edid_checking = ConfigYesNo(default=True)
+		config.av.bypass_edid_checking.addNotifier(setEDIDBypass)
+	else:
+		config.av.bypass_edid_checking = ConfigNothing()
+	colorspace = fileReadLine("/proc/stb/video/hdmi_colorspace", default=None, source=MODULE_NAME)
+	colorspace = colorspace.split() if colorspace else False
+	BoxInfo.setItem("havecolorspace", colorspace)
+	if colorspace:
+		def setHDMIColorspace(configElement):
+			fileWriteLine("/proc/stb/video/hdmi_colorspace", configElement.value, source=MODULE_NAME)
+
+		if MACHINEBUILD in ("vusolo4k", "vuuno4k", "vuuno4kse", "vuultimo4k", "vuduo4k", "vuduo4kse"):
+			default = "Edid(Auto)"
+			choiceList = [
+				("Edid(Auto)", _("Auto")),
+				("Hdmi_Rgb", "RGB"),
+				("444", "YCbCr 444"),
+				("422", "YCbCr 422"),
+				("420", "YCbCr 420")
+			]
+		elif MACHINEBUILD in ("dm900", "dm920", "vuzero4k"):
+			default = "Edid(Auto)"
+			choiceList = [
+				("Edid(Auto)", _("Auto")),
+				("Hdmi_Rgb", "RGB"),
+				("Itu_R_BT_709", "BT.709"),
+				("DVI_Full_Range_RGB", _("Full Range RGB")),
+				("FCC", "FCC 1953"),
+				("Itu_R_BT_470_2_BG", "BT.470 BG"),
+				("Smpte_170M", "SMPTE 170M"),
+				("Smpte_240M", "SMPTE 240M"),
+				("Itu_R_BT_2020_NCL", "BT.2020 NCL"),
+				("Itu_R_BT_2020_CL", "BT.2020 CL"),
+				("XvYCC_709", "BT.709 XvYCC"),
+				("XvYCC_601", "BT.601 XvYCC")
+			]
+		else:
+			default = "auto"
+			choiceList = [
+				("auto", _("Auto")),
+				("rgb", "RGB"),
+				("420", "YCbCr 420"),
+				("422", "YCbCr 422"),
+				("444", "YCbCr 444")
+			]
+		config.av.hdmicolorspace = ConfigSelection(default=default, choices=choiceList)
+		config.av.hdmicolorspace.addNotifier(setHDMIColorspace)
+	else:
+		config.av.hdmicolorspace = ConfigNothing()
+	colorimetry = fileReadLine("/proc/stb/video/hdmi_colorimetry", default=None, source=MODULE_NAME)
+	colorimetry = colorimetry.split() if colorimetry else False
+	BoxInfo.setItem("havecolorimetry", colorimetry)
+	if colorimetry:
+		def setHDMIColorimetry(configElement):
+			sleep(0.1)
+			fileWriteLine("/proc/stb/video/hdmi_colorimetry", configElement.value, source=MODULE_NAME)
+
+		config.av.hdmicolorimetry = ConfigSelection(default="auto", choices=[
+			("auto", _("Auto")),
+			("bt2020ncl", "BT.2020 NCL"),
+			("bt2020cl", "BT.2020 CL"),
+			("bt709", "BT.709")
+		])
+		config.av.hdmicolorimetry.addNotifier(setHDMIColorimetry)
+	else:
+		config.av.hdmicolorimetry = ConfigNothing()
+	boxMode = fileReadLine("/proc/stb/info/boxmode", default=None, source=MODULE_NAME)
+	boxMode = boxMode.split() if boxMode else False
+	BoxInfo.setItem("haveboxmode", boxMode)
+	if boxMode:
+		def setBoxMode(configElement):
+			fileWriteLine("/proc/stb/info/boxmode", configElement.value, source=MODULE_NAME)
+
+		config.av.boxmode = ConfigSelection(default="12", choices=[
+			("12", _("Enable PiP no HDR")),
+			("1", _("12bit 4:2:0/4:2:2 no PiP"))
+		])
+		config.av.boxmode.addNotifier(setBoxMode)
+	else:
+		config.av.boxmode = ConfigNothing()
+	colorDepth = fileReadLine("/proc/stb/video/hdmi_colordepth", default=None, source=MODULE_NAME)
+	colorDepth = colorDepth.split() if colorDepth else False
+	BoxInfo.setItem("havehdmicolordepth", colorDepth)
+	if colorDepth:
+		def setColorDepth(configElement):
+			fileWriteLine("/proc/stb/video/hdmi_colordepth", configElement.value, source=MODULE_NAME)
+
+		config.av.hdmicolordepth = ConfigSelection(default="auto", choices=[
+			("auto", _("Auto")),
+			("8bit", _("8bit")),
+			("10bit", _("10bit")),
+			("12bit", _("12bit"))
+		])
+		config.av.hdmicolordepth.addNotifier(setColorDepth)
+	else:
+		config.av.hdmicolordepth = ConfigNothing()
+
+	syncMode = fileReadLine("/proc/stb/video/sync_mode_choices", default=None, source=MODULE_NAME)
+	syncMode = syncMode.split() if syncMode else False
+	BoxInfo.setItem("havesyncmode", syncMode)
+	if syncMode:
+		def setSyncMode(configElement):
+			fileWriteLine("/proc/stb/video/sync_mode", configElement.value, source=MODULE_NAME)
+
+		config.av.sync_mode = ConfigSelection(default="slow", choices=[
+			("slow", _("Slow Motion")),
+			("hold", _("Hold First Frame")),
+			("black", _("Black Screen")),
+		])
+		config.av.sync_mode.addNotifier(setSyncMode)
+	else:
+		config.av.sync_mode = ConfigNothing()
+	AMLHDRSupport = exists("/sys/class/amhdmitx/amhdmitx0/config")
+	BoxInfo.setItem("haveamlhdrsupport", AMLHDRSupport)
+	if AMLHDRSupport:
+		def setAMLHDR10(configElement):
+			fileWriteLine("/sys/class/amhdmitx/amhdmitx0/config", configElement.value, source=MODULE_NAME)
+
+		def setAMLHLG(configElement):
+			fileWriteLine("/sys/class/amhdmitx/amhdmitx0/config", configElement.value, source=MODULE_NAME)
+
+		config.av.amlhdr10_support = ConfigSelection(default="hdr10-2", choices=[
+			("hdr10-0", _("Force enabled")),
+			("hdr10-1", _("Force disabled")),
+			("hdr10-2", _("Controlled by HDMI"))
+		])
+		config.av.amlhdr10_support.addNotifier(setAMLHDR10)
+		config.av.amlhlg_support = ConfigSelection(default="hlg-2", choices=[
+			("hlg-0", _("Force enabled")),
+			("hlg-1", _("Force disabled")),
+			("hlg-2", _("Controlled by HDMI"))
+		])
+		config.av.amlhlg_support.addNotifier(setAMLHLG)
+	else:
+		config.av.amlhdr10_support = ConfigNothing()
+		config.av.amlhlg_support = ConfigNothing()
+	hdrType = fileReadLine("/proc/stb/video/hdmi_hdrtype", default=None, source=MODULE_NAME)
+	hdrType = hdrType.split() if hdrType else False
+	BoxInfo.setItem("havehdmihdrtype", hdrType)
+	if hdrType:
+		def setHDRType(configElement):
+			fileWriteLine("/proc/stb/video/hdmi_hdrtype", configElement.value, source=MODULE_NAME)
+
+		config.av.hdmihdrtype = ConfigSelection(default="auto", choices=[
+			("auto", _("Auto")),
+			("dolby", "Dolby Vision"),
+			("none", "SDR"),
+			("hdr10", "HDR10"),
+			# ("hdr10+", "HDR10+"),
+			("hlg", "HLG")
+		])
+		config.av.hdmihdrtype.addNotifier(setHDRType)
+	else:
+		config.av.hdmihdrtype = ConfigNothing()
+	hdrSupport = fileReadLine("/proc/stb/hdmi/hlg_support_choices", default=None, source=MODULE_NAME)
+	hdrSupport = hdrSupport.split() if hdrSupport else False
+	BoxInfo.setItem("HDRSupport", hdrSupport)
+	if hdrSupport:
+		def setHlgSupport(configElement):
+			fileWriteLine("/proc/stb/hdmi/hlg_support", configElement.value, source=MODULE_NAME)
+
+		def setHdr10Support(configElement):
+			fileWriteLine("/proc/stb/hdmi/hdr10_support", configElement.value, source=MODULE_NAME)
+
+		def setDisable12Bit(configElement):
+			fileWriteLine("/proc/stb/video/disable_12bit", "1" if configElement.value else "0", source=MODULE_NAME)
+
+		def setDisable10Bit(configElement):
+			fileWriteLine("/proc/stb/video/disable_10bit", "1" if configElement.value else "0", source=MODULE_NAME)
+
+		config.av.hlg_support = ConfigSelection(default="auto(EDID)", choices=[
+			("auto(EDID)", _("Controlled by HDMI")),
+			("yes", _("Force enabled")),
+			("no", _("Force disabled"))
+		])
+		config.av.hlg_support.addNotifier(setHlgSupport)
+		config.av.hdr10_support = ConfigSelection(default="auto(EDID)", choices=[
+			("auto(EDID)", _("Controlled by HDMI")),
+			("yes", _("Force enabled")),
+			("no", _("Force disabled"))
+		])
+		config.av.hdr10_support.addNotifier(setHdr10Support)
+		config.av.allow_12bit = ConfigYesNo(default=False)
+		config.av.allow_12bit.addNotifier(setDisable12Bit)
+		config.av.allow_10bit = ConfigYesNo(default=False)
+		config.av.allow_10bit.addNotifier(setDisable10Bit)
+	audioSource = fileReadLine("/sys/devices/virtual/amhdmitx/amhdmitx0/audio_source" if AMLOGIC else "/proc/stb/hdmi/audio_source", default=None, source=MODULE_NAME)
+	audioSource = audioSource.split() if audioSource else False
+	BoxInfo.setItem("Canaudiosource", audioSource)
+	if audioSource:
+		def setAudioSource(configElement):
+			fileWriteLine("/sys/devices/virtual/amhdmitx/amhdmitx0/audio_source" if AMLOGIC else "/proc/stb/hdmi/audio_source", configElement.value, source=MODULE_NAME)
+
+		if AMLOGIC:
+			config.av.audio_source = ConfigSelection(default="0", choices=[
+				("0", "PCM"),
+				("1", "S/PDIF"),
+				("2", _("Bluetooth"))
+			])
+		else:
+			config.av.audio_source = ConfigSelection(default="pcm", choices=[
+				("pcm", "PCM"),
+				("spdif", "S/PDIF")
+			])
+		config.av.audio_source.addNotifier(setAudioSource)
+	else:
+		config.av.audio_source = ConfigNothing()
+	surround = fileReadLine("/proc/stb/audio/3d_surround_choices", default=None, source=MODULE_NAME)
+	surround = surround.split() if surround else False
+	BoxInfo.setItem("Can3DSurround", surround)
+	if surround:
+		def set3DSurround(configElement):
+			fileWriteLine("/proc/stb/audio/3d_surround", configElement.value, source=MODULE_NAME)
+
+		config.av.surround_3d = ConfigSelection(default="none", choices=[
+			("none", _("Off")),
+			("hdmi", "HDMI"),
+			("spdif", "S/PDIF"),
+			("dac", "DAC")
+		])
+		config.av.surround_3d.addNotifier(set3DSurround)
+	else:
+		config.av.surround_3d = ConfigNothing()
+	surroundSpeaker = fileReadLine("/proc/stb/audio/3d_surround_speaker_position_choices", default=None, source=MODULE_NAME)
+	surroundSpeaker = surroundSpeaker.split() if surroundSpeaker else False
+	BoxInfo.setItem("Can3DSpeaker", surroundSpeaker)
+	if surroundSpeaker:
+		def set3DSurroundSpeaker(configElement):
+			fileWriteLine("/proc/stb/audio/3d_surround_speaker_position", configElement.value, source=MODULE_NAME)
+
+		config.av.surround_3d_speaker = ConfigSelection(default="center", choices=[
+			("center", _("Center")),
+			("wide", _("Wide")),
+			("extrawide", _("Extra wide"))
+		])
+		config.av.surround_3d_speaker.addNotifier(set3DSurroundSpeaker)
+	else:
+		config.av.surround_3d_speaker = ConfigNothing()
+	autoVolume = fileReadLine("/proc/stb/audio/avl_choices", default=None, source=MODULE_NAME)
+	autoVolume = autoVolume.split() if autoVolume else False
+	BoxInfo.setItem("CanAutoVolume", autoVolume)
+	if autoVolume:
+		def setAutoVolume(configElement):
+			fileWriteLine("/proc/stb/audio/avl", configElement.value, source=MODULE_NAME)
+
+		config.av.autovolume = ConfigSelection(default="none", choices=[
+			("none", _("Off")),
+			("hdmi", "HDMI"),
+			("spdif", "S/PDIF"),
+			("dac", "DAC")
+		])
+		config.av.autovolume.addNotifier(setAutoVolume)
+	else:
+		config.av.autovolume = ConfigNothing()
+	multiChannel = access("/proc/stb/audio/multichannel_pcm", W_OK)
+	BoxInfo.setItem("supportPcmMultichannel", multiChannel)
+	if multiChannel:
+		def setPCMMultichannel(configElement):
+			fileWriteLine("/proc/stb/audio/multichannel_pcm", configElement.value and "enable" or "disable", source=MODULE_NAME)
+
+		config.av.pcm_multichannel = ConfigYesNo(default=False)
+		config.av.pcm_multichannel.addNotifier(setPCMMultichannel)
+
+	def setVolumeStepSize(configElement):
+		eDVBVolumecontrol.getInstance().setVolumeSteps(int(configElement.value))
+
+	config.av.volume_stepsize = ConfigSelectionNumber(min=1, max=10, stepwidth=1, default=5)
+	config.av.volume_stepsize.addNotifier(setVolumeStepSize)
+	config.av.volume_stepsize_fastmode = ConfigSelectionNumber(min=1, max=10, stepwidth=1, default=5)
+	config.av.volume_hide_mute = ConfigYesNo(default=True)
+	if AMLOGIC:
+		downmixAC3 = True
+		BoxInfo.setItem("CanPcmMultichannel", True)
+	else:
+		downmixAC3 = fileReadLine("/proc/stb/audio/ac3_choices", default=None, source=MODULE_NAME)
+		if downmixAC3:
+			downmixAC3 = "downmix" in downmixAC3
+		else:
+			downmixAC3 = False
+			BoxInfo.setItem("CanPcmMultichannel", False)
+	BoxInfo.setItem("CanDownmixAC3", downmixAC3)
+	if downmixAC3:
+		def setAC3Downmix(configElement):
+			if AMLOGIC:
+				fileWriteLine("/sys/class/audiodsp/digital_raw", configElement.value, source=MODULE_NAME)
+			else:
+				value = configElement.value and "downmix" or "passthrough"
+				if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800"):
+					value = configElement.value
+				fileWriteLine("/proc/stb/audio/ac3", value, source=MODULE_NAME)
+
+			if BoxInfo.getItem("supportPcmMultichannel", False) and not configElement.value:
+				BoxInfo.setItem("CanPcmMultichannel", True)
+			else:
+				BoxInfo.setItem("CanPcmMultichannel", False)
+				if multiChannel:
+					config.av.pcm_multichannel.setValue(False)
+
+		if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800"):
+			config.av.downmix_ac3 = ConfigSelection(default="downmix", choices=[
+				("downmix", _("Downmix")),
+				("passthrough", _("Pass-through")),
+				("multichannel", _("Convert to multi-channel PCM")),
+				("hdmi_best", _("Use best / Controlled by HDMI"))
+			])
+		elif MACHINEBUILD in ("dreamone", "dreamtwo"):
+			config.av.downmix_ac3 = ConfigSelection(default="0", choices=[
+				("0", _("Downmix")),
+				("1", _("Pass-through")),
+				("2", _("Use best / Controlled by HDMI"))
+			])
+		else:
+			config.av.downmix_ac3 = ConfigYesNo(default=True)
+		config.av.downmix_ac3.addNotifier(setAC3Downmix)
+	else:
+		config.av.downmix_ac3 = ConfigNothing()
+	AC3plusTranscode = fileReadLine("/proc/stb/audio/ac3plus_choices", default=None, source=MODULE_NAME)
+	AC3plusTranscode = AC3plusTranscode.split() if AC3plusTranscode else False
+	BoxInfo.setItem("CanAC3plusTranscode", AC3plusTranscode)
+	if AC3plusTranscode:
+		def setAC3plusTranscode(configElement):
+			fileWriteLine("/proc/stb/audio/ac3plus", configElement.value, source=MODULE_NAME)
+
+		if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800"):
+			choiceList = [
+					("use_hdmi_caps", _("Controlled by HDMI")),
+					("force_ac3", _("Convert to AC3")),
+					("multichannel", _("Convert to multi-channel PCM")),
+					("hdmi_best", _("Use best / Controlled by HDMI")),
+					("force_ddp", _("Force AC3plus"))
+				]
+		elif MACHINEBUILD in ("gbquad4k", "gbue4k", "gbx34k"):
+			choiceList = [
+					("downmix", _("Downmix")),
+					("passthrough", _("Pass-through")),
+					("force_ac3", _("Convert to AC3")),
+					("multichannel", _("Convert to multi-channel PCM")),
+					("force_dts", _("Convert to DTS"))
+				]
+		else:
+			choiceList = [
+					("use_hdmi_caps", _("Controlled by HDMI")),
+					("force_ac3", _("Convert to AC3"))
+				]
+		config.av.transcodeac3plus = ConfigSelection(default="force_ac3", choices=choiceList)
+		config.av.transcodeac3plus.addNotifier(setAC3plusTranscode)
+	dtsHD = fileReadLine("/proc/stb/audio/dtshd_choices", default=None, source=MODULE_NAME)
+	dtsHD = dtsHD.split() if dtsHD else False
+	BoxInfo.setItem("CanDTSHD", dtsHD)
+	if dtsHD:
+		def setDTSHD(configElement):
+			fileWriteLine("/proc/stb/audio/dtshd", configElement.value, source=MODULE_NAME)
+
+		if MACHINEBUILD in ("dm7080", "dm820"):
+			default = "use_hdmi_caps"
+			choiceList = [
+				("use_hdmi_caps", _("Controlled by HDMI")),
+				("force_dts", _("Convert to DTS"))
+			]
+		else:
+			default = "downmix"
+			choiceList = [
+				("downmix", _("Downmix")),
+				("force_dts", _("Convert to DTS")),
+				("use_hdmi_caps", _("Controlled by HDMI")),
+				("multichannel", _("Convert to multi-channel PCM")),
+				("hdmi_best", _("Use best / Controlled by HDMI"))
+			]
+		config.av.dtshd = ConfigSelection(default=default, choices=choiceList)
+		config.av.dtshd.addNotifier(setDTSHD)
+	wmaPro = fileReadLine("/proc/stb/audio/wmapro_choices", default=None, source=MODULE_NAME)
+	wmaPro = wmaPro.split() if wmaPro else False
+	BoxInfo.setItem("CanWMAPRO", wmaPro)
+	if wmaPro:
+		def setWMAPro(configElement):
+			fileWriteLine("/proc/stb/audio/wmapro", configElement.value, source=MODULE_NAME)
+
+		config.av.wmapro = ConfigSelection(default="downmix", choices=[
+			("downmix", _("Downmix")),
+			("passthrough", _("Pass-through")),
+			("multichannel", _("Convert to multi-channel PCM")),
+			("hdmi_best", _("Use best / Controlled by HDMI"))
+		])
+		config.av.wmapro.addNotifier(setWMAPro)
+	dtsDownmix = fileReadLine("/proc/stb/audio/dts_choices", default=None, source=MODULE_NAME)
+	dtsDownmix = "downmix" in dtsDownmix if dtsDownmix else False
+	BoxInfo.setItem("CanDownmixDTS", dtsDownmix)
+	if dtsDownmix:
+		def setDTSDownmix(configElement):
+			fileWriteLine("/proc/stb/audio/dts", configElement.value and "downmix" or "passthrough", source=MODULE_NAME)
+
+		config.av.downmix_dts = ConfigYesNo(default=True)
+		config.av.downmix_dts.addNotifier(setDTSDownmix)
+	aacDownmix = fileReadLine("/proc/stb/audio/aac_choices", default=None, source=MODULE_NAME)
+	aacDownmix = "downmix" in aacDownmix if aacDownmix else False
+	BoxInfo.setItem("CanDownmixAAC", aacDownmix)
+	if aacDownmix:
+		def setAACDownmix(configElement):
+			value = configElement.value if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800", "gbquad4k", "gbue4k", "gbx34k") else configElement.value and "downmix" or "passthrough"
+			fileWriteLine("/proc/stb/audio/aac", value, source=MODULE_NAME)
+
+		if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800"):
+			config.av.downmix_aac = ConfigSelection(default="downmix", choices=[
+				("downmix", _("Downmix")),
+				("passthrough", _("Pass-through")),
+				("multichannel", _("Convert to multi-channel PCM")),
+				("hdmi_best", _("Use best / Controlled by HDMI"))
+			])
+		elif MACHINEBUILD in ("gbquad4k", "gbue4k", "gbx34k"):
+			config.av.downmix_aac = ConfigSelection(default="downmix", choices=[
+				("downmix", _("Downmix")),
+				("passthrough", _("Pass-through")),
+				("multichannel", _("Convert to multi-channel PCM")),
+				("force_ac3", _("Convert to AC3")),
+				("force_dts", _("Convert to DTS")),
+				("use_hdmi_cacenter", _("Use best / Controlled by HDMI")),
+				("wide", _("Wide")),
+				("extrawide", _("Extra wide"))
+			])
+		else:
+			config.av.downmix_aac = ConfigYesNo(default=True)
+		config.av.downmix_aac.addNotifier(setAACDownmix)
+	aacplusDownmix = fileReadLine("/proc/stb/audio/aacplus_choices", default=None, source=MODULE_NAME)
+	aacplusDownmix = "downmix" in aacplusDownmix if aacplusDownmix else False
+	BoxInfo.setItem("CanDownmixAACPlus", aacplusDownmix)
+	if aacplusDownmix:
+		def setAACDownmixPlus(configElement):
+			fileWriteLine("/proc/stb/audio/aacplus", configElement.value, source=MODULE_NAME)
+
+		config.av.downmix_aacplus = ConfigSelection(default="downmix", choices=[
+			("downmix", _("Downmix")),
+			("passthrough", _("Pass-through")),
+			("multichannel", _("Convert to multi-channel PCM")),
+			("force_ac3", _("Convert to AC3")),
+			("force_dts", _("Convert to DTS")),
+			("use_hdmi_cacenter", _("Use best / Controlled by HDMI")),
+			("wide", _("Wide")),
+			("extrawide", _("Extra wide"))
+		])
+		config.av.downmix_aacplus.addNotifier(setAACDownmixPlus)
+	if exists("/proc/stb/audio/aac_transcode_choices"):
+		aacTranscodeAll = [
+			("off", _("Off")),
+			("ac3", "AC3"),
+			("dts", "DTS")
+		]
+		# The translation text must look exactly like the read value. It is then adjusted with the PO file.
+		aactranscodeChoices = fileReadLine("/proc/stb/audio/aac_transcode_choices", default=None, source=MODULE_NAME)
+		aactranscodeChoices = aactranscodeChoices.split() if aactranscodeChoices else []
+		aacTranscode = [(x[0], x[1]) for x in aacTranscodeAll if x[0] in aactranscodeChoices]
+		default = aacTranscode[0][0] if aacTranscode else "off"
+		print(f"[AVSwitch] aactranscodeChoices choices={aactranscodeChoices}, default={default}.")
+	else:
+		aacTranscode = False
+	BoxInfo.setItem("CanAACTranscode", aacTranscode)
+	if aacTranscode:
+		def setAACTranscode(configElement):
+			fileWriteLine("/proc/stb/audio/aac_transcode", configElement.value, source=MODULE_NAME)
+
+		config.av.transcodeaac = ConfigSelection(default=default, choices=aacTranscode)
+		config.av.transcodeaac.addNotifier(setAACTranscode)
+	else:
+		config.av.transcodeaac = ConfigNothing()
+	btAudio = fileReadLine("/proc/stb/audio/btaudio", default=None, source=MODULE_NAME)
+	btAudio = btAudio.split() if btAudio else False
+	BoxInfo.setItem("CanBTAudio", btAudio)
+	if btAudio:
+		def setBTAudio(configElement):
+			fileWriteLine("/proc/stb/audio/btaudio", "on" if configElement.value else "off", source=MODULE_NAME)
+
+		config.av.btaudio = ConfigOnOff(default=False)
+		config.av.btaudio.addNotifier(setBTAudio)
+	else:
+		config.av.btaudio = ConfigNothing()
+	btAudioDelay = fileReadLine("/proc/stb/audio/btaudio_delay", default=None, source=MODULE_NAME)
+	btAudioDelay = btAudioDelay.split() if btAudioDelay else False
+	BoxInfo.setItem("CanBTAudioDelay", btAudioDelay)
+	if btAudioDelay:
+		def setBTAudioDelay(configElement):
+			fileWriteLine("/proc/stb/audio/btaudio_delay", format(configElement.value * 90, "x"), source=MODULE_NAME)
+
+		config.av.btaudiodelay = ConfigSelectionNumber(min=-1000, max=1000, stepwidth=5, default=0)
+		config.av.btaudiodelay.addNotifier(setBTAudioDelay)
+	else:
+		config.av.btaudiodelay = ConfigNothing()
+	if exists("/proc/stb/vmpeg/0/pep_scaler_sharpness"):
+		def setScalerSharpness(configElement):
+			error = False
+			if not fileWriteLine("/proc/stb/vmpeg/0/pep_scaler_sharpness", f"{configElement.value:08X}\n", source=MODULE_NAME):
+				error = True
+			if not error and not fileWriteLine("/proc/stb/vmpeg/0/pep_apply", "1", source=MODULE_NAME):
+				error = True
+			if error:
+				print(f"[AVSwitch] Setting scaler sharpness to '{configElement.value:08X}' failed!")
+			else:
+				print(f"[AVSwitch] Setting scaler sharpness to '{configElement.value:08X}'.")
+
+		default = 5 if MACHINEBUILD in ("gbquad", "gbquadplus") else 13
+		config.av.scaler_sharpness = ConfigSlider(default=default, limits=(0, 26))
+		config.av.scaler_sharpness.addNotifier(setScalerSharpness)
+	else:
+		config.av.scaler_sharpness = NoSave(ConfigNothing())
+	avSwitch.setConfiguredMode()
 
 
 class AVSwitchBase:
@@ -29,7 +866,6 @@ class AVSwitchBase:
 		"2160p": "0 0 3839 2159",
 		"smpte": "0 0 4095 2159"
 	}
-
 	rates = {}  # High-level, use selectable modes.
 	rates["PAL"] = {
 		"50Hz": {50: "pal"},
@@ -42,7 +878,7 @@ class AVSwitchBase:
 	rates["Multi"] = {
 		"multi": {50: "pal", 60: "ntsc"}
 	}
-	if BoxInfo.getItem("AmlogicFamily"):
+	if AMLOGIC:
 		rates["480i"] = {
 			"60Hz": {60: "480i60hz"}
 		}
@@ -121,7 +957,6 @@ class AVSwitchBase:
 			"multi": {50: "2160p25", 60: "2160p30"},
 			"auto": {50: "2160p25", 60: "2160p30", 24: "2160p24"}
 		}
-
 	rates["smpte"] = {
 		"50Hz": {50: "smpte50hz"},
 		"60Hz": {60: "smpte60hz"},
@@ -130,7 +965,6 @@ class AVSwitchBase:
 		"24Hz": {24: "smpte24hz"},
 		"auto": {60: "smpte60hz"}
 	}
-
 	rates["PC"] = {
 		"1024x768": {60: "1024x768"},
 		"800x600": {60: "800x600"},  # also not possible
@@ -152,11 +986,7 @@ class AVSwitchBase:
 		"NTSC",
 		"Multi"
 	]
-	# modes["DVI-PC"] = [  # This mode does not exist.
-	# 	"PC"
-	# ]
-
-	if BoxInfo.getItem("AmlogicFamily"):
+	if AMLOGIC:
 		modes["HDMI"] = ["720p", "1080p", "smpte", "2160p30", "2160p", "1080i", "576p", "576i", "480p", "480i"]
 	elif (about.getChipSetString() in ("7366", "7376", "5272s", "7444", "7445", "7445s")):
 		modes["HDMI"] = ["720p", "1080p", "2160p", "1080i", "576p", "576i", "480p", "480i"]
@@ -166,37 +996,32 @@ class AVSwitchBase:
 		modes["HDMI"] = ["720p", "1080p", "1080i", "576p", "576i", "480p", "480i"]
 	else:
 		modes["HDMI"] = ["720p", "1080i", "576p", "576i", "480p", "480i"]
-
 	modes["YPbPr"] = modes["HDMI"]
 	if BoxInfo.getItem("scartyuv", False):
 		modes["Scart-YPbPr"] = modes["HDMI"]
-	# if "DVI-PC" in modes and not getModeList("DVI-PC"):
-	# 	print "[AVSwitch] Remove DVI-PC because that mode does not exist."
-	# 	del modes["DVI-PC"]
 	if "YPbPr" in modes and not BoxInfo.getItem("yuv", False):
 		del modes["YPbPr"]
 	if "Scart" in modes and not BoxInfo.getItem("scart", False) and not BoxInfo.getItem("rca", False) and not BoxInfo.getItem("avjack", False):
 		del modes["Scart"]
-
 	if MACHINEBUILD == "mutant2400":
 		mode = fileReadLine("/proc/stb/info/board_revision", default="", source=MODULE_NAME)
 		if mode >= "2":
 			del modes["YPbPr"]
-
 	widescreenModes = tuple([x for x in modes["HDMI"] if x not in ("576p", "576i", "480p", "480i")])
-
+	letterbox = _("Letterbox")
 	ASPECT_SWITCH_MSG = (_("16:9 reset to normal"),
-			"1.85:1 %s" % _("Letterbox"),
-			"2.00:1 %s" % _("Letterbox"),
-			"2.21:1 %s" % _("Letterbox"),
-			"2.35:1 %s" % _("Letterbox"))
+		f"1.85:1 {letterbox}",
+		f"2.00:1 {letterbox}",
+		f"2.21:1 {letterbox}",
+		f"2.35:1 {letterbox}"
+	)
 
 	def __init__(self):
 		self.last_modes_preferred = []
 		self.on_hotplug = CList()
 		self.current_mode = None
 		self.current_port = None
-		print("[AVSwitch] getAvailableModes:'%s'" % eAVControl.getInstance().getAvailableModes())
+		print(f"[AVSwitch] getAvailableModes: '{eAVControl.getInstance().getAvailableModes()}'.")
 		self.is24hzAvailable()
 		self.readPreferredModes()
 		self.createConfig()
@@ -216,20 +1041,16 @@ class AVSwitchBase:
 				modes = modes.split()
 				return modes if len(modes) > 1 else []
 
-			print("[AVSwitch] getPreferredModes:'%s'" % modes)
+			print(f"[AVSwitch] getPreferredModes: '{modes}'.")
 			self.modes_preferred = modes.split()
-
 		if len(modes) < 2:
 			self.modes_preferred = self.readAvailableModes()
-			print("[AVSwitch] used default modes:%s" % self.modes_preferred)
-
+			print(f"[AVSwitch] Used default modes: {self.modes_preferred}.")
 		if len(self.modes_preferred) <= 2:
-			print("[AVSwitch] preferend modes not ok, possible driver failer, len=%s" % len(self.modes_preferred))
+			print(f"[AVSwitch] Preferend modes not okay, possible driver failer, length={len(self.modes_preferred)}.")
 			self.modes_preferred = self.readAvailableModes()
-
 		if readOnly:
 			return self.modes_preferred
-
 		if self.modes_preferred != self.last_modes_preferred:
 			self.last_modes_preferred = self.modes_preferred
 			self.on_hotplug("HDMI")  # must be HDMI
@@ -275,20 +1096,20 @@ class AVSwitchBase:
 				config.av.autores_rate_fhd[mode] = ConfigSelection(choices=rateList)
 				config.av.autores_rate_uhd[mode] = ConfigSelection(choices=rateList)
 		config.av.videoport = ConfigSelection(choices=portList)
-
-		defaults = (0,  # the preset values for the offset heights
-				62,   # 1.85:1
-				100,  # 2.00:1
-				144,  # 2.21:1
-				170)  # 2.35:1
-
 		config.av.aspectswitch = ConfigSubsection()
 		config.av.aspectswitch.enabled = ConfigYesNo(default=False)
+		defaults = (  # The preset values for the offset heights.
+			0,
+			62,  # 1.85:1
+			100,  # 2.00:1
+			144,  # 2.21:1
+			170  # 2.35:1
+		)
 		config.av.aspectswitch.offsets = ConfigSubDict()
 		for aspect in range(5):
 			config.av.aspectswitch.offsets[str(aspect)] = ConfigInteger(default=defaults[aspect], limits=(0, 170))
 
-	def isPortAvailable(self, port):  # Fix me!
+	def isPortAvailable(self, port):  # Fix me!  What needs to be done here?
 		return True
 
 	def isModeAvailable(self, port, mode, rate, availableModes):  # Check if a high-level mode with a given rate is available.
@@ -308,11 +1129,10 @@ class AVSwitchBase:
 		else:
 			return True
 
-	def isWidescreenMode(self, port, mode):  # This is only used in getOutputAspect
+	def isWidescreenMode(self, port, mode):  # This is only used in getOutputAspect.
 		return mode in self.widescreenModes
 
-	# TODO AML
-	def getAspectRatioSetting(self):
+	def getAspectRatioSetting(self):  # TODO AML.  What needs to be done here?
 		return {
 			"4_3_letterbox": 0,
 			"4_3_panscan": 1,
@@ -344,20 +1164,19 @@ class AVSwitchBase:
 	def setAspectRatio(self, value):
 		if value < 100:
 			eAVControl.getInstance().setAspectRatio(value)
-		else:  # Aspect Switcher
+		else:  # Aspect switcher.
 			value -= 100
 			offset = config.av.aspectswitch.offsets[str(value)].value
-			newheight = 576 - offset
-			newtop = offset // 2
+			newTop = offset // 2
+			newHeight = 576 - offset
 			if value:
-				newwidth = 720
+				newWidth = 720
 			else:
-				newtop = 0
-				newwidth = 0
-				newheight = 0
-
-			eAVControl.getInstance().setAspectRatio(2)  # 16:9
-			eAVControl.getInstance().setVideoSize(newtop, 0, newwidth, newheight)
+				newTop = 0
+				newWidth = 0
+				newHeight = 0
+			eAVControl.getInstance().setAspectRatio(2)  # 16:9.
+			eAVControl.getInstance().setVideoSize(newTop, 0, newWidth, newHeight)
 
 	def setColorFormat(self, value):
 		if not self.current_port:
@@ -385,7 +1204,7 @@ class AVSwitchBase:
 		eAVControl.getInstance().setInput(input, 1)
 
 	def setVideoModeDirect(self, mode):
-		if BoxInfo.getItem("AmlogicFamily"):
+		if AMLOGIC:
 			rate = mode[-4:].replace("hz", "Hz")
 			force = int(rate[:-2])
 			mode = mode[:-4]
@@ -394,16 +1213,11 @@ class AVSwitchBase:
 			eAVControl.getInstance().setVideoMode(mode)
 
 	def setMode(self, port, mode, rate, force=None):
-		print("[AVSwitch] Setting mode for port '%s', mode '%s', rate '%s'." % (port, mode, rate))
-		# config.av.videoport.value = port  # We can ignore "port".
-		self.current_mode = mode
-		self.current_port = port
+		print(f"[AVSwitch] Setting mode for port '{port}', mode '{mode}', rate '{rate}'.")
 		modes = self.rates[mode][rate]
-
 		mode50 = modes.get(50)
 		mode60 = modes.get(60)
 		mode24 = modes.get(24)
-
 		if mode50 is None or force == 60:
 			mode50 = mode60
 		if mode60 is None or force == 50:
@@ -412,51 +1226,47 @@ class AVSwitchBase:
 			mode24 = mode60
 			if force == 50:
 				mode24 = mode50
-
-		if BoxInfo.getItem("AmlogicFamily"):
+		if AMLOGIC:
 			amlmode = list(modes.values())[0]
-			oldamlmode = fileReadLine("/sys/class/display/mode", default="", source=MODULE_NAME)
 			fileWriteLine("/sys/class/display/mode", amlmode, source=MODULE_NAME)
-			print("[AVSwitch] Amlogic setting videomode to mode: %s" % amlmode)
-			fileWriteLine("/etc/u-boot.scr.d/000_hdmimode.scr", "setenv hdmimode %s" % amlmode, source=MODULE_NAME)
-			fileWriteLine("/etc/u-boot.scr.d/000_outputmode.scr", "setenv outputmode %s" % amlmode, source=MODULE_NAME)
+			print(f"[AVSwitch] Amlogic setting videomode to mode '{amlmode}'.")
+			fileWriteLine("/etc/u-boot.scr.d/000_hdmimode.scr", f"setenv hdmimode {amlmode}", source=MODULE_NAME)
+			fileWriteLine("/etc/u-boot.scr.d/000_outputmode.scr", f"setenv outputmode {amlmode}", source=MODULE_NAME)
 			system("update-autoexec")
 			fileWriteLine("/sys/class/ppmgr/ppscaler", "1", source=MODULE_NAME)
 			fileWriteLine("/sys/class/ppmgr/ppscaler", "0", source=MODULE_NAME)
 			fileWriteLine("/sys/class/video/axis", self.axis[mode], source=MODULE_NAME)
 			stride = fileReadLine("/sys/class/graphics/fb0/stride", default="", source=MODULE_NAME)
-			limits = [int(x) for x in self.axis[mode].split()]
-			config.osd.dst_left = ConfigSelectionNumber(default=limits[0], stepwidth=1, min=limits[0] - 255, max=limits[0] + 255, wraparound=False)
-			config.osd.dst_top = ConfigSelectionNumber(default=limits[1], stepwidth=1, min=limits[1] - 255, max=limits[1] + 255, wraparound=False)
-			config.osd.dst_width = ConfigSelectionNumber(default=limits[2], stepwidth=1, min=limits[2] - 255, max=limits[2] + 255, wraparound=False)
-			config.osd.dst_height = ConfigSelectionNumber(default=limits[3], stepwidth=1, min=limits[3] - 255, max=limits[3] + 255, wraparound=False)
-
-			if oldamlmode != amlmode:
-				config.osd.dst_width.setValue(limits[0])
-				config.osd.dst_height.setValue(limits[1])
+			if self.current_mode is None:
+				self.current_mode = mode
+			if self.axis[self.current_mode] != self.axis[mode]:
+				limits = [int(x) for x in self.axis[mode].split()]
+				config.osd.dst_left.setChoices(default=limits[0], first=limits[0] - 255, last=limits[0] + 255)
+				config.osd.dst_top.setChoices(default=limits[1], first=limits[1] - 255, last=limits[1] + 255)
+				config.osd.dst_width.setChoices(default=limits[2], first=limits[2] - 255, last=limits[2] + 255)
+				config.osd.dst_height.setChoices(default=limits[3], first=limits[3] - 255, last=limits[3] + 255)
 				config.osd.dst_left.setValue(limits[2])
 				config.osd.dst_top.setValue(limits[3])
+				config.osd.dst_width.setValue(limits[0])
+				config.osd.dst_height.setValue(limits[1])
 				config.osd.dst_left.save()
-				config.osd.dst_width.save()
 				config.osd.dst_top.save()
+				config.osd.dst_width.save()
 				config.osd.dst_height.save()
-			print("[AVSwitch] Framebuffer mode:%s  stride:%s axis:%s" % (getDesktop(0).size().width(), stride, self.axis[mode]))
-			return
-
-		success = fileWriteLine("/proc/stb/video/videomode_50hz", mode50, source=MODULE_NAME)
-		if success:
-			success = fileWriteLine("/proc/stb/video/videomode_60hz", mode60, source=MODULE_NAME)
-		if not success:  # Fallback if no possibility to setup 50/60 hz mode
-			fileWriteLine("/proc/stb/video/videomode", mode50, source=MODULE_NAME)
-
-		if BoxInfo.getItem("have24hz"):
-			fileWriteLine("/proc/stb/video/videomode_24hz", mode24, source=MODULE_NAME)
-
-		if BRAND == "gigablue":
-			# use 50Hz mode (if available) for booting
-			fileWriteLine("/etc/videomode", mode50, source=MODULE_NAME)
-
-		self.setColorFormat(config.av.colorformat.value)
+			print(f"[AVSwitch] Framebuffer mode '{getDesktop(0).size().width()}', stride {stride}, axis '{self.axis[mode]}'.")
+		else:
+			success = fileWriteLine("/proc/stb/video/videomode_50hz", mode50, source=MODULE_NAME)
+			if success:
+				success = fileWriteLine("/proc/stb/video/videomode_60hz", mode60, source=MODULE_NAME)
+			if not success:  # Fallback if no possibility to setup 50/60 hz mode
+				fileWriteLine("/proc/stb/video/videomode", mode50, source=MODULE_NAME)
+			if BoxInfo.getItem("have24hz"):
+				fileWriteLine("/proc/stb/video/videomode_24hz", mode24, source=MODULE_NAME)
+			if BRAND == "gigablue":  # Use 50Hz mode (if available) for booting.
+				fileWriteLine("/etc/videomode", mode50, source=MODULE_NAME)
+			self.setColorFormat(config.av.colorformat.value)
+		self.current_mode = mode
+		self.current_port = port
 
 	def setPolicy43(self, configElement):
 		eAVControl.getInstance().setPolicy43(configElement.value, 1)
@@ -478,1026 +1288,6 @@ class AVSwitchBase:
 			config.av.videorate[mode].save()
 
 
-def InitAVSwitch():
-	if MACHINEBUILD == "vuduo":
-		config.av.yuvenabled = ConfigBoolean(default=False)
-	else:
-		config.av.yuvenabled = ConfigBoolean(default=True)
-	config.av.osd_alpha = ConfigSlider(default=255, increment=5, limits=(20, 255))  # Make openATV compatible with some plugins who still use config.av.osd_alpha.
-
-	config.av.autores = ConfigSelection(default="disabled", choices=[
-		("disabled", _("Disabled")),
-		("simple", _("Simple")),
-		("native", _("Native")),
-		("all", _("All resolutions")),
-		("hd", _("Only HD"))
-	])
-
-	config.av.autores_preview = NoSave(ConfigYesNo(default=False))
-	config.av.autores_1080i_deinterlace = ConfigYesNo(default=False)
-	choiceList = [
-		("24,24", "24p/24p"),  # These display values do not require translation.
-		("24,25", "24p/25p"),
-		("24,30", "24p/30p"),
-		("24,50", "24p/50p"),
-		("24,60", "24p/60p"),
-		("25,24", "25p/24p"),
-		("30,24", "30p/24p"),
-		("50,24", "50p/24p"),
-		("60,24", "60p/24p"),
-		("25,25", "25p/25p"),
-		("25,30", "25p/30p"),
-		("25,50", "25p/50p"),
-		("25,60", "25p/60p"),
-		("30,25", "30p/25p"),
-		("50,25", "50p/25p"),
-		("60,25", "60p/25p"),
-		("30,30", "30p/30p"),
-		("30,50", "30p/50p"),
-		("30,60", "30p/60p"),
-		("50,30", "50p/30p"),
-		("60,30", "60p/30p"),
-		("50,50", "50p/50p"),
-		("50,60", "50p/60p"),
-		("60,50", "60p/50p"),
-		("60,60", "60p/60p")
-	]  # First value <= 720p, second value > 720p.
-	config.av.autores_24p = ConfigSelection(default="50,24", choices=choiceList)
-	config.av.autores_25p = ConfigSelection(default="50,25", choices=choiceList)
-	config.av.autores_30p = ConfigSelection(default="60,30", choices=choiceList)
-
-	config.av.autores_unknownres = ConfigSelection(default="next", choices=[
-		("next", _("Next higher resolution")),
-		("highest", _("Highest resolution"))
-	])
-
-	choiceList = []
-	for timeout in range(5, 16):
-		choiceList.append((timeout, ngettext("%d Second", "%d Seconds", timeout) % timeout))
-	config.av.autores_label_timeout = ConfigSelection(default=5, choices=[(0, _("Not Shown"))] + choiceList)
-	config.av.autores_delay = ConfigSelectionNumber(min=0, max=3000, stepwidth=50, default=400, wraparound=True)
-	config.av.autores_deinterlace = ConfigYesNo(default=False)
-	hertz = _("Hz")
-	if BoxInfo.getItem("AmlogicFamily"):
-		config.av.autores_sd = ConfigSelection(default="720p50hz", choices=[
-			("720p50hz", "720p50%s" % hertz),
-			("720p", "720p"),
-			("1080i50hz", "1080i50%s" % hertz),
-			("1080i", "1080i")
-		])
-		config.av.autores_480p24 = ConfigSelection(default="1080p24hz", choices=[
-			("480p24", "480p 24%s" % hertz),
-			("720p24hz", "720p 24%s" % hertz),
-			("1080p24hz", "1080p 24%s" % hertz)
-		])
-		config.av.autores_720p24 = ConfigSelection(default="720p24hz", choices=[
-			("720p24hz", "720p 24%s" % hertz),
-			("1080p24hz", "1080p 24%s" % hertz),
-			("1080i50hz", "1080i 50%s" % hertz),
-			("1080i", "1080i 60%s" % hertz)
-		])
-		config.av.autores_1080p24 = ConfigSelection(default="1080p24hz", choices=[
-			("1080p24hz", "1080p 24%s" % hertz),
-			("1080p25hz", "1080p 25%s" % hertz),
-			("1080i50hz", "1080p 50%s" % hertz),
-			("1080i", "1080i 60%s" % hertz)
-		])
-		config.av.autores_1080p25 = ConfigSelection(default="1080p25hz", choices=[
-			("1080p25hz", "1080p 25%s" % hertz),
-			("1080p50hz", "1080p 50%s" % hertz),
-			("1080i50hz", "1080i 50%s" % hertz)
-		])
-		config.av.autores_1080p30 = ConfigSelection(default="1080p30hz", choices=[
-			("1080p30hz", "1080p 30%s" % hertz),
-			("1080p60hz", "1080p 60%s" % hertz),
-			("1080i", "1080i 60%s" % hertz)
-		])
-		config.av.autores_2160p24 = ConfigSelection(default="2160p24hz", choices=[
-			("2160p24hz", "2160p 24%s" % hertz),
-			("2160p25hz", "2160p 25%s" % hertz),
-			("2160p30hz", "2160p 30%s" % hertz)
-		])
-		config.av.autores_2160p25 = ConfigSelection(default="2160p25hz", choices=[
-			("2160p25hz", "2160p 25%s" % hertz),
-			("2160p50hz", "2160p 50%s" % hertz)
-		])
-		config.av.autores_2160p30 = ConfigSelection(default="2160p30hz", choices=[
-			("2160p30hz", "2160p 30%s" % hertz),
-			("2160p60hz", "2160p 60%s" % hertz)
-		])
-
-		policy_choices = [
-			("4", _("Stretch nonlinear")),
-			("3", _("Stretch linear")),
-			("1", _("Stretch full")),
-			("10", _("Ignore")),
-			("11", _("Letterbox")),
-			("12", _("Pan&scan")),
-			("13", _("Combined")),
-			("0", _("Pillarbox")),
-		]
-
-		config.av.policy_169 = ConfigSelection(default="11", choices=policy_choices)
-
-		policy_choices = [
-			("2", _("Pillarbox")),
-			("6", _("Ignore")),
-			("7", _("Letterbox")),
-			("8", _("Pan&scan")),
-			("9", _("Combined")),
-		]
-
-		config.av.policy_43 = ConfigSelection(default="8", choices=policy_choices)
-	else:
-		config.av.autores_sd = ConfigSelection(default="720p50", choices=[
-			("720p50", "720p50"),
-			("720p", "720p"),
-			("1080i50", "1080i50"),
-			("1080i", "1080i")
-		])
-		config.av.autores_480p24 = ConfigSelection(default="1080p24", choices=[
-			("480p24", "480p 24%s" % hertz),
-			("720p24", "720p 24%s" % hertz),
-			("1080p24", "1080p 24%s" % hertz)
-		])
-		config.av.autores_720p24 = ConfigSelection(default="720p24", choices=[
-			("720p24", "720p 24%s" % hertz),
-			("1080p24", "1080p 24%s" % hertz),
-			("1080i50", "1080i 50%s" % hertz),
-			("1080i", "1080i 60%s" % hertz)
-		])
-		config.av.autores_1080p24 = ConfigSelection(default="1080p24", choices=[
-			("1080p24", "1080p 24%s" % hertz),
-			("1080p25", "1080p 25%s" % hertz),
-			("1080i50", "1080p 50%s" % hertz),
-			("1080i", "1080i 60%s" % hertz)
-		])
-		config.av.autores_1080p25 = ConfigSelection(default="1080p25", choices=[
-			("1080p25", "1080p 25%s" % hertz),
-			("1080p50", "1080p 50%s" % hertz),
-			("1080i50", "1080i 50%s" % hertz)
-		])
-		config.av.autores_1080p30 = ConfigSelection(default="1080p30", choices=[
-			("1080p30", "1080p 30%s" % hertz),
-			("1080p60", "1080p 60%s" % hertz),
-			("1080i", "1080i 60%s" % hertz)
-		])
-		config.av.autores_2160p24 = ConfigSelection(default="2160p24", choices=[
-			("2160p24", "2160p 24%s" % hertz),
-			("2160p25", "2160p 25%s" % hertz),
-			("2160p30", "2160p 30%s" % hertz)
-		])
-		config.av.autores_2160p25 = ConfigSelection(default="2160p25", choices=[
-			("2160p25", "2160p 25%s" % hertz),
-			("2160p50", "2160p 50%s" % hertz)
-		])
-		config.av.autores_2160p30 = ConfigSelection(default="2160p30", choices=[
-			("2160p30", "2160p 30%s" % hertz),
-			("2160p60", "2160p 60%s" % hertz)
-		])
-
-		# Some boxes have a redundant proc entry for policy2 choices, but some don't (The choices are from a 16:9 point of view anyways)
-		policy2_choices_proc = "/proc/stb/video/policy2_choices"
-		if not exists(policy2_choices_proc):
-			policy2_choices_proc = "/proc/stb/video/policy_choices"
-
-		policy2_choices_raw = "letterbox"
-		try:
-			with open(policy2_choices_proc) as fd:
-				policy2_choices_raw = fd.read()
-		except OSError:
-			pass
-
-		policy2_choices = {}
-
-		if "letterbox" in policy2_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: black bars on top/bottom) in doubt, keep english term.
-			policy2_choices.update({"letterbox": _("Letterbox")})
-
-		if "panscan" in policy2_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: cropped content on left/right) in doubt, keep english term
-			policy2_choices.update({"panscan": _("Pan&scan")})
-
-		if "nonliner" in policy2_choices_raw and "nonlinear" not in policy2_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching the top/bottom (Center of picture maintains aspect, top/bottom lose aspect heaver than on linear stretch))
-			policy2_choices.update({"nonliner": _("Stretch nonlinear")})
-		if "nonlinear" in policy2_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching the top/bottom (Center of picture maintains aspect, top/bottom lose aspect heaver than on linear stretch))
-			policy2_choices.update({"nonlinear": _("Stretch nonlinear")})
-
-		if "scale" in policy2_choices_raw and "auto" not in policy2_choices_raw and "bestfit" not in policy2_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (All parts lose aspect))
-			policy2_choices.update({"scale": _("Stretch linear")})
-		if "full" in policy2_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (force aspect))
-			policy2_choices.update({"full": _("Stretch full")})
-		if "auto" in policy2_choices_raw and "bestfit" not in policy2_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (All parts lose aspect))
-			policy2_choices.update({"auto": _("Stretch linear")})
-		if "bestfit" in policy2_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (All parts lose aspect))
-			policy2_choices.update({"bestfit": _("Stretch linear")})
-
-		config.av.policy_169 = ConfigSelection(default="letterbox", choices=policy2_choices)
-
-		policy_choices_proc = "/proc/stb/video/policy_choices"
-		policy_choices_raw = "panscan"
-		try:
-			with open(policy_choices_proc) as fd:
-				policy_choices_raw = fd.read()
-		except OSError:
-			pass
-
-		policy_choices = {}
-
-		if "pillarbox" in policy_choices_raw and "panscan" not in policy_choices_raw:
-			# Very few boxes support "pillarbox" as an alias for "panscan" (Which in fact does pillarbox)
-			# So only add "pillarbox" if "panscan" is not listed in choices
-
-			# TRANSLATORS: (aspect ratio policy: black bars on left/right) in doubt, keep english term.
-			policy_choices.update({"pillarbox": _("Pillarbox")})
-
-		if "panscan" in policy_choices_raw:
-			# DRIVER BUG:	"panscan" in /proc actually does "pillarbox" (That's probably why an alias to it named "pillarbox" existed)!
-			#		Interpret "panscan" setting with a "Pillarbox" text in order to show the correct value in GUI
-
-			# TRANSLATORS: (aspect ratio policy: black bars on left/right) in doubt, keep english term.
-			policy_choices.update({"panscan": _("Pillarbox")})
-
-		if "letterbox" in policy_choices_raw:
-			# DRIVER BUG:	"letterbox" in /proc actually does pan&scan
-			#		"letterbox" and 4:3 content on 16:9 TVs is mutually exclusive, as "letterbox" is the method to show wide content on narrow TVs
-			#		Probably the bug arose as the driver actually does the same here as it would for wide content on narrow TVs (It stretches the picture to fit width)
-
-			# TRANSLATORS: (aspect ratio policy: Fit width, cut/crop top and bottom (Maintain aspect ratio))
-			policy_choices.update({"letterbox": _("Pan&scan")})
-
-		if "nonliner" in policy_choices_raw and "nonlinear" not in policy_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching the left/right (Center 50% of picture maintain aspect, left/right 25% lose aspect heaver than on linear stretch))
-			policy_choices.update({"nonliner": _("Stretch nonlinear")})
-		if "nonlinear" in policy_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching the left/right (Center 50% of picture maintain aspect, left/right 25% lose aspect heaver than on linear stretch))
-			policy_choices.update({"nonlinear": _("Stretch nonlinear")})
-
-		# "auto", "bestfit" and "scale" are aliasses for the same: Stretch linear
-		if "scale" in policy_choices_raw and "auto" not in policy_choices_raw and "bestfit" not in policy_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (All parts lose aspect))
-			policy_choices.update({"scale": _("Stretch linear")})
-		if "full" in policy_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (force aspect))
-			policy_choices.update({"full": _("Stretch full")})
-		if "auto" in policy_choices_raw and "bestfit" not in policy_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (All parts lose aspect))
-			policy_choices.update({"auto": _("Stretch linear")})
-		if "bestfit" in policy_choices_raw:
-			# TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching all parts of the picture with the same factor (All parts lose aspect))
-			policy_choices.update({"bestfit": _("Stretch linear")})
-
-		config.av.policy_43 = ConfigSelection(default="panscan", choices=policy_choices)
-
-	config.av.smart1080p = ConfigSelection(default="false", choices=[
-		("false", _("Off")),
-		("true", "1080p50: 24p/50p/60p"),
-		("2160p50", "2160p50: 24p/50p/60p"),
-		("1080i50", "1080i50: 24p/50i/60i"),
-		("720p50", "720p50: 24p/50p/60p")
-	])
-
-	choiceList = [
-		("cvbs", "CVBS"),
-		("rgb", "RGB"),
-		("svideo", "S-Video")
-	]
-	if config.av.yuvenabled.value:  # When YUV is not enabled, don't let the user select it.
-		choiceList.append(("yuv", "YPbPr"))
-
-	config.av.colorformat = ConfigSelection(default="rgb", choices=choiceList)
-
-	config.av.aspectratio = ConfigSelection(default="16_9", choices=[
-		("4_3_letterbox", _("4:3 Letterbox")),
-		("4_3_panscan", _("4:3 PanScan")),
-		("16_9", "16:9"),
-		("16_9_always", _("16:9 Always")),
-		("16_10_letterbox", _("16:10 Letterbox")),
-		("16_10_panscan", _("16:10 PanScan")),
-		("16_9_letterbox", _("16:9 Letterbox"))
-	])
-
-	config.av.aspect = ConfigSelection(default="16:9", choices=[
-		("4:3", "4:3"),
-		("16:9", "16:9"),
-		("16:10", "16:10"),
-		("auto", _("Automatic"))
-	])
-
-	config.av.tvsystem = ConfigSelection(default="pal", choices=[
-		("pal", "PAL"),
-		("ntsc", "NTSC"),
-		("multinorm", _("multinorm"))
-	])
-
-	config.av.wss = ConfigEnableDisable(default=True)
-	config.av.generalAC3delay = ConfigSelectionNumber(-1000, 1000, 5, default=0)
-	config.av.generalPCMdelay = ConfigSelectionNumber(-1000, 1000, 5, default=0)
-	config.av.vcrswitch = ConfigEnableDisable(default=False)
-
-	#config.av.aspect.setValue('16:9')
-	config.av.aspect.addNotifier(iAVSwitch.setAspect)
-	config.av.wss.addNotifier(iAVSwitch.setWss)
-	config.av.policy_43.addNotifier(iAVSwitch.setPolicy43)
-	config.av.policy_169.addNotifier(iAVSwitch.setPolicy169)
-
-	def setAspectRatio(configElement):  # Not used
-		aspects = {
-			"4_3_letterbox": 0,
-			"4_3_panscan": 1,
-			"16_9": 2,
-			"16_9_always": 3,
-			"16_10_letterbox": 4,
-			"16_10_panscan": 5,
-			"16_9_letterbox": 6
-		}
-		iAVSwitch.setAspectRatio(aspects[configElement.value])
-
-	def setColorFormat(configElement):
-		if config.av.videoport and config.av.videoport.value in ("YPbPr", "Scart-YPbPr"):
-			iAVSwitch.setColorFormat("yuv")
-		elif config.av.videoport and config.av.videoport.value in ("RCA"):
-			iAVSwitch.setColorFormat("cvbs")
-		else:
-			iAVSwitch.setColorFormat(configElement.value)
-	config.av.colorformat.addNotifier(setColorFormat)
-
-	iAVSwitch.setInput("encoder")  # init on startup
-
-	BoxInfo.setItem("ScartSwitch", eAVControl.getInstance().hasScartSwitch())
-
-	bypassEDID = fileReadLine("/proc/stb/hdmi/bypass_edid_checking", default=None, source=MODULE_NAME)
-	bypassEDID = bypassEDID.split() if bypassEDID else False
-
-	BoxInfo.setItem("Canedidchecking", bypassEDID)
-
-	if bypassEDID:
-		config.av.bypass_edid_checking = ConfigYesNo(default=True)
-
-		def setEDIDBypass(configElement):
-			if configElement.value:
-				value = "00000001" if configElement.value else "00000000"
-				fileWriteLine("/proc/stb/hdmi/bypass_edid_checking", value, source=MODULE_NAME)
-		config.av.bypass_edid_checking.addNotifier(setEDIDBypass)
-	else:
-		config.av.bypass_edid_checking = ConfigNothing()
-
-	def setUnsupportModes(configElement):
-		iAVSwitch.readPreferredModes()
-		iAVSwitch.createConfig()
-		# print("[AVSwitch] Setting EDID override to '%s'." % configElement.value)
-
-	config.av.edid_override.addNotifier(setUnsupportModes)
-
-	colorspace = fileReadLine("/proc/stb/video/hdmi_colorspace", default=None, source=MODULE_NAME)
-	colorspace = colorspace.split() if colorspace else False
-
-	BoxInfo.setItem("havecolorspace", colorspace)
-	if colorspace:
-		if MACHINEBUILD in ("vusolo4k", "vuuno4k", "vuuno4kse", "vuultimo4k", "vuduo4k", "vuduo4kse"):
-			default = "Edid(Auto)"
-			choiceList = [
-				("Edid(Auto)", _("Auto")),
-				("Hdmi_Rgb", "RGB"),
-				("444", "YCbCr 444"),
-				("422", "YCbCr 422"),
-				("420", "YCbCr 420")
-			]
-		elif MACHINEBUILD in ("dm900", "dm920", "vuzero4k"):
-			default = "Edid(Auto)"
-			choiceList = [
-				("Edid(Auto)", _("Auto")),
-				("Hdmi_Rgb", "RGB"),
-				("Itu_R_BT_709", "BT.709"),
-				("DVI_Full_Range_RGB", _("Full Range RGB")),
-				("FCC", "FCC 1953"),
-				("Itu_R_BT_470_2_BG", "BT.470 BG"),
-				("Smpte_170M", "SMPTE 170M"),
-				("Smpte_240M", "SMPTE 240M"),
-				("Itu_R_BT_2020_NCL", "BT.2020 NCL"),
-				("Itu_R_BT_2020_CL", "BT.2020 CL"),
-				("XvYCC_709", "BT.709 XvYCC"),
-				("XvYCC_601", "BT.601 XvYCC")
-			]
-		else:
-			default = "auto"
-			choiceList = [
-				("auto", _("Auto")),
-				("rgb", "RGB"),
-				("420", "YCbCr 420"),
-				("422", "YCbCr 422"),
-				("444", "YCbCr 444")
-			]
-		config.av.hdmicolorspace = ConfigSelection(default=default, choices=choiceList)
-
-		def setHDMIColorspace(configElement):
-			fileWriteLine("/proc/stb/video/hdmi_colorspace", configElement.value, source=MODULE_NAME)
-
-		config.av.hdmicolorspace.addNotifier(setHDMIColorspace)
-	else:
-		config.av.hdmicolorspace = ConfigNothing()
-
-	colorimetry = fileReadLine("/proc/stb/video/hdmi_colorimetry", default=None, source=MODULE_NAME)
-	colorimetry = colorimetry.split() if colorimetry else False
-
-	BoxInfo.setItem("havecolorimetry", colorimetry)
-	if colorimetry:
-		config.av.hdmicolorimetry = ConfigSelection(default="auto", choices=[
-			("auto", _("Auto")),
-			("bt2020ncl", "BT.2020 NCL"),
-			("bt2020cl", "BT.2020 CL"),
-			("bt709", "BT.709")
-		])
-
-		def setHDMIColorimetry(configElement):
-			sleep(0.1)
-			fileWriteLine("/proc/stb/video/hdmi_colorimetry", configElement.value, source=MODULE_NAME)
-		config.av.hdmicolorimetry.addNotifier(setHDMIColorimetry)
-	else:
-		config.av.hdmicolorimetry = ConfigNothing()
-
-	boxMode = fileReadLine("/proc/stb/info/boxmode", default=None, source=MODULE_NAME)
-	boxMode = boxMode.split() if boxMode else False
-
-	BoxInfo.setItem("haveboxmode", boxMode)
-	if boxMode:
-		config.av.boxmode = ConfigSelection(default="12", choices=[
-			("12", _("Enable PiP no HDR")),
-			("1", _("12bit 4:2:0/4:2:2 no PiP"))
-		])
-
-		def setBoxMode(configElement):
-			fileWriteLine("/proc/stb/info/boxmode", configElement.value, source=MODULE_NAME)
-		config.av.boxmode.addNotifier(setBoxMode)
-	else:
-		config.av.boxmode = ConfigNothing()
-
-	colorDepth = fileReadLine("/proc/stb/video/hdmi_colordepth", default=None, source=MODULE_NAME)
-	colorDepth = colorDepth.split() if colorDepth else False
-
-	BoxInfo.setItem("havehdmicolordepth", colorDepth)
-
-	if colorDepth:
-		config.av.hdmicolordepth = ConfigSelection(default="auto", choices=[
-			("auto", _("Auto")),
-			("8bit", _("8bit")),
-			("10bit", _("10bit")),
-			("12bit", _("12bit"))
-		])
-
-		def setColorDepth(configElement):
-			fileWriteLine("/proc/stb/video/hdmi_colordepth", configElement.value, source=MODULE_NAME)
-		config.av.hdmicolordepth.addNotifier(setColorDepth)
-	else:
-		config.av.hdmicolordepth = ConfigNothing()
-
-	syncMode = fileReadLine("/proc/stb/video/sync_mode_choices", default=None, source=MODULE_NAME)
-	syncMode = syncMode.split() if syncMode else False
-
-	BoxInfo.setItem("havesyncmode", syncMode)
-
-	if syncMode:
-		def setSyncMode(configElement):
-			fileWriteLine("/proc/stb/video/sync_mode", configElement.value, source=MODULE_NAME)
-
-		config.av.sync_mode = ConfigSelection(default="slow", choices=[
-			("slow", _("Slow Motion")),
-			("hold", _("Hold First Frame")),
-			("black", _("Black Screen")),
-		])
-		config.av.sync_mode.addNotifier(setSyncMode)
-	else:
-		config.av.sync_mode = ConfigNothing()
-
-	if exists("/sys/class/amhdmitx/amhdmitx0/config"):
-		AMLHDRSupport = True
-	else:
-		AMLHDRSupport = False
-
-	BoxInfo.setItem("haveamlhdrsupport", AMLHDRSupport)
-
-	if AMLHDRSupport:
-
-		config.av.amlhdr10_support = ConfigSelection(default="hdr10-2", choices=[
-			("hdr10-0", _("Force enabled")),
-			("hdr10-1", _("Force disabled")),
-			("hdr10-2", _("Controlled by HDMI"))
-		])
-
-		def setAMLHDR10(configElement):
-			fileWriteLine("/sys/class/amhdmitx/amhdmitx0/config", configElement.value, source=MODULE_NAME)
-
-		config.av.amlhdr10_support.addNotifier(setAMLHDR10)
-	else:
-		config.av.amlhdr10_support = ConfigNothing()
-
-	if AMLHDRSupport:
-
-		config.av.amlhlg_support = ConfigSelection(default="hlg-2", choices=[
-			("hlg-0", _("Force enabled")),
-			("hlg-1", _("Force disabled")),
-			("hlg-2", _("Controlled by HDMI"))
-		])
-
-		def setAMLHLG(configElement):
-			fileWriteLine("/sys/class/amhdmitx/amhdmitx0/config", configElement.value, source=MODULE_NAME)
-
-		config.av.amlhlg_support.addNotifier(setAMLHLG)
-	else:
-		config.av.amlhlg_support = ConfigNothing()
-
-	hdrType = fileReadLine("/proc/stb/video/hdmi_hdrtype", default=None, source=MODULE_NAME)
-	hdrType = hdrType.split() if hdrType else False
-
-	BoxInfo.setItem("havehdmihdrtype", hdrType)
-
-	if hdrType:
-		config.av.hdmihdrtype = ConfigSelection(default="auto", choices=[
-			("auto", _("Auto")),
-			("dolby", "Dolby Vision"),
-			("none", "SDR"),
-			("hdr10", "HDR10"),
-			# ("hdr10+", "HDR10+"),
-			("hlg", "HLG")
-		])
-
-		def setHDRType(configElement):
-			fileWriteLine("/proc/stb/video/hdmi_hdrtype", configElement.value, source=MODULE_NAME)
-
-		config.av.hdmihdrtype.addNotifier(setHDRType)
-	else:
-		config.av.hdmihdrtype = ConfigNothing()
-
-	hdrSupport = fileReadLine("/proc/stb/hdmi/hlg_support_choices", default=None, source=MODULE_NAME)
-	hdrSupport = hdrSupport.split() if hdrSupport else False
-
-	BoxInfo.setItem("HDRSupport", hdrSupport)
-
-	if hdrSupport:
-		def setHlgSupport(configElement):
-			fileWriteLine("/proc/stb/hdmi/hlg_support", configElement.value, source=MODULE_NAME)
-
-		config.av.hlg_support = ConfigSelection(default="auto(EDID)", choices=[
-			("auto(EDID)", _("Controlled by HDMI")),
-			("yes", _("Force enabled")),
-			("no", _("Force disabled"))
-		])
-		config.av.hlg_support.addNotifier(setHlgSupport)
-
-		def setHdr10Support(configElement):
-			fileWriteLine("/proc/stb/hdmi/hdr10_support", configElement.value, source=MODULE_NAME)
-
-		config.av.hdr10_support = ConfigSelection(default="auto(EDID)", choices=[
-			("auto(EDID)", _("Controlled by HDMI")),
-			("yes", _("Force enabled")),
-			("no", _("Force disabled"))
-		])
-		config.av.hdr10_support.addNotifier(setHdr10Support)
-
-		def setDisable12Bit(configElement):
-			fileWriteLine("/proc/stb/video/disable_12bit", "1" if configElement.value else "0", source=MODULE_NAME)
-
-		config.av.allow_12bit = ConfigYesNo(default=False)
-		config.av.allow_12bit.addNotifier(setDisable12Bit)
-
-		def setDisable10Bit(configElement):
-			fileWriteLine("/proc/stb/video/disable_10bit", "1" if configElement.value else "0", source=MODULE_NAME)
-
-		config.av.allow_10bit = ConfigYesNo(default=False)
-		config.av.allow_10bit.addNotifier(setDisable10Bit)
-
-	audioSource = fileReadLine("/sys/devices/virtual/amhdmitx/amhdmitx0/audio_source" if BoxInfo.getItem("AmlogicFamily") else "/proc/stb/hdmi/audio_source", default=None, source=MODULE_NAME)
-	audioSource = audioSource.split() if audioSource else False
-
-	BoxInfo.setItem("Canaudiosource", audioSource)
-
-	if audioSource:
-		if BoxInfo.getItem("AmlogicFamily"):
-			config.av.audio_source = ConfigSelection(default="0", choices=[
-				("0", "PCM"),
-				("1", "S/PDIF"),
-				("2", _("Bluetooth"))
-			])
-		else:
-			config.av.audio_source = ConfigSelection(default="pcm", choices=[
-				("pcm", "PCM"),
-				("spdif", "S/PDIF")
-			])
-
-		def setAudioSource(configElement):
-			fileWriteLine("/sys/devices/virtual/amhdmitx/amhdmitx0/audio_source" if BoxInfo.getItem("AmlogicFamily") else "/proc/stb/hdmi/audio_source", configElement.value, source=MODULE_NAME)
-
-		config.av.audio_source.addNotifier(setAudioSource)
-	else:
-		config.av.audio_source = ConfigNothing()
-
-	surround = fileReadLine("/proc/stb/audio/3d_surround_choices", default=None, source=MODULE_NAME)
-	surround = surround.split() if surround else False
-
-	BoxInfo.setItem("Can3DSurround", surround)
-
-	if surround:
-		config.av.surround_3d = ConfigSelection(default="none", choices=[
-			("none", _("Off")),
-			("hdmi", "HDMI"),
-			("spdif", "S/PDIF"),
-			("dac", "DAC")
-		])
-
-		def set3DSurround(configElement):
-			fileWriteLine("/proc/stb/audio/3d_surround", configElement.value, source=MODULE_NAME)
-
-		config.av.surround_3d.addNotifier(set3DSurround)
-	else:
-		config.av.surround_3d = ConfigNothing()
-
-	surroundSpeaker = fileReadLine("/proc/stb/audio/3d_surround_speaker_position_choices", default=None, source=MODULE_NAME)
-	surroundSpeaker = surroundSpeaker.split() if surroundSpeaker else False
-
-	BoxInfo.setItem("Can3DSpeaker", surroundSpeaker)
-
-	if surroundSpeaker:
-		config.av.surround_3d_speaker = ConfigSelection(default="center", choices=[
-			("center", _("Center")),
-			("wide", _("Wide")),
-			("extrawide", _("Extra wide"))
-		])
-
-		def set3DSurroundSpeaker(configElement):
-			fileWriteLine("/proc/stb/audio/3d_surround_speaker_position", configElement.value, source=MODULE_NAME)
-
-		config.av.surround_3d_speaker.addNotifier(set3DSurroundSpeaker)
-	else:
-		config.av.surround_3d_speaker = ConfigNothing()
-
-	autoVolume = fileReadLine("/proc/stb/audio/avl_choices", default=None, source=MODULE_NAME)
-	autoVolume = autoVolume.split() if autoVolume else False
-
-	BoxInfo.setItem("CanAutoVolume", autoVolume)
-
-	if autoVolume:
-		config.av.autovolume = ConfigSelection(default="none", choices=[
-			("none", _("Off")),
-			("hdmi", "HDMI"),
-			("spdif", "S/PDIF"),
-			("dac", "DAC")
-		])
-
-		def setAutoVolume(configElement):
-			fileWriteLine("/proc/stb/audio/avl", configElement.value, source=MODULE_NAME)
-
-		config.av.autovolume.addNotifier(setAutoVolume)
-	else:
-		config.av.autovolume = ConfigNothing()
-
-	filename = "/proc/stb/audio/multichannel_pcm"
-	multiChannel = exists(filename) and access(filename, W_OK)
-
-	BoxInfo.setItem("supportPcmMultichannel", multiChannel)
-	if multiChannel:
-		config.av.pcm_multichannel = ConfigYesNo(default=False)
-
-		def setPCMMultichannel(configElement):
-			fileWriteLine("/proc/stb/audio/multichannel_pcm", configElement.value and "enable" or "disable", source=MODULE_NAME)
-		config.av.pcm_multichannel.addNotifier(setPCMMultichannel)
-	config.av.volume_stepsize = ConfigSelectionNumber(min=1, max=10, stepwidth=1, default=5)
-
-	def setVolumeStepSize(configElement):
-		eDVBVolumecontrol.getInstance().setVolumeSteps(int(configElement.value))
-	config.av.volume_stepsize.addNotifier(setVolumeStepSize)
-	config.av.volume_stepsize_fastmode = ConfigSelectionNumber(min=1, max=10, stepwidth=1, default=5)
-	config.av.volume_hide_mute = ConfigYesNo(default=True)
-
-	if BoxInfo.getItem("AmlogicFamily"):
-		downmixAC3 = True
-		BoxInfo.setItem("CanPcmMultichannel", True)
-	else:
-		downmixAC3 = fileReadLine("/proc/stb/audio/ac3_choices", default=None, source=MODULE_NAME)
-		if downmixAC3:
-			downmixAC3 = "downmix" in downmixAC3
-		else:
-			downmixAC3 = False
-			BoxInfo.setItem("CanPcmMultichannel", False)
-
-	BoxInfo.setItem("CanDownmixAC3", downmixAC3)
-	if downmixAC3:
-		if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800"):
-			config.av.downmix_ac3 = ConfigSelection(default="downmix", choices=[
-				("downmix", _("Downmix")),
-				("passthrough", _("Pass-through")),
-				("multichannel", _("Convert to multi-channel PCM")),
-				("hdmi_best", _("Use best / Controlled by HDMI"))
-			])
-
-		elif MACHINEBUILD in ("dreamone", "dreamtwo"):
-			config.av.downmix_ac3 = ConfigSelection(default="0", choices=[
-				("0", _("Downmix")),
-				("1", _("Pass-through")),
-				("2", _("Use best / Controlled by HDMI"))
-			])
-		else:
-			config.av.downmix_ac3 = ConfigYesNo(default=True)
-
-		def setAC3Downmix(configElement):
-			if BoxInfo.getItem("AmlogicFamily"):
-				fileWriteLine("/sys/class/audiodsp/digital_raw", configElement.value, source=MODULE_NAME)
-			else:
-				value = configElement.value and "downmix" or "passthrough"
-				if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800"):
-					value = configElement.value
-				fileWriteLine("/proc/stb/audio/ac3", value, source=MODULE_NAME)
-
-			if BoxInfo.getItem("supportPcmMultichannel", False) and not configElement.value:
-				BoxInfo.setItem("CanPcmMultichannel", True)
-			else:
-				BoxInfo.setItem("CanPcmMultichannel", False)
-				if multiChannel:
-					config.av.pcm_multichannel.setValue(False)
-
-		config.av.downmix_ac3.addNotifier(setAC3Downmix)
-	else:
-		config.av.downmix_ac3 = ConfigNothing()
-
-	AC3plusTranscode = fileReadLine("/proc/stb/audio/ac3plus_choices", default=None, source=MODULE_NAME)
-	AC3plusTranscode = AC3plusTranscode.split() if AC3plusTranscode else False
-
-	BoxInfo.setItem("CanAC3plusTranscode", AC3plusTranscode)
-
-	if AC3plusTranscode:
-		if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800"):
-			choiceList = [
-					("use_hdmi_caps", _("Controlled by HDMI")),
-					("force_ac3", _("Convert to AC3")),
-					("multichannel", _("Convert to multi-channel PCM")),
-					("hdmi_best", _("Use best / Controlled by HDMI")),
-					("force_ddp", _("Force AC3plus"))
-				]
-		elif MACHINEBUILD in ("gbquad4k", "gbue4k", "gbx34k"):
-			choiceList = [
-					("downmix", _("Downmix")),
-					("passthrough", _("Pass-through")),
-					("force_ac3", _("Convert to AC3")),
-					("multichannel", _("Convert to multi-channel PCM")),
-					("force_dts", _("Convert to DTS"))
-				]
-		else:
-			choiceList = [
-					("use_hdmi_caps", _("Controlled by HDMI")),
-					("force_ac3", _("Convert to AC3"))
-				]
-
-		config.av.transcodeac3plus = ConfigSelection(default="force_ac3", choices=choiceList)
-
-		def setAC3plusTranscode(configElement):
-			fileWriteLine("/proc/stb/audio/ac3plus", configElement.value, source=MODULE_NAME)
-
-		config.av.transcodeac3plus.addNotifier(setAC3plusTranscode)
-
-	dtsHD = fileReadLine("/proc/stb/audio/dtshd_choices", default=None, source=MODULE_NAME)
-	dtsHD = dtsHD.split() if dtsHD else False
-
-	BoxInfo.setItem("CanDTSHD", dtsHD)
-	if dtsHD:
-		if MACHINEBUILD in ("dm7080", "dm820"):
-			default = "use_hdmi_caps"
-			choiceList = [
-				("use_hdmi_caps", _("Controlled by HDMI")),
-				("force_dts", _("Convert to DTS"))
-			]
-		else:
-			default = "downmix"
-			choiceList = [
-				("downmix", _("Downmix")),
-				("force_dts", _("Convert to DTS")),
-				("use_hdmi_caps", _("Controlled by HDMI")),
-				("multichannel", _("Convert to multi-channel PCM")),
-				("hdmi_best", _("Use best / Controlled by HDMI"))
-			]
-		config.av.dtshd = ConfigSelection(default=default, choices=choiceList)
-
-		def setDTSHD(configElement):
-			fileWriteLine("/proc/stb/audio/dtshd", configElement.value, source=MODULE_NAME)
-
-		config.av.dtshd.addNotifier(setDTSHD)
-
-	wmaPro = fileReadLine("/proc/stb/audio/wmapro_choices", default=None, source=MODULE_NAME)
-	wmaPro = wmaPro.split() if wmaPro else False
-
-	BoxInfo.setItem("CanWMAPRO", wmaPro)
-	if wmaPro:
-
-		config.av.wmapro = ConfigSelection(default="downmix", choices=[
-			("downmix", _("Downmix")),
-			("passthrough", _("Pass-through")),
-			("multichannel", _("Convert to multi-channel PCM")),
-			("hdmi_best", _("Use best / Controlled by HDMI"))
-		])
-
-		def setWMAPro(configElement):
-			fileWriteLine("/proc/stb/audio/wmapro", configElement.value, source=MODULE_NAME)
-
-		config.av.wmapro.addNotifier(setWMAPro)
-
-	dtsDownmix = fileReadLine("/proc/stb/audio/dts_choices", default=None, source=MODULE_NAME)
-	dtsDownmix = "downmix" in dtsDownmix if dtsDownmix else False
-
-	BoxInfo.setItem("CanDownmixDTS", dtsDownmix)
-	if dtsDownmix:
-		config.av.downmix_dts = ConfigYesNo(default=True)
-
-		def setDTSDownmix(configElement):
-			fileWriteLine("/proc/stb/audio/dts", configElement.value and "downmix" or "passthrough", source=MODULE_NAME)
-		config.av.downmix_dts.addNotifier(setDTSDownmix)
-
-	aacDownmix = fileReadLine("/proc/stb/audio/aac_choices", default=None, source=MODULE_NAME)
-	aacDownmix = "downmix" in aacDownmix if aacDownmix else False
-
-	BoxInfo.setItem("CanDownmixAAC", aacDownmix)
-	if aacDownmix:
-		if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800"):
-
-			config.av.downmix_aac = ConfigSelection(default="downmix", choices=[
-				("downmix", _("Downmix")),
-				("passthrough", _("Pass-through")),
-				("multichannel", _("Convert to multi-channel PCM")),
-				("hdmi_best", _("Use best / Controlled by HDMI"))
-			])
-
-		elif MACHINEBUILD in ("gbquad4k", "gbue4k", "gbx34k"):
-
-			config.av.downmix_aac = ConfigSelection(default="downmix", choices=[
-				("downmix", _("Downmix")),
-				("passthrough", _("Pass-through")),
-				("multichannel", _("Convert to multi-channel PCM")),
-				("force_ac3", _("Convert to AC3")),
-				("force_dts", _("Convert to DTS")),
-				("use_hdmi_cacenter", _("Use best / Controlled by HDMI")),
-				("wide", _("Wide")),
-				("extrawide", _("Extra wide"))
-			])
-
-		else:
-			config.av.downmix_aac = ConfigYesNo(default=True)
-
-		def setAACDownmix(configElement):
-			value = configElement.value if MACHINEBUILD in ("dm900", "dm920", "dm7080", "dm800", "gbquad4k", "gbue4k", "gbx34k") else configElement.value and "downmix" or "passthrough"
-			fileWriteLine("/proc/stb/audio/aac", value, source=MODULE_NAME)
-
-		config.av.downmix_aac.addNotifier(setAACDownmix)
-
-	aacplusDownmix = fileReadLine("/proc/stb/audio/aacplus_choices", default=None, source=MODULE_NAME)
-	aacplusDownmix = "downmix" in aacplusDownmix if aacplusDownmix else False
-
-	BoxInfo.setItem("CanDownmixAACPlus", aacplusDownmix)
-	if aacplusDownmix:
-		config.av.downmix_aacplus = ConfigSelection(default="downmix", choices=[
-			("downmix", _("Downmix")),
-			("passthrough", _("Pass-through")),
-			("multichannel", _("Convert to multi-channel PCM")),
-			("force_ac3", _("Convert to AC3")),
-			("force_dts", _("Convert to DTS")),
-			("use_hdmi_cacenter", _("Use best / Controlled by HDMI")),
-			("wide", _("Wide")),
-			("extrawide", _("Extra wide"))
-		])
-
-		def setAACDownmixPlus(configElement):
-			fileWriteLine("/proc/stb/audio/aacplus", configElement.value, source=MODULE_NAME)
-
-		config.av.downmix_aacplus.addNotifier(setAACDownmixPlus)
-
-	if exists("/proc/stb/audio/aac_transcode_choices"):
-		aacTranscodeAll = [("off", _("Off")), ("ac3", "AC3"), ("dts", "DTS")]
-		# The translation text must look exactly like the read value. It is then adjusted with the PO file
-
-		aactranscodeChoices = fileReadLine("/proc/stb/audio/aac_transcode_choices", default=None, source=MODULE_NAME)
-		aactranscodeChoices = aactranscodeChoices.split() if aactranscodeChoices else []
-		aacTranscode = [(x[0], x[1]) for x in aacTranscodeAll if x[0] in aactranscodeChoices]
-		default = aacTranscode[0][0] if aacTranscode else "off"
-		print("[AVSwitch] aactranscodeChoices choices=%s, default=%s" % (aactranscodeChoices, default))
-
-	else:
-		aacTranscode = False
-
-	BoxInfo.setItem("CanAACTranscode", aacTranscode)
-
-	if aacTranscode:
-		def setAACTranscode(configElement):
-			fileWriteLine("/proc/stb/audio/aac_transcode", configElement.value, source=MODULE_NAME)
-
-		config.av.transcodeaac = ConfigSelection(default=default, choices=aacTranscode)
-		config.av.transcodeaac.addNotifier(setAACTranscode)
-	else:
-		config.av.transcodeaac = ConfigNothing()
-
-	btAudio = fileReadLine("/proc/stb/audio/btaudio", default=None, source=MODULE_NAME)
-	btAudio = btAudio.split() if btAudio else False
-
-	BoxInfo.setItem("CanBTAudio", btAudio)
-	if btAudio:
-		config.av.btaudio = ConfigOnOff(default=False)
-
-		def setBTAudio(configElement):
-			fileWriteLine("/proc/stb/audio/btaudio", "on" if configElement.value else "off", source=MODULE_NAME)
-
-		config.av.btaudio.addNotifier(setBTAudio)
-	else:
-		config.av.btaudio = ConfigNothing()
-
-	btAudioDelay = fileReadLine("/proc/stb/audio/btaudio_delay", default=None, source=MODULE_NAME)
-	btAudioDelay = btAudioDelay.split() if btAudioDelay else False
-
-	BoxInfo.setItem("CanBTAudioDelay", btAudioDelay)
-	if btAudioDelay:
-		config.av.btaudiodelay = ConfigSelectionNumber(min=-1000, max=1000, stepwidth=5, default=0)
-
-		def setBTAudioDelay(configElement):
-			fileWriteLine("/proc/stb/audio/btaudio_delay", format(configElement.value * 90, "x"), source=MODULE_NAME)
-
-		config.av.btaudiodelay.addNotifier(setBTAudioDelay)
-	else:
-		config.av.btaudiodelay = ConfigNothing()
-
-	if exists("/proc/stb/vmpeg/0/pep_scaler_sharpness"):
-		default = 5 if MACHINEBUILD in ("gbquad", "gbquadplus") else 13
-		config.av.scaler_sharpness = ConfigSlider(default=default, limits=(0, 26))
-
-		def setScalerSharpness(configElement):
-			error = False
-			if not fileWriteLine("/proc/stb/vmpeg/0/pep_scaler_sharpness", "%0.8X\n" % configElement.value, source=MODULE_NAME):
-				error = True
-			if not error and not fileWriteLine("/proc/stb/vmpeg/0/pep_apply", "1", source=MODULE_NAME):
-				error = True
-			if error:
-				print("[AVSwitch] Setting scaler sharpness to '%0.8X' failed!" % configElement.value)
-			else:
-				print("[AVSwitch] Setting scaler sharpness to '%0.8X'." % configElement.value)
-
-		config.av.scaler_sharpness.addNotifier(setScalerSharpness)
-	else:
-		config.av.scaler_sharpness = NoSave(ConfigNothing())
-
-	iAVSwitch.setConfiguredMode()
-
-
-class VideomodeHotplug:
-	def __init__(self):
-		pass
-
-	def start(self):
-		iAVSwitch.on_hotplug.append(self.hotplug)
-
-	def stop(self):
-		iAVSwitch.on_hotplug.remove(self.hotplug)
-
-	def hotplug(self, what):
-		print("[AVSwitch] Hot-plug detected on port '%s'." % what)
-		port = config.av.videoport.value
-		mode = config.av.videomode[port].value
-		rate = config.av.videorate[mode].value
-		availableModes = iAVSwitch.readAvailableModes()
-		if not iAVSwitch.isModeAvailable(port, mode, rate, availableModes):
-			print("[AVSwitch] VideoModeHoyplug: Mode for port '%s', mode '%s', rate '%s' went away." % (port, mode, rate))
-			modeList = iAVSwitch.getModeList(port)
-			if len(modeList):
-				mode = modeList[0][0]
-				rate = modeList[0][1]
-				# FIXME: The rate needs to be a single value.
-				if isinstance(rate, list):
-					print("[AVSwitch] ERROR: Rate is a list and needs to be a single value!")
-					rate = rate[0]
-				print("[AVSwitch] VideoModeHoyplug: Setting mode for port '%s', mode '%s', rate '%s'." % (port, mode, rate))
-				iAVSwitch.setMode(port, mode, rate)
-			else:
-				print("[AVSwitch] VideoModeHoyplug: Sorry, no other mode is available (unplug?). Doing nothing.")
-
-
-def startHotplug():
-	global hotplug
-	hotplug = VideomodeHotplug()
-	hotplug.start()
-
-
-def stopHotplug():
-	global hotplug
-	hotplug.stop()
-
-
-def InitiVideomodeHotplug(**kwargs):
-	startHotplug()
-
-
-avSwitch = AVSwitchBase()
-iAVSwitch = avSwitch
-hotplug = None
-
-
 # This is a dummy class to stop the constant re-instantiation of the AVSwitchBase class!
 #
 # NOTE: All code that uses a syntax like AVSwitch().getFramebufferScale() should
@@ -1512,13 +1302,54 @@ hotplug = None
 #
 class AVSwitch:
 	def setInput(self, input):
-		return iAVSwitch.setInput(input)
+		return avSwitch.setInput(input)
 
 	def getAspectRatioSetting(self):
-		return iAVSwitch.getAspectRatioSetting()
+		return avSwitch.getAspectRatioSetting()
 
 	def setAspectRatio(self, value):
-		return iAVSwitch.setAspectRatio(value)
+		return avSwitch.setAspectRatio(value)
 
 	def getFramebufferScale(self):
 		return (1, 1)
+
+
+def InitiVideomodeHotplug(**kwargs):
+	global hotplug
+	hotplug = VideomodeHotplug()
+
+
+class VideomodeHotplug:
+	def __init__(self):
+		self.start()
+
+	def start(self):
+		avSwitch.on_hotplug.append(self.hotplug)
+
+	def stop(self):
+		avSwitch.on_hotplug.remove(self.hotplug)
+
+	def hotplug(self, what):
+		print(f"[AVSwitch] Hot-plug detected on port '{what}'.")
+		port = config.av.videoport.value
+		mode = config.av.videomode[port].value
+		rate = config.av.videorate[mode].value
+		availableModes = avSwitch.readAvailableModes()
+		if not avSwitch.isModeAvailable(port, mode, rate, availableModes):
+			print(f"[AVSwitch] VideoModeHoyplug: Mode for port '{port}', mode '{mode}', rate '{rate}' went away.")
+			modeList = avSwitch.getModeList(port)
+			if len(modeList):
+				mode = modeList[0][0]
+				rate = modeList[0][1]
+				if isinstance(rate, list):  # FIXE: The rate needs to be a single value.
+					print("[AVSwitch] ERROR: Rate is a list and needs to be a single value!")
+					rate = rate[0]
+				print(f"[AVSwitch] VideoModeHoyplug: Setting mode for port '{port}', mode '{mode}', rate '{rate}'.")
+				avSwitch.setMode(port, mode, rate)
+			else:
+				print("[AVSwitch] VideoModeHoyplug: Sorry, no other mode is available (device unpluged?), nothing to do.")
+
+
+avSwitch = AVSwitchBase()
+iAVSwitch = avSwitch
+hotplug = None

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -15,7 +15,6 @@ from Components.NimManager import nimmanager
 from Components.ServiceList import refreshServiceList
 from Components.SystemInfo import BoxInfo
 from Tools.Directories import SCOPE_HDD, SCOPE_SKINS, SCOPE_TIMESHIFT, defaultRecordingLocation, fileReadXML, fileWriteLine, resolveFilename
-from Components.AVSwitch import iAVSwitch
 
 MODULE_NAME = __name__.split(".")[-1]
 DEFAULTKEYMAP = eEnv.resolve("${datadir}/enigma2/keymap.xml")
@@ -861,10 +860,7 @@ def InitUsageConfig():
 		(_("%A %Y/%-m/%d"), _("Dayname Year/M/DD")),
 		(_("%A %Y/%-m/%-d"), _("Dayname Year/M/D"))]
 
-	if config.osd.language.value == "de_DE":
-		config.usage.date.dayfull = ConfigSelection(default=_("%A %d.%m.%Y"), choices=choicelist)
-	else:
-		config.usage.date.dayfull = ConfigSelection(default=_("%A %-d %B %Y"), choices=choicelist)
+	config.usage.date.dayfull = ConfigSelection(default=_("%A %d.%m.%Y") if config.misc.locale.value == "de_DE" else _("%A %-d %B %Y"), choices=choicelist)
 
 	# TRANSLATORS: Long date representation short dayname daynum monthname year in strftime() format! See 'man strftime'.
 	config.usage.date.shortdayfull = ConfigText(default=_("%a %-d %B %Y"))
@@ -1212,35 +1208,6 @@ def InitUsageConfig():
 		eEPGCache.getInstance().setDebug(configElement.value)
 
 	config.crash.debugEPG.addNotifier(debugEPGhanged, immediate_feedback=False, initial_call=False)
-
-	if BoxInfo.getItem("AmlogicFamily"):
-		limits = [int(x) for x in iAVSwitch.getWindowsAxis().split()]
-		config.osd.dst_left = ConfigSelectionNumber(default=limits[0], stepwidth=1, min=limits[0] - 255, max=limits[0] + 255, wraparound=False)
-		config.osd.dst_top = ConfigSelectionNumber(default=limits[1], stepwidth=1, min=limits[1] - 255, max=limits[1] + 255, wraparound=False)
-		config.osd.dst_width = ConfigSelectionNumber(default=limits[2], stepwidth=1, min=limits[2] - 255, max=limits[2] + 255, wraparound=False)
-		config.osd.dst_height = ConfigSelectionNumber(default=limits[3], stepwidth=1, min=limits[3] - 255, max=limits[3] + 255, wraparound=False)
-	else:
-		config.osd.dst_left = ConfigSelectionNumber(default=0, stepwidth=1, min=0, max=720, wraparound=False)
-		config.osd.dst_width = ConfigSelectionNumber(default=720, stepwidth=1, min=0, max=720, wraparound=False)
-		config.osd.dst_top = ConfigSelectionNumber(default=0, stepwidth=1, min=0, max=576, wraparound=False)
-		config.osd.dst_height = ConfigSelectionNumber(default=576, stepwidth=1, min=0, max=576, wraparound=False)
-
-	config.osd.alpha = ConfigSelectionNumber(default=255, stepwidth=1, min=0, max=255, wraparound=False)
-	config.osd.alpha_teletext = ConfigSelectionNumber(default=255, stepwidth=1, min=0, max=255, wraparound=False)
-	config.osd.alpha_webbrowser = ConfigSelectionNumber(default=255, stepwidth=1, min=0, max=255, wraparound=False)
-	config.av.osd_alpha = NoSave(ConfigNumber(default=255))
-	config.osd.threeDmode = ConfigSelection(default="auto", choices=[
-		("off", _("Off")),
-		("auto", _("Auto")),
-		("sidebyside", _("Side by Side")),
-		("topandbottom", _("Top and Bottom"))
-	])
-	config.osd.threeDznorm = ConfigSlider(default=50, increment=1, limits=(0, 100))
-	config.osd.show3dextensions = ConfigYesNo(default=False)
-	config.osd.threeDsetmode = ConfigSelection(default="mode1", choices=[
-		("mode1", _("Mode 1")),
-		("mode2", _("Mode 2"))
-	])
 
 	hddChoices = [("/etc/enigma2/", _("Internal Flash"))]
 	for partition in harddiskmanager.getMountedPartitions():

--- a/lib/python/Screens/OSDCalibration.py
+++ b/lib/python/Screens/OSDCalibration.py
@@ -1,402 +1,203 @@
-from os import access, R_OK
+from os import W_OK, access
 from os.path import exists
-from enigma import getDesktop
 
-from Components.ActionMap import ActionMap, HelpableActionMap
-from Components.AVSwitch import iAVSwitch
-from Components.config import config, configfile
-from Components.ConfigList import ConfigListScreen
+from enigma import eAVControl, getDesktop
+
+from Components.ActionMap import HelpableActionMap
+from Components.AVSwitch import avSwitch
+from Components.config import ConfigNumber, ConfigSelection, ConfigSelectionInteger, ConfigSlider, ConfigSubsection, ConfigText, ConfigYesNo, NoSave, config, configfile
 from Components.Label import Label
 from Components.SystemInfo import BoxInfo
 from Components.Sources.StaticText import StaticText
-from Screens.MessageBox import MessageBox
-from Screens.Screen import Screen
-from Screens.Setup import Setup, SetupSummary
-from Tools.Directories import fileWriteLine
+from Screens.Setup import Setup
+from Tools.Directories import fileReadLine, fileWriteLine
 
 MODULE_NAME = __name__.split(".")[-1]
 
 
 def InitOSDCalibration():
-
-	BoxInfo.setItem("OSD3DCalibration", access("/proc/stb/fb/3dmode", R_OK))
-	BoxInfo.setItem("CanChangeOsdAlpha", access("/proc/stb/video/alpha", R_OK))
-	BoxInfo.setItem("CanChangeOsdPlaneAlpha", access("/sys/class/graphics/fb0/osd_plane_alpha", R_OK))
-	BoxInfo.setItem("CanChangeOsdPosition", access("/proc/stb/fb/dst_left", R_OK))
-	BoxInfo.setItem("CanChangeOsdPositionAML", access("/sys/class/graphics/fb0/free_scale", R_OK))
-	BoxInfo.setItem("OsdSetup", BoxInfo.getItem("CanChangeOsdPosition"))
-	if BoxInfo.getItem("CanChangeOsdAlpha") is True or BoxInfo.getItem("CanChangeOsdPosition") is True or BoxInfo.getItem("CanChangeOsdPositionAML") is True or BoxInfo.getItem("CanChangeOsdPlaneAlpha") is True:
-		BoxInfo.setItem("OSDCalibration", True)
-	else:
-		BoxInfo.setItem("OSDCalibration", False)
-
-	if BoxInfo.getItem("CanChangeOsdPosition"):
-		def setPositionParameter(parameter, configElement):
-			fileWriteLine(f"/proc/stb/fb/dst_{parameter}", "%08X\n" % configElement.value, source=MODULE_NAME)
-			fileName = "/proc/stb/fb/dst_apply"
-			if exists(fileName):
-				fileWriteLine(fileName, "1", source=MODULE_NAME)
-	elif BoxInfo.getItem("CanChangeOsdPositionAML"):
-		def setPositionParameter(parameter, configElement):
+	BoxInfo.setItem("CanChangeOsdPosition", access("/proc/stb/fb/dst_left", W_OK))
+	BoxInfo.setItem("CanChangeOsdPositionAML", access("/sys/class/graphics/fb0/free_scale", W_OK))  # Is this the same as BoxInfo.getItem("AmlogicFamily")?
+	BoxInfo.setItem("CanChangeOsdAlpha", eAVControl.getInstance().hasOSDAlpha())
+	BoxInfo.setItem("OSDCalibration", BoxInfo.getItem("CanChangeOsdPosition") or BoxInfo.getItem("CanChangeOsdPositionAML") or BoxInfo.getItem("CanChangeOsdAlpha"))
+	BoxInfo.setItem("OSD3DCalibration", access("/proc/stb/fb/3dmode", W_OK))
+	# BoxInfo.setItem("OsdSetup", BoxInfo.getItem("CanChangeOsdPosition"))  # This does not appear to be used.
+	if BoxInfo.getItem("CanChangeOsdPositionAML"):
+		def setPositionParameter(parameter, value):
 			value = f"{config.osd.dst_left.value} {config.osd.dst_top.value} {config.osd.dst_width.value} {config.osd.dst_height.value}"
 			fileWriteLine("/sys/class/graphics/fb0/window_axis", value, source=MODULE_NAME)
 			fileWriteLine("/sys/class/graphics/fb0/free_scale", "0x10001", source=MODULE_NAME)
 
-	else:
-		def setPositionParameter(parameter, configElement):
-			# dummy else case
-			pass
+	elif BoxInfo.getItem("CanChangeOsdPosition"):
+		def setPositionParameter(parameter, value):
+			fileWriteLine(f"/proc/stb/fb/dst_{parameter}", f"{value:08x}\n", source=MODULE_NAME)
+			fileName = "/proc/stb/fb/dst_apply"
+			if exists(fileName):
+				fileWriteLine(fileName, "1", source=MODULE_NAME)
 
-	def setOSDLeft(configElement):
-		setPositionParameter("left", configElement)
-	config.osd.dst_left.addNotifier(setOSDLeft)
+	else:  # Dummy else case.
+		def setPositionParameter(parameter, value):
+			dummy = (parameter, value)  # Dummy code to make SONAR happy.
 
-	def setOSDWidth(configElement):
-		setPositionParameter("width", configElement)
-	config.osd.dst_width.addNotifier(setOSDWidth)
+	def setLeft(configElement):
+		setPositionParameter("left", configElement.value)
 
-	def setOSDTop(configElement):
-		setPositionParameter("top", configElement)
-	config.osd.dst_top.addNotifier(setOSDTop)
+	def setTop(configElement):
+		setPositionParameter("top", configElement.value)
 
-	def setOSDHeight(configElement):
-		setPositionParameter("height", configElement)
-	config.osd.dst_height.addNotifier(setOSDHeight)
+	def setWidth(configElement):
+		setPositionParameter("width", configElement.value)
 
-	print(f"[UserInterfacePositioner] Setting OSD position: {config.osd.dst_left.value} {config.osd.dst_width.value} {config.osd.dst_top.value} {config.osd.dst_height.value}")
+	def setHeight(configElement):
+		setPositionParameter("height", configElement.value)
 
-	def setOSDAlpha(configElement):
-		if BoxInfo.getItem("CanChangeOsdAlpha"):
-			print(f"[UserInterfacePositioner] Setting OSD alpha:{str(configElement.value)}")
-			config.av.osd_alpha.setValue(configElement.value)
-			fileWriteLine("/proc/stb/video/alpha", str(configElement.value), source=MODULE_NAME)
-	config.osd.alpha.addNotifier(setOSDAlpha)
-
-	def setOSDPlaneAlpha(configElement):
-		if BoxInfo.getItem("CanChangeOsdPlaneAlpha"):
-			print(f"[UserInterfacePositioner] Setting OSD plane alpha:{str(configElement.value)}")
-			config.av.osd_alpha.setValue(configElement.value)
-			fileWriteLine("/sys/class/graphics/fb0/osd_plane_alpha", hex(configElement.value), source=MODULE_NAME)
-	config.osd.alpha.addNotifier(setOSDPlaneAlpha)
+	def setAlpha(configElement):
+		value = configElement.value
+		print(f"[OSDCalibration] Setting OSD alpha to {value}.")
+		config.av.osd_alpha.setValue(value)
+		eAVControl.getInstance().setOSDAlpha(value)
 
 	def set3DMode(configElement):
-		if BoxInfo.getItem("OSD3DCalibration"):
-			value = configElement.value
-			print(f"[UserInterfacePositioner] Setting 3D mode: {str(value)}")
-			try:
-				if BoxInfo.getItem("CanUse3DModeChoices"):
-					f = open("/proc/stb/fb/3dmode_choices")
-					choices = f.readlines()[0].split()
-					f.close()
-					if value not in choices:
-						if value == "sidebyside":
-							value = "sbs"
-						elif value == "topandbottom":
-							value = "tab"
-						elif value == "auto":
-							value = "off"
-				fileWriteLine("/proc/stb/fb/3dmode", value, source=MODULE_NAME)
-			except OSError:
-				pass
-	config.osd.threeDmode.addNotifier(set3DMode)
+		value = configElement.value
+		print(f"[OSDCalibration] Setting 3D mode to {value}.")
+		if BoxInfo.getItem("CanUse3DModeChoices"):
+			choices = fileReadLine("/proc/stb/fb/3dmode_choices", "", source=MODULE_NAME).split()
+			if value not in choices:
+				match value:
+					case "sidebyside":
+						value = "sbs"
+					case "topandbottom":
+						value = "tab"
+					case "auto":
+						value = "off"
+			fileWriteLine("/proc/stb/fb/3dmode", value, source=MODULE_NAME)
 
 	def set3DZnorm(configElement):
-		if BoxInfo.getItem("OSD3DCalibration"):
-			print(f"[UserInterfacePositioner] Setting 3D depth: {str(configElement.value)}")
-			fileWriteLine("/proc/stb/fb/znorm", str(int(configElement.value)), source=MODULE_NAME)
-	config.osd.threeDznorm.addNotifier(set3DZnorm)
+		value = configElement.value
+		print(f"[OSDCalibration] Setting 3D depth to {value}.")
+		fileWriteLine("/proc/stb/fb/znorm", str(value), source=MODULE_NAME)
+
+	print(f"[OSDCalibration] Setting OSD position to (X={config.osd.dst_left.value}, Y={config.osd.dst_top.value}) and size to (W={config.osd.dst_width.value}, H={config.osd.dst_height.value}).")
+	config.osd.dst_left.addNotifier(setLeft)
+	config.osd.dst_top.addNotifier(setTop)
+	config.osd.dst_width.addNotifier(setWidth)
+	config.osd.dst_height.addNotifier(setHeight)
+	if BoxInfo.getItem("CanChangeOsdAlpha"):
+		config.osd.alpha.addNotifier(setAlpha)
+	if BoxInfo.getItem("OSD3DCalibration"):
+		config.osd.threeDmode.addNotifier(set3DMode)
+		config.osd.threeDznorm.addNotifier(set3DZnorm)
 
 
-class OSDCalibration(Screen, ConfigListScreen):
-	if (getDesktop(0).size().width() == 1920):
-		skin = """
-			<screen position="center,center" size="1920,1080" backgroundColor="#000000" title="OSD Adjustment" >
-
-				<widget name="text" position="300,165" zPosition="1" size="1320,180" font="Regular;32" halign="center" valign="center" foregroundColor="yellow" backgroundColor="#1f771f" transparent="1" />
-				<widget name="config" position="225,375" zPosition="1" size="1470,315" itemHeight="45" font="Regular;30" transparent="1" />
-				<widget source="status" render="Label" position="300,713" zPosition="1" size="1320,120" font="Regular;32" halign="center" valign="center" foregroundColor="yellow" backgroundColor="#1f771f" transparent="1" />
-
-				<eLabel backgroundColor="red" position="0,0" size="1920,1" zPosition="0" />
-				<eLabel backgroundColor="red" position="0,1079" size="1920,1" zPosition="0" />
-				<eLabel backgroundColor="red" position="0,0" size="1,1080" zPosition="0" />
-				<eLabel backgroundColor="red" position="1919,0" size="1,1080" zPosition="0" />
-				<eLabel backgroundColor="green" position="38,38" size="1845,1" zPosition="0" />
-				<eLabel backgroundColor="green" position="38,1041" size="1845,1" zPosition="0" />
-				<eLabel backgroundColor="green" position="38,38" size="1,1005" zPosition="0" />
-				<eLabel backgroundColor="green" position="1881,38" size="1,1005" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="75,75" size="1770,1" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="75,1004" size="1770,1" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="75,75" size="1,930" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="1844,75" size="1,930" zPosition="0" />
-				<eLabel backgroundColor="blue" position="113,113" size="1695,1" zPosition="0" />
-				<eLabel backgroundColor="blue" position="113,966" size="1695,1" zPosition="0" />
-				<eLabel backgroundColor="blue" position="113,113" size="1,855" zPosition="0" />
-				<eLabel backgroundColor="blue" position="1806,113" size="1,855" zPosition="0" />
-
-				<eLabel backgroundColor="red" position="284,941" size="210,5" zPosition="0" />
-				<eLabel backgroundColor="green" position="665,941" size="210,5" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="1046,941" size="210,5" zPosition="0" />
-				<eLabel backgroundColor="blue" position="1427,941" size="210,5" zPosition="0" />
-				<widget source="key_red" render="Label" position="284,908" zPosition="1" size="210,33" font="Regular;27" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_green" render="Label" position="665,908" zPosition="1" size="210,33" font="Regular;27" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_yellow" render="Label" position="1046,908" zPosition="1" size="210,33" font="Regular;27" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_blue" render="Label" position="1427,908" zPosition="1" size="210,33" font="Regular;27" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-
-			</screen>"""
-	elif (getDesktop(0).size().width() == 1280):
-		skin = """
-			<screen position="center,center" size="1280,720" backgroundColor="#000000" title="OSD Adjustment" >
-
-				<widget name="text" position="200,110" zPosition="1" size="880,120" font="Regular;21" halign="center" valign="center" foregroundColor="yellow" backgroundColor="#1f771f" transparent="1" />
-				<widget name="config" position="150,250" zPosition="1" size="980,210" itemHeight="30" font="Regular;20" transparent="1" />
-				<widget source="status" render="Label" position="200,475" zPosition="1" size="880,80" font="Regular;21" halign="center" valign="center" foregroundColor="yellow" backgroundColor="#1f771f" transparent="1" />
-
-				<eLabel backgroundColor="red" position="0,0" size="1280,1" zPosition="0" />
-				<eLabel backgroundColor="red" position="0,719" size="1280,1" zPosition="0" />
-				<eLabel backgroundColor="red" position="0,0" size="1,720" zPosition="0" />
-				<eLabel backgroundColor="red" position="1279,0" size="1,720" zPosition="0" />
-				<eLabel backgroundColor="green" position="25,25" size="1230,1" zPosition="0" />
-				<eLabel backgroundColor="green" position="25,694" size="1230,1" zPosition="0" />
-				<eLabel backgroundColor="green" position="25,25" size="1,670" zPosition="0" />
-				<eLabel backgroundColor="green" position="1254,25" size="1,670" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="50,50" size="1180,1" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="50,669" size="1180,1" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="50,50" size="1,620" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="1229,50" size="1,620" zPosition="0" />
-				<eLabel backgroundColor="blue" position="75,75" size="1130,1" zPosition="0" />
-				<eLabel backgroundColor="blue" position="75,644" size="1130,1" zPosition="0" />
-				<eLabel backgroundColor="blue" position="75,75" size="1,570" zPosition="0" />
-				<eLabel backgroundColor="blue" position="1204,75" size="1,570" zPosition="0" />
-
-				<eLabel backgroundColor="red" position="189,627" size="140,3" zPosition="0" />
-				<eLabel backgroundColor="green" position="443,627" size="140,3" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="697,627" size="140,3" zPosition="0" />
-				<eLabel backgroundColor="blue" position="951,627" size="140,3" zPosition="0" />
-				<widget source="key_red" render="Label" position="189,605" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_green" render="Label" position="443,605" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_yellow" render="Label" position="697,605" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_blue" render="Label" position="951,605" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-
-			</screen>"""
-
-	elif (getDesktop(0).size().width() == 1024):
-		skin = """
-			<screen position="center,center" size="1024,576" backgroundColor="#000000" title="OSD Adjustment" >
-
-				<widget name="text"  position="200,180" zPosition="1" size="624,100" font="Regular;21" halign="center" valign="center" foregroundColor="yellow" backgroundColor="#1f771f" transparent="1" />
-				<widget name="config" position="100,180" zPosition="1" size="824,50" font="Regular;24" halign="center" valign="center" transparent="1" />
-				<widget source="status" render="Label" position="200,450" zPosition="1" size="624,80" font="Regular;21" halign="center" valign="center" foregroundColor="yellow" backgroundColor="#1f771f" transparent="1" />
-
-				<eLabel backgroundColor="red" position="0,0" size="1024,1" zPosition="0" />
-				<eLabel backgroundColor="red" position="0,575" size="1024,1" zPosition="0" />
-				<eLabel backgroundColor="red" position="0,0" size="1,576" zPosition="0" />
-				<eLabel backgroundColor="red" position="1023,0" size="1,576" zPosition="0" />
-				<eLabel backgroundColor="green" position="25,25" size="974,1" zPosition="0" />
-				<eLabel backgroundColor="green" position="25,551" size="974,1" zPosition="0" />
-				<eLabel backgroundColor="green" position="25,25" size="1,526" zPosition="0" />
-				<eLabel backgroundColor="green" position="999,25" size="1,526" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="50,50" size="924,1" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="50,526" size="924,1" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="50,50" size="1,476" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="974,50" size="1,476" zPosition="0" />
-				<eLabel backgroundColor="blue" position="75,75" size="874,1" zPosition="0" />
-				<eLabel backgroundColor="blue" position="75,501" size="874,1" zPosition="0" />
-				<eLabel backgroundColor="blue" position="75,75" size="1,426" zPosition="0" />
-				<eLabel backgroundColor="blue" position="949,75" size="1,426" zPosition="0" />
-
-				<eLabel backgroundColor="red" position="138,477" size="140,3" zPosition="0" />
-				<eLabel backgroundColor="green" position="341,477" size="140,3" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="544,477" size="140,3" zPosition="0" />
-				<eLabel backgroundColor="blue" position="747,477" size="140,3" zPosition="0" />
-				<widget source="key_red" render="Label" position="138,455" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_green" render="Label" position="341,455" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_yellow" render="Label" position="544,455" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_blue" render="Label" position="747,455" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-			</screen>"""
-
-	else:
-		skin = """
-			<screen position="center,center" size="720,576" backgroundColor="#000000" title="OSD Adjustment" >
-
-				<widget source="text" render="Label" position="75,80" zPosition="1" size="570,100" font="Regular;21" halign="center" valign="center" foregroundColor="yellow" backgroundColor="#1f771f" transparent="1" />
-				<widget source="config" render="Label" position="75,180" zPosition="1" size="570,50" font="Regular;21" halign="center" valign="center" transparent="1" />
-				<widget source="status" render="Label" position="75,450" zPosition="1" size="570,80" font="Regular;21" halign="center" valign="center" foregroundColor="yellow" backgroundColor="#1f771f" transparent="1" />
-
-				<eLabel backgroundColor="red" position="0,0" size="720,1" zPosition="0" />
-				<eLabel backgroundColor="red" position="0,575" size="720,1" zPosition="0" />
-				<eLabel backgroundColor="red" position="0,0" size="1,576" zPosition="0" />
-				<eLabel backgroundColor="red" position="719,0" size="1,576" zPosition="0" />
-				<eLabel backgroundColor="green" position="25,25" size="670,1" zPosition="0" />
-				<eLabel backgroundColor="green" position="25,551" size="670,1" zPosition="0" />
-				<eLabel backgroundColor="green" position="25,25" size="1,526" zPosition="0" />
-				<eLabel backgroundColor="green" position="694,25" size="1,526" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="50,50" size="620,1" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="50,526" size="620,1" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="50,50" size="1,476" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="670,50" size="1,476" zPosition="0" />
-				<eLabel backgroundColor="blue" position="75,75" size="570,1" zPosition="0" />
-				<eLabel backgroundColor="blue" position="75,501" size="570,1" zPosition="0" />
-				<eLabel backgroundColor="blue" position="75,75" size="1,426" zPosition="0" />
-				<eLabel backgroundColor="blue" position="645,75" size="1,426" zPosition="0" />
-
-				<eLabel backgroundColor="red" position="80,477" size="140,3" zPosition="0" />
-				<eLabel backgroundColor="green" position="220,477" size="140,3" zPosition="0" />
-				<eLabel backgroundColor="yellow" position="360,477" size="140,3" zPosition="0" />
-				<eLabel backgroundColor="blue" position="500,477" size="140,3" zPosition="0" />
-				<widget source="key_red" render="Label" position="80,455" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_green" render="Label" position="220,455" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_yellow" render="Label" position="360,455" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-				<widget source="key_blue" render="Label" position="500,455" zPosition="1" size="140,22" font="Regular;18" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-
-			</screen>"""
+class OSDCalibration(Setup):
+	match getDesktop(0).size().width():  # This skin shouldn't be scaled as we need pixel perfect accuracy at each resolution!
+		case 1920:  # 1920x1080 resolution.
+			buttonHeight = 60
+			colorButtonWidth = 270
+			fontSize = 30
+			iconButtonWidth = 120
+			itemHeight = 37
+			menuFontSize = 52
+			spacer = 38
+			spacing = 15
+			textHeight = 150
+		case 1280:  # 1280x720 resolution.
+			buttonHeight = 40
+			colorButtonWidth = 180
+			fontSize = 20
+			iconButtonWidth = 80
+			itemHeight = 35
+			menuFontSize = 25
+			spacer = 25
+			spacing = 10
+			textHeight = 100
+		case 1024:  # 1024x576 resolution.
+			buttonHeight = 22
+			colorButtonWidth = 140
+			fontSize = 18
+			iconButtonWidth = 70
+			itemHeight = 25
+			menuFontSize = 20
+			spacer = 10
+			spacing = 10
+			textHeight = 80
+		case _:  # 720x576 resolution.
+			buttonHeight = 22
+			colorButtonWidth = 140
+			fontSize = 18
+			iconButtonWidth = 70
+			itemHeight = 25
+			menuFontSize = 20
+			spacer = 10
+			spacing = 10
+			textHeight = 80
+	skin = f"""
+	<screen name="OSDCalibration" title="OSD Calibration Settings" position="fill" backgroundColor="#00000000" >
+		<eRectangle position="0,0" size="e,e" borderColor="#00FF0000" backgroundColor="#00000000" borderWidth="1" zPosition="+0" />
+		<eRectangle position="25,25" size="e-50,e-50" backgroundColor="#00000000" borderColor="#0000FF00" borderWidth="1" zPosition="+1" />
+		<eRectangle position="50,50" size="e-100,e-100" backgroundColor="#00000000" borderColor="#00FFFF00" borderWidth="1" zPosition="+2" />
+		<eRectangle position="75,75" size="e-150,e-150" backgroundColor="#00000000" borderColor="#000000FF" borderWidth="1" zPosition="+3" />
+		<widget name="text" position="85,85" size="e-170,{textHeight}" font="Regular;{fontSize}" foregroundColor="#00FFFF00" transparent="1" verticalAlignment="center" zPosition="+4" />
+		<widget name="config" position="300,{85 + textHeight + spacer}" size="e-600,{itemHeight * 7}" font="Regular;{menuFontSize}" itemHeight="{itemHeight}" transparent="1" zPosition="+4" />
+		<widget name="footnote" position="0,0" size="0,0" />
+		<widget name="description" position="300,{85 + textHeight + spacer + (itemHeight * 7) + spacer}" size="e-600,{textHeight}" font="Regular;{fontSize}" foregroundColor="#00FFFFFF" transparent="1" verticalAlignment="center" zPosition="+4" />
+		<panel position="85,e-{85 + buttonHeight}" size="e-170,{buttonHeight}" layout="horizontal" spacing="{spacing}">
+			<widget source="key_red" render="Label" position="left" size="{colorButtonWidth},{buttonHeight}" backgroundColor="key_red" conditional="key_red" font="Regular;{fontSize}" foregroundColor="key_text" horizontalAlignment="center" verticalAlignment="center" zPosition="+4">
+				<convert type="ConditionalShowHide" />
+			</widget>
+			<widget source="key_green" render="Label" position="left" size="{colorButtonWidth},{buttonHeight}" backgroundColor="key_green" conditional="key_green" font="Regular;{fontSize}" foregroundColor="key_text" horizontalAlignment="center" verticalAlignment="center" zPosition="+4">
+				<convert type="ConditionalShowHide" />
+			</widget>
+			<widget source="key_yellow" render="Label" position="left" size="{colorButtonWidth},{buttonHeight}" backgroundColor="key_yellow" conditional="key_yellow" font="Regular;{fontSize}" foregroundColor="key_text" horizontalAlignment="center" verticalAlignment="center" zPosition="+4">
+				<convert type="ConditionalShowHide" />
+			</widget>
+			<widget source="key_help" render="Label" position="right" size="{iconButtonWidth},{buttonHeight}" backgroundColor="key_back" conditional="key_help" font="Regular;{fontSize}" foregroundColor="key_text" horizontalAlignment="center" verticalAlignment="center" zPosition="+4">
+				<convert type="ConditionalShowHide" />
+			</widget>
+			<widget source="key_menu" render="Label" position="right" size="{iconButtonWidth},{buttonHeight}" backgroundColor="key_back" conditional="key_menu" font="Regular;{fontSize}" foregroundColor="key_text" horizontalAlignment="center" verticalAlignment="center" zPosition="+4">
+				<convert type="ConditionalShowHide" />
+			</widget>
+		</panel>
+	</screen>"""
 
 	def __init__(self, session):
-		Screen.__init__(self, session)
-		self.skinName = ["OSDCalibration", "UserInterfacePositioner2"]
-		self.setup_title = _("Position Setup")
-#		self.Console = Console()
-		self["status"] = StaticText()
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-		self["key_yellow"] = StaticText(_("Defaults"))
-		self["key_blue"] = StaticText()
-
-		self["title"] = StaticText(_("OSD Adjustment"))
-		self["text"] = Label(_("Please setup your user interface by adjusting the values till the edges of the red box are touching the edges of your TV.\nWhen you are ready press green to continue."))
-
-		self["actions"] = ActionMap(["SetupActions", "ColorActions"],
-			{
-				"cancel": self.keyCancel,
-				"save": self.keySave,
-				"left": self.keyLeft,
-				"right": self.keyRight,
-				"yellow": self.keyDefault,
-			}, -2)
-
-		self.onChangedEntry = []
-		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
-		if BoxInfo.getItem("CanChangeOsdAlpha") or BoxInfo.getItem("CanChangeOsdPlaneAlpha"):
-			self.list.append((_("User interface visibility"), config.osd.alpha, _("This option lets you adjust the transparency of the user interface")))
-			self.list.append((_("Teletext base visibility"), config.osd.alpha_teletext, _("Base transparency for teletext, more options available within teletext screen.")))
-			self.list.append((_("Web browser base visibility"), config.osd.alpha_webbrowser, _("Base transparency for OpenOpera web browser")))
-		if BoxInfo.getItem("CanChangeOsdPosition"):
-			self.list.append((_("Move Left/Right"), config.osd.dst_left, _("Use the Left/Right buttons on your remote to move the user interface left/right")))
-			self.list.append((_("Width"), config.osd.dst_width, _("Use the Left/Right buttons on your remote to adjust the size of the user interface. Left button decreases the size, Right increases the size.")))
-			self.list.append((_("Move Up/Down"), config.osd.dst_top, _("Use the Left/Right buttons on your remote to move the user interface up/down")))
-			self.list.append((_("Height"), config.osd.dst_height, _("Use the Left/Right buttons on your remote to adjust the size of the user interface. Left button decreases the size, Right increases the size.")))
-		if BoxInfo.getItem("CanChangeOsdPositionAML"):
-			self.list.append((_("Left"), config.osd.dst_left, _("Use the Left/Right buttons on your remote to move the user interface left")))
-			self.list.append((_("Right"), config.osd.dst_width, _("Use the Left/Right buttons on your remote to move the user interface right")))
-			self.list.append((_("Top"), config.osd.dst_top, _("Use the Left/Right buttons on your remote to move the user interface top")))
-			self.list.append((_("Bottom"), config.osd.dst_height, _("Use the Left/Right buttons on your remote to move the user interface bottom")))
-
-		self["config"].list = self.list
-		self["config"].l.setList(self.list)
-
-		self.onLayoutFinish.append(self.layoutFinished)
-		if self.selectionChanged not in self["config"].onSelectionChanged:
-			self["config"].onSelectionChanged.append(self.selectionChanged)
-		self.selectionChanged()
-
-	def selectionChanged(self):
-		self["status"].setText(self["config"].getCurrent()[2])
-
-	def layoutFinished(self):
-		self.setTitle(_(self.setup_title))
-#		self.Console.ePopen("/usr/bin/showiframe /usr/share/enigma2/hd-testcard.mvi")
-
-	def createSummary(self):
-		return SetupSummary
-
-	# for summary:
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-
-	def getCurrentEntry(self):
-		return self["config"].getCurrent()[0]
-
-	def getCurrentValue(self):
-		return str(self["config"].getCurrent()[1].getText())
+		Setup.__init__(self, session, "OSDCalibration")
+		self.skinName = ["OSDCalibration"]
+		text = []
+		text.append(_("Before changing these settings try to disable any overscan settings on th TV / display screen. To calibrate the On-Screen-Display (OSD) adjust the position and size values until the red box is *just* visible and touches the edges of the screen."))
+		text.append(_("When the red box is correctly visible press the GREEN button to save the settings and exit."))
+		self["text"] = Label("\n".join(text))
+		self.screenWidthScale = getDesktop(0).size().width() / 720.0
+		self.screenHeightScale = getDesktop(0).size().height() / 576.0
 
 	def keyLeft(self):
-		ConfigListScreen.keyLeft(self)
+		Setup.keyLeft(self)
 		if BoxInfo.getItem("CanChangeOsdPosition"):
 			self.setPreviewPosition()
 
 	def keyRight(self):
-		ConfigListScreen.keyRight(self)
+		Setup.keyRight(self)
 		if BoxInfo.getItem("CanChangeOsdPosition"):
 			self.setPreviewPosition()
 
-	def keyDefault(self):
-		config.osd.alpha.setValue(255)
-		config.osd.alpha_teletext.setValue(255)
-		config.osd.alpha_webbrowser.setValue(255)
-
-		if BoxInfo.getItem("CanChangeOsdPosition"):
-			config.osd.dst_width.setValue(720)
-			config.osd.dst_height.setValue(576)
-			config.osd.dst_left.setValue(0)
-			config.osd.dst_top.setValue(0)
-		elif BoxInfo.getItem("CanChangeOsdPositionAML"):
-			limits = [int(x) for x in iAVSwitch.getWindowsAxis().split()]
-			config.osd.dst_left.setValue(limits[0])
-			config.osd.dst_top.setValue(limits[1])
-			config.osd.dst_width.setValue(limits[2])
-			config.osd.dst_height.setValue(limits[3])
-		self["config"].l.setList(self.list)
-
 	def setPreviewPosition(self):
-		size_w = getDesktop(0).size().width()
-		size_h = getDesktop(0).size().height()
-		dsk_w = int(float(size_w)) / float(720)
-		dsk_h = int(float(size_h)) / float(576)
-		dst_left = int(config.osd.dst_left.value)
-		dst_width = int(config.osd.dst_width.value)
-		dst_top = int(config.osd.dst_top.value)
-		dst_height = int(config.osd.dst_height.value)
-		while dst_width + (dst_left / float(dsk_w)) >= 720.5 or dst_width + dst_left > 720:
-			dst_width = int(dst_width) - 1
-		while dst_height + (dst_top / float(dsk_h)) >= 576.5 or dst_height + dst_top > 576:
-			dst_height = int(dst_height) - 1
+		left = config.osd.dst_left.value
+		top = config.osd.dst_top.value
+		width = config.osd.dst_width.value
+		height = config.osd.dst_height.value
+		while width + (left / self.screenWidthScale) >= 720.5 or width + left > 720:
+			width -= 1
+		while height + (top / self.screenHeightScale) >= 576.5 or height + top > 576:
+			height -= 1
+		print(f"[OSDCalibration] Setting OSD position to (X={left}, Y={top}) and size to (W={width}, H={height}).")
+		config.osd.dst_left.setValue(left)
+		config.osd.dst_top.setValue(top)
+		config.osd.dst_width.setValue(width)
+		config.osd.dst_height.setValue(height)
+		for entry in self["config"].getList():
+			self["config"].invalidate(entry)
 
-		config.osd.dst_left.setValue(dst_left)
-		config.osd.dst_width.setValue(dst_width)
-		config.osd.dst_top.setValue(dst_top)
-		config.osd.dst_height.setValue(dst_height)
-		print(f"[UserInterfacePositioner] Setting OSD position: {config.osd.dst_left.value} {config.osd.dst_width.value} {config.osd.dst_top.value} {config.osd.dst_height.value}")
-
-	def saveAll(self):
-		for x in self["config"].list:
-			x[1].save()
-		configfile.save()
-
-	# keySave and keyCancel are just provided in case you need them.
-	# you have to call them by yourself.
-	def keySave(self):
-		self.saveAll()
-		self.close()
-
-	def cancelConfirm(self, result):
-		if not result:
-			return
-
-		for x in self["config"].list:
-			x[1].cancel()
-		self.close()
-
-	def keyCancel(self):
-		if self["config"].isChanged():
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), default=False)
-		else:
-			self.close()
-
-	def run(self):
-		config.osd.dst_left.save()
-		config.osd.dst_width.save()
-		config.osd.dst_top.save()
-		config.osd.dst_height.save()
+	def run(self):  # This is called by the Wizard.
+		config.osd.save()
 		configfile.save()
 		self.close()

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -697,20 +697,15 @@ if BoxInfo.getItem("architecture") in ("aarch64"):
 from traceback import print_exc
 from Components.config import config, ConfigYesNo, ConfigSubsection, ConfigInteger, ConfigText, ConfigOnOff, ConfigSelection
 
-config.osd = ConfigSubsection()
-
 defaultLocale = {
 	"Atto.TV": "pt_BR",
 	"Zgemma": "en_US",
 	"Beyonwiz": "en_AU"
 }.get(DISPLAYBRAND, "de_DE")
 config.misc.locale = ConfigText(default=defaultLocale)
+config.misc.locale.addNotifier(localeNotifier)
 config.misc.language = ConfigText(default=international.getLanguage(defaultLocale))
 config.misc.country = ConfigText(default=international.getCountry(defaultLocale))
-config.osd.language = ConfigText(default=defaultLocale)
-config.osd.language.addNotifier(localeNotifier)
-# TODO
-# config.misc.locale.addNotifier(localeNotifier)
 
 # These entries should be moved back to UsageConfig.py when it is safe to bring UsageConfig init to this location in StartEnigma.py.
 #

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -184,7 +184,7 @@ eServiceDVD::eServiceDVD(eServiceReference ref):
 	ddvd_set_dvd_path(m_ddvdconfig, ref.path.c_str());
 	ddvd_set_ac3thru(m_ddvdconfig, 0);
 
-	std::string ddvd_language = eConfigManager::getConfigValue("config.osd.language");
+	std::string ddvd_language = eConfigManager::getConfigValue("config.misc.locale");
 	if (ddvd_language != "")
 		ddvd_set_language(m_ddvdconfig, (ddvd_language.substr(0, 2)).c_str());
 


### PR DESCRIPTION
[AVSwitch.py]
- Complete rewrite and optimization of the code.
- Remove dead code and duplicated methods.
- Use C++ helper code to reduce the Python code complexity.
- Move "config.osd" ConfigSubsection here from"StartEnigma.py" and "UsageConfig.py" here as this is where it is most appropriate.
- Raname "iAVSwitch" to "avSwitch" to better reflect its definition and usage.  The old name pointed to the new name to keep old code functional.
- Use f-strings.

[StartEnigma.py]
- Remove "config.osd" ConfigSubsection definition and move it to "AVSwitch.py"..
- Remove the defunct "config.osd.language" definition and use the newer "config.misc.locale" definition.  The "config.osd.language" functionality is still maintained for code that has not yet been fixed. Note that "config.osd.language" is actually a locale and not a language!

[UsageConfig.py]
- Remove "config.osd" ConfigSubsection usage and move it to "AVSwitch.py".
- Remove the now defunct "AVSwitch" import.
- Small code optimization.

[dvbci.cpp]
- Adjust the code to use the primary "config.misc.locale" definition.

[servicedvb.cpp]
- Adjust the code to use the primary "config.misc.locale" definition.

[OSDCalibration.py]
- Complete code refactor and optimization.
- Make the screen a subclass of "Setup".
- Create a smarter singular embedded screen for the user interface.

[Setup.xml]
- Create a new "OSDCalibration" section to support the new "OSDCalibration" Setup based screen.

This code and pull request is based on the effort and work of @Captain, @Jbleyel, and @IanSav.
