### PR TITLE
[cahandler] Restore legacy softcam compatibility

### DIFF
--- a/lib/dvb/cahandler.h
+++ b/lib/dvb/cahandler.h
@@ -98,12 +98,12 @@ protected:
 	void connectionLost();
 	void dataAvailable();
 	// OSCam Protocol 3 handlers
-	void sendClientInfo();
 	bool processCaSetDescrPacket();
 	bool processServerInfoPacket();
 	bool processEcmInfoPacket();
 public:
 	ePMTClient(eDVBCAHandler *handler, int socket);
+	void sendClientInfo();
 	int writeCAPMTObject(const char* capmt, int len);
 };
 

--- a/lib/dvb/csasession.cpp
+++ b/lib/dvb/csasession.cpp
@@ -233,6 +233,7 @@ void eDVBCSASession::ecmDataReceived(const uint8_t *data)
 		else
 		{
 			eDebug("[CSASession] ECM analyzed: Not CSA-ALT, hardware descrambling will be used");
+			stopECMMonitor();
 		}
 	}
 }


### PR DESCRIPTION
The SoftCSA introduction added Protocol-3 (DVBAPI) support to the .listen.camd.socket server. This broke legacy softcams (CCcam, doscam) that also connect to this socket but cannot parse Protocol-3 data.

The root cause was sendClientInfo() in the ePMTClient constructor, which immediately sent a Protocol-3 CLIENT_INFO packet (0xFFFF0001) to every connecting client before any CAPMT data. Legacy softcams interpret these bytes as malformed TLV data and disconnect.

Fix by reversing the order in newConnection(): first distribute CAPMTs in legacy format (understood by all clients), then send CLIENT_INFO to initiate the Protocol-3 handshake. This way:
- OSCam mode 6 receives the initial CAPMTs in legacy format, then CLIENT_INFO triggers the handshake. After SERVER_INFO response, all subsequent CAPMTs use Protocol-3 format with message IDs.
- Legacy clients (CCcam/doscam) receive their CAPMTs before the CLIENT_INFO arrives. The CLIENT_INFO causes a disconnect, but CAPMTs were already delivered. Ongoing CAPMT delivery continues via the /tmp/camd.socket path (sendCAPMT).

Additional fixes included in this commit:
- Remove m_serverInfoReceived gate from writeCAPMTObject() that blocked CAPMT delivery until Protocol-3 handshake completed. Dispatch based on m_protocolVersion instead: Protocol-3 clients get the full packet with 0xA5 header, others get legacy format.
- Restore sendCAPMT() in unregisterService() for all service types, not just streamserver. The legacy camd.socket path needs CAPMT updates whenever demux assignments change.