### PR TITLE
timeshift recovery

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -998,6 +998,7 @@
 		<item level="2" text="Time shift checking for free space" description="If the free space is less than setting value, then an attempt is made to delete the old time shift files.">config.timeshift.checkFreeSpace</item>
 		<item level="2" text="Time shift buffer delete after zap" description="Select 'No' to save older events even after zapping or interrupting time shifting.">config.timeshift.deleteAfterZap</item>
 		<item level="2" text="Time shift event based file splitting" description="Select 'No' to make time shift use a single buffer file. Use 'Time shift checking for older files [in minutes]' and 'Time shift checking for free space?' to control the size of the buffer file.">config.timeshift.fileSplitting</item>
+		<item level="2" text="Streaming recovery delay" description="Enter the duration to be added to the streaming buffer after a streaming error. This extra buffer can help to avoid further streaming issues due to a lack of buffer space.">config.timeshift.recoveryBufferDelay</item>
 	</setup>
 	<setup key="Tuner" title="Tuner Settings" level="1">
 		<item level="1" text="Force LNB Power" description="Force LNB Tuner Power settings." requires="ForceLNBPowerChanged">config.tunermisc.forceLnbPower</item>

--- a/lib/dvb/decoder.h
+++ b/lib/dvb/decoder.h
@@ -222,6 +222,9 @@ public:
 	RESULT fccSetPids(int fe_id, int vpid, int vtype, int pcrpid);
 	RESULT fccGetFD();
 	RESULT fccFreeFD();
+
+	bool canFlush() const { return true; }
+
 };
 
 #endif

--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -550,7 +550,14 @@ int eDVBRecordFileThread::asyncWrite(int len)
 	gettimeofday(&starttime, NULL);
 #endif
 	if(!getProtocol())
-		m_ts_parser.parseData(m_current_offset, m_buffer, len);
+	{
+		int parse_result = m_ts_parser.parseData(m_current_offset, m_buffer, len);
+		if (parse_result == -2)
+		{
+			m_event(eFilePushThreadRecorder::evtStreamCorrupt);
+			return len;
+		}
+	}
 
 #ifdef SHOW_WRITE_TIME
 	gettimeofday(&now, NULL);
@@ -1022,6 +1029,10 @@ void eDVBTSRecorder::filepushEvent(int event)
 	{
 	case eFilePushThread::evtWriteError:
 		m_event(eventWriteError);
+		break;
+	case eFilePushThreadRecorder::evtStreamCorrupt:
+		eDebug("[eDVBTSRecorder] Stream corruption detected, emitting signal!");
+		m_event(eventStreamCorrupt);
 		break;
 	}
 }

--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -1804,8 +1804,8 @@ bool eDVBResourceManager::canMeasureFrontendInputPower()
 class eDVBChannelFilePush: public eFilePushThread
 {
 public:
-	eDVBChannelFilePush(int packetsize = 188):
-		eFilePushThread(IOPRIO_CLASS_BE, 0, packetsize, packetsize * 512),
+	eDVBChannelFilePush(int packetsize = 188, int flags = 0):
+		eFilePushThread(IOPRIO_CLASS_BE, 0, packetsize, packetsize * 512, flags),
 		m_iframe_search(0),
 		m_iframe_state(0),
 		m_pid(0),
@@ -2526,7 +2526,14 @@ RESULT eDVBChannel::playSource(ePtr<iTsSource> &source, const char *streaminfo_f
 		}
 	}
 
-	m_pvr_thread = new eDVBChannelFilePush(m_source->getPacketSize());
+	int flags = 0;
+	if (streaminfo_file && strstr(streaminfo_file, "timeshift"))
+	{
+		eDebug("[eDVBChannel] playsource timeshift mode");
+		flags = 1;
+	}
+
+	m_pvr_thread = new eDVBChannelFilePush(m_source->getPacketSize(), flags);
 	m_pvr_thread->enablePVRCommit(1);
 	m_pvr_thread->setStreamMode(m_source->isStream());
 	m_pvr_thread->setScatterGather(this);

