### PR TITLE
[servicemp3] custom DASH pipeline for .mpd URIs

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -31,6 +31,7 @@ Licensed under GPLv2.
 
 #include <lib/base/cfile.h>
 
+#include <cctype>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -83,6 +84,102 @@ typedef enum {
 static bool first_play_eServicemp3 = false;
 static GstElement *dvb_audiosink, *dvb_videosink, *dvb_subsink;
 static bool dvb_audiosink_ok, dvb_videosink_ok, dvb_subsink_ok;
+
+static std::string gstLaunchQuote(const std::string& value)
+{
+	std::string quoted = "\"";
+	for (std::string::const_iterator it = value.begin(); it != value.end(); ++it) {
+		if (*it == '\\' || *it == '"')
+			quoted += '\\';
+		quoted += *it;
+	}
+	quoted += "\"";
+	return quoted;
+}
+
+static bool isDashUri(const std::string& uri)
+{
+	std::string lower = uri;
+	for (std::string::iterator it = lower.begin(); it != lower.end(); ++it)
+		*it = static_cast<char>(tolower(static_cast<unsigned char>(*it)));
+	return lower.find(".mpd") != std::string::npos ||
+	       lower.find("manifest.mpd") != std::string::npos ||
+	       lower.find("application/dash+xml") != std::string::npos;
+}
+
+/* g_object_set on missing prop logs a critical; skip for sinks that don't expose it. */
+static void gstSetBoolIfAvailable(GstElement* element, const char* property, gboolean value)
+{
+	if (!element || !property) return;
+	if (g_object_class_find_property(G_OBJECT_GET_CLASS(element), property))
+		g_object_set(G_OBJECT(element), property, value, NULL);
+}
+
+static void gstSetStringIfAvailable(GstElement* element, const char* property, const std::string& value)
+{
+	if (!element || !property || value.empty()) return;
+	if (g_object_class_find_property(G_OBJECT_GET_CLASS(element), property))
+		g_object_set(G_OBJECT(element), property, value.c_str(), NULL);
+}
+
+static GstElement* createDashPlaybackPipeline(const std::string& uri, const std::string& useragent)
+{
+	/* HW audio sink expects stream-format=raw post-aacparse. */
+#ifdef DREAMNEXTGEN
+	const char *vsink_factory = "dreamvideosink";
+	const char *asink_factory = "dreamaudiosink";
+#else
+	const char *vsink_factory = "dvbvideosink";
+	const char *asink_factory = "dvbaudiosink";
+#endif
+	std::string pipeline =
+		"souphttpsrc name=dashsrc location=" + gstLaunchQuote(uri) + " timeout=60 retries=20 "
+		"! dashdemux name=d connection-speed=4000 max-bitrate=3200000 "
+		"max-video-width=1280 max-video-height=720 max-video-framerate=50/1 "
+		"presentation-delay=6s "
+		"d.video_00 ! queue max-size-buffers=0 max-size-bytes=4194304 max-size-time=5000000000 "
+		"! qtdemux ! h264parse "
+		"! video/x-h264,stream-format=avc,alignment=au "
+		"! " + vsink_factory + " name=dashvideosink "
+		"d.audio_00 ! queue max-size-buffers=0 max-size-bytes=1048576 max-size-time=5000000000 "
+		"! qtdemux ! aacparse "
+		"! audio/mpeg,mpegversion=4,framed=true,stream-format=raw "
+		"! " + asink_factory + " name=dashaudiosink";
+
+	GError* error = NULL;
+	GstElement* element = gst_parse_launch(pipeline.c_str(), &error);
+	if (!element) {
+		eWarning("[eServiceMP3] failed to create DASH pipeline: %s",
+		         error ? error->message : "unknown error");
+		if (error) g_error_free(error);
+		return NULL;
+	}
+	if (error) {
+		eWarning("[eServiceMP3] DASH pipeline parse warning: %s", error->message);
+		g_error_free(error);
+	}
+
+	GstElement* source = gst_bin_get_by_name(GST_BIN(element), "dashsrc");
+	if (source) {
+		gstSetBoolIfAvailable(source, "ssl-strict", FALSE);
+		gstSetStringIfAvailable(source, "user-agent", useragent);
+		gst_object_unref(source);
+	}
+	/* e2-sync/e2-async are dvb*sink-only; no-op on dream*sinks. */
+	GstElement* vsink = gst_bin_get_by_name(GST_BIN(element), "dashvideosink");
+	if (vsink) {
+		gstSetBoolIfAvailable(vsink, "e2-sync",  FALSE);
+		gstSetBoolIfAvailable(vsink, "e2-async", FALSE);
+		gst_object_unref(vsink);
+	}
+	GstElement* asink = gst_bin_get_by_name(GST_BIN(element), "dashaudiosink");
+	if (asink) {
+		gstSetBoolIfAvailable(asink, "e2-sync",  FALSE);
+		gstSetBoolIfAvailable(asink, "e2-async", FALSE);
+		gst_object_unref(asink);
+	}
+	return element;
+}
 
 /*static functions */
 
