### PR TITLE
StreamRelay: Fix service restart on disable and refresh channel list

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -1559,7 +1559,11 @@ class ChannelContextMenu(Screen):
 
 	def toggleStreamrelay(self):
 		from Screens.InfoBarGenerics import streamrelay
+		from enigma import eTimer
 		streamrelay.toggle(self.session.nav, self.csel.getCurrentSelection())
+		self.csel.refreshServiceListTimer = eTimer()
+		self.csel.refreshServiceListTimer.callback.append(self.csel.servicelist.resetRoot)
+		self.csel.refreshServiceListTimer.start(100, True)
 		self.close()
 
 	def selectCamProvider(self):

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -1765,13 +1765,14 @@ class InfoBarStreamRelay:
 			service = service or nav.getCurrentlyPlayingServiceReference()
 			if service:
 				servicestring = service.toCompareString()
+				currentlyPlaying = nav.getCurrentlyPlayingServiceReference()
 				if servicestring in self.__services:
 					self.__services.remove(servicestring)
 				else:
 					self.__services.append(servicestring)
-					if nav.getCurrentlyPlayingServiceReference() and nav.getCurrentlyPlayingServiceReference() == service:
-						nav.restartService()
 				self.write()
+				if currentlyPlaying and currentlyPlaying == service:
+					nav.restartService()
 
 	def __getData(self):
 		return self.__services


### PR DESCRIPTION
Previously, disabling StreamRelay did not restart the service, causing a black screen until manually switching channels. Also, the channel list displayed incorrect colors (grayed out) after toggling StreamRelay until the list was closed and reopened.

Changes:
* InfoBarGenerics: Call restartService() for both enable and disable operations
* ChannelSelection: Add delayed resetRoot() call after StreamRelay toggle to refresh visual state