### PR TITLE
[SoftCSA] Fix false AIO fallback to sync mode during stop

### DIFF
--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -763,6 +763,8 @@ int eDVBRecordFileThread::writeData(int len)
 		len = asyncWrite(len);
 		if (len < 0)
 		{
+			if (m_stop)
+				return len;
 			// Check for ENOSYS (AIO not supported by kernel) - automatic fallback to sync
 			if (errno == ENOSYS)
 			{
@@ -779,6 +781,8 @@ int eDVBRecordFileThread::writeData(int len)
 		int r = m_current_buffer->wait(&m_stop);
 		if (r < 0)
 		{
+			if (m_stop)
+				return len;
 			// Check for ENOSYS in wait (aio_return) - automatic fallback to sync
 			if (errno == ENOSYS)
 			{


### PR DESCRIPTION
When stopping the SoftDecoder, ENOSYS errors from aio_return() on a closed fd were incorrectly interpreted as "AIO not supported", setting s_aio_not_supported=true globally.

This fix adds m_stop check in writeData() to ignore ENOSYS during shutdown, preventing false fallback to sync mode on boxes that support AIO.