### PR TITLE
[Scan] Fix services with same SID on different transponders overwriting each other

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -828,10 +828,27 @@ void eDVBScan::channelDone()
 
 		m_ch_current->getHash(hash);
 
-		eDVBNamespace dvbnamespace = buildNamespace(
-			(**m_SDT->getSections().begin()).getOriginalNetworkId(),
-			(**m_SDT->getSections().begin()).getTransportStreamId(),
-			hash);
+		eOriginalNetworkID onid = (**m_SDT->getSections().begin()).getOriginalNetworkId();
+		eTransportStreamID tsid = (**m_SDT->getSections().begin()).getTransportStreamId();
+
+		eDVBNamespace dvbnamespace = buildNamespace(onid, tsid, hash);
+
+		/* Detect namespace collision: if a channel with the same stripped namespace+TSID+ONID
+		 * already exists in the database but points to a different physical transponder,
+		 * preserve the frequency in the namespace to keep services unique.
+		 * This prevents services with the same SID on different transponders (e.g. EBU feeds)
+		 * from overwriting each other during manual scan. */
+		eDVBChannelID chid_check(dvbnamespace, tsid, onid);
+		if (ePtr<iDVBFrontendParameters> existing_ch;
+			!eDVBDB::getInstance()->getChannelFrontendData(chid_check, existing_ch))
+		{
+			int diff = 0;
+			if (!m_ch_current->calculateDifference(&*existing_ch, diff, false) && diff > 0)
+			{
+				dvbnamespace = eDVBNamespace(hash);
+				SCAN_eDebug("[eDVBScan] namespace collision detected: different transponder uses same TSID/ONID, preserving frequency in namespace");
+			}
+		}
 
 		SCAN_eDebug("[eDVBScan] SDT: ");
 		std::vector<ServiceDescriptionSection*>::const_iterator i;
@@ -847,10 +864,24 @@ void eDVBScan::channelDone()
 		m_ch_current->getHash(hash);
 
 		int onid = 0; /* TODO: ATSC ONID? */
+		eTransportStreamID tsid = (**m_VCT->getSections().begin()).getTransportStreamId();
 		eDVBNamespace dvbnamespace = buildNamespace(
 			eOriginalNetworkID(onid),
-			(**m_VCT->getSections().begin()).getTransportStreamId(),
+			tsid,
 			hash);
+
+		/* Detect namespace collision (same as SDT block above) */
+		eDVBChannelID chid_check(dvbnamespace, tsid, eOriginalNetworkID(onid));
+		if (ePtr<iDVBFrontendParameters> existing_ch;
+			!eDVBDB::getInstance()->getChannelFrontendData(chid_check, existing_ch))
+		{
+			int diff = 0;
+			if (!m_ch_current->calculateDifference(&*existing_ch, diff, false) && diff > 0)
+			{
+				dvbnamespace = eDVBNamespace(hash);
+				SCAN_eDebug("[eDVBScan] namespace collision detected: different transponder uses same TSID/ONID, preserving frequency in namespace");
+			}
+		}
 
 		SCAN_eDebug("[eDVBScan] VCT: ");
 		std::vector<VirtualChannelTableSection*>::const_iterator i;


### PR DESCRIPTION
When multiple services share the same SID, TSID, and ONID across different transponders (e.g. EBU feeds EBU 1/2/3 ENC on Eutelsat 7C at 7.0E), buildNamespace() strips the frequency from the namespace hash (subnetwork feature), causing all services to receive identical service references. This results in each manual scan overwriting the previously scanned service, so only the last scanned channel remains in the channel list.

The fix adds collision detection in channelDone() for both SDT and VCT processing: after building the namespace, we check if a channel with the same eDVBChannelID (namespace+TSID+ONID) already exists in the database. If it does, we compare the actual transponder parameters using calculateDifference(). When the existing channel is on a physically different transponder (diff > 0), the frequency is preserved in the namespace instead of being stripped, ensuring each service gets a unique service reference.

This preserves the existing subnetwork behavior for normal channels where TSID+ONID uniquely identifies a transponder, while preventing collisions for the edge case of different services sharing SID+TSID+ONID on separate frequencies.