### PR TITLE
Link/connect Infobar and muteDialog

### DIFF
--- a/lib/python/Components/VolumeControl.py
+++ b/lib/python/Components/VolumeControl.py
@@ -97,11 +97,6 @@ class VolumeControl:
 		config.volumeControl.volume.setValue(self.dvbVolumeControl.getVolume())
 		config.volumeControl.save()
 
-	def showMute(self):  # This method is only called by InfoBarGenerics.py:
-		if self.dvbVolumeControl.isMuted():
-			self.muteDialog.show()
-			self.hideTimer.start(config.volumeControl.hideTimer.value * 1000, True)
-
 	# These methods are provided for compatibly with shared plugins.
 	#
 	def volUp(self):

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -827,7 +827,6 @@ class InfoBarShowHide(InfoBarScreenSaver):
 		for x in self.onShowHideNotifiers:
 			x(True)
 		self.startHideTimer()
-		VolumeControl.instance and VolumeControl.instance.showMute()
 
 	def doDimming(self):
 		if config.usage.show_infobar_do_dimming.value:


### PR DESCRIPTION
Issue #3504 Infobar opens the muteDialog, but couldn't handle it.
Now Infobar open and close it together.
The muteDialog will not longer coverup other Screens while its open, this is only desired for a volume action.
Fix a Bug that an open Infobar cancels the volumeMuteLong action.