### PR TITLE
[build] link libatomic on architectures that need it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,8 @@ PKG_CHECK_MODULES(LIBDDVD, libdreamdvd, HAVE_LIBDDVD="yes", HAVE_LIBDDVD="no")
 AM_CONDITIONAL(HAVE_LIBDDVD, test "$HAVE_LIBDDVD" = "yes")
 PKG_CHECK_MODULES(AVAHI, avahi-client)
 
+AC_CHECK_LIB([atomic], [__atomic_exchange_8], [LIBATOMIC_LIBS="-latomic"], [LIBATOMIC_LIBS=""])
+AC_SUBST(LIBATOMIC_LIBS)
 AC_CHECK_LIB([udfread], [udfread_init])
 AC_CHECK_LIB([dl], [dlopen], [LIBDL_LIBS="-ldl"], [AC_MSG_ERROR([Could not find libdl])])
 AC_SUBST(LIBDL_LIBS)

--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -48,6 +48,7 @@ enigma2_LDADD = \
 	@AVAHI_LIBS@ \
 	@LIBHIACCEL_LIBS@ \
 	@SWSCALE_LIBS@ \
+	@LIBATOMIC_LIBS@ \
 	-ltuxtxt32bpp -lcrypt -lrt -ldl
 
 enigma2_LDFLAGS = -Wl,--export-dynamic


### PR DESCRIPTION
mipsel (and other 32-bit targets) requires libatomic for 64-bit atomic operations (std::atomic<off_t>) introduced in a18f4cdc42.