### PR TITLE
[DreamNextGen] suppress cosmetic "Error 0 (Success)" on AML video sysfs

### DIFF
--- a/lib/driver/avcontrol.cpp
+++ b/lib/driver/avcontrol.cpp
@@ -206,7 +206,8 @@ int eAVControl::getResolutionX(int defaultVal, int flags) const
 {
 	int value;
 #ifdef DREAMNEXTGEN
-	int ret = CFile::parseInt(&value, "/sys/class/video/frame_width", __MODULE__, flags);
+	int ret = CFile::parseInt(&value, "/sys/class/video/frame_width",
+				  __MODULE__, flags | FLAGS_SUPPRESS_READWRITE_ERROR);
 #else
 	int ret = CFile::parseIntHex(&value, "/proc/stb/vmpeg/0/xres", __MODULE__, flags);
 #endif
@@ -230,7 +231,8 @@ int eAVControl::getResolutionY(int defaultVal, int flags) const
 
 	int value;
 #ifdef DREAMNEXTGEN
-	int ret = CFile::parseInt(&value, "/sys/class/video/frame_height", __MODULE__, flags);
+	int ret = CFile::parseInt(&value, "/sys/class/video/frame_height",
+				  __MODULE__, flags | FLAGS_SUPPRESS_READWRITE_ERROR);
 #else
 	int ret = CFile::parseIntHex(&value, "/proc/stb/vmpeg/0/yres", __MODULE__, flags);
 #endif


### PR DESCRIPTION
/sys/class/video/frame_width and frame_height are 0-byte for the first ~100 ms after every channel switch (AML video subsystem hasn't decoded the first frame yet). fscanf fails, errno stays 0, and the default error log emits "Error 0: ... (Success)" — pure noise during every zap.

Pass FLAGS_SUPPRESS_READWRITE_ERROR for these two AML paths only; the surrounding code already retries via the next poll cycle.