### PR TITLE
[cahandler] Skip CLIENT_INFO on reconnects for legacy softcams

### DIFF
--- a/lib/dvb/cahandler.h
+++ b/lib/dvb/cahandler.h
@@ -176,6 +176,8 @@ DECLARE_REF(eDVBCAHandler);
 	std::map<eServiceReferenceDVB, ePtr<eTable<ProgramMapSection> > > pmtCache;
 	std::map<uint32_t, uint16_t> m_service_caid;  // serviceId -> CAID (from softcam ECM_INFO)
 	uint32_t serviceIdCounter;
+	bool m_protocol3_established;  // SERVER_INFO received from at least one client
+	bool m_handshake_attempted;    // CLIENT_INFO sent at least once
 
 	void newConnection(int socket);
 	void processPMTForService(eDVBCAService *service, eTable<ProgramMapSection> *ptr);


### PR DESCRIPTION
CLIENT_INFO was sent on every new connection to .listen.camd.socket, causing repeated "error in capmt length field read 4" in legacy softcam logs and risking disconnect loops with softcams that cannot parse Protocol-3 data.

Track handshake state at eDVBCAHandler level:
- First connection: send CLIENT_INFO to probe for Protocol-3
- If SERVER_INFO received: mark Protocol-3 established, always send CLIENT_INFO on reconnects
- If no SERVER_INFO: legacy client detected, skip CLIENT_INFO on subsequent connections