### PR TITLE
[cahandler] Remove PMT PID append code that caused malformed CAPMT packets

### DIFF
--- a/lib/dvb/cahandler.cpp
+++ b/lib/dvb/cahandler.cpp
@@ -931,43 +931,7 @@ int eDVBCAService::buildCAPMT(eTable<ProgramMapSection> *ptr)
 		m_capmt[2] = m_id >> 16;
 		m_capmt[3] = m_id >>  8;
 		m_capmt[4] = m_id & 0xFF; // msgid
-		size_t total = capmt.writeToBuffer(m_capmt + 5);
-
-		if(!eDVBDB::getInstance()->getService(m_service, dvbservice))
-		{
-			pmtpid = dvbservice->getCacheEntry(eDVBService::cPMTPID);
-			if (pmtpid > 0)
-			{
-				// total is length returned by writeToBuffer, add 5 for header offset
-				size_t pos = 5 + total;
-				m_capmt[pos++] = 0x0d; // Datastream (DSM CC)
-				m_capmt[pos++] = pmtpid>>8;
-				m_capmt[pos++] = pmtpid&0xFF;
-				m_capmt[pos++] = 0x00;
-				m_capmt[pos++] = 0x00;
-				// update length field - handle both short and long form
-				// byte 8 is length byte: if bit 7 is set, it indicates number of following length bytes
-				if (m_capmt[8] & 0x80)
-				{
-					// long form: m_capmt[8] = 0x81 or 0x82, actual length in following bytes
-					int lenbytes = m_capmt[8] & 0x7f;
-					if (lenbytes == 1)
-						m_capmt[9] += 5;
-					else if (lenbytes == 2)
-					{
-						int len = (m_capmt[9] << 8) | m_capmt[10];
-						len += 5;
-						m_capmt[9] = len >> 8;
-						m_capmt[10] = len & 0xff;
-					}
-				}
-				else
-				{
-					// short form: length directly in byte 8
-					m_capmt[8] += 5;
-				}
-			}
-		}
+		capmt.writeToBuffer(m_capmt + 5);
 	}
 
 	m_prev_build_hash = build_hash;


### PR DESCRIPTION
The code that appended the cached PMT PID as a Datastream (DSM CC) element to the CAPMT buffer was causing malformed packets when communicating with OSCam.

This code was introduced in SoftCSA PR #3679 but only became active after the scan commit (7f7e6e1f61) started caching cPMTPID during channel scans. Previously cPMTPID was typically -1 (uncached) so the code path was never executed.

OSCam does not require or expect this additional PMT PID element in the CAPMT, and its presence causes parsing issues.