### PR TITLE
[Menu.py] Fix menu navigation via digit entry

### DIFF
--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -10,9 +10,9 @@ from Components.AVSwitch import avSwitch
 from Components.config import ConfigDictionarySet, NoSave, config, configfile
 from Components.Pixmap import Pixmap
 from Components.PluginComponent import plugins
-from Components.SystemInfo import BoxInfo, getBoxDisplayName
 from Components.Sources.List import List
 from Components.Sources.StaticText import StaticText
+from Components.SystemInfo import BoxInfo, getBoxDisplayName
 from Plugins.Plugin import PluginDescriptor
 from Screens.ParentalControlSetup import ProtectedScreen
 from Screens.Screen import Screen, ScreenSummary
@@ -574,7 +574,7 @@ class Menu(Screen, ProtectedScreen):
 		count = self["menu"].count()
 		if self.number and self.number <= count:
 			self["menu"].setIndex(self.number - 1)
-			if count < 10 or self.number >= 10:
+			if count < 10 or self.number * 10 > count:
 				self.okbuttonClick()
 			else:
 				self.nextNumberTimer.start(1500, True)


### PR DESCRIPTION
- Change code to correctly processes menu digit entries such that valid digit entries no longer cause the UI to wait for the next digit when there can be no further valid digits. This issue was often seen on the second screen of a multi menu selection sequence. For example, on the main menu press 7 to go to Setup and then press 8 for Software Management and the UI would wait after the digit 8 for another digit. There can be no valid digit after the 8 so the new code immediately jumps into the Software Management screen. If the first digit is 1 then the code needs to wait to see if the user meant 1 or 10 or 11, etc.
- Use the new import sorting order.
