### PR TITLE
[VolumeControl.py] Defend against invalid volume.xml files

### DIFF
--- a/lib/python/Screens/VolumeControl.py
+++ b/lib/python/Screens/VolumeControl.py
@@ -334,15 +334,15 @@ class VolumeAdjust:
 			print(f"[VolumeControl] Volume adjustment data initialized from '{self.VOLUME_FILE}'.")
 			for offsets in volumeDom.findall("offsets"):
 				for entry in offsets.findall("offset"):
-					serviceReference = unescape(entry.get("serviceReference"))
-					serviceName = unescape(entry.get("serviceName"))
+					serviceReference = unescape(entry.get("serviceReference", ""))
+					serviceName = unescape(entry.get("serviceName", ""))
 					offset = int(entry.get("value", 0))
 					if serviceReference and serviceName:
 						volumeOffsets[serviceReference] = [serviceName, offset]
 			for remembered in volumeDom.findall("remembered"):
 				for entry in remembered.findall("remember"):
-					serviceReference = unescape(entry.get("serviceReference"))
-					serviceName = unescape(entry.get("serviceName"))
+					serviceReference = unescape(entry.get("serviceReference", ""))
+					serviceName = unescape(entry.get("serviceName", ""))
 					last = int(entry.get("value", self.DEFAULT_VOLUME))
 					if serviceReference and serviceName:
 						volumeRemembered[serviceReference] = [serviceName, last]


### PR DESCRIPTION
This change protects against the following error:

```
2025-07-12 16:42:36.1265   File "/usr/lib/python3.13/html/__init__.py", line 130, in unescape
2025-07-12 16:42:36.1267 TypeError: argument of type 'NoneType' is not iterable
```
If the volume.xml file is incorrect or invalid.
