### PR TITLE
[ChannelSelection]  Final subservices improvements

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -718,8 +718,6 @@ class InfoBarNumberZap:
 		if number == 0:
 			if isinstance(self, InfoBarPiP) and self.pipHandles0Action():
 				self.pipDoHandle0Action()
-			elif self.servicelist.history and self.servicelist.isSubservices():
-				self.servicelist.setHistoryPath()
 			elif len(self.servicelist.history) > 1 or config.usage.panicbutton.value:
 				self.checkTimeshiftRunning(self.recallPrevService)
 		else:


### PR DESCRIPTION
- Remove outdated comments from previous subservices integration
- Fix issues where ChannelSelection(Subservices) could be empty
- Add current to history for more consistent behavior
  (e.g. show it in HistoryZapSelector)
  But subservices are not kept in history after leaving them, same on exit via KEY_0.
  (avoids expensive cleanup logic)