### PR TITLE
[cahandler] Fix wrong offsets in buildCAPMT(eDVBService) after Protocol-3 header

### DIFF
--- a/lib/dvb/cahandler.cpp
+++ b/lib/dvb/cahandler.cpp
@@ -1091,7 +1091,6 @@ int eDVBCAService::buildCAPMT(ePtr<eDVBService> &dvbservice)
 	pidtype[eDVBService::cDDPPID]    = 0x06;
 	pidtype[eDVBService::cAACAPID]   = 0x06;
 	pidtype[eDVBService::cDATAPID]   = 0x90; // Datastream (Blu-ray subtitling)
-	pidtype[eDVBService::cPMTPID]    = 0x0d; // Datastream (DSM CC)
 
 	// cached pids
 	for (int x = 0; x < eDVBService::cacheMax; ++x)
@@ -1117,12 +1116,12 @@ int eDVBCAService::buildCAPMT(ePtr<eDVBService> &dvbservice)
 		}
 	}
 
-	// calculate capmt length
-	m_capmt[3] = pos - 9;
+	// calculate capmt length (offset 8 = position 3 after 5-byte protocol header)
+	m_capmt[8] = pos - 9;
 
-	// calculate programinfo leght
-	m_capmt[8] = programInfoLength>>8;
-	m_capmt[9] = programInfoLength&0xFF;
+	// calculate programinfo length (offset 13/14 = position 8/9 after 5-byte protocol header)
+	m_capmt[13] = programInfoLength>>8;
+	m_capmt[14] = programInfoLength&0xFF;
 
 	m_prev_build_hash = build_hash;
 	m_version = pmt_version;


### PR DESCRIPTION
The 5-byte Protocol-3 header (0xA5 + 4-byte msgid) was added to m_capmt but the offsets for the length field and programInfoLength in buildCAPMT(eDVBService) were not adjusted accordingly.

- capmt length: offset 3 -> 8 (position 3 + 5-byte header)
- programInfoLength: offset 8/9 -> 13/14 (position 8/9 + 5-byte header)

This function is used when the dxIsScrambledPMT flag (f:400 in lamedb) is manually set on a service. This flag tells enigma2 that the PMT itself is encrypted and needs to be descrambled before it can be parsed. When set, eDVBServicePMTHandler::handlePMT() calls buildCAPMT(eDVBService) to create a CAPMT from cached service data (PIDs, CAIDs) instead of from a live PMT.

Without this fix, services with f:400 would send malformed CAPMT packets to the CA handler breaking descrambling.