### PR TITLE
[Menu.py] Use only ActionMap navigation

### DIFF
--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -431,6 +431,7 @@ class Menu(Screen, ProtectedScreen):
 		self["menu"].setList(menu)
 
 	def layoutFinished(self):
+		self["menu"].enableAutoNavigation(False)
 		self["menu"].setStyle(config.usage.menuEntryStyle.value)
 		self.selectionChanged()
 


### PR DESCRIPTION
This change ensures that the C++ default navigation is disabled so that only the ActionMap navigation is used.
