### PR TITLE
[SoftCSA] Fix audio dropouts and decoder deadlocks

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -972,6 +972,7 @@
 		<item level="0" text="Decoder release strategy" description="How to release the hardware decoder when switching to software descrambling. 'Quick' releases immediately (faster zapping). 'Normal' performs clean shutdown first (more stable on some boxes)." restart="gui">config.softcsa.decoderRelease</item>
 		<item level="0" text="Sync mode" description="Select how the descrambled data stream is processed. 'Automatic' uses asynchronous writes (lower CPU usage) with automatic fallback to synchronous if kernel AIO is not supported. 'Synchronous' forces blocking writes (stable, most compatible)." restart="gui">config.softcsa.syncMode</item>
 		<item level="2" text="Decoder start timeout" description="Maximum time to wait for the first descrambling key (CW) before starting the decoder. 'Disabled' starts the decoder immediately without waiting." restart="gui">config.softcsa.waitForDataTimeout</item>
+		<item level="2" text="Decoder start delay" description="Select the delay to buffer descrambled data before starting playback. This can reduce AC3 audio dropouts by ensuring enough data is available when the decoder starts. Higher values are more stable but increase channel switch time." restart="gui">config.softcsa.bufferTime</item>
 	</setup>
 	<setup key="StreamRelay" title="Stream Relay Settings">
 		<item level="2" text="Stream Relay URL" description="IP address of the Stream Relay server used to descramble services that can only be decrypted via Stream Relay.">config.misc.softcam_streamrelay_url</item>

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -971,7 +971,7 @@
 	<setup key="SoftCSA" title="SoftCSA Settings">
 		<item level="0" text="Decoder release strategy" description="How to release the hardware decoder when switching to software descrambling. 'Quick' releases immediately (faster zapping). 'Normal' performs clean shutdown first (more stable on some boxes)." restart="gui">config.softcsa.decoderRelease</item>
 		<item level="0" text="Sync mode" description="Select how the descrambled data stream is processed. 'Automatic' uses asynchronous writes (lower CPU usage) with automatic fallback to synchronous if kernel AIO is not supported. 'Synchronous' forces blocking writes (stable, most compatible)." restart="gui">config.softcsa.syncMode</item>
-		<item level="1" text="Decoder start timeout" description="Maximum time to wait for the incoming data and descrambling keys (CW) before starting decoder. Usually both arrive much faster and this is only for special cases." restart="gui">config.softcsa.waitForDataTimeout</item>
+		<item level="2" text="Decoder start timeout" description="Maximum time to wait for the first descrambling key (CW) before starting the decoder. 'Disabled' starts the decoder immediately without waiting." restart="gui">config.softcsa.waitForDataTimeout</item>
 	</setup>
 	<setup key="StreamRelay" title="Stream Relay Settings">
 		<item level="2" text="Stream Relay URL" description="IP address of the Stream Relay server used to descramble services that can only be decrypted via Stream Relay.">config.misc.softcam_streamrelay_url</item>

--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -1375,3 +1375,8 @@ bool eDVBTSRecorder::waitForFirstData(int timeout_ms)
 	// Other thread types return immediately via base class default
 	return m_thread->waitForFirstData(timeout_ms);
 }
+
+void eDVBTSRecorder::setMinWrite(size_t size)
+{
+	m_thread->setMinWrite(size);
+}

