### PR TITLE
[InfoBarGenerics] tolerate non-ASCII paths on setResumePoint

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -105,10 +105,13 @@ def setResumePoint(session):
 				for k, v in list(resumePointCache.items()):
 					if v[0] < lru:
 						candidate = k
-						filepath = realpath(candidate.split(":")[-1])
-						mountpoint = findMountPoint(filepath)
-						if ismount(mountpoint) and not exists(filepath):
-							del resumePointCache[candidate]
+						try:
+							filepath = realpath(candidate.split(":")[-1])
+							mountpoint = findMountPoint(filepath)
+							if ismount(mountpoint) and not exists(filepath):
+								del resumePointCache[candidate]
+						except (UnicodeEncodeError, OSError):
+							pass
 				saveResumePoints()
 
 


### PR DESCRIPTION
posixpath.realpath() uses fsencode under ASCII locale → UnicodeEncodeError on filenames with chars like en-dash (U+2013), killing the MoviePlayer when the user presses STOP. Swallow it and skip the dead-cache cleanup for that entry. Seen on aarch64 devices (e.g. dreamone)