### PR TITLE
Add forceRestart parameter to callback on PIN entry

### DIFF
--- a/lib/python/Components/ParentalControl.py
+++ b/lib/python/Components/ParentalControl.py
@@ -174,7 +174,7 @@ class ParentalControl:
 		if result is not None and result:
 			self.setSessionPinCached()
 			self.hideBlacklist()
-			self.callback(ref=service)
+			self.callback(ref=service, forceRestart=True)
 		else:  # This is the new function of caching canceling of service PIN.
 			if result is not None:
 				messageText = _("The PIN code entered is incorrect!")


### PR DESCRIPTION
Now it switches to the PIN-protected channel in the same bouquet.
Previously, it correctly switched to the PIN-protected channel if it was in a different bouquet.