### PR TITLE
[DreamNextGen] VideoEnhancement: fix slider ranges, color clamp UX and read-back

### DIFF
--- a/lib/python/Plugins/SystemPlugins/VideoEnhancementAML/VideoEnhancement.py
+++ b/lib/python/Plugins/SystemPlugins/VideoEnhancementAML/VideoEnhancement.py
@@ -1,7 +1,65 @@
 from os.path import exists
-from Components.config import config, ConfigSubsection, ConfigInteger, ConfigSlider, ConfigSelection, ConfigNothing, NoSave
+from Components.config import config, ConfigSubsection, ConfigSlider, ConfigSelection, ConfigNothing, NoSave
 
 # The "VideoEnhancement" is the interface to /sys/class/amvecm.
+#
+# UX convention (matches the non-AML VideoEnhancement plugin):
+#   Every slider is unsigned 0..255 with 128 = neutral. The notifier maps
+#   that to the kernel-native signed range before writing to sysfs.
+#
+# Kernel-accepted ranges on Amlogic S922X amvecm (probed live):
+#   contrast1/2:      -127..127
+#   brightness1/2:    -1024..1023
+#   saturation (saturation_hue_post, first field):  -128..127
+#   saturation_hue (packed 32-bit, hi half 0..0x200, default 0x100 = neutral)
+#   color_top / color_bottom: 0..0x3fffffff (per-channel 10-bit RGB clamp)
+
+AMVECM = "/sys/class/amvecm"
+SLIDER_MAX = 255
+SLIDER_NEUTRAL = 128
+
+
+def _readRawText(p):
+	try:
+		with open(p, "r") as f:
+			return f.read().strip()
+	except OSError:
+		return None
+
+
+def _readInt(p, fallback):
+	v = _readRawText(p)
+	if v is None:
+		return fallback
+	try:
+		return int(v, 0)
+	except ValueError:
+		return fallback
+
+
+def _readPair(p, fallback):
+	# saturation_hue_post returns "<sat> <hue>"
+	v = _readRawText(p)
+	if v is None:
+		return fallback
+	parts = v.split()
+	try:
+		return (int(parts[0], 0), int(parts[1], 0))
+	except (ValueError, IndexError):
+		return fallback
+
+
+def _clamp(v, lo, hi):
+	return max(lo, min(hi, v))
+
+
+def _kernelToSlider(kval, scale):
+	# kval is signed, neutral at 0 in kernel space. slider neutral = 128.
+	return _clamp(SLIDER_NEUTRAL + int(round(kval / scale)), 0, SLIDER_MAX)
+
+
+def _sliderToKernel(sval, scale, lo, hi):
+	return _clamp(int(round((sval - SLIDER_NEUTRAL) * scale)), lo, hi)
 
 
 class VideoEnhancement:
@@ -15,152 +73,207 @@ class VideoEnhancement:
 		config.amvecm = ConfigSubsection()
 		config.amvecm.configsteps = NoSave(ConfigSelection(choices=[1, 5, 10, 25], default=1))
 
-		if exists("/sys/class/amvecm/contrast1"):
+		# --- contrast1: kernel -127..127, slider 0..255 (scale 1.0) ---
+		if exists("%s/contrast1" % AMVECM):
+			initial = _kernelToSlider(_readInt("%s/contrast1" % AMVECM, 0), 1.0)
+
 			def setContrast1(configItem):
-				myval = str(configItem.value)
+				kval = _sliderToKernel(int(configItem.value), 1.0, -127, 127)
 				try:
-					print("--> setting video contrast to:%s" % myval)
-					f = open("/sys/class/amvecm/contrast1", "w")
-					f.write(myval)
-					f.close()
+					print("--> setting contrast1 (video) to: %d" % kval)
+					with open("%s/contrast1" % AMVECM, "w") as f:
+						f.write(str(kval))
 				except OSError:
-					print("couldn't write video contrast.")
+					print("couldn't write contrast1.")
 
 				if not VideoEnhancement.firstRun:
 					self.setConfiguredValues()
 
-			config.amvecm.contrast1 = ConfigSlider(default=0, limits=(-1022, 1022))
+			config.amvecm.contrast1 = ConfigSlider(default=initial, limits=(0, SLIDER_MAX))
 			config.amvecm.contrast1.addNotifier(setContrast1)
 		else:
 			config.amvecm.contrast1 = NoSave(ConfigNothing())
 