@@ -945,6 +1042,7 @@ eServiceMP3::eServiceMP3(eServiceReference ref)
 	m_first_paused = false;
 	m_cuesheet_loaded = false; /* cuesheet CVR */
 	m_audiosink_not_running = false;
+	m_is_dash_pipeline = false;
 	m_use_chapter_entries = false; /* TOC chapter support CVR */
 	m_play_position_timer = eTimer::create(eApp);
 	CONNECT(m_play_position_timer->timeout, eServiceMP3::playPositionTiming);
@@ -1101,6 +1199,9 @@ eServiceMP3::eServiceMP3(eServiceReference ref)
 		m_sourceinfo.audiotype = atDRA;
 	} else if (strcasecmp(ext, ".m3u8") == 0)
 		m_sourceinfo.is_hls = TRUE;
+	else if (strcasecmp(ext, ".mpd") == 0) {
+		m_sourceinfo.is_video = TRUE;  /* .mpd → DASH pipeline branch below */
+	}
 	else if (strcasecmp(ext, ".mp3") == 0) {
 		m_sourceinfo.audiotype = atMP3;
 		m_sourceinfo.is_audio = TRUE;
@@ -1162,6 +1263,35 @@ eServiceMP3::eServiceMP3(eServiceReference ref)
 	} else
 		uri = g_filename_to_uri(filename, NULL, NULL);
 
+	std::string uri_string = uri ? uri : "";
+	m_is_dash_pipeline = m_sourceinfo.is_streaming && isDashUri(uri_string);
+
+	if (m_is_dash_pipeline) {
+		/* playbin auto-plug stalls dreamvideosink on .mpd; build explicit pipeline. */
+		eDebug("[eServiceMP3] DASH uri=%s", uri);
+		m_is_live = true;
+		m_use_prefillbuffer = false;
+		m_gst_playbin = createDashPlaybackPipeline(uri_string, m_useragent);
+		if (m_gst_playbin) {
+			GstBus* bus = gst_pipeline_get_bus(GST_PIPELINE(m_gst_playbin));
+			gst_bus_set_sync_handler(bus, gstBusSyncHandler, this, NULL);
+			gst_object_unref(bus);
+
+			/* Single AAC entry for the audio-track UI; track switching N/A. */
+			m_audioStreams.clear();
+			audioStream audio;
+			audio.type = atAAC;
+			audio.language_code = "und";
+			audio.codec = "AAC";
+			m_audioStreams.push_back(audio);
+			m_currentAudioStream = 0;
+		} else {
+			m_event((iPlayableService*)this, evUser + 12);
+			m_gst_playbin = NULL;
+			m_errorInfo.error_message = "failed to create GStreamer DASH pipeline!\n";
+			eDebug("[eServiceMP3] sorry, can't play DASH: %s", m_errorInfo.error_message.c_str());
+		}
+	} else {
 	eDebug("[eServiceMP3] playbin uri=%s", uri);
 	if (suburi != NULL)
 		eDebug("[eServiceMP3] playbin suburi=%s", suburi);
@@ -1279,6 +1409,7 @@ eServiceMP3::eServiceMP3(eServiceReference ref)
 		m_errorInfo.error_message = "failed to create GStreamer pipeline!\n";
 		eDebug("[eServiceMP3] sorry, can't play: %s", m_errorInfo.error_message.c_str());
 	}