--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -486,7 +486,7 @@ int eDVBRecordFileThread::getFirstPTS(pts_t &pts)
 
 int eDVBRecordFileThread::AsyncIO::wait(volatile int* stop_flag)
 {
-	if (aio.aio_buf == NULL) // Only if we had a request outstanding
+	if (aio.aio_buf == nullptr) // No request outstanding
 		return 0;
 
 	// Limit consecutive timeouts to prevent infinite blocking
@@ -634,12 +634,14 @@ int eDVBRecordFileThread::AsyncIO::start(int fd, off_t offset, size_t nbytes, vo
 	return aio_write(&aio);
 }
 
-// AIO write mode state - locked after first determination for entire session.
-// -1 = unknown (not yet tested), 0 = not supported, 1 = supported
+// AIO write mode detection: locked after verification for entire session.
+// -1 = unknown (probing), 0 = not supported (sync), 1 = supported (async)
 static int s_aio_state = -1;
+static const int AIO_VERIFY_THRESHOLD = 3;
 
 int eDVBRecordFileThread::asyncWrite(int len)
 {
+	static int s_aio_verify_count = 0;
 #ifdef SHOW_WRITE_TIME
 	struct timeval starttime = {};
 	struct timeval now = {};
@@ -672,11 +674,6 @@ int eDVBRecordFileThread::asyncWrite(int len)
 		eDebug("[eDVBRecordFileThread] aio_write failed: %m");
 		return r;
 	}
-	if (s_aio_state != 1)
-	{
-		s_aio_state = 1;
-		eDebug("[eDVBRecordFileThread] AIO supported - locked for session");
-	}
 	m_current_offset += len;
 
 #ifdef SHOW_WRITE_TIME
@@ -708,6 +705,19 @@ int eDVBRecordFileThread::asyncWrite(int len)
 		}
 	}
 	++m_buffer_use_histogram[busy_count];
+
+	// Verify AIO by counting successful write+poll roundtrips.
+	// On broken kernels, the poll loop fails on the 2nd
+	// write when checking the previous buffer, so we never reach the threshold.
+	if (s_aio_state != 1)
+	{
+		++s_aio_verify_count;
+		if (s_aio_verify_count >= AIO_VERIFY_THRESHOLD)
+		{
+			s_aio_state = 1;
+			eDebug("[eDVBRecordFileThread] AIO verified after %d writes - locked for session", s_aio_verify_count);
+		}
+	}
 
 	++m_current_buffer;
 	if (m_current_buffer == m_aio.end())
