### PR TITLE
[ButtonSetup.py] Remove redundant definition

### DIFF
--- a/lib/python/Screens/ButtonSetup.py
+++ b/lib/python/Screens/ButtonSetup.py
@@ -36,7 +36,7 @@ BUTTON_SETUP_KEYS = [
 	(_("Left"), "cross_left", ""),
 	(_("Left"), "cross_left_long", ""),
 	(_("Right"), "cross_right", ""),
-	(_("Right"), "cross_right_long", "Infobar/seekFwdVod"),
+	(_("Right"), "cross_right_long", ""),
 	(_("Up"), "cross_up", ""),
 	(_("Down"), "cross_down", ""),
 	(_("PageUp"), "pageup", ""),


### PR DESCRIPTION
The hard coded initialization definition "Infobar/seekFwdVod" for a long RIGHT is not required as this is already coded into the InfoBarSeek class.
