### PR TITLE
[Menu] Add an option to show all Information screens

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -20,7 +20,7 @@
 		<menu key="information" level="0" text="Information" description="This menu contains selections to display information about the receiver." weight="5">
 			<item key="distribution_info_screen" level="0" text="About openATV" weight="5"><screen module="Information" screen="DistributionInformation" /></item>
 			<item key="receiver_info_screen" level="0" text="Receiver" weight="10"><screen module="Information" screen="ReceiverInformation" /></item>
-			<!--item key="picture_info_screen" level="0" text="Pictures" weight="15"><screen module="Information" screen="PictureInformation" /></item-->
+			<item key="picture_info_screen" level="0" text="Pictures" weight="15" conditional="config.usage.informationShowAllMenuScreens.value"><screen module="Information" screen="PictureInformation" /></item>
 			<item key="tuner_info_screen" level="0" text="Tuners" weight="20"><screen module="Information" screen="TunerInformation" /></item>
 			<item key="storage_info_screen" level="0" text="Storage / Disks" weight="25"><screen module="Information" screen="StorageInformation" /></item>
 			<item key="memory_info_screen" level="0" text="Memory" weight="30"><screen module="Information" screen="MemoryInformation" /></item>
@@ -28,11 +28,11 @@
 			<item key="multiboot_info_screen" level="0" text="MultiBoot" weight="40" requires="canMultiBoot"><screen module="Information" screen="MultiBootInformation" /></item>
 			<item key="streaming_info_screen" level="2" text="Streaming" weight="45"><screen module="Information" screen="StreamingInformation" /></item>
 			<item key="geolocation_info_screen" level="0" text="Geolocation" weight="50"><screen module="Information" screen="GeolocationInformation" /></item>
-			<!--item key="build_info_screen" level="2" text="Build" weight="55"><screen module="Information" screen="BuildInformation" /></item-->
-			<!--item key="system_info_screen" level="2" text="System" weight="60"><screen module="Information" screen="SystemInformation" /></item-->
-			<!--item key="commit_info_screen" level="2" text="Commit" weight="65"><screen module="Information" screen="CommitInformation" /></item-->
-			<!--item key="debug_info_screen" level="2" text="Debug" weight="70"><screen module="Information" screen="DebugInformation" /></item-->
-			<!--item key="translation_info_screen" level="2" text="Translation" weight="75"><screen module="Information" screen="TranslationInformation" /></item-->
+			<item key="build_info_screen" level="2" text="Build" weight="55" conditional="config.usage.informationShowAllMenuScreens.value"><screen module="Information" screen="BuildInformation" /></item>
+			<item key="system_info_screen" level="2" text="System" weight="60" conditional="config.usage.informationShowAllMenuScreens.value"><screen module="Information" screen="SystemInformation" /></item>
+			<item key="commit_info_screen" level="2" text="Commit" weight="65" conditional="config.usage.informationShowAllMenuScreens.value"><screen module="Information" screen="CommitInformation" /></item>
+			<item key="debug_info_screen" level="2" text="Debug" weight="70" conditional="config.usage.informationShowAllMenuScreens.value"><screen module="Information" screen="DebugInformation" /></item>
+			<item key="translation_info_screen" level="2" text="Translation" weight="75" conditional="config.usage.informationShowAllMenuScreens.value"><screen module="Information" screen="TranslationInformation" /></item>
 			<item key="service_info_screen" level="1" text="Service" weight="80"><screen module="Information" screen="ServiceInformation" /></item>
 		</menu>
 		<!-- Menu / Timer -->

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -996,6 +996,7 @@
 		<item level="0" text="Button error timeout" description="Select how long to display the button error pop up. Button input is still permitted while the pop up is displayed.">config.usage.unhandledKeyTimeout</item>
 		<item level="0" text="Show animation while busy" description="Show a spinning logo when the system is busy.">config.usage.show_spinner</item>
 		<item level="2" text="Show screensaver" description="Configure the duration in minutes before the screen saver will be displayed.">config.usage.screen_saver</item>
+		<item level="2" text="Show all Information screens" description="Enable this option to show all the available Information screens in the Information menu item list.">config.usage.informationShowAllMenuScreens</item>
 		<item level="2" text="Show extra spacing in Information" description="Enable to add some extra spacing to the Information screens. This can improve readability.">config.usage.informationExtraSpacing</item>
 		<item level="0" text="1st InfoBar timeout" description="Set the time to hide the infobar.">config.usage.infobar_timeout</item>
 		<item level="0" text="2nd InfoBar" description="Enable and set the duration of the second InfoBar (press 'OK' twice) that may include additional information.">config.usage.show_second_infobar</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -109,6 +109,7 @@ def InitUsageConfig():
 	config.usage.unhandledKeyTimeout = ConfigSelection(default=2, choices=[(x, ngettext("%d Second", "%d Seconds", x) % x) for x in range(1, 6)])
 	config.usage.show_spinner = ConfigYesNo(default=True)
 	config.usage.screen_saver = ConfigSelection(default="0", choices=[(0, _("Disabled"))] + [(x, _("%d Seconds") % x) for x in (5, 30)] + [(x * 60, ngettext("%d Minute", "%d Minutes", x) % x) for x in (1, 5, 10, 15, 20, 30, 45, 60)])
+	config.usage.informationShowAllMenuScreens = ConfigYesNo(default=False)
 	config.usage.informationExtraSpacing = ConfigYesNo(False)
 
 	# Settings for servicemp3 and handling from cue sheet file.


### PR DESCRIPTION
Add a configuration item "Show all Information screens" to the "OSD Settings" setup screen to enable the display of all available Information screens in the top level menu.  This can make some screens easier to access.