@@ -804,7 +814,7 @@ int eDVBRecordFileThread::writeData(int len)
 			{
 				if (s_aio_state == 1)
 				{
-					eDebug("[eDVBRecordFileThread] ENOSYS ignored - AIO confirmed for session");
+					eDebug("[eDVBRecordFileThread] ENOSYS ignored - AIO verified for session");
 					return -1;
 				}
 				s_aio_state = 0;
@@ -825,7 +835,7 @@ int eDVBRecordFileThread::writeData(int len)
 			{
 				if (s_aio_state == 1)
 				{
-					eDebug("[eDVBRecordFileThread] ENOSYS in wait ignored - AIO confirmed for session");
+					eDebug("[eDVBRecordFileThread] ENOSYS in wait ignored - AIO verified for session");
 					return len;
 				}
 				s_aio_state = 0;

--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -778,6 +778,8 @@ int eDVBRecordFileThread::writeData(int len)
 				continue;
 			if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
 			{
+				if (m_stop)
+					return -1;
 				usleep(1000);
 				continue;
 			}

--- a/lib/dvb/demux.h
+++ b/lib/dvb/demux.h
@@ -210,6 +210,7 @@ public:
 
 	// Wait for first data to be written (for SoftDecoder sync)
 	bool waitForFirstData(int timeout_ms);
+	void setMinWrite(size_t size) override;
 private:
 	RESULT startPID(int pid);
 	void stopPID(int pid);

--- a/lib/dvb/filepush.cpp
+++ b/lib/dvb/filepush.cpp
@@ -358,16 +358,11 @@ eFilePushThreadRecorder::eFilePushThreadRecorder(unsigned char *buffer, size_t b
 																							 m_buffer(buffer),
 																							 m_overflow_count(0),
 																							 m_buffer_fill(0),
-																							 m_buffer_min_write(0),
 																							 m_stop(1),
 																							 m_messagepump(eApp, 0, "eFilePushThreadRecorder")
 {
 	m_protocol = m_stream_id = m_session_id = m_packet_no = 0;
 	CONNECT(m_messagepump.recv_msg, eFilePushThreadRecorder::recvEvent);
-
-	/* Read accumulation threshold: 32 KB fixed */
-	/* This reduces syscall overhead on boxes with small DVR read sizes (e.g. SF8008: 564 bytes) */
-	m_buffer_min_write = 32 * 1024;
 
 	/* Ensure min_write doesn't exceed buffer size */
 	if (m_buffer_min_write > m_buffersize)

--- a/lib/dvb/filepush.h
+++ b/lib/dvb/filepush.h
@@ -79,6 +79,9 @@ public:
 	int getProtocol() { return m_protocol;}
 	void setProtocol(int i){ m_protocol = i;}
 	void setSession(int se, int st) { m_session_id = se; m_stream_id = st;}
+	static const size_t minWriteDefault = 32 * 1024;
+	static const size_t minWriteMPEG = 4 * 1024;
+	void setMinWrite(size_t s) { m_buffer_min_write = s; }
 	int read_dmx(int fd, void *m_buffer, int size);
 	int pushReply(void *buf, int len);	
 	void sendEvent(int evt);
@@ -98,7 +101,7 @@ protected:
 	unsigned char* m_buffer;
 	unsigned int m_overflow_count;
 	size_t m_buffer_fill;
-	size_t m_buffer_min_write;
+	size_t m_buffer_min_write = minWriteDefault;
 	int m_stop;
 private:
 	eFixedMessagePump<int> m_messagepump;

--- a/lib/dvb/idemux.h
+++ b/lib/dvb/idemux.h
@@ -57,6 +57,9 @@ public:
 	// Wait for first data to be written (for SoftDecoder sync)
 	virtual bool waitForFirstData(int timeout_ms) = 0;
 
+	// Set write accumulation threshold (0 = continuous writing)
+	virtual void setMinWrite(size_t size) = 0;
+
 	enum {
 		eventWriteError,
 				/* a write error has occurred. data won't get lost if fd is writable after return. */

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -2364,6 +2364,10 @@ def InitUsageConfig():
 		default=800,
 		choices=[(0, _("Disabled"))] + [(x, _("%d ms") % x) for x in range(100, 2001, 100)]
 	)
+	config.softcsa.bufferTime = ConfigSelection(
+		default=0,
+		choices=[(0, _("Disabled"))] + [(x, _("%d ms") % x) for x in range(100, 2001, 100)]
+	)
 
 	config.misc.softcam_streamrelay_url = ConfigIP(default=[127, 0, 0, 1], auto_jump=True)
 	config.misc.softcam_streamrelay_port = ConfigInteger(default=17999, limits=(0, 65535))

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -2362,7 +2362,7 @@ def InitUsageConfig():
 	])
 	config.softcsa.waitForDataTimeout = ConfigSelection(
 		default=800,
-		choices=[(x, _("%d ms") % x) for x in range(100, 2001, 100)]
+		choices=[(0, _("Disabled"))] + [(x, _("%d ms") % x) for x in range(100, 2001, 100)]
 	)
 
 	config.misc.softcam_streamrelay_url = ConfigIP(default=[127, 0, 0, 1], auto_jump=True)

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -219,6 +219,16 @@ void eDVBSoftDecoder::stop()
 		m_dvr_fd = -1;
 	}
 
+	// Stop decoder - release PID filters and pause
+	if (m_decoder)
+	{
+		eDebug("[eDVBSoftDecoder] Stopping decoder");
+		m_decoder->pause();
+		m_decoder->setVideoPID(-1, -1);
+		m_decoder->setAudioPID(-1, -1);
+		m_decoder->set();  // Apply the changes to release PID filters
+	}
+
 	// Release decode demux
 	if (m_decode_demux)
 	{
@@ -226,20 +236,16 @@ void eDVBSoftDecoder::stop()
 		m_decode_demux = nullptr;
 	}
 
-	// Stop decoder - release video/audio devices
-	if (m_decoder)
-	{
-		eDebug("[eDVBSoftDecoder] Stopping decoder");
-		m_decoder->pause();
-		m_decoder->setVideoPID(-1, -1);
-		m_decoder->setAudioPID(-1, -1);
-		m_decoder->set();  // Apply the changes to release devices
-		m_decoder = nullptr;
-	}
-
-	// Free PVR handler last
+	// Free PVR handler before releasing the decoder
 	eDebug("[eDVBSoftDecoder] Freeing PVR handler");
 	m_pvr_handler.free();
+
+	// Release decoder
+	if (m_decoder)
+	{
+		eDebug("[eDVBSoftDecoder] Releasing decoder");
+		m_decoder = nullptr;
+	}
 
 	m_pids_active.clear();
 	m_running = false;

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -81,7 +81,7 @@ void eDVBSoftDecoder::onFirstCwReceived()
 	if (m_decoder_started)
 		return;  // Already started
 
-	eDebug("[eDVBSoftDecoder] First CW received - starting decoder with DVR wait");
+	eDebug("[eDVBSoftDecoder] First CW received - starting decoder");
 
 	// Stop timer
 	if (m_start_timer)
@@ -91,7 +91,7 @@ void eDVBSoftDecoder::onFirstCwReceived()
 	if (m_first_cw_conn.connected())
 		m_first_cw_conn.disconnect();
 
-	startDecoderWithDvrWait();
+	startDecoder();
 }
 
 void eDVBSoftDecoder::onWaitForFirstDataTimeout()
