### PR TITLE
[ChannelSelection] improve Subservices

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -2644,7 +2644,7 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 		return ret
 
 	def addToHistory(self, ref):
-		if not self.isSubservices():
+		if not self.isSubservices() or not self.history:
 			if self.delhistpoint is not None:
 				x = self.delhistpoint
 				while x <= len(self.history) - 1:


### PR DESCRIPTION
- don't let the history empty(on startup), this can crash.