### PR TITLE
[AudioSelection.py] Remove the volume control options

### DIFF
--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -12,7 +12,6 @@ from Components.Sources.StaticText import StaticText
 from Components.Sources.List import List
 from Components.Sources.Boolean import Boolean
 from Components.SystemInfo import BoxInfo
-from Components.VolumeControl import VolumeControl
 
 from enigma import iPlayableService, eTimer, eSize
 
@@ -68,9 +67,6 @@ class AudioSelection(ConfigListScreen, Screen):
 			"down": self.keyDown,
 			"left": self.keyLeft,
 			"right": self.keyRight,
-			"volumeUp": self.volumeUp,
-			"volumeDown": self.volumeDown,
-			"volumeMute": self.volumeMute,
 			"menu": self.openAutoLanguageSetup,
 			"1": self.keyNumberGlobal,
 			"2": self.keyNumberGlobal,
@@ -546,15 +542,6 @@ class AudioSelection(ConfigListScreen, Screen):
 				self.focus = FOCUS_STREAMS
 		elif self.focus == FOCUS_STREAMS:
 			self["streams"].selectNext()
-
-	def volumeUp(self):
-		VolumeControl.instance and VolumeControl.instance.volUp()
-
-	def volumeDown(self):
-		VolumeControl.instance and VolumeControl.instance.volDown()
-
-	def volumeMute(self):
-		VolumeControl.instance and VolumeControl.instance.volMute()
 
 	def keyNumberGlobal(self, number):
 		if number <= len(self["streams"].list):


### PR DESCRIPTION
These volume control options do not work as they are not accessible through any of the active ActionMaps.  Further, the volume controls are actually global functions that are centrally managed anyway so there would be no reason to force replicate those commands here.