@@ -99,35 +99,19 @@ void eDVBSoftDecoder::onWaitForFirstDataTimeout()
 	if (m_decoder_started)
 		return;  // Already started
 
-	eWarning("[eDVBSoftDecoder] CW timeout - starting decoder with DVR wait anyway");
+	eWarning("[eDVBSoftDecoder] CW timeout - starting decoder anyway");
 
 	// Disconnect signal
 	if (m_first_cw_conn.connected())
 		m_first_cw_conn.disconnect();
 
-	startDecoderWithDvrWait();
+	startDecoder();
 }
 
-void eDVBSoftDecoder::startDecoderWithDvrWait()
+void eDVBSoftDecoder::startDecoder()
 {
 	if (m_decoder_started)
 		return;
-
-	// Safety check: m_record must exist
-	if (!m_record)
-	{
-		eWarning("[eDVBSoftDecoder] startDecoderWithDvrWait: m_record is NULL!");
-		return;
-	}
-
-	// Wait for DVR data (blocking)
-	int wait_timeout = eSimpleConfig::getInt("config.softcsa.waitForDataTimeout", 800);
-	eDebug("[eDVBSoftDecoder] Waiting for DVR data (timeout=%dms)", wait_timeout);
-
-	if (!m_record->waitForFirstData(wait_timeout))
-	{
-		eWarning("[eDVBSoftDecoder] DVR timeout - starting decoder anyway");
-	}
 
 	// Start decoder
 	eDebug("[eDVBSoftDecoder] Starting decoder");
@@ -343,12 +327,24 @@ int eDVBSoftDecoder::setupRecorder()
 	// Reset state
 	m_decoder_started = false;
 
+	// Start record thread
+	m_record->start();
+
+	int wait_timeout = eSimpleConfig::getInt("config.softcsa.waitForDataTimeout", 800);
+
+	// Disabled (0): start decoder immediately, no CW waiting
+	if (wait_timeout == 0)
+	{
+		eDebug("[eDVBSoftDecoder] CW wait disabled - starting decoder immediately");
+		startDecoder();
+		return 0;
+	}
+
 	// Check if CW is already available (e.g. fast channel switch)
 	if (m_session && m_session->hasKeys())
 	{
-		eDebug("[eDVBSoftDecoder] First CW already available - starting decoder with DVR wait");
-		m_record->start();
-		startDecoderWithDvrWait();
+		eDebug("[eDVBSoftDecoder] First CW already available - starting decoder");
+		startDecoder();
 		return 0;
 	}
 
@@ -360,15 +356,11 @@ int eDVBSoftDecoder::setupRecorder()
 	}
 
 	// Start timeout timer for CW
