### PR TITLE
Capitalize library name in information display

### DIFF
--- a/lib/python/Screens/Information.py
+++ b/lib/python/Screens/Information.py
@@ -712,7 +712,7 @@ class DistributionInformation(InformationBase):
 			libName = eDVBCSAEngine.getLibraryName()
 			libVersion = eDVBCSAEngine.getLibraryVersion()
 			if libName and libVersion:
-				libName = libName.capitalize()				
+				libName = libName.capitalize()
 				versions.append((libName, libVersion))
 		for version in versions:
 			info.append(formatLine("P1", _("%s version") % version[0], version[1]))


### PR DESCRIPTION
Matching to other versions in software info.
![soft](https://github.com/user-attachments/assets/2149bb4e-4066-45f8-ad8e-b45d4f7dc2f8)
