### PR TITLE
[scan] extract and store PIDs and CAIDs from PMT during channel scan

### DIFF
--- a/lib/dvb/scan.h
+++ b/lib/dvb/scan.h
@@ -15,12 +15,20 @@
 struct service
 {
 	service(unsigned short pmtPid)
-		:pmtPid(pmtPid), serviceType(0xFF), scrambled(false)
+		:pmtPid(pmtPid), serviceType(0xFF), scrambled(false),
+		 pcrPid(0xFFFF), videoPid(0xFFFF), audioPid(0xFFFF),
+		 audioCacheId(eDVBService::cMPEGAPID), videoType(-1)
 	{
 	}
 	unsigned short pmtPid;
 	unsigned char serviceType;
 	bool scrambled;
+	unsigned short pcrPid;
+	unsigned short videoPid;
+	unsigned short audioPid;
+	eDVBService::cacheID audioCacheId;
+	int videoType;  // -1 = MPEG2 (default), 1 = H.264, 4 = MPEG4 Part2, 7 = H.265/HEVC
+	CAID_LIST caids;
 };
 
 class eDVBScan: public sigc::trackable, public iObject

--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -1697,7 +1697,7 @@ int eDVBCISlot::setCaParameter(eDVBServicePMTHandler *pmthandler)
 	}
 
 	m_video_pid = program.videoStreams.empty() ? 0 : program.videoStreams[0].pid;
-	m_audio_pid = program.audioStreams.empty() ? 0 : program.audioStreams[program.defaultAudioStream].pid;
+	m_audio_pid = (program.audioStreams.empty() || program.defaultAudioStream < 0 || static_cast<size_t>(program.defaultAudioStream) >= program.audioStreams.size()) ? 0 : program.audioStreams[program.defaultAudioStream].pid;
 
 	m_tunernum = -1;
 	if (!pmthandler->getChannel(channel))


### PR DESCRIPTION
Parse the Program Map Table during channel scan to cache stream information in lamedb for faster channel switching and streaming.

Cached data:
- Video/Audio/PCR PIDs (cVPID, cMPEGAPID, cAC3PID, cPCRPID)
- Video type (cVTYPE) for codec detection
- PMT PID (cPMTPID) for CAPMT construction
- CAIDs from CA descriptors for encrypted channels

This eliminates the need to wait for PMT parsing when switching to channels that were previously scanned.

Additional fixes required for stability:

The cached PMT PID is appended to the CAPMT buffer in cahandler.cpp. The writeToBuffer() function writes CAPMT data starting at offset 5 (after a 5-byte header) and returns the length written, not an absolute position. The correct position to append PMT PID data is therefore (5 + total), not total.

Additionally, the CAPMT length field uses ASN.1 BER encoding where lengths > 127 use long form (0x81/0x82 followed by length bytes). The length update now correctly handles both short form (length in single byte) and long form (length in following bytes).

The setCaParameter function in dvbci.cpp accessed the array audioStreams[defaultAudioStream] without validating that defaultAudioStream is within bounds. Added proper bounds checking before array access.

When merging CAIDs from PMT with existing SDT data, duplicates are now filtered to avoid redundant entries in the channel database.