-	int wait_timeout = eSimpleConfig::getInt("config.softcsa.waitForDataTimeout", 800);
 	eDebug("[eDVBSoftDecoder] Waiting for first CW (timeout=%dms)", wait_timeout);
 
 	m_start_timer = eTimer::create(eApp);
 	CONNECT(m_start_timer->timeout, eDVBSoftDecoder::onWaitForFirstDataTimeout);
 	m_start_timer->start(wait_timeout, true);  // single-shot
-
-	// Start record thread
-	m_record->start();
 
 	return 0;
 }

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -27,6 +27,8 @@ eDVBSoftDecoder::eDVBSoftDecoder(eDVBServicePMTHandler& source_handler,
 	, m_paused(false)
 	, m_last_health_check(0)
 {
+	m_buffer_timer = eTimer::create(eApp);
+	CONNECT(m_buffer_timer->timeout, eDVBSoftDecoder::onBufferTimerExpired);
 	eDebug("[eDVBSoftDecoder] Created for decoder %d", decoder_index);
 }
 
@@ -37,6 +39,8 @@ eDVBSoftDecoder::~eDVBSoftDecoder()
 		m_start_timer->stop();
 	if (m_health_timer)
 		m_health_timer->stop();
+	if (m_buffer_timer)
+		m_buffer_timer->stop();
 	if (m_first_cw_conn.connected())
 		m_first_cw_conn.disconnect();
 
@@ -91,7 +95,7 @@ void eDVBSoftDecoder::onFirstCwReceived()
 	if (m_first_cw_conn.connected())
 		m_first_cw_conn.disconnect();
 
-	startDecoder();
+	startDecoderOrBuffer();
 }
 
 void eDVBSoftDecoder::onWaitForFirstDataTimeout()
@@ -105,6 +109,23 @@ void eDVBSoftDecoder::onWaitForFirstDataTimeout()
 	if (m_first_cw_conn.connected())
 		m_first_cw_conn.disconnect();
 
+	startDecoderOrBuffer();
+}
+
+void eDVBSoftDecoder::startDecoderOrBuffer()
+{
+	if (int bufferTime = eSimpleConfig::getInt("config.softcsa.bufferTime", 0); bufferTime > 0)
+	{
+		eDebug("[eDVBSoftDecoder] Pre-buffering %dms before decoder start", bufferTime);
+		m_buffer_timer->start(bufferTime, true);
+		return;
+	}
+	startDecoder();
+}
+
+void eDVBSoftDecoder::onBufferTimerExpired()
+{
+	eDebug("[eDVBSoftDecoder] Pre-buffer complete - starting decoder");
 	startDecoder();
 }
 
@@ -336,7 +357,7 @@ int eDVBSoftDecoder::setupRecorder()
 	if (wait_timeout == 0)
 	{
 		eDebug("[eDVBSoftDecoder] CW wait disabled - starting decoder immediately");
-		startDecoder();
+		startDecoderOrBuffer();
 		return 0;
 	}
 
@@ -344,7 +365,7 @@ int eDVBSoftDecoder::setupRecorder()
 	if (m_session && m_session->hasKeys())
 	{
 		eDebug("[eDVBSoftDecoder] First CW already available - starting decoder");
-		startDecoder();
+		startDecoderOrBuffer();
 		return 0;
 	}
 

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -720,6 +720,20 @@ void eDVBSoftDecoder::updateDecoder(int vpid, int vpidtype, int pcrpid)
 			{
 				m_decoder->setAudioPID(apid, atype);
 
+				// On Broadcom, MPEG audio decoders have tiny internal buffers
+				// and need frequent writes to avoid underruns. Reduce write
+				// threshold so data reaches the decoder with less delay.
+#if !defined(HAVE_HISILICON) && !defined(DREAMNEXTGEN)
+				if (m_record)
+				{
+					bool mpeg = (atype == eDVBServicePMTHandler::audioStream::atMPEG);
+					size_t threshold = mpeg ? eFilePushThreadRecorder::minWriteMPEG : eFilePushThreadRecorder::minWriteDefault;
+					m_record->setMinWrite(threshold);
+					eDebug("[eDVBSoftDecoder] Write threshold set to %zu KB (%s audio)",
+						threshold >> 10, mpeg ? "MPEG" : "non-MPEG");
+				}
+#endif
+
 				// Notify parent about selected audio PID
 				m_audio_pid_selected(apid);
 			}