+	}  /* end !m_is_dash_pipeline */
 	g_free(uri);
 	if (suburi != NULL)
 		g_free(suburi);
@@ -2596,6 +2727,8 @@ int eServiceMP3::getNumberOfTracks() {
  * @return int Returns the index of the current audio track, or -1 if no audio stream is set.
  */
 int eServiceMP3::getCurrentTrack() {
+	if (m_is_dash_pipeline)
+		return m_currentAudioStream >= 0 ? m_currentAudioStream : 0;
 	if (m_currentAudioStream == -1)
 		g_object_get(m_gst_playbin, "current-audio", &m_currentAudioStream, NULL);
 	return m_currentAudioStream;
@@ -2669,6 +2802,11 @@ void eServiceMP3::clearBuffers(bool force) {
  * @return int Returns 0 on success, or -1 if the selection fails.
  */
 int eServiceMP3::selectAudioStream(int i, bool skipAudioFix) {
+	if (m_is_dash_pipeline) {
+		/* Single-track DASH pipeline; any non-zero index = unsupported. */
+		m_currentAudioStream = 0;
+		return i == 0 ? 0 : -1;
+	}
 	int current_audio, current_audio_orig;
 	g_object_get(m_gst_playbin, "current-audio", &current_audio_orig, NULL);
 	g_object_set(m_gst_playbin, "current-audio", i, NULL);
@@ -3168,6 +3306,15 @@ void eServiceMP3::gstBusCall(GstMessage* msg) {
 			if (GST_MESSAGE_SRC(msg) != GST_OBJECT(m_gst_playbin))
 				break;
 
+			if (m_is_dash_pipeline) {
+				/* No playbin n-video/n-audio to introspect; streams pre-registered. */
+				if (m_send_ev_start) {
+					m_event((iPlayableService*)this, evUpdatedInfo);
+					m_send_ev_start = false;
+				}
+				break;
+			}
+
 			if (m_send_ev_start) {
 				gint i, n_video = 0, n_audio = 0, n_text = 0;
 				// bool codec_tofix = false;
@@ -3396,6 +3543,8 @@ void eServiceMP3::gstBusCall(GstMessage* msg) {
 			break;
 		}
 		case GST_MESSAGE_BUFFERING:
+			if (m_is_dash_pipeline)
+				break;  /* dashdemux's own buffering, not playbin's — ignore */
 			if (m_sourceinfo.is_streaming) {
 				// GstBufferingMode mode;
 				gst_message_parse_buffering(msg, &(m_bufferInfo.bufferPercent));

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -361,6 +361,8 @@ private:
 	/* cuesheet load check */
 	bool m_cuesheet_loaded;
 	bool m_audiosink_not_running;
+	/* DASH path: bypass playbin, build explicit pipeline via gst_parse_launch */
+	bool m_is_dash_pipeline;
 	/* servicemMP3 chapter TOC support CVR */
 	bool m_use_chapter_entries;
 	/* last used seek position gst-1 only */


### PR DESCRIPTION
playbin auto-plug stalls the hardware video sink on MPEG-DASH/fMP4 — pts_video freezes after the first preroll burst. Bypass playbin for any .mpd/manifest.mpd URI and build the pipeline explicitly via gst_parse_launch:

  souphttpsrc → dashdemux → qtdemux → h264parse → video sink
                          → qtdemux → aacparse  → audio sink

dashdemux capped to HD-50p, presentation-delay 6s, queues 5s + 4MB video / 5s + 1MB audio. AAC stream-format=raw post-aacparse for the HW audio sink's parser. Sink factories default to dvb*sinks; DREAMNEXTGEN swaps in dream*sinks since AML boxes don't ship dvbmediasink.

m_is_dash_pipeline gates the rest:
- getCurrentTrack / selectAudioStream: single AAC entry, no playbin current-audio property to read
- gstBusCall ASYNC_DONE: skip the n-video/n-audio introspection, fire evUpdatedInfo once
- gstBusCall BUFFERING: dashdemux's own buffering messages — ignore