### PR TITLE
[ChannelSelection.py] Correct legacy bouquet navigation

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -183,12 +183,12 @@ class ChannelSelectionBase(Screen):
 			"bottom": (self.servicelist.goBottom, _("Move to the last line / screen"))
 		}, prio=0, description=_("Channel Selection Navigation Actions"))
 		self["legacyNavigationActions"] = HelpableActionMap(self, ["NavigationActions", "PreviousNextActions"], {
-			"pageUp": (self.prevBouquet, _("Move to previous bouquet")),
+			"pageUp": (self.nextBouquet, _("Move to next bouquet")),
 			"previous": (self.prevMarker, _("Move to previous marker")),
 			"left": (self.servicelist.goLeft, _("Move up a screen / Move to previous item")),
 			"right": (self.servicelist.goRight, _("Move down a screen / Move to next item")),
 			"next": (self.nextMarker, _("Move to next marker")),
-			"pageDown": (self.nextBouquet, _("Move to next bouquet"))
+			"pageDown": (self.prevBouquet, _("Move to previous bouquet"))
 		}, prio=0, description=_("Channel Selection Navigation Actions"))
 		self["legacyNavigationActions"].setEnabled(config.misc.actionLeftRightToPageUpPageDown.value)
 		self["newNavigationActions"] = HelpableActionMap(self, ["NavigationActions"], {


### PR DESCRIPTION
This commit corrects the legacy navigation where the buttons for previous and next bouquet selection were reversed.
