### PR TITLE
[Navigation.py] fix 8178f8eeaabb38a264cf0b81a794aeeef0dd61ec

### DIFF
--- a/lib/python/Navigation.py
+++ b/lib/python/Navigation.py
@@ -404,7 +404,7 @@ class Navigation:
 				originalPlayref = playref.toString()
 				for extensionFunc in Navigation.playServiceExtensions:
 					ret = extensionFunc(self, playref, event, InfoBarInstance)
-					if isinstance(ret, (ServiceReference, eServiceReference)):
+					if isinstance(ret, (ServiceReference.ServiceReference, eServiceReference)):
 						playref = ret
 					else:
 						playref, isAsyncPlay = ret


### PR DESCRIPTION
In the original the import is "from ServiceReference import ServiceReference" but in OpenATV it is "import ServiceReference"