### PR TITLE
[InstantRecordTimerEdit] remove wrong line

### DIFF
--- a/lib/python/Screens/Timers.py
+++ b/lib/python/Screens/Timers.py
@@ -1814,6 +1814,8 @@ class InstantRecordTimerEdit(RecordTimerEdit):
 
 	def keySave(self, result=None):
 		if self.timer.justplay:
+			# self.timer.begin += config.recording.zap_margin_before.value * 60
+			# self.timer.marginBefore = 0
 			self.timer.hasEndTime = config.recording.zap_has_endtime.value
 			if not self.timer.hasEndTime:
 				self.timer.end = self.timer.begin + 1


### PR DESCRIPTION
[This commit](https://github.com/openatv/enigma2/commit/e5b09ccd90600db4d1c720c0752383a1199af545) starts removing the default margin(serious used for recordings).
Later it was replaced by the zap margin but now we have a seperate zap margin and this should not removed anymore.