### PR TITLE
[SoftCSA] Suppress audio in SoftDecoder for PIP to prevent audio routing corruption

### DIFF
--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -4365,6 +4365,7 @@ void eDVBServicePlay::setupSpeculativeDescrambling()
 
 	// Create SoftDecoder (will start when session activates)
 	m_soft_decoder = new eDVBSoftDecoder(m_service_handler, m_dvb_service, m_decoder_index);
+	m_soft_decoder->setNoAudio(m_noaudio);
 	m_soft_decoder->setSession(m_csa_session);
 
 	// Connect to SoftDecoder's audio PID selection signal

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -17,6 +17,7 @@ eDVBSoftDecoder::eDVBSoftDecoder(eDVBServicePMTHandler& source_handler,
 	, m_dvr_fd(-1)
 	, m_running(false)
 	, m_stopping(false)
+	, m_noaudio(false)
 	, m_decoder_started(false)
 	, m_last_pts(0)
 	, m_stall_count(0)
@@ -675,10 +676,13 @@ void eDVBSoftDecoder::updateDecoder(int vpid, int vpidtype, int pcrpid)
 				       apid, atype, audio_index, program.audioStreams.size());
 			}
 
-			m_decoder->setAudioPID(apid, atype);
+			if (!m_noaudio)
+			{
+				m_decoder->setAudioPID(apid, atype);
 
-			// Notify parent about selected audio PID
-			m_audio_pid_selected(apid);
+				// Notify parent about selected audio PID
+				m_audio_pid_selected(apid);
+			}
 		}
 
 		// Using explicit pcrpid breaks video on some HiSilicon devices (e.g. sf8008) in PVR loopback mode
@@ -750,6 +754,8 @@ int eDVBSoftDecoder::setTrickmode()
 
 int eDVBSoftDecoder::setAudioPID(int pid, int type)
 {
+	if (m_noaudio)
+		return 0;
 	if (m_decoder)
 		return m_decoder->setAudioPID(pid, type);
 	return -1;

--- a/lib/service/servicedvbsoftdecoder.h
+++ b/lib/service/servicedvbsoftdecoder.h
@@ -44,6 +44,9 @@ public:
 	int start();
 	void stop();
 
+	// Suppress audio output (PIP mode)
+	void setNoAudio(bool noaudio) { m_noaudio = noaudio; }
+
 	// Status
 	bool isRunning() const { return m_running; }
 
@@ -110,6 +113,7 @@ private:
 	int m_dvr_fd;
 	bool m_running;
 	bool m_stopping;
+	bool m_noaudio;  // When true, suppress audio (PIP mode)
 	std::set<int> m_pids_active;
 
 	// CW waiting: Timer-based decoder start


### PR DESCRIPTION
When a CSA-ALT channel runs as PIP, the SoftDecoder unconditionally called setAudioPID(), opening audio1 and interfering with the main picture's audio0 routing. This caused reproducible audio loss when switching PIP from a SoftCSA channel to FreeTV.

Add m_noaudio flag to eDVBSoftDecoder, matching the existing guard in the hardware decoder path (eDVBServicePlay::selectAudioStream).