@@ -796,6 +810,16 @@ int eDVBSoftDecoder::setAudioPID(int pid, int type)
 {
 	if (m_noaudio)
 		return 0;
+#if !defined(HAVE_HISILICON) && !defined(DREAMNEXTGEN)
+	if (m_record)
+	{
+		bool mpeg = (type == eDVBServicePMTHandler::audioStream::atMPEG);
+		size_t threshold = mpeg ? eFilePushThreadRecorder::minWriteMPEG : eFilePushThreadRecorder::minWriteDefault;
+		m_record->setMinWrite(threshold);
+		eDebug("[eDVBSoftDecoder] Write threshold set to %zu KB (%s audio)",
+			threshold >> 10, mpeg ? "MPEG" : "non-MPEG");
+	}
+#endif
 	if (m_decoder)
 		return m_decoder->setAudioPID(pid, type);
 	return -1;

--- a/lib/service/servicedvbsoftdecoder.h
+++ b/lib/service/servicedvbsoftdecoder.h
@@ -121,6 +121,10 @@ private:
 	sigc::connection m_first_cw_conn;
 	bool m_decoder_started;
 
+	// Pre-buffer: delay decoder start to let DVR data accumulate
+	ePtr<eTimer> m_buffer_timer;
+	void onBufferTimerExpired();
+
 	ePtr<eTimer> m_health_timer;
 	pts_t m_last_pts;
 	int m_stall_count;
@@ -134,6 +138,7 @@ private:
 	void onSessionActivated(bool active);
 	void onFirstCwReceived();
 	void onWaitForFirstDataTimeout();
+	void startDecoderOrBuffer();
 	void startDecoder();
 	void serviceEventSource(int event);
 	void recordEvent(int event);

--- a/lib/service/servicedvbsoftdecoder.h
+++ b/lib/service/servicedvbsoftdecoder.h
@@ -134,7 +134,7 @@ private:
 	void onSessionActivated(bool active);
 	void onFirstCwReceived();
 	void onWaitForFirstDataTimeout();
-	void startDecoderWithDvrWait();
+	void startDecoder();
 	void serviceEventSource(int event);
 	void recordEvent(int event);
 	void videoEvent(struct iTSMPEGDecoder::videoEvent event);


### PR DESCRIPTION
### **!! PLEASE DO NOT SQUASH THE COMMITS !!**

Five fixes for SoftCSA software descrambling stability and audio quality:

**Fix async write (AIO) detection** — Verify async write support with 3 successful roundtrips before locking. Prevents broken drivers (ENOSYS/EAGAIN) from causing unwanted mode switches during operation.

**Change decoder start timeout to only wait for CW** — Remove blocking DVR data wait that timed out on most boxes. Add 'Disabled' option to skip CW waiting entirely and start the decoder immediately.

**Add decoder start delay** — Configurable pre-buffer time (0–2000ms) that delays decoder start, allowing descrambled data to accumulate in the DVR kernel buffer. Prevents AC3 audio dropouts caused by the PVR loopback timing gap.

**Reduce write threshold for MPEG audio channels** — Automatically reduce the DVR write accumulation threshold from 32 KB to 4 KB when MPEG audio is selected, and restore the default when switching to AC3/DTS/AAC.

**Fix decoder shutdown deadlock** — Reorder shutdown sequence so the PVR handler is freed before the decoder destructor runs (mipsel DMX_STOP blocking fix). Also fix sync write EAGAIN retry loop missing m_stop check causing recorder thread hang on fast zapping.