### PR TITLE
[Navigation] Fix dish not moving when zapping from StreamRelay to different satellite

### DIFF
--- a/lib/python/Navigation.py
+++ b/lib/python/Navigation.py
@@ -68,6 +68,7 @@ class Navigation:
 		self.isRecordTimerImageStandard = False
 		self.isCurrentServiceStreamRelay = False
 		self.skipServiceReferenceReset = False
+		self.retryServicePlayCount = 0
 		for p in plugins.getPlugins(PluginDescriptor.WHERE_RECORDTIMER):  # Do we really need this?
 			self.RecordTimer = p()
 			if self.RecordTimer:
@@ -313,6 +314,8 @@ class Navigation:
 			return 0
 
 		oldref = self.currentlyPlayingServiceOrGroup
+		if oldref is not None:
+			self.retryServicePlayCount = 0
 
 		if ref and oldref and ref == oldref and not forceRestart:
 			print("[Navigation] Ignore request to play already running service.  (1)")
@@ -411,6 +414,7 @@ class Navigation:
 					self.isCurrentServiceStreamRelay = False
 					self.currentlyPlayingServiceReference = None
 					self.currentlyPlayingServiceOrGroup = None
+					self.retryServicePlayCount = 1  # Pre-arm retry cycle in case play fails after delay.
 					print("[Navigation] Stream relay was active, delay the zap till tuner is freed.")
 					self.retryServicePlayTimer = eTimer()
 					self.retryServicePlayTimer.callback.append(boundFunction(self.playService, ref, checkParentalControl, forceRestart, adjust))
@@ -424,10 +428,18 @@ class Navigation:
 					self.originalPlayingServiceReference = None
 					self.currentlyPlayingServiceOrGroup = None
 					if oldref and ("://" in oldref.getPath() or streamrelay.checkService(oldref)):
-						print("[Navigation] Streaming was active, try again.")  # Use timer to give the stream server the time to deallocate the tuner.
+						self.retryServicePlayCount = 1  # Start retry cycle for stream relay tuner deallocation.
+					if self.retryServicePlayCount > 0 and self.retryServicePlayCount <= 20:
+						print(f"[Navigation] Streaming was active, try again (attempt {self.retryServicePlayCount}).")  # Use timer to give the stream server the time to deallocate the tuner.
 						self.retryServicePlayTimer = eTimer()
 						self.retryServicePlayTimer.callback.append(boundFunction(self.playService, ref, checkParentalControl, forceRestart, adjust))
 						self.retryServicePlayTimer.start(500, True)
+						self.retryServicePlayCount += 1
+					elif self.retryServicePlayCount > 20:
+						print(f"[Navigation] Gave up retrying after {self.retryServicePlayCount - 1} attempts.")
+						self.retryServicePlayCount = 0
+				else:
+					self.retryServicePlayCount = 0
 				self.skipServiceReferenceReset = False
 				self.isCurrentServiceStreamRelay = isStreamRelay
 				if InfoBarInstance and "%3a//" in playref.toString():


### PR DESCRIPTION
When zapping from a StreamRelay channel to a channel on a different satellite, the dish would refuse to move because the tuner was still held by the StreamRelay recording service. The user had to select the channel a second time after StreamRelay had fully closed.

Root cause: The StreamRelay recording service takes several seconds to detect the HTTP client disconnect, stop the recording and release the tuner. The existing retry logic only attempted a single retry after 500ms, which was not enough. On the second attempt, the original service reference (oldref) had already been cleared, so the streaming detection failed and no further retries were scheduled.

Fix: Add a persistent retry counter (retryServicePlayCount) that survives across playService calls. When the tuner cannot be allocated and the previous service was streaming, retry every 500ms for up to 20 attempts (~10 seconds). The counter is reset on fresh zap requests (oldref is not None) or on successful playback. For the delay path (softcam_streamrelay_delay > 0), the counter is pre-armed so retries continue if the play after the delay also fails.

