### PR TITLE
[SystemInfo] add OE-Alliance Core to commit logs

### DIFF
--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -5,7 +5,7 @@ from os import listdir, readlink
 from os.path import basename, exists, isfile, islink, join
 from subprocess import PIPE, Popen
 
-from enigma import eDBoxLCD, eDVBCIInterfaces, eDVBCSAEngine, eDVBResourceManager, eGetEnigmaDebugLvl, getE2Rev, Misc_Options
+from enigma import eDBoxLCD, eDVBCIInterfaces, eDVBCSAEngine, eDVBResourceManager, eGetEnigmaDebugLvl, getE2Rev, getOARev, Misc_Options
 from Tools.Directories import fileCheck, fileExists, fileHas, fileReadLine, fileReadLines, isPluginInstalled, pathExists, resolveFilename, SCOPE_LIBDIR, SCOPE_SKINS
 from Tools.MultiBoot import MultiBoot
 
@@ -347,8 +347,14 @@ try:
 	branch = f"?sha={branch}"
 except IndexError:
 	branch = ""
+try:
+	oaBranch = getOARev()
+	oaBranch = f"?sha={oaBranch}" if oaBranch else ""
+except Exception:
+	oaBranch = ""
 commitLogs = [
 	("OpenATV Enigma2", f"https://api.github.com/repos/openatv/enigma2/commits{branch}"),
+	("OE-Alliance Core", f"https://api.github.com/repos/oe-alliance/oe-alliance-core/commits{oaBranch}"),
 	("OE-Alliance Plugins", "https://api.github.com/repos/oe-alliance/oe-alliance-plugins/commits"),
 	("Enigma2 Plugins", "https://api.github.com/repos/oe-alliance/enigma2-plugins/commits"),
 	("OpenWebif", "https://api.github.com/repos/E2OpenPlugins/e2openplugin-OpenWebif/commits"),

--- a/lib/python/enigma_python.i
+++ b/lib/python/enigma_python.i
@@ -563,6 +563,7 @@ extern void resetBsodCounter();
 extern void addFont(const char *filename, const char *alias, int scale_factor, int is_replacement, int renderflags = 0);
 extern const char *getEnigmaVersionString();
 extern const char *getE2Rev();
+extern const char *getOARev();
 extern const char *getGStreamerVersionString();
 extern void dump_malloc_stats(void);
 #ifndef HAVE_OSDANIMATION
@@ -588,6 +589,7 @@ extern void quitMainloop(int exit_code);
 extern eApplication *getApplication();
 extern const char *getEnigmaVersionString();
 extern const char *getE2Rev();
+extern const char *getOARev();
 extern const char *getGStreamerVersionString();
 extern void dump_malloc_stats(void);
 #ifndef HAVE_OSDANIMATION


### PR DESCRIPTION
Import getOARev() and use the oe-alliance-core git SHA to add OE-A Core as a commit log source. Users can now see recent oe-alliance-core changes alongside enigma2 and plugin commits.