### PR TITLE
[demux] Fix double parseData call causing broken Access Points in recordings

### DIFF
--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -1009,13 +1009,12 @@ int eDVBRecordScrambledThread::writeData(int len)
 	// For SoftCSA: descrambles in-place when CW available,
 	// passes through encrypted when no CW (may cause artifacts at channel start)
 	if (m_serviceDescrambler)
+	{
 		m_serviceDescrambler->descramble(m_buffer, len);
 
-	// Parse AFTER descrambling for correct Access Points (.ap files)
-	// This is needed because asyncWrite/writeData skip parseData when m_serviceDescrambler is set
-	if (!getProtocol())
-	{
-		m_ts_parser.parseData(m_current_offset, m_buffer, len);
+		// Parse AFTER descrambling for correct Access Points (.ap files)
+		if (!getProtocol())
+			m_ts_parser.parseData(m_current_offset, m_buffer, len);
 	}
 
 	// Call the appropriate parent writeData based on target type:


### PR DESCRIPTION
Since the SoftCSA PR, all recordings use eDVBRecordScrambledThread. The original code called parseData() unconditionally after descramble():

    if (m_serviceDescrambler)
        m_serviceDescrambler->descramble(m_buffer, len);
    if (!getProtocol())
        m_ts_parser.parseData(...);  // ALWAYS called
    ret = eDVBRecordFileThread::writeData(len);  // calls parseData again if !m_serviceDescrambler

For SoftCSA recordings (m_serviceDescrambler set):
- parseData() called here, parent skips it -> OK (1x)

For FTA/CI/CI+ recordings (m_serviceDescrambler is NULL):
- parseData() called here unconditionally
- Parent writeData() also calls parseData() (because !m_serviceDescrambler)
- Result: parseData() called TWICE -> corrupted .ap files

The .ap files contain Access Points (I-Frame positions + PTS timestamps) used for fast-forward (16x/32x/64x/128x). Double-parsing creates duplicate/invalid entries, breaking trick modes for new recordings while older recordings (before SoftCSA PR) still worked.

Fix: Move parseData() inside the if(m_serviceDescrambler) block. Now parseData() is only called here when descrambler is active (and parent skips it). Without descrambler, parent handles it.