### PR TITLE
[MovieSelection.py] Make empty directories deletable

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -1570,6 +1570,9 @@ class MovieSelection(Screen, SelectionEventInfo, InfoBarBase, ProtectedScreen):
 					folder_filename = split(split(name)[0])[1]
 					self.session.openWithCallback(self.delete, MessageBox, _("'%s' contains %d file(s) and %d sub-directories.\n") % (folder_filename, files, subdirs) + are_you_sure, windowTitle=self.getTitle())
 					return
+				else:
+					self.session.openWithCallback(self.delete, MessageBox, are_you_sure, windowTitle=self.getTitle())
+					return
 			else:
 				if TRASHCAN in cur_path:
 					are_you_sure = _("Do you really want to permanently remove from trash can ?")


### PR DESCRIPTION
This change allows empty directories to be deleted.  For some reason this was previously prohibited.

If anyone knows why this was previously not allowed and there is still an objection to this fix then please post some details so the fix can be reviewed.