--- a/lib/dvb/filepush.h
+++ b/lib/dvb/filepush.h
@@ -19,7 +19,7 @@ class eFilePushThread: public eThread, public sigc::trackable, public iObject
 {
 	DECLARE_REF(eFilePushThread);
 public:
-	eFilePushThread(int prio_class=IOPRIO_CLASS_BE, int prio_level=0, int blocksize=188, size_t buffersize=188*1024);
+	eFilePushThread(int prio_class=IOPRIO_CLASS_BE, int prio_level=0, int blocksize=188, size_t buffersize=188*1024, int flags=0);
 	~eFilePushThread();
 	void thread();
 	void stop();
@@ -48,6 +48,7 @@ private:
 	int m_fd_dest;
 	int m_send_pvr_commit;
 	int m_stream_mode;
+	int m_flags;
 	int m_sof;
 	int m_blocksize;
 	size_t m_buffersize;
@@ -72,7 +73,7 @@ public:
 	void stop();
 	void start(int sourcefd);
 
-	enum { evtEOF, evtReadError, evtWriteError, evtUser, evtStopped };
+	enum { evtEOF, evtReadError, evtWriteError, evtUser, evtStopped, evtStreamCorrupt };
 	sigc::signal<void(int)> m_event;
 
 	int getProtocol() { return m_protocol;}

--- a/lib/dvb/idemux.h
+++ b/lib/dvb/idemux.h
@@ -55,6 +55,7 @@ public:
 		eventReachedBoundary,
 				/* the programmed boundary was reached. you might set a new target fd. you can close the */
 				/* old one. */
+		eventStreamCorrupt
 	};
 	virtual RESULT connectEvent(const sigc::slot<void(int)> &event, ePtr<eConnection> &conn)=0;
 };

--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -848,6 +848,10 @@ public:
 
 	virtual RESULT setRadioPic(const std::string &filename) = 0;
 
+	virtual bool canFlush() const { return false; }
+
+	virtual RESULT flush() const { return -1; }
+
 	struct videoEvent
 	{
 		enum { eventUnknown = 0,

--- a/lib/dvb/pmt.h
+++ b/lib/dvb/pmt.h
@@ -144,6 +144,7 @@ public:
 		eventStopped,
 		eventStartPvrDescramble,   // start PVR Descramble Convert
 		eventChannelAllocated,
+		eventStreamCorrupt,
 	};
 #ifndef SWIG
 	sigc::signal<void(int)> serviceEvent;

--- a/lib/dvb/pvrparse.h
+++ b/lib/dvb/pvrparse.h
@@ -115,7 +115,7 @@ class eMPEGStreamParserTS: public eMPEGStreamInformationWriter
 {
 public:
 	eMPEGStreamParserTS(int packetsize = 188);
-	void parseData(off_t offset, const void *data, unsigned int len);
+	int parseData(off_t offset, const void *data, unsigned int len);
 	void setPid(int pid, iDVBTSRecorder::timing_pid_type pidtype, int streamtype);
 	int getLastPTS(pts_t &last_pts);
 	int getFirstPTS(pts_t &first_pts);

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -249,6 +249,7 @@ protected:
 
 	/* pvr */
 	bool m_is_pvr;
+	pts_t m_pause_position;
 	int m_is_paused, m_timeshift_enabled, m_timeshift_active, m_timeshift_changed, m_save_timeshift;
 	int m_first_program_info;
 
@@ -335,6 +336,23 @@ protected:
 	void video_event(struct iTSMPEGDecoder::videoEvent);
 
 	virtual ePtr<iTsSource> createTsSource(eServiceReferenceDVB& ref, int packetsize = 188);
+
+	ePtr<eConnection> m_con_record_event;
+	void recordEvent(int event);
+
+private:
+	// -- START: Precise Recovery System --
+	// This system handles stream corruption during timeshift, with support for a custom recovery delay.
+	ePtr<eTimer> m_precise_recovery_timer;
+	bool m_stream_corruption_detected;
+	pts_t m_original_timeshift_delay; // Stores the target timeshift delay.
+	bool m_delay_calculated; // Flag to ensure delay is calculated only once.
+	int m_recovery_delay_seconds; // Custom recovery delay in seconds, set via API.
+
+	void handleEofRecovery();
+	void startPreciseRecoveryCheck();
+	void resetRecoveryState(); // Resets all recovery state variables.
+	// -- END: Precise Recovery System --
 };
 
 class eStaticServiceDVBBouquetInformation : public iStaticServiceInformation {


### PR DESCRIPTION
This commit introduces a robust recovery mechanism for time shift to handle stream interruptions gracefully.

Previously, events like signal loss or stream corruption would often cause the time shift session to fail, disrupting the user experience, especially on scrambled channels.

The new "precise recovery" system implements the following logic:
* On a tune failure or stream corruption event, video playback is paused instead of being stopped.
* The time shift buffer continues to be recorded in the background.
* The system captures the user's current time shift delay to use as a recovery target.
* Playback is automatically and smoothly resumed once the buffer has been replenished to the target delay plus a safety margin.

Co-authored-by @Najar1991