### PR TITLE
[SoftCSA] fix no audio on encrypted QuadPiP tile when brought to focus

### DIFF
--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -4355,6 +4355,9 @@ void eDVBServicePlay::setQpipMode(bool value, bool audio)
 
 		m_decoder->set();
 	}
+
+	if (m_soft_decoder)
+		m_soft_decoder->setNoAudio(m_noaudio, m_current_audio_pid);
 }
 
 // ==================== Software Descrambling ====================

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -794,6 +794,59 @@ int eDVBSoftDecoder::setTrickmode()
 // Audio Control - Delegate to decoder
 // ============================================================================
 
+void eDVBSoftDecoder::setNoAudio(bool noaudio, int preferred_pid)
+{
+	if (!m_decoder || !m_decoder_started)
+	{
+		m_noaudio = noaudio;
+		return;
+	}
+
+	if (m_noaudio == noaudio)
+		return;
+
+	m_noaudio = noaudio;
+
+	if (noaudio)
+	{
+		m_decoder->setAudioPID(-1, -1);
+		m_decoder->set();
+		return;
+	}
+
+	eDVBServicePMTHandler::program program;
+	if (m_source_handler.getProgramInfo(program) || program.audioStreams.empty())
+		return;
+
+	int apid = -1, atype = -1;
+
+	if (preferred_pid > 0)
+	{
+		for (const auto& a : program.audioStreams)
+		{
+			if (a.pid == preferred_pid)
+			{
+				apid = a.pid;
+				atype = a.type;
+				break;
+			}
+		}
+	}
+
+	if (apid == -1)
+	{
+		unsigned int audio_index = program.defaultAudioStream;
+		if (audio_index >= program.audioStreams.size())
+			audio_index = 0;
+		apid = program.audioStreams[audio_index].pid;
+		atype = program.audioStreams[audio_index].type;
+	}
+
+	m_decoder->setAudioPID(apid, atype);
+	m_decoder->set();
+	m_audio_pid_selected(apid);
+}
+
 int eDVBSoftDecoder::setAudioPID(int pid, int type)
 {
 	if (m_noaudio)

--- a/lib/service/servicedvbsoftdecoder.h
+++ b/lib/service/servicedvbsoftdecoder.h
@@ -44,8 +44,7 @@ public:
 	int start();
 	void stop();
 
-	// Suppress audio output (PIP mode)
-	void setNoAudio(bool noaudio) { m_noaudio = noaudio; }
+	void setNoAudio(bool noaudio, int preferred_pid = -1);
 
 	// Status
 	bool isRunning() const { return m_running; }


### PR DESCRIPTION
setQpipMode only touched m_decoder, which is nullptr while the SoftDecoder is active. Forward mute/unmute to m_soft_decoder and restore the previously selected audio pid on unmute.