-		if exists("/sys/class/amvecm/contrast2"):
+		# --- contrast2: kernel -127..127, slider 0..255 (scale 1.0) ---
+		if exists("%s/contrast2" % AMVECM):
+			initial = _kernelToSlider(_readInt("%s/contrast2" % AMVECM, 0), 1.0)
+
 			def setContrast2(configItem):
-				myval = str(configItem.value)
+				kval = _sliderToKernel(int(configItem.value), 1.0, -127, 127)
 				try:
-					print("--> setting video & OSD contrast to:%s" % myval)
-					f = open("/sys/class/amvecm/contrast2", "w")
-					f.write(myval)
-					f.close()
+					print("--> setting contrast2 (video+OSD) to: %d" % kval)
+					with open("%s/contrast2" % AMVECM, "w") as f:
+						f.write(str(kval))
 				except OSError:
-					print("couldn't write video & OSD contrast.")
+					print("couldn't write contrast2.")
 
 				if not VideoEnhancement.firstRun:
 					self.setConfiguredValues()
 
-			config.amvecm.contrast2 = ConfigSlider(default=0, limits=(-1022, 1022))
+			config.amvecm.contrast2 = ConfigSlider(default=initial, limits=(0, SLIDER_MAX))
 			config.amvecm.contrast2.addNotifier(setContrast2)
 		else:
 			config.amvecm.contrast2 = NoSave(ConfigNothing())
 
-		if exists("/sys/class/amvecm/saturation_hue_post"):
+		# --- saturation: kernel -127..127, slider 0..255 (scale 1.0) ---
+		if exists("%s/saturation_hue_post" % AMVECM):
+			initialSat, _initialHuePost = _readPair("%s/saturation_hue_post" % AMVECM, (0, 0))
+			initial = _kernelToSlider(initialSat, 1.0)
+
 			def setSaturation(configItem):
-				myval = str(configItem.value)
+				kval = _sliderToKernel(int(configItem.value), 1.0, -127, 127)
+				# preserve current hue_post so we don't clobber it with a hard 0
+				_curSat, curHuePost = _readPair("%s/saturation_hue_post" % AMVECM, (0, 0))
 				try:
-					print("--> setting saturation to: %s" % myval)
-					f = open("/sys/class/amvecm/saturation_hue_post", "w")
-					f.write("%s 0" % myval)
-					f.close()
+					print("--> setting saturation to: %d (hue_post preserved: %d)" % (kval, curHuePost))
+					with open("%s/saturation_hue_post" % AMVECM, "w") as f:
+						f.write("%d %d" % (kval, curHuePost))
 				except OSError:
-					print("couldn't write saturaion.")
+					print("couldn't write saturation.")
 
 				if not VideoEnhancement.firstRun:
 					self.setConfiguredValues()
 
-			config.amvecm.saturation = ConfigSlider(default=0, limits=(-127, 127))
+			config.amvecm.saturation = ConfigSlider(default=initial, limits=(0, SLIDER_MAX))
 			config.amvecm.saturation.addNotifier(setSaturation)
 		else:
 			config.amvecm.saturation = NoSave(ConfigNothing())
 
