### PR TITLE
 eRamServicePlay: override timeshift() to bypass disk checks for RAM-only timeshift 

### DIFF
--- a/lib/service/eramserviceplay.cpp
+++ b/lib/service/eramserviceplay.cpp
@@ -23,6 +23,14 @@ eRamServicePlay::~eRamServicePlay() {
 	stopTimeshift(false);
 }
 
+RESULT eRamServicePlay::timeshift(ePtr<iTimeshiftService>& ptr)
+{
+	// RAM timeshift does not need a disk path or free space check.
+	// It works entirely in RAM, so it's always available for live TV.
+	ptr = this;
+	return 0;
+}
+
 RESULT eRamServicePlay::startTimeshift() {
 	if (m_timeshift_enabled)
 		return -1;

--- a/lib/service/eramserviceplay.h
+++ b/lib/service/eramserviceplay.h
@@ -32,6 +32,7 @@ public:
 	RESULT seekRelative(int direction, pts_t to)   override;
 
 	// Timeshift management
+	RESULT timeshift(ePtr<iTimeshiftService>& ptr) override;
 	RESULT activateTimeshift()              override;
 	RESULT saveTimeshiftFile()              override; // no-op: nothing on disk
 	void   serviceEventTimeshift(int event) override;


### PR DESCRIPTION
 Override timeshift() in eRamServicePlay to skip disk path and free space checks for RAM-only timeshift. Hard-disk timeshift remains completely unaffected. This allows users without a hard disk to use RAM timeshift by pressing Pause on live TV. 