**Test 1: `softcam_streamrelay_delay = 2000`**
```
15:12:36.7075 [Navigation] Stream relay was active, delay the zap till tuner is freed.
                                                                  # 2000ms delay before first attempt
15:12:38.7967 [eDVBResourceManager] allocate channel.. 000d:0085
15:12:38.7974 [eDVBResourceManager] can't allocate frontend!
15:12:38.7984 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:12:38.7985 [Navigation] Streaming was active, try again (attempt 1).
                                                                  # retry logic kicks in
15:12:39.2989 [eDVBResourceManager] allocate channel.. 000d:0085
15:12:39.2997 [eDVBResourceManager] can't allocate frontend!
15:12:39.3006 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:12:39.3007 [Navigation] Streaming was active, try again (attempt 2).

15:12:39.8010 [eDVBResourceManager] allocate channel.. 000d:0085
15:12:39.8018 [eDVBResourceManager] can't allocate frontend!
15:12:39.8027 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:12:39.8028 [Navigation] Streaming was active, try again (attempt 3).

15:12:40.3032 [eDVBResourceManager] allocate channel.. 000d:0085
15:12:40.3040 [eDVBResourceManager] can't allocate frontend!
15:12:40.3049 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:12:40.3050 [Navigation] Streaming was active, try again (attempt 4).

15:12:40.8054 [eDVBResourceManager] allocate channel.. 000d:0085
15:12:40.8062 [eDVBResourceManager] can't allocate frontend!
15:12:40.8071 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:12:40.8072 [Navigation] Streaming was active, try again (attempt 5).

15:12:41.0211 [eDVBServiceStream] stop streaming m_state 2       # tuner freed!

15:12:41.3076 [eDVBResourceManager] allocate channel.. 000d:0085
15:12:41.3114 [eDVBSatelliteEquipmentControl] RotorCmd 0d, lastRotorCmd 0b
15:12:41.3116 [eDVBServicePMTHandler] allocate Channel: res 0    # SUCCESS on attempt 6
15:12:41.4004 [SEC] tuner 0 sendDiseqc: e0316b0d                 # dish moves!
```

**Test 2: `softcam_streamrelay_delay = 0`**
```
15:30:45.8125 [Navigation] Playref is '1:0:19:7F:D:85:C02ED8:0:0:0:'.
                                                                  # no delay, immediate attempt
15:30:45.8865 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:45.8872 [eDVBResourceManager] can't allocate frontend!
15:30:45.8881 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:45.8884 [Navigation] Streaming was active, try again (attempt 1).
                                                                  # retry logic kicks in
15:30:46.3889 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:46.3897 [eDVBResourceManager] can't allocate frontend!
15:30:46.3906 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:46.3907 [Navigation] Streaming was active, try again (attempt 2).

15:30:46.8911 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:46.8919 [eDVBResourceManager] can't allocate frontend!
15:30:46.8928 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:46.8929 [Navigation] Streaming was active, try again (attempt 3).

15:30:47.3933 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:47.3941 [eDVBResourceManager] can't allocate frontend!
15:30:47.3950 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:47.3951 [Navigation] Streaming was active, try again (attempt 4).

15:30:47.8955 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:47.8963 [eDVBResourceManager] can't allocate frontend!
15:30:47.8972 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:47.8973 [Navigation] Streaming was active, try again (attempt 5).

15:30:48.3977 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:48.3985 [eDVBResourceManager] can't allocate frontend!
15:30:48.3994 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:48.3995 [Navigation] Streaming was active, try again (attempt 6).

15:30:48.8999 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:48.9007 [eDVBResourceManager] can't allocate frontend!
15:30:48.9016 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:48.9017 [Navigation] Streaming was active, try again (attempt 7).

15:30:49.4021 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:49.4029 [eDVBResourceManager] can't allocate frontend!
15:30:49.4038 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:49.4039 [Navigation] Streaming was active, try again (attempt 8).

15:30:49.9043 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:49.9051 [eDVBResourceManager] can't allocate frontend!
15:30:49.9060 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:49.9061 [Navigation] Streaming was active, try again (attempt 9).

15:30:50.4065 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:50.4073 [eDVBResourceManager] can't allocate frontend!
15:30:50.4082 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:50.4083 [Navigation] Streaming was active, try again (attempt 10).

15:30:50.9087 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:50.9095 [eDVBResourceManager] can't allocate frontend!
15:30:50.9104 [Navigation] Failed to start '1:0:19:7F:D:85:C02ED8:0:0:0:'.
15:30:50.9105 [Navigation] Streaming was active, try again (attempt 11).

15:30:51.1245 [eDVBServiceStream] stop streaming m_state 2       # tuner freed!

15:30:51.4109 [eDVBResourceManager] allocate channel.. 000d:0085
15:30:51.4147 [eDVBSatelliteEquipmentControl] RotorCmd 0d, lastRotorCmd 0b
15:30:51.4149 [eDVBServicePMTHandler] allocate Channel: res 0    # SUCCESS on attempt 12
15:30:51.5017 [SEC] tuner 0 sendDiseqc: e0316b0d                 # dish moves!
```