### PR TITLE
[OSCamInfo] plugin improvements

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -566,9 +566,11 @@
 		<if conditional="not config.oscaminfo.userDataFromConf.value">
 			<item level="0" text="Username (httpuser)" description="Username (httpuser)">config.oscaminfo.username</item>
 			<item level="0" text="Password (httpwd)" description="Password (httpuser)">config.oscaminfo.password</item>
-			<item level="0" text="IP address" description="IP address">config.oscaminfo.ip</item>
+			<item level="0" text="DNS name or IP address" description="DNS name or IP address">config.oscaminfo.ip</item>
 			<item level="0" text="Port" description="Port">config.oscaminfo.port</item>
+			<item level="0" text="Use HTTPS protocol" description="Use HTTPS protocol">config.oscaminfo.usessl</item>
 		</if>
+		<item level="0" text="Verify WebIf SSL certificate" description="Verify WebIf SSL certificate">config.oscaminfo.verifycert</item>
 		<item level="0" text="Automatically update Client/Server View" description="Automatically update Client/Server View">config.oscaminfo.autoUpdate</item>
 		<item level="0" text="Automatically update Log-Fullscreen View" description="Automatically update Log-Fullscreen View">config.oscaminfo.autoUpdateLog</item>
 	</setup>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -2200,8 +2200,10 @@ def InitUsageConfig():
 	config.oscaminfo.userDataFromConf = ConfigYesNo(default=True)
 	config.oscaminfo.username = ConfigText(default="username", fixed_size=False, visible_width=12)
 	config.oscaminfo.password = ConfigPassword(default="password", fixed_size=False)
-	config.oscaminfo.ip = ConfigIP(default=[127, 0, 0, 1], auto_jump=True)
-	config.oscaminfo.port = ConfigInteger(default=16002, limits=(0, 65536))
+	config.oscaminfo.ip = ConfigText(default="127.0.0.1", fixed_size=False)
+	config.oscaminfo.port = ConfigInteger(default=83, limits=(0, 65536))
+	config.oscaminfo.usessl = ConfigYesNo(default=False)
+	config.oscaminfo.verifycert = ConfigYesNo(default=False)
 	choiceList = [
 		(0, _("Disabled"))
 	] + [(x, ngettext("%d Second", "%d Seconds", x) % x) for x in (2, 5, 10, 20, 30)] + [(x * 60, ngettext("%d Minute", "%d Minutes", x) % x) for x in (1, 2, 3)]


### PR DESCRIPTION
- OSCamInfo screen: show binary signing information if oscam binary was signed
- OSCamInfo screen: adjust some elements in position and size
- OSCamInfoSetup screen: ip address option now also accepts dns names (config.oscaminfo.ip, default=127.0.0.1)
- OSCamInfoSetup screen: new default value for port option (config.oscaminfo.port, default=83)
- OSCamInfoSetup screen: new option to enable the use of https protocol (config.oscaminfo.usessl, default=off)
- OSCamInfoSetup screen: new option to enable certificate verifying (config.oscaminfo.verifycert, default=off)