### PR TITLE
[SoftCSA] Fix double-free crash in CSASession during timeshift channel switch

### DIFF
--- a/lib/dvb/csasession.cpp
+++ b/lib/dvb/csasession.cpp
@@ -8,7 +8,6 @@
 #endif
 
 DEFINE_REF(eDVBCSASession);
-DEFINE_REF(iServiceScrambled);
 
 static const uint8_t DEFAULT_ECM_MODE = 0x04;
 

--- a/lib/service/iservicescrambled.h
+++ b/lib/service/iservicescrambled.h
@@ -11,7 +11,6 @@
  */
 class iServiceScrambled: public iObject
 {
-	DECLARE_REF(iServiceScrambled);
 public:
 	/**
 	 * Descramble packets in-place


### PR DESCRIPTION
iServiceScrambled and eDVBCSASession both had DECLARE_REF, creating two separate reference counters. When the recorder held an ePtr<iServiceScrambled> and m_timeshift_csa_session held an ePtr<eDVBCSASession>, they incremented different counters.

During channel switch with active timeshift:
1. m_record->setDescrambler(nullptr) decremented iServiceScrambled::ref to 0
2. This triggered delete, freeing the object
3. m_timeshift_csa_session = nullptr then tried to delete the already-freed object, causing "corrupted double-linked list" heap corruption

Fix: Remove DECLARE_REF from iServiceScrambled interface and DEFINE_REF from csasession.cpp, so both ePtr types use the same reference counter (eDVBCSASession::ref).