### PR TITLE
[SoftCSA] Free resources after ECM analysis, fix ePMTClient leak

### DIFF
--- a/lib/dvb/cahandler.cpp
+++ b/lib/dvb/cahandler.cpp
@@ -302,14 +302,9 @@ bool ePMTClient::processEcmInfoPacket()
 					memcpy(&ecmTime, receivedData + 11, sizeof(uint32_t));
 					ecmTime = ntohl(ecmTime);
 
-					eServiceReferenceDVB service;
-					if (parent->getServiceReference(service, serviceId) == 0)
-					{
-						eDebug("[ePMTClient] ECM Info %s", service.toString().c_str());
-					}
 					// Store CAID for this service (will be sent with next CW)
 					parent->m_service_caid[serviceId] = caid;
-					eTrace("[ePMTClient] ECM Info serviceId %u, caid %04X, ecmTime %u, cardsystem %s, reader %s, from %s, protocol %s, hops %d", serviceId, caid, ecmTime, cardsystem, reader, from, protocol, hops);
+					eDebug("[ePMTClient] ECM Info msgid %u | caid %04X pid %04X prov %06X | %ums | %s via %s from %s hops %d", serviceId, caid, pid, providerId, ecmTime, reader, protocol, from, hops);
 
 					return true;
 				}

--- a/lib/dvb/cahandler.h
+++ b/lib/dvb/cahandler.h
@@ -104,6 +104,7 @@ protected:
 	bool processEcmInfoPacket();
 public:
 	ePMTClient(eDVBCAHandler *handler, int socket);
+	~ePMTClient() { delete[] receivedData; }
 	void sendClientInfo();
 	int writeCAPMTObject(const char* capmt, int len);
 	bool isProtocol3() const { return m_serverInfoReceived; }

--- a/lib/dvb/csasession.cpp
+++ b/lib/dvb/csasession.cpp
@@ -146,14 +146,14 @@ void eDVBCSASession::startECMMonitor(iDVBDemux *demux, uint16_t ecm_pid, uint16_
 		m_ecm_mode = info.ecm_mode;
 		m_ecm_mode_detected = true;
 
+		m_ecm_analyzed = true;
+		m_csa_alt = info.is_csa_alt;
+
 		if (info.is_csa_alt && !m_active)
 		{
-			m_ecm_analyzed = true;
-			m_csa_alt = true;
 			if (shouldSuppressActivation && shouldSuppressActivation())
 			{
 				eDebug("[eDVBCSASession] ECM Monitor: CSA-ALT cached but activation suppressed (CI module)");
-				stopECMMonitor();
 			}
 			else
 			{
@@ -161,6 +161,8 @@ void eDVBCSASession::startECMMonitor(iDVBDemux *demux, uint16_t ecm_pid, uint16_
 				setActive(true);
 			}
 		}
+
+		return;
 	}
 
 	// Create section reader
@@ -256,7 +258,6 @@ void eDVBCSASession::ecmDataReceived(const uint8_t *data)
 				if (shouldSuppressActivation && shouldSuppressActivation())
 				{
 					eDebug("[eDVBCSASession] Activation suppressed (CI module handles decryption)");
-					stopECMMonitor();
 				}
 				else
 				{
@@ -267,8 +268,9 @@ void eDVBCSASession::ecmDataReceived(const uint8_t *data)
 		else
 		{
 			eDebug("[eDVBCSASession] ECM analyzed: Not CSA-ALT, hardware descrambling will be used");
-			stopECMMonitor();
 		}
+
+		stopECMMonitor();
 	}
 }
 

--- a/lib/dvb/csasession.h
+++ b/lib/dvb/csasession.h
@@ -115,9 +115,6 @@ private:
 	bool m_csa_alt;               // true if CSA-ALT was detected
 	void ecmDataReceived(const uint8_t *data);
 
-	// Signal Connections
-	ePtr<eConnection> m_cw_connection;
-
 	// CW Handler (called from eDVBCAHandler signal)
 	void onCwReceived(eServiceReferenceDVB ref, int parity, const char* cw, uint16_t caid, uint32_t serviceId);
 

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1314,7 +1314,7 @@ void eDVBServicePlay::serviceEvent(int event)
 				ePtr<iDVBDemux> demux;
 				if (m_service_handler.getDataDemux(demux) == 0 && demux)
 				{
-					eDebug("[eDVBServicePlay] Starting ECM monitor: PID=%d, CAID=0x%04X", ecm_pid, caid);
+					eDebug("[eDVBServicePlay] Requesting ECM monitor: PID=%d, CAID=0x%04X", ecm_pid, caid);
 					m_csa_session->startECMMonitor(demux, ecm_pid, caid);
 					// Note: If CSA-ALT was cached, session is now active and onSessionActivated() has already been called!
 				}

--- a/lib/service/servicedvbfcc.cpp
+++ b/lib/service/servicedvbfcc.cpp
@@ -105,7 +105,7 @@ void eDVBServiceFCCPlay::serviceEvent(int event)
 						ePtr<iDVBDemux> demux;
 						if (m_service_handler.getDataDemux(demux) == 0 && demux)
 						{
-							eDebug("[eDVBServiceFCCPlay] Starting ECM monitor: PID=%d, CAID=0x%04X", ecm_pid, caid);
+							eDebug("[eDVBServiceFCCPlay] Requesting ECM monitor: PID=%d, CAID=0x%04X", ecm_pid, caid);
 							m_csa_session->startECMMonitor(demux, ecm_pid, caid);
 						}
 					}

--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -377,12 +377,12 @@ int eDVBServiceRecord::setupSoftwareDescrambler(eDVBServicePMTHandler::program& 
 	// This is needed for timer recordings where no Live-TV is running
 	if (!program.caids.empty())
 	{
-		uint16_t ecm_pid = program.caids.front().capid;
-		uint16_t caid = program.caids.front().caid;
 		ePtr<iDVBDemux> demux;
 		if (m_service_handler.getDataDemux(demux) == 0 && demux)
 		{
-			eDebug("[eDVBServiceRecord] Starting ECM monitor on PID %d, CAID 0x%04X", ecm_pid, caid);
+			uint16_t ecm_pid = program.caids.front().capid;
+			uint16_t caid = program.caids.front().caid;
+			eDebug("[eDVBServiceRecord] Requesting ECM monitor on PID %d, CAID 0x%04X", ecm_pid, caid);
 			m_csa_session->startECMMonitor(demux, ecm_pid, caid);
 		}
 	}


### PR DESCRIPTION
- ECM Monitor: Always call stopECMMonitor() after CSA-ALT analysis completes, freeing Demux FD, Section Reader and ~40 callbacks/s. Previously the monitor kept running for all CSA-ALT channels (Live-TV, Recording, PiP, FCC) because stopECMMonitor() was only reachable in the !m_active branch.

- ECM Monitor cache path: Return early from startECMMonitor() when the cache already provides the CSA-ALT result, avoiding creation of an unnecessary Section Reader.

- ePMTClient: Add destructor to free receivedData buffer on mid-packet disconnect (softcam crash/restart).

- eDVBCSASession: Remove unused m_cw_connection member. CW signal uses sigc::trackable for automatic disconnect.

- Improve logging:
  - Rename caller log "Starting ECM monitor" to "Requesting ECM monitor" to clarify that startECMMonitor() may return early (cache hit or invalid PID) without actually starting a reader.
  - ECM Info: Replace sparse eDebug + eTrace with single eDebug containing all parsed fields grouped by pipe separators (crypto | timing | routing). Fix format string where cardsystem was mislabeled as reader.