### PR TITLE
Optionally add MovieSelection to Main Menu

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -42,6 +42,7 @@
 			<item key="crontimer_edit" level="0" text="Cron Timers" weight="10"><screen module="CronTimer" screen="CronTimers" /></item>
 			<item key="sleep" level="0" text="Sleep Timers" weight="20" requires="DeepstandbySupport"><screen module="SleepTimer" screen="SleepTimer" /></item>
 		</menu>
+		<item key="movie_selection" level="0" text="Movie Selection Player" description="Select and play movie files." weight="8" conditional="config.usage.movieSelectionInMenu.value"><screen module="MovieSelection" screen="MovieSelection" /></item>
 		<item key="plugin_selection" level="1" text="Plugin Browser" weight="10"><screen module="PluginBrowser" screen="PluginBrowser" /></item>
 		<item key="scart_switch" level="1" text="VCR Scart Settings" weight="15" conditional="config.usage.show_vcr_scart.value" requires="ScartSwitch"><code>self.session.scart.VCRSbChanged(3)</code></item>
 		<!-- Menu / Setup -->

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -1015,6 +1015,7 @@
 		<item level="2" text="Screen saver movement" description="Select how long the screen saver image will stay in the same location on the screen before it will be moved." conditional="config.usage.screenSaverStartTimer.value">config.usage.screenSaverMoveTimer</item>
 		<item level="2" text="Show all Information screens" description="Enable this option to show all the available Information screens in the Information menu item list.">config.usage.informationShowAllMenuScreens</item>
 		<item level="2" text="Show extra spacing in Information" description="Enable to add some extra spacing to the Information screens. This can improve readability.">config.usage.informationExtraSpacing</item>
+		<item level="0" text="Show Movie Selection Player in Main Menu" description="Select 'Yes' to show the 'Movie Selection Player' entry in the Main Menu. This can provide access to the Movie Selection Player screen when there is no assigned button on the remote control." restart="gui">config.usage.movieSelectionInMenu</item>
 		<item level="0" text="1st InfoBar timeout" description="Set the time to hide the infobar.">config.usage.infobar_timeout</item>
 		<item level="0" text="2nd InfoBar" description="Enable and set the duration of the second InfoBar (press 'OK' twice) that may include additional information.">config.usage.show_second_infobar</item>
 		<item level="0" text="2nd InfoBar timeout" description="Set the time to hide the second infobar. The bar also disappears on pressing 'OK'.">config.usage.second_infobar_timeout</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -116,6 +116,7 @@ def InitUsageConfig():
 	config.usage.screenSaverMoveTimer = ConfigSelection(default=10, choices=[(x, ngettext("%d Second", "%d Seconds", x) % x) for x in range(1, 61)])
 	config.usage.informationShowAllMenuScreens = ConfigYesNo(default=False)
 	config.usage.informationExtraSpacing = ConfigYesNo(False)
+	config.usage.movieSelectionInMenu = ConfigYesNo(False)
 
 	# Settings for servicemp3 and handling from cue sheet file.
 	config.usage.useVideoCuesheet = ConfigYesNo(default=True)  # Use marker for video media file.


### PR DESCRIPTION
This change adds an option "Show Movie Selection Player" to the "OSD Settings" screen that will allow users to add a ""Movie Selection Player" option to the Main Menu.  This is useful for users who do not have the appropriate FILE, LIST, MEDIA, PVR, or VIDEO button on their remote control.  The default is to not add this menu item to the Main Menu.
