### PR TITLE
[DreamNextGen] audio settings UI: per-codec passthrough/transcode

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -14,6 +14,7 @@
 		<item level="1" text="AC3 plus transcoding" description="Select whether AC3 Plus audio tracks should be transcoded to AC3." requires="CanAC3plusTranscode">config.av.transcodeac3plus</item>
 		<item level="1" text="DTS downmix" description="Select whether DTS channel audio tracks should be downmixed to stereo." requires="CanDownmixDTS">config.av.downmix_dts</item>
 		<item level="1" text="DTS/DTS-HD HR/DTS-HD MA/DTS:X" description="Select whether DTS channel audio tracks should be downmixed or transcoded." requires="CanDTSHD">config.av.dtshd</item>
+		<item level="1" text="Dolby TrueHD" description="Select whether Dolby TrueHD audio tracks should be passed through or decoded." requires="CanTrueHD">config.av.truehd</item>
 		<item level="1" text="WMA Pro" description="Select whether WMA Pro channel audio tracks should be downmixed or transcoded." requires="CanWMAPRO">config.av.wmapro</item>
 		<item level="1" text="AAC downmix" description="Select whether multichannel audio tracks should be downmixed to stereo." requires="CanDownmixAAC">config.av.downmix_aac</item>
 		<item level="1" text="AAC plus downmix" description="Select whether multichannel audio tracks should be downmixed to stereo." requires="CanDownmixAACPlus">config.av.downmix_aacplus</item>

--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -661,6 +661,8 @@ def InitAVSwitch():
 		config.av.downmix_ac3 = ConfigNothing()
 	AC3plusTranscode = fileReadLine("/proc/stb/audio/ac3plus_choices", default=None, source=MODULE_NAME)
 	AC3plusTranscode = AC3plusTranscode.split() if AC3plusTranscode else False
+	if not AC3plusTranscode and MACHINEBUILD in ("dreamone", "dreamtwo"):
+		AC3plusTranscode = ["downmix", "passthrough", "hdmi_best", "force_ac3"]
 	BoxInfo.setItem("CanAC3plusTranscode", AC3plusTranscode)
 	if AC3plusTranscode:
 		def setAC3plusTranscode(configElement):
@@ -682,15 +684,25 @@ def InitAVSwitch():
 					("multichannel", _("Convert to multi-channel PCM")),
 					("force_dts", _("Convert to DTS"))
 				]
+		elif MACHINEBUILD in ("dreamone", "dreamtwo"):
+			choiceList = [
+					("hdmi_best", _("Use best / Controlled by HDMI")),
+					("passthrough", _("Pass-through")),
+					("downmix", _("Downmix")),
+					("force_ac3", _("Convert to AC3"))
+				]
 		else:
 			choiceList = [
 					("use_hdmi_caps", _("Controlled by HDMI")),
 					("force_ac3", _("Convert to AC3"))
 				]
 		config.av.transcodeac3plus = ConfigSelection(default="force_ac3", choices=choiceList)
-		config.av.transcodeac3plus.addNotifier(setAC3plusTranscode)
+		if MACHINEBUILD not in ("dreamone", "dreamtwo"):
+			config.av.transcodeac3plus.addNotifier(setAC3plusTranscode)
 	dtsHD = fileReadLine("/proc/stb/audio/dtshd_choices", default=None, source=MODULE_NAME)
 	dtsHD = dtsHD.split() if dtsHD else False
+	if not dtsHD and MACHINEBUILD in ("dreamone", "dreamtwo"):
+		dtsHD = ["downmix", "passthrough", "hdmi_best"]
 	BoxInfo.setItem("CanDTSHD", dtsHD)
 	if dtsHD:
 		def setDTSHD(configElement):
@@ -702,6 +714,13 @@ def InitAVSwitch():
 				("use_hdmi_caps", _("Controlled by HDMI")),
 				("force_dts", _("Convert to DTS"))
 			]
+		elif MACHINEBUILD in ("dreamone", "dreamtwo"):
+			default = "downmix"
+			choiceList = [
+				("hdmi_best", _("Use best / Controlled by HDMI")),
+				("passthrough", _("Pass-through")),
+				("downmix", _("Downmix"))
+			]
 		else:
 			default = "downmix"
 			choiceList = [
@@ -712,7 +731,17 @@ def InitAVSwitch():
 				("hdmi_best", _("Use best / Controlled by HDMI"))
 			]
 		config.av.dtshd = ConfigSelection(default=default, choices=choiceList)
-		config.av.dtshd.addNotifier(setDTSHD)
+		if MACHINEBUILD not in ("dreamone", "dreamtwo"):
+			config.av.dtshd.addNotifier(setDTSHD)
+	if MACHINEBUILD in ("dreamone", "dreamtwo"):
+		BoxInfo.setItem("CanTrueHD", ["downmix", "passthrough", "hdmi_best"])
+		config.av.truehd = ConfigSelection(default="downmix", choices=[
+			("hdmi_best", _("Use best / Controlled by HDMI")),
+			("passthrough", _("Pass-through")),
+			("downmix", _("Downmix"))
+		])
+	else:
+		BoxInfo.setItem("CanTrueHD", False)
 	wmaPro = fileReadLine("/proc/stb/audio/wmapro_choices", default=None, source=MODULE_NAME)
 	wmaPro = wmaPro.split() if wmaPro else False
 	BoxInfo.setItem("CanWMAPRO", wmaPro)
@@ -792,13 +821,17 @@ def InitAVSwitch():
 		print(f"[AVSwitch] aactranscodeChoices choices={aactranscodeChoices}, default={default}.")
 	else:
 		aacTranscode = False
+	if not aacTranscode and MACHINEBUILD in ("dreamone", "dreamtwo"):
+		aacTranscode = [("off", _("off")), ("force_ac3", _("Convert to AC3"))]
+		default = "off"
 	BoxInfo.setItem("CanAACTranscode", aacTranscode)
 	if aacTranscode:
 		def setAACTranscode(configElement):
 			fileWriteLine("/proc/stb/audio/aac_transcode", configElement.value, source=MODULE_NAME)
 
 		config.av.transcodeaac = ConfigSelection(default=default, choices=aacTranscode)
-		config.av.transcodeaac.addNotifier(setAACTranscode)
+		if MACHINEBUILD not in ("dreamone", "dreamtwo"):
+			config.av.transcodeaac.addNotifier(setAACTranscode)
 	else:
 		config.av.transcodeaac = ConfigNothing()
 	btAudio = fileReadLine("/proc/stb/audio/btaudio", default=None, source=MODULE_NAME)

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -185,6 +185,8 @@ class AudioSelection(ConfigListScreen, Screen):
 				elif BoxInfo.getItem("machinebuild") in ("gbquad4k", "gbquad4kpro", "gbue4k", "gbx34k"):
 					choice_list = [("downmix", _("Downmix")), ("passthrough", _("Pass-through")), ("force_ac3", _("Convert to AC3")), ("multichannel", _("Convert to multi-channel PCM")), ("force_dts", _("Convert to DTS"))]
 					self.settings.transcodeac3plus = ConfigSelection(choices=choice_list, default=config.av.transcodeac3plus.value)
+				elif BoxInfo.getItem("machinebuild") in ("dreamone", "dreamtwo"):
+					choice_list = [("hdmi_best", _("Use best / Controlled by HDMI")), ("passthrough", _("Pass-through")), ("downmix", _("Downmix")), ("force_ac3", _("Convert to AC3"))]
 				else:
 					choice_list = [("use_hdmi_caps", _("Controlled by HDMI")), ("force_ac3", _("Convert to AC3"))]
 				self.settings.transcodeac3plus = ConfigSelection(choices=choice_list, default=config.av.transcodeac3plus.value)
