### PR TITLE
[SoftCSA] Fix race condition crash when stopping recorder with active descrambler

### DIFF
--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -201,12 +201,13 @@ void eDVBSoftDecoder::stop()
 		m_dvr_fd = -1;
 	}
 
-	// Stop the recorder thread - poll() should have been unblocked by closing DVR fd
+	// Stop the recorder thread FIRST - poll() should have been unblocked by closing DVR fd
+	// Must stop before setDescrambler(nullptr) to prevent race condition
 	if (m_record)
 	{
 		eDebug("[SoftDecoder] Stopping recorder thread");
-		m_record->setDescrambler(nullptr);
 		m_record->stop();
+		m_record->setDescrambler(nullptr);
 		m_record = nullptr;
 	}
 

--- a/lib/service/servicedvbstream.cpp
+++ b/lib/service/servicedvbstream.cpp
@@ -36,12 +36,12 @@ void eDVBServiceStream::cleanupCSASession()
 	{
 		eDebug("[eDVBServiceStream] Cleaning up CSA session");
 		m_csa_session->stopECMMonitor();
-		// Detach descrambler and stop recorder BEFORE destroying session
-		// This ensures the descrambling thread is not using the session anymore
+		// Stop recorder thread FIRST to prevent race condition with m_serviceDescrambler access
+		// Then detach descrambler before destroying session
 		if (m_record)
 		{
-			m_record->setDescrambler(nullptr);
 			m_record->stop();
+			m_record->setDescrambler(nullptr);
 		}
 		// Now destroy session
 		m_csa_session = nullptr;


### PR DESCRIPTION
The recording thread accesses m_serviceDescrambler without synchronization. When setDescrambler(nullptr) was called before stop(), the ePtr was released (potentially deleting the object) while the thread was still running and could access the deleted object, causing "corrupted double-linked list" heap corruption.

Fix: Always call m_record->stop() BEFORE setDescrambler(nullptr) to ensure the thread is not running when we release the descrambler reference.

Affected locations:
- eDVBServicePlay::stopTimeshift()
- eDVBServicePlay::stopTapToFD()
- eDVBServiceRecord::stop()
- eDVBServiceStream::cleanupCSASession()
- eDVBSoftDecoder::stop()