### PR TITLE
Improve getWindowsAxis with fallback for video modes

### DIFF
--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -1047,9 +1047,24 @@ class AVSwitchBase:
 			self.on_hotplug("HDMI")  # must be HDMI
 
 	def getWindowsAxis(self):
-		port = config.av.videoport.value
-		mode = config.av.videomode[port].value
-		return self.axis[mode]
+		port = getattr(config.av.videoport, "value", None)
+		mode = None
+		if port and port in config.av.videomode:
+			mode = config.av.videomode[port].value
+		elif "HDMI" in config.av.videomode:
+			port = "HDMI"
+			mode = config.av.videomode[port].value
+		else:
+			for fallbackPort in config.av.videomode.keys():
+				port = fallbackPort
+				mode = config.av.videomode[fallbackPort].value
+				break
+
+		if mode not in self.axis:
+			print(f"[AVSwitch] getWindowsAxis: Missing port/mode mapping for port='{port}', mode='{mode}', fallback to 720p.")
+			mode = "720p"
+
+		return self.axis.get(mode, self.axis["720p"])
 
 	def createConfig(self, *args):
 		config.av.videomode = ConfigSubDict()


### PR DESCRIPTION
Refactor getWindowsAxis to handle missing video modes and add fallback logic.

22:37:40.8326 [Skin] Loading XML templates from '/usr/share/enigma2/MetrixHD/skinTemplates.xml'. 22:37:40.8342 [InputDevice] InitInputDevices DEBUG: Creating config entry for device: 'event0' -> 'aml_keypad'. 22:37:40.8345 [InputDevice] InitInputDevices DEBUG: Creating config entry for device: 'event1' -> 'cec_input'. 22:37:40.8347 [InputDevice] InitInputDevices DEBUG: Creating config entry for device: 'event2' -> 'dreambox front panel'. 22:37:40.8349 [InputDevice] InitInputDevices DEBUG: Creating config entry for device: 'event3' -> 'dreambox remote control (bluetooth le)'. 22:37:40.8351 [InputDevice] InitInputDevices DEBUG: Creating config entry for device: 'event4' -> 'dreambox remote control (native)'. 22:37:40.8352 [InputDevice] InitInputDevices DEBUG: Creating config entry for device: 'event5' -> 'dreambox advanced remote control (native)'. 22:37:40.8370 [AVSwitch] getPreferredModes: ''. 22:37:40.8371 [AVSwitch] Used default modes: []. 22:37:40.8371 [AVSwitch] Preferend modes not okay, possible driver failer, length=0. 22:37:40.8377 [AVSwitch] Setting EDID override to 'False'. 22:37:40.8393 [eAVControl] Error 2: Unable to open file '/proc/stb/video/aspect'! (No such file or directory) 22:37:40.8394 [eAVControl] setAspect: 16:9 22:37:40.8395 [eAVControl] Error 2: Unable to open file '/proc/stb/video/policy'! (No such file or directory) 22:37:40.8395 [eAVControl] setPolicy43: 8 22:37:40.8396 [eAVControl] Error 2: Unable to open file '/proc/stb/video/policy2'! (No such file or directory) 22:37:40.8396 [eAVControl] setPolicy169: 11 22:37:40.8451 Traceback (most recent call last): 22:37:40.8460 File "/usr/lib/enigma2/python/StartEnigma.py", line 873, in <module> InitAVSwitch() ~~~~~~~~~~~~^^ 22:37:40.8461 File "/usr/lib/enigma2/python/Components/AVSwitch.py", line 312, in InitAVSwitch 22:37:40.8461 File "/usr/lib/enigma2/python/Components/AVSwitch.py", line 1051, in getWindowsAxis 22:37:40.8462 KeyError: 'HDMI' 22:37:40.8514 [eDVBResourceManager] release cached channel (timer timeout) 22:37:40.8515 [Avahi] avahi_watch_free