### PR TITLE
[InfoBar] Remove duplicated timer button class

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -992,11 +992,6 @@
 		<key id="KEY_TEXT" mapto="startTeletext" flags="b" />
 	</map>
 
-	<map context="InfobarTimerButtonActions">
-		<key id="KEY_PROGRAM" mapto="timerSelection" flags="b" />
-		<key id="KEY_CALENDAR" mapto="openAutoTimerList" flags="b" />
-	</map>
-
 	<map context="InfobarTimeshiftActions">
 		<key id="KEY_PLAY" mapto="timeshiftStart" flags="m" />
 		<key id="KEY_TV" mapto="timeshiftStop" flags="m" />

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -22,7 +22,7 @@ boxtype = BoxInfo.getItem("machinebuild")
 
 eProfileWrite("LOAD:InfoBarGenerics")
 from Screens.InfoBarGenerics import InfoBarShowHide, \
-	InfoBarNumberZap, InfoBarChannelSelection, InfoBarMenu, InfoBarRdsDecoder, InfoBarRedButton, InfoBarTimerButton, InfoBarVmodeButton, \
+	InfoBarNumberZap, InfoBarChannelSelection, InfoBarMenu, InfoBarRdsDecoder, InfoBarRedButton, InfoBarVmodeButton, \
 	InfoBarEPG, InfoBarSeek, InfoBarInstantRecord, InfoBarResolutionSelection, InfoBarAspectSelection, \
 	InfoBarAudioSelection, InfoBarAdditionalInfo, InfoBarNotifications, InfoBarDish, InfoBarUnhandledKey, InfoBarLongKeyDetection, \
 	InfoBarSubserviceSelection, InfoBarShowMovies, \
@@ -42,7 +42,7 @@ eProfileWrite("LOAD:InfoBar_Class")
 
 class InfoBar(InfoBarBase, InfoBarShowHide,
 	InfoBarNumberZap, InfoBarChannelSelection, InfoBarMenu, InfoBarEPG, InfoBarRdsDecoder,
-	InfoBarInstantRecord, InfoBarAudioSelection, InfoBarRedButton, InfoBarTimerButton, InfoBarResolutionSelection, InfoBarAspectSelection, InfoBarVmodeButton,
+	InfoBarInstantRecord, InfoBarAudioSelection, InfoBarRedButton, InfoBarResolutionSelection, InfoBarAspectSelection, InfoBarVmodeButton,
 	InfoBarAdditionalInfo, InfoBarNotifications, InfoBarDish, InfoBarUnhandledKey, InfoBarLongKeyDetection,
 	InfoBarSubserviceSelection, InfoBarTimeshift, InfoBarSeek, InfoBarCueSheetSupport, InfoBarBuffer,
 	InfoBarSummarySupport, InfoBarTimeshiftState, InfoBarTeletextPlugin, InfoBarExtensions,
@@ -89,7 +89,7 @@ class InfoBar(InfoBarBase, InfoBarShowHide,
 		self.radioTV = 0
 		for x in InfoBarBase, InfoBarShowHide, \
 				InfoBarNumberZap, InfoBarChannelSelection, InfoBarMenu, InfoBarEPG, InfoBarRdsDecoder, \
-				InfoBarInstantRecord, InfoBarAudioSelection, InfoBarRedButton, InfoBarTimerButton, InfoBarUnhandledKey, InfoBarLongKeyDetection, InfoBarResolutionSelection, InfoBarVmodeButton, \
+				InfoBarInstantRecord, InfoBarAudioSelection, InfoBarRedButton, InfoBarUnhandledKey, InfoBarLongKeyDetection, InfoBarResolutionSelection, InfoBarVmodeButton, \
 				InfoBarAdditionalInfo, InfoBarNotifications, InfoBarDish, InfoBarSubserviceSelection, InfoBarAspectSelection, InfoBarBuffer, \
 				InfoBarTimeshift, InfoBarSeek, InfoBarCueSheetSupport, InfoBarSummarySupport, InfoBarTimeshiftState, \
 				InfoBarTeletextPlugin, InfoBarExtensions, InfoBarPiP, InfoBarSubtitleSupport, InfoBarJobman, InfoBarZoom, InfoBarSleepTimer, InfoBarOpenOnTopHelper, InfoBarHandleBsod, \

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -4133,16 +4133,6 @@ class InfoBarRedButton:
 		# x()
 
 
-class InfoBarTimerButton:
-	def __init__(self):
-		self["TimerButtonActions"] = HelpableActionMap(self, "InfobarTimerButtonActions", {
-			"timerSelection": (self.timerSelection, _("Open RecordTimer Overview")),
-		}, prio=0, description=_("Timer Actions"))
-
-	def timerSelection(self):
-		self.session.open(RecordTimerOverview)
-
-
 class InfoBarAspectSelection:
 	STATE_HIDDEN = 0
 	STATE_ASPECT = 1


### PR DESCRIPTION
The functionality of the TIMER button is duplicated in both the InfoBar.py and InfoBarGenerics.py modules.  This change removes the InfoBarGenerics.py duplication.  The defunct key map is also removed.