-		if exists("/sys/class/amvecm/saturation_hue"):
+		# --- hue: kernel saturation_hue packed 32-bit, hi half 0..0x200, neutral 0x100.
+		# Map slider 0..255 to hi half 0..510 (slider 128 -> 256 = 0x100 neutral). ---
+		if exists("%s/saturation_hue" % AMVECM):
+			rawInitial = _readInt("%s/saturation_hue" % AMVECM, 0x1000000)
+			hiInitial = (rawInitial >> 16) & 0xffff
+			initial = _clamp(hiInitial // 2, 0, SLIDER_MAX)
+
 			def setHue(configItem):
-				myval = int(configItem.value)
+				hi = _clamp(int(configItem.value) * 2, 0, 0x1ff)
+				packed = (hi << 16) & 0xffffffff
 				try:
-					print("--> setting hue to: %s" % myval)
-					f = open("/sys/class/amvecm/saturation_hue", "w")
-					f.write("%s0000" % hex(myval))
-					f.close()
+					print("--> setting saturation_hue hi to: 0x%x (raw=0x%x)" % (hi, packed))
+					with open("%s/saturation_hue" % AMVECM, "w") as f:
+						f.write("0x%x" % packed)
 				except OSError:
-					print("couldn't write hue.")
+					print("couldn't write saturation_hue.")
 
 				if not VideoEnhancement.firstRun:
 					self.setConfiguredValues()
 
-			config.amvecm.hue = ConfigSlider(default=256, limits=(-1022, 1022))
+			config.amvecm.hue = ConfigSlider(default=initial, limits=(0, SLIDER_MAX))
 			config.amvecm.hue.addNotifier(setHue)
 		else:
 			config.amvecm.hue = NoSave(ConfigNothing())
 
-		if exists("/sys/class/amvecm/brightness1"):
+		# --- brightness1: kernel -1024..1023, slider 0..255 (scale ~8) ---
+		if exists("%s/brightness1" % AMVECM):
+			initial = _kernelToSlider(_readInt("%s/brightness1" % AMVECM, 0), 8.0)
+
 			def setBrightness1(configItem):
-				myval = str(configItem.value)
+				kval = _sliderToKernel(int(configItem.value), 8.0, -1024, 1023)
 				try:
-					print("--> setting brightness Video to: %s" % myval)
-					f = open("/sys/class/amvecm/brightness1", "w")
-					f.write(myval)
-					f.close()
+					print("--> setting brightness1 (video) to: %d" % kval)
+					with open("%s/brightness1" % AMVECM, "w") as f:
+						f.write(str(kval))
 				except OSError:
 					print("couldn't write brightness1.")
 
 				if not VideoEnhancement.firstRun:
 					self.setConfiguredValues()
-			config.amvecm.brightness1 = ConfigSlider(default=0, limits=(-1022, 1022))
+
+			config.amvecm.brightness1 = ConfigSlider(default=initial, limits=(0, SLIDER_MAX))
 			config.amvecm.brightness1.addNotifier(setBrightness1)
 		else:
 			config.amvecm.brightness1 = NoSave(ConfigNothing())
 
-		if exists("/sys/class/amvecm/brightness2"):
+		# --- brightness2: kernel -1024..1023, slider 0..255 (scale ~8) ---
+		if exists("%s/brightness2" % AMVECM):
+			initial = _kernelToSlider(_readInt("%s/brightness2" % AMVECM, 0), 8.0)
+
 			def setBrightness2(configItem):
-				myval = str(configItem.value)
+				kval = _sliderToKernel(int(configItem.value), 8.0, -1024, 1023)
 				try:
-					print("--> setting brightness Video & OSD to: %s" % myval)
-					f = open("/sys/class/amvecm/brightness2", "w")
-					f.write(myval)
-					f.close()
+					print("--> setting brightness2 (video+OSD) to: %d" % kval)
+					with open("%s/brightness2" % AMVECM, "w") as f:
+						f.write(str(kval))
 				except OSError:
 					print("couldn't write brightness2.")
 
 				if not VideoEnhancement.firstRun:
 					self.setConfiguredValues()
-			config.amvecm.brightness2 = ConfigSlider(default=0, limits=(-1022, 1022))
+
+			config.amvecm.brightness2 = ConfigSlider(default=initial, limits=(0, SLIDER_MAX))
 			config.amvecm.brightness2.addNotifier(setBrightness2)
 		else:
 			config.amvecm.brightness2 = NoSave(ConfigNothing())
 
-		if exists("/sys/class/amvecm/color_bottom"):
+		# --- color_top / color_bottom: 30-bit RGB clamp presets ---
+		# (R << 20) | (G << 10) | B, each channel 10-bit (0..1023).
+		# Full range (no clipping): top=0x3fffffff, bottom=0x0
+		# Limited broadcast-safe (64..940): top=0x3aceb3ac, bottom=0x04010040
+		COLOR_TOP_PRESETS = {
+			"full": 0x3fffffff,
+			"limited": 0x3aceb3ac,
+		}
+		COLOR_BOTTOM_PRESETS = {
+			"full": 0x00000000,
+			"limited": 0x04010040,
+		}
+
+		def _detectMode(raw, presets):
+			for name, val in presets.items():
+				if raw == val:
+					return name
+			return "full"
+
+		COLOR_MODE_CHOICES = [
+			("full", _("Full range (no clipping)")),
+			("limited", _("Limited range (64..940)")),
+		]
+
+		if exists("%s/color_bottom" % AMVECM):
+			initialRaw = _readInt("%s/color_bottom" % AMVECM, 0)
+			initialMode = _detectMode(initialRaw, COLOR_BOTTOM_PRESETS)
+
 			def setColor_bottom(configItem):
-				myval = int(configItem.value)
+				mode = configItem.value
+				val = COLOR_BOTTOM_PRESETS.get(mode)
+				if val is None:
+					return
 				try:
-					print("--> setting color button to: %s" % myval)
-					f = open("/sys/class/amvecm/color_bottom", "w")
-					f.write("%s" % hex(myval))
-					f.close()
+					print("--> setting color_bottom to: 0x%08x (%s)" % (val, mode))
+					with open("%s/color_bottom" % AMVECM, "w") as f:
+						f.write("0x%x" % val)
 				except OSError:
-					print("couldn't write color button.")
+					print("couldn't write color_bottom.")
 
 				if not VideoEnhancement.firstRun:
 					self.setConfiguredValues()
 
-			config.amvecm.color_bottom = ConfigInteger(default=0, limits=(0, 268435454))
+			config.amvecm.color_bottom = ConfigSelection(choices=COLOR_MODE_CHOICES, default=initialMode)
 			config.amvecm.color_bottom.addNotifier(setColor_bottom)
 		else:
 			config.amvecm.color_bottom = NoSave(ConfigNothing())
 
-		if exists("/sys/class/amvecm/color_top"):
+		if exists("%s/color_top" % AMVECM):
+			initialRaw = _readInt("%s/color_top" % AMVECM, 0x3fffffff)
+			initialMode = _detectMode(initialRaw, COLOR_TOP_PRESETS)
+
 			def setColor_top(configItem):
-				myval = int(configItem.value)
+				mode = configItem.value
+				val = COLOR_TOP_PRESETS.get(mode)
+				if val is None:
+					return
 				try:
-					print("--> setting color top to: %s" % myval)
-					f = open("/sys/class/amvecm/color_top", "w")
-					f.write("%s" % hex(myval))
-					f.close()
+					print("--> setting color_top to: 0x%08x (%s)" % (val, mode))
+					with open("%s/color_top" % AMVECM, "w") as f:
+						f.write("0x%x" % val)
 				except OSError:
-					print("couldn't write color top.")
+					print("couldn't write color_top.")
 
 				if not VideoEnhancement.firstRun:
 					self.setConfiguredValues()
 
-			config.amvecm.color_top = ConfigInteger(default=1073741823, limits=(0, 268435454))
+			config.amvecm.color_top = ConfigSelection(choices=COLOR_MODE_CHOICES, default=initialMode)
 			config.amvecm.color_top.addNotifier(setColor_top)
 		else:
 			config.amvecm.color_top = NoSave(ConfigNothing())
@@ -171,7 +284,7 @@ class VideoEnhancement:
 		VideoEnhancement.firstRun = False
 
 	def setConfiguredValues(self):
-		# TODO is there something missing?
+		# amvecm has no global "apply" trigger; per-attribute writes take effect immediately.
 		pass
 
 

--- a/lib/python/Plugins/SystemPlugins/VideoEnhancementAML/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/VideoEnhancementAML/plugin.py
@@ -67,12 +67,12 @@ class VideoEnhancementSetup(ConfigListScreen, Screen):
 	def createSetup(self):
 		self.list = []
 		addToConfigList = self.addToConfigList
-		self.brightness1Entry = addToConfigList(_("Brightness Video"), config.amvecm.brightness1, _("This option sets the video picture brightness."))
-		self.brightness2Entry = addToConfigList(_("Brightness Video & OSD"), config.amvecm.brightness2, _("This option sets the video & osd picture brightness."))
-		self.color_bottomEntry = addToConfigList(_("Color Bottom"), config.amvecm.color_bottom, _("This option allows you to boost the blue tones in the picture."))
-		self.color_topEntry = addToConfigList(_("Color Top"), config.amvecm.color_top, _("This option allows you to boost the green tones in the picture."))
-		self.contrast1Entry = addToConfigList(_("Contrast Video"), config.amvecm.contrast1, _("This option sets the video picture contrast."))
-		self.contrast2Entry = addToConfigList(_("Contrast Video & OSD"), config.amvecm.contrast2, _("This option sets the video & osd picture contrast."))
+		self.brightness1Entry = addToConfigList(_("Brightness Video"), config.amvecm.brightness1, _("Brightness applied to the video layer only. Does not affect enigma2 menus or OSD."))
+		self.brightness2Entry = addToConfigList(_("Brightness Video & OSD"), config.amvecm.brightness2, _("Brightness applied to the combined video + OSD output. Affects everything on screen including this menu."))
+		self.color_bottomEntry = addToConfigList(_("RGB clamp (lower)"), config.amvecm.color_bottom, _("Lower RGB output clipping limit. 'Full range' = no lower clipping, 'Limited range' clips RGB outputs to 64 (broadcast safe)."))
+		self.color_topEntry = addToConfigList(_("RGB clamp (upper)"), config.amvecm.color_top, _("Upper RGB output clipping limit. 'Full range' = no upper clipping, 'Limited range' clips RGB outputs to 940 (broadcast safe)."))
+		self.contrast1Entry = addToConfigList(_("Contrast Video"), config.amvecm.contrast1, _("Contrast applied to the video layer only. Does not affect enigma2 menus or OSD."))
+		self.contrast2Entry = addToConfigList(_("Contrast Video & OSD"), config.amvecm.contrast2, _("Contrast applied to the combined video + OSD output. Affects everything on screen including this menu."))
 		self.hueEntry = addToConfigList(_("Hue"), config.amvecm.hue, _("This option sets the picture hue."))
 		self.saturationEntry = addToConfigList(_("Saturation"), config.amvecm.saturation, _("This option sets the picture saturation."))
 		self["config"].list = self.list
@@ -160,21 +160,21 @@ class VideoEnhancementSetup(ConfigListScreen, Screen):
 			print("not confirmed")
 		else:
 			if self.contrast1Entry is not None:
-				config.amvecm.contrast1.setValue(0)
+				config.amvecm.contrast1.setValue(128)
 			if self.contrast2Entry is not None:
-				config.amvecm.contrast2.setValue(0)
+				config.amvecm.contrast2.setValue(128)
 			if self.saturationEntry is not None:
-				config.amvecm.saturation.setValue(0)
+				config.amvecm.saturation.setValue(128)
 			if self.hueEntry is not None:
-				config.amvecm.hue.setValue(256)
+				config.amvecm.hue.setValue(128)
 			if self.brightness1Entry is not None:
-				config.amvecm.brightness1.setValue(0)
+				config.amvecm.brightness1.setValue(128)
 			if self.brightness2Entry is not None:
-				config.amvecm.brightness2.setValue(0)
+				config.amvecm.brightness2.setValue(128)
 			if self.color_bottomEntry is not None:
-				config.amvecm.color_bottom.setValue(0)
+				config.amvecm.color_bottom.setValue("full")
 			if self.color_topEntry is not None:
-				config.amvecm.color_top.setValue(1073741823)
+				config.amvecm.color_top.setValue("full")
 			self.keySave()
 
 	def keyBlue(self):


### PR DESCRIPTION
The amvecm menu showed defaults and limits that did not match the actual Amlogic kernel ranges, so values appeared bogus and writes to /sys silently failed.

Slider limits aligned with kernel reality (probed live on S922X):
- contrast1/2:    kernel accepts -127..127  (plugin claimed +-1022)
- brightness1/2:  kernel accepts -1024..1023 (plugin claimed +-1022)
- saturation:     kernel accepts -127..127 (already correct)
- saturation_hue: packed 32-bit, hi half 0..0x200 with 0x100 neutral

UX now matches the non-AML VideoEnhancement plugin: every slider is an unsigned 0..255 range with 128 as the visual neutral point. The notifier maps the slider value to the kernel-native signed range and writes to sysfs. Bar position now agrees with the displayed number.

Initial slider value is taken from the current sysfs reading, so the menu reflects actual kernel state instead of always showing hard-coded defaults. Saturation notifier preserves the current hue_post value instead of pinning it to 0.

color_top / color_bottom are 30-bit per-channel RGB clamp limits, not "boost blue / boost green tones" as the old tooltips claimed. The old ConfigInteger had default 1073741823 outside its own limit 268435454, which produced the visible garbage value. Replaced with a two-option ConfigSelection (Full range / Limited range 64..940 broadcast-safe).

Tooltips clarified: brightness1/contrast1 affect only the video layer, brightness2/contrast2 affect video plus enigma2 OSD.