### PR TITLE
[SoftCSA] create separate CSA session for timeshift

### DIFF
--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -274,6 +274,7 @@ protected:
 
 	/* time shift */
 	ePtr<iDVBTSRecorder> m_record;
+	ePtr<eDVBCSASession> m_timeshift_csa_session;
 	std::set<int> m_pids_active;
 
 	void updateTimeshiftPids();

--- a/lib/service/servicedvbsoftdecoder.h
+++ b/lib/service/servicedvbsoftdecoder.h
@@ -118,6 +118,7 @@ private:
 	pts_t m_last_pts;
 	int m_stall_count;
 	bool m_stream_stalled;
+	bool m_paused;
 	void streamHealthCheck();
 
 	// Event Handlers


### PR DESCRIPTION
When SoftDecoder and Timeshift recorder both used the same CSA session, they would call descramble() concurrently on the same engine, causing race conditions on the shared m_batch_even/m_batch_odd vectors.

This resulted in "broken startcode" errors and video glitches, particularly with auto-timeshift on CSA-ALT channels.

Solution: Create independent m_timeshift_csa_session for timeshift recorder, matching the recording architecture which already uses separate sessions. Each session has its own engine with independent batch buffers - no mutex needed, no blocking on CW updates.

Both sessions receive CWs from CAHandler (same service reference) and descramble independently without interference.

Also fix StreamHealthCheck false stall detection during pause: Add m_paused flag to SoftDecoder to track pause state. Skip stall detection while paused since PTS naturally stops when decoder is paused (e.g. during timeshift pause).