### PR TITLE
[Skin.py] Correct deprecation warning from Python.

### DIFF
--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -2327,7 +2327,7 @@ def findWidgets(name):
 # Return the XML formatting and style template for a multi content listbox.
 #
 def getcomponentTemplate(component, name):
-	if component in componentTemplates and componentTemplates[component][name]:
+	if component in componentTemplates and componentTemplates[component][name] is not None:
 		return componentTemplates[component][name]
 	return None
 


### PR DESCRIPTION
Correct a deprecation warning from Python being logged in the Enigma logs.