@@ -203,11 +205,19 @@ class AudioSelection(ConfigListScreen, Screen):
 			if BoxInfo.getItem("CanDTSHD"):
 				if BoxInfo.getItem("machinebuild") in ("dm7080", "dm820"):
 					choice_list = [("use_hdmi_caps", _("Controlled by HDMI")), ("force_dts", _("Convert to DTS"))]
+				elif BoxInfo.getItem("machinebuild") in ("dreamone", "dreamtwo"):
+					choice_list = [("hdmi_best", _("Use best / Controlled by HDMI")), ("passthrough", _("Pass-through")), ("downmix", _("Downmix"))]
 				else:
 					choice_list = [("downmix", _("Downmix")), ("force_dts", _("Convert to DTS")), ("use_hdmi_caps", _("Controlled by HDMI")), ("multichannel", _("Convert to multi-channel PCM")), ("hdmi_best", _("Use best / Controlled by HDMI"))]
 				self.settings.dtshd = ConfigSelection(choices=choice_list, default=config.av.dtshd.value)
 				self.settings.dtshd.addNotifier(self.setDTSHD, initial_call=False)
 				conflist.append(getConfigListEntry(_("DTS HD downmix"), self.settings.dtshd, None))
+
+			if BoxInfo.getItem("CanTrueHD"):
+				choice_list = [("hdmi_best", _("Use best / Controlled by HDMI")), ("passthrough", _("Pass-through")), ("downmix", _("Downmix"))]
+				self.settings.truehd = ConfigSelection(choices=choice_list, default=config.av.truehd.value)
+				self.settings.truehd.addNotifier(self.setTrueHD, initial_call=False)
+				conflist.append(getConfigListEntry(_("Dolby TrueHD"), self.settings.truehd, None))
 
 			if BoxInfo.getItem("CanWMAPRO"):
 				choice_list = [("downmix", _("Downmix")), ("passthrough", _("Pass-through")), ("multichannel", _("Convert to multi-channel PCM")), ("hdmi_best", _("Use best / Controlled by HDMI"))]
@@ -477,6 +487,10 @@ class AudioSelection(ConfigListScreen, Screen):
 	def setDTSHD(self, downmix):
 		config.av.dtshd.setValue(downmix.value)
 		config.av.dtshd.save()
+
+	def setTrueHD(self, downmix):
+		config.av.truehd.setValue(downmix.value)
+		config.av.truehd.save()
 
 	def changeDTSDownmix(self, downmix):
 		if downmix.value:


### PR DESCRIPTION
Adds the missing capability flags + per-codec settings entries that were never wired up for the AML dreamone/two boxes. All changes are guarded by MACHINEBUILD in ("dreamone", "dreamtwo") and the per-stream entries are gated by BoxInfo "Can…" flags, so other boxes are unaffected and no UI element appears for boxes that do not synthesise the cap.

Settings exposed (global "Audio Settings" via data/setup.xml, plus per-stream during playback via AudioSelection.py):
  - AC3 plus transcoding (config.av.transcodeac3plus) — choices hdmi_best / passthrough / downmix / force_ac3, default force_ac3 (= same default as other boxes; EAC3 → AC3 transcode for legacy AC3-only AVRs)
  - DTS / DTS-HD HR/MA / DTS:X (config.av.dtshd) — hdmi_best / passthrough / downmix, default downmix
  - Dolby TrueHD (config.av.truehd) — new flag, same choices as DTS-HD
  - AAC transcoding (config.av.transcodeaac) — off / Convert to AC3

The Python side is intentionally standalone: no addNotifier is registered on dreamone/two (notifiers normally write /proc/stb/audio files which do not exist on AML), so the config values land in /etc/enigma2/settings via the standard save mechanism and are read directly by tsparser.cpp / dream_decoder.c via eSimpleConfig at routing time.