### PR TITLE
[eDVBServiceStream] fix missing audio when streaming with incomplete lamedb

### DIFF
--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -1,8 +1,10 @@
+#include <array>
 #include <errno.h>
 #include <unistd.h>
 #include <lib/dvb/db.h>
 #include <lib/dvb/dvb.h>
 #include <lib/dvb/frontend.h>
+#include <lib/dvb/pmtparse.h>
 #include <lib/dvb/epgcache.h>
 #include <lib/base/cfile.h>
 #include <lib/base/eenv.h>
@@ -401,6 +403,29 @@ bool eDVBService::cacheAudioEmpty()
 			if (m_cache[audioCacheTags[i]] != -1)
 				return false;
 	return true;
+}
+
+void eDVBService::updateAudioCache(int apid, int apidtype)
+{
+	struct audioMapEntry {
+		int streamType;
+		cacheID cacheTag;
+	};
+	static const std::array<audioMapEntry, 10> audioMap = {{
+		{ eDVBPMTParser::audioStream::atMPEG,  cMPEGAPID  },
+		{ eDVBPMTParser::audioStream::atAC3,   cAC3PID    },
+		{ eDVBPMTParser::audioStream::atAC4,   cAC4PID    },
+		{ eDVBPMTParser::audioStream::atDDP,   cDDPPID    },
+		{ eDVBPMTParser::audioStream::atAAC,   cAACAPID   },
+		{ eDVBPMTParser::audioStream::atDTS,   cDTSPID    },
+		{ eDVBPMTParser::audioStream::atLPCM,  cLPCMPID   },
+		{ eDVBPMTParser::audioStream::atDTSHD, cDTSHDPID  },
+		{ eDVBPMTParser::audioStream::atAACHE, cAACHEAPID },
+		{ eDVBPMTParser::audioStream::atDRA,   cDRAAPID   },
+	}};
+
+	for (const auto &entry : audioMap)
+		setCacheEntry(entry.cacheTag, apidtype == entry.streamType ? apid : -1);
 }
 
 void eDVBService::initCache()

--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -344,6 +344,7 @@ public:
 
 	bool cacheEmpty();
 	bool cacheAudioEmpty();
+	void updateAudioCache(int apid, int apidtype);
 
 	eDVBService();
 	/* m_service_name_sort is uppercase, with special chars removed, to increase sort performance. */

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2727,28 +2727,7 @@ void eDVBServicePlay::updateAudioCache(int apid, int apidtype)
 	if (!m_dvb_service)
 		return;
 
-	const static struct {
-		int streamType;
-		eDVBService::cacheID cacheTag;
-	} audioMap [] = {
-		{ eDVBAudio::aMPEG,  eDVBService::cMPEGAPID,  },
-		{ eDVBAudio::aAC3,   eDVBService::cAC3PID,    },
-		{ eDVBAudio::aAC4,   eDVBService::cAC4PID,    },
-		{ eDVBAudio::aDDP,   eDVBService::cDDPPID,    },
-		{ eDVBAudio::aAAC,   eDVBService::cAACAPID,   },
-		{ eDVBAudio::aDTS,   eDVBService::cDTSPID,    },
-		{ eDVBAudio::aLPCM,  eDVBService::cLPCMPID,   },
-		{ eDVBAudio::aDTSHD, eDVBService::cDTSHDPID,  },
-		{ eDVBAudio::aAACHE, eDVBService::cAACHEAPID, },
-		{ eDVBAudio::aDRA,   eDVBService::cDRAAPID,   },
-	};
-	static const int nAudioMap = sizeof audioMap / sizeof audioMap[0];
-
-	for(int m = 0; m < nAudioMap; m++)
-	{
-		m_dvb_service->setCacheEntry(audioMap[m].cacheTag, apidtype == audioMap[m].streamType ? apid : -1);
-	}
-
+	m_dvb_service->updateAudioCache(apid, apidtype);
 	eDebug("[eDVBServicePlay] updateAudioCache: pid=%04x type=%d", apid, apidtype);
 }
 

--- a/lib/service/servicedvbstream.cpp
+++ b/lib/service/servicedvbstream.cpp
@@ -203,6 +203,20 @@ int eDVBServiceStream::doRecord()
 	bool have_program_info = (m_service_handler.getProgramInfo(program) == 0);
 	bool is_encrypted = have_program_info && program.isCrypted();
 
+	/* wait for real PMT if we only have cached (possibly incomplete) PIDs */
+	if (have_program_info && program.isCached)
+	{
+		eServiceReferenceDVB sref = m_ref.getParentServiceReference();
+		ePtr<eDVBService> service;
+		if (!sref.valid())
+			sref = m_ref;
+		if (!eDVBDB::getInstance()->getService(sref, service) && service->usePMT())
+		{
+			eDebug("[eDVBServiceStream] have cached program info only, waiting for real PMT...");
+			return 0;
+		}
+	}
+
 	if (!m_record && m_tuned)
 	{
 		// Must wait for PMT before creating recorder to choose correct thread type
@@ -406,6 +420,10 @@ int eDVBServiceStream::doRecord()
 		pids_to_record.insert(0x14);
 
 		recordPids(pids_to_record, timing_pid, timing_stream_type, timing_pid_type);
+
+		/* update service cache with fresh PMT PIDs */
+		if (!program.isCached)
+			updateServiceCache(program);
 	}
 
 	return 0;
@@ -507,6 +525,44 @@ void eDVBServiceStream::recordPids(std::set<int> pids_to_record, int timing_pid,
 		m_record->start();
 		m_state = stateRecording;
 	}
+}
+
+void eDVBServiceStream::updateServiceCache(eDVBServicePMTHandler::program &program) const
+{
+	eServiceReferenceDVB sref = m_ref.getParentServiceReference();
+	ePtr<eDVBService> service;
+
+	if (!sref.valid())
+		sref = m_ref;
+
+	if (eDVBDB::getInstance()->getService(sref, service))
+		return;
+
+	if (!program.videoStreams.empty())
+	{
+		service->setCacheEntry(eDVBService::cVPID, program.videoStreams[0].pid);
+		service->setCacheEntry(eDVBService::cVTYPE,
+			program.videoStreams[0].type == eDVBPMTParser::videoStream::vtMPEG2 ? -1 : program.videoStreams[0].type);
+	}
+	if (program.pcrPid >= 0)
+		service->setCacheEntry(eDVBService::cPCRPID, program.pcrPid);
+	if (program.textPid >= 0)
+		service->setCacheEntry(eDVBService::cTPID, program.textPid);
+	if (program.pmtPid >= 0)
+		service->setCacheEntry(eDVBService::cPMTPID, program.pmtPid);
+
+	if (!program.audioStreams.empty())
+	{
+		int idx = program.defaultAudioStream;
+		if (idx < 0 || idx >= (int)program.audioStreams.size())
+			idx = 0;
+		service->updateAudioCache(program.audioStreams[idx].pid, program.audioStreams[idx].type);
+	}
+
+	eDebug("[eDVBServiceStream] updated service cache from PMT: vpid=%d apid=%d pcrpid=%d pmtpid=%d",
+		program.videoStreams.empty() ? -1 : program.videoStreams[0].pid,
+		program.audioStreams.empty() ? -1 : program.audioStreams[0].pid,
+		program.pcrPid, program.pmtPid);
 }
 
 void eDVBServiceStream::recordEvent(int event)

--- a/lib/service/servicedvbstream.h
+++ b/lib/service/servicedvbstream.h
@@ -57,6 +57,7 @@ protected:
 	int m_record_no_pids = 0;
 	void recordPids(std::set<int> pids_to_record, int timing_pid, int timing_stream_type, iDVBTSRecorder::timing_pid_type timing_pid_type);
 	bool recordCachedPids();
+	void updateServiceCache(eDVBServicePMTHandler::program &program) const;
 
 	// Speculative software descrambler - always attached for encrypted channels
 	// Does nothing unless algo=3 is received


### PR DESCRIPTION
Wait for real PMT instead of using potentially incomplete cached PIDs when starting a stream. Update service cache from PMT data so subsequent streams have complete PID information. Move audio cache mapping into eDVBService::updateAudioCache() to share between live TV and streaming.

fix #3736