### PR TITLE
Performance:

### DIFF
--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -529,9 +529,9 @@ int eListbox::event(int event, void *data, void *data2)
 
 			// determine source offset based on scroll direction
 			if (m_scroll_config.direction == eScrollConfig::scrollLeft || m_scroll_config.direction == eScrollConfig::scrollRight)
-				scrollX = m_content->getScollPos();
+				scrollX = m_content->getScrollPos();
 			else if (m_scroll_config.direction == eScrollConfig::scrollTop || m_scroll_config.direction == eScrollConfig::scrollBottom)
-				scrollY = m_content->getScollPos();
+				scrollY = m_content->getScrollPos();
 
 			// perform blit of the text pixmap
 			eSize s(m_scroll_rect.width(), m_scroll_rect.height());

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -58,7 +58,7 @@ protected:
 	virtual int getItemWidth() { return -1; }
 	virtual uint8_t getOrientation() { return 1; }
 	virtual int getMaxItemTextWidth() { return 1; }
-	virtual int getScollPos() { return 0; }
+	virtual int getScrollPos() { return 0; }
 
 	eListbox *m_listbox;
 #endif

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -20,6 +20,17 @@ Licensed under GPLv2.
 #include <lib/gui/ewindowstyleskinned.h>
 #include <sstream>
 
+// Width used for unbounded text measurement (wider than any real screen)
+static constexpr int TEXT_MEASURE_MAX_WIDTH = 8000;
+
+// Maximum pixmap size in pixels for scroll cache (protects low-memory devices)
+static constexpr int MAX_SCROLL_PIXMAP_PIXELS = 1'000'000;
+
+// Extra buffer factor added to roll-mode pixmap width/height
+static constexpr float SCROLL_ROLL_EXTRA_FACTOR = 1.5f;
+
+RESULT SwigFromPython(ePtr<gPixmap> &res, PyObject *obj);
+
 using namespace std;
 
 /*
@@ -64,10 +75,7 @@ int iListboxContent::currentCursorSelectable() {
 
 DEFINE_REF(eListboxPythonStringContent);
 
-eListboxPythonStringContent::eListboxPythonStringContent()
-	: m_saved_cursor_line(0), scrollTimer(eTimer::create(eApp)), m_cursor(0), m_saved_cursor(0), m_itemheight(25), m_itemwidth(25), m_max_text_width(0), m_orientation(1) {
-	CONNECT(scrollTimer->timeout, eListboxPythonStringContent::updateScrollPosition);
-}
+eListboxPythonStringContent::eListboxPythonStringContent() {} // NOSONAR
 
 eListboxPythonStringContent::~eListboxPythonStringContent() {
 	Py_XDECREF(m_list);
@@ -147,18 +155,23 @@ void eListboxPythonStringContent::setSize(const eSize& size) {
 }
 
 int eListboxPythonStringContent::getMaxItemTextWidth() {
+	// Return cached result if already calculated
+	if (m_max_text_width >= 0)
+		return m_max_text_width;
+
 	ePtr<gFont> fnt;
-	eListboxStyle* local_style = 0;
-	int m_text_offset = 1;
+	eListboxStyle* local_style = nullptr;
+	int text_offset = 1;
 	if (m_listbox)
 		local_style = m_listbox->getLocalStyle();
 	if (local_style) {
 		fnt = local_style->m_font;
-		m_text_offset = local_style->m_text_padding.x();
+		text_offset = local_style->m_text_padding.x();
 	}
 	if (!fnt)
 		fnt = new gFont("Regular", 20);
 
+    int max_width = 0;
 	for (int i = 0; i < size(); i++) {
 		ePyObject item = PyList_GET_ITEM(m_list, i);
 		if (PyTuple_Check(item)) {
@@ -166,19 +179,20 @@ int eListboxPythonStringContent::getMaxItemTextWidth() {
 		}
 		if (item != Py_None) {
 			const char* string = PyUnicode_Check(item) ? PyUnicode_AsUTF8(item) : "<not-a-string>";
-			eRect textRect = eRect(0, 0, 8000, 100);
+			eRect textRect = eRect(0, 0, TEXT_MEASURE_MAX_WIDTH, 100);
 
 			ePtr<eTextPara> para = new eTextPara(textRect);
 			para->setFont(fnt);
 			para->renderString(string);
 			int textWidth = para->getBoundBox().width();
-			if (textWidth > m_max_text_width) {
-				m_max_text_width = textWidth;
+			if (textWidth > max_width) {
+				max_width = textWidth;
 			}
 		}
 	}
-
-	return m_max_text_width + (m_text_offset * 2);
+    // Store result; cache is invalidated by setList()
+    m_max_text_width = max_width + (text_offset * 2);
+	return m_max_text_width;
 }
 
 void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected)
@@ -466,6 +480,9 @@ void eListboxPythonStringContent::setList(ePyObject list) {
 		Py_INCREF(m_list);
 	}
 
+	// Invalidate cached text width so it is recalculated for the new list
+	m_max_text_width = -1;
+
 	if (m_listbox)
 		m_listbox->entryReset(false);
 
@@ -540,7 +557,7 @@ void eListboxPythonStringContent::updateTextSize(std::string& text, gFont* font,
 		stopScroll();
 
 	if (m_listbox) {
-		int scroll_text_direction = m_listbox->m_scroll_config.direction;
+		const int scroll_text_direction = m_listbox->m_scroll_config.direction;
 
 		if (scroll_text_direction == eScrollConfig::scrollLeft || scroll_text_direction == eScrollConfig::scrollRight) {
 			m_text_size = calculateTextSize(font, text, m_scroll_size, true); // nowrap
@@ -551,7 +568,7 @@ void eListboxPythonStringContent::updateTextSize(std::string& text, gFont* font,
 				m_scroll_text = true;
 
 				if (m_listbox->m_scroll_config.mode == eScrollConfig::scrollModeRoll)
-					m_text_size.setWidth(m_text_size.width() + m_scroll_size.width() * 1.5);
+					m_text_size.setWidth(m_text_size.width() + static_cast<int>(m_scroll_size.width() * SCROLL_ROLL_EXTRA_FACTOR));
 
 				/*
 				if (m_listbox->m_scroll_config.mode == eScrollConfig::scrollModeRoll && scroll_text_direction == eScrollConfig::scrollLeft)
@@ -570,10 +587,15 @@ void eListboxPythonStringContent::updateTextSize(std::string& text, gFont* font,
 				m_text_size.setHeight(m_text_size.height() + font->pointSize / 10); // avoid issues with rounding
 				m_scroll_text = true;
 				if (m_listbox->m_scroll_config.mode == eScrollConfig::scrollModeRoll)
-					m_text_size.setHeight(m_text_size.height() + m_scroll_size.height() * 1.5);
+					m_text_size.setHeight(m_text_size.height() + static_cast<int>(m_scroll_size.height() * SCROLL_ROLL_EXTRA_FACTOR));
 			}
 		}
 		if (m_scroll_text) {
+
+			if (!scrollTimer) {
+				scrollTimer = eTimer::create(eApp);
+				CONNECT(scrollTimer->timeout, eListboxPythonStringContent::updateScrollPosition);
+			}
 
 			int visibleW = m_scroll_size.width();
 			int visibleH = m_scroll_size.height();
@@ -585,7 +607,7 @@ void eListboxPythonStringContent::updateTextSize(std::string& text, gFont* font,
 
 			if (m_listbox->m_scroll_config.cached) {
 				// limit 1MB pixmap size
-				if ((m_text_size.width() * m_text_size.height()) > 1000000) {
+				if ((m_text_size.width() * m_text_size.height()) > MAX_SCROLL_PIXMAP_PIXELS) {
 					m_listbox->m_scroll_config.cached = false;
 					if (m_listbox->m_scroll_config.mode == eScrollConfig::scrollModeRoll)
 						m_listbox->m_scroll_config.mode = eScrollConfig::scrollModeNormal;
@@ -602,6 +624,18 @@ void eListboxPythonStringContent::createScrollPixmap(std::string& text, gFont* f
 
 	int w = std::max(m_text_size.width(), m_scroll_size.width());
 	int h = std::max(m_text_size.height(), m_scroll_size.height());
+
+	// Guard against excessively large pixmap allocations
+	if (w * h > MAX_SCROLL_PIXMAP_PIXELS)
+	{
+		eWarning("[eListboxPythonStringContent] createScrollPixmap: "
+					"pixmap size %dx%d exceeds limit (%d px), skipping cache",
+					w, h, MAX_SCROLL_PIXMAP_PIXELS);
+		m_listbox->m_scroll_config.cached = false;
+		if (m_listbox->m_scroll_config.mode == eScrollConfig::scrollModeRoll)
+			m_listbox->m_scroll_config.mode = eScrollConfig::scrollModeNormal;
+		return;
+	}
 
 	eSize s = eSize(w, h);
 
@@ -664,26 +698,27 @@ void eListboxPythonStringContent::stopScroll() {
 	m_scroll_swap = false;
 }
 
+// Returns the maximum scroll position for the current direction.
+static int computeMaxScroll(int direction, const eSize& textSize, const eSize& visibleSize)
+{
+	if (direction == eScrollConfig::scrollLeft || direction == eScrollConfig::scrollRight)
+		return std::max(0, textSize.width() - visibleSize.width());
+	if (direction == eScrollConfig::scrollTop || direction == eScrollConfig::scrollBottom)
+		return std::max(0, textSize.height() - visibleSize.height());
+	return 0;
+}
+
 void eListboxPythonStringContent::updateScrollPosition() {
 	if (m_listbox) {
-		int scroll_text_direction = m_listbox->m_scroll_config.direction;
-		int repeat = m_listbox->m_scroll_config.repeat;
-		int end_delay = m_listbox->m_scroll_config.endDelay;
-		int scroll_mode = m_listbox->m_scroll_config.mode;
+		const int scroll_text_direction = m_listbox->m_scroll_config.direction;
+		const int repeat = m_listbox->m_scroll_config.repeat;
+		const int end_delay = m_listbox->m_scroll_config.endDelay;
+		const int scroll_mode = m_listbox->m_scroll_config.mode;
 
 		if (!m_scroll_text)
 			return;
 
-		// calculate visible area
-		int visibleW = m_scroll_size.width();
-		int visibleH = m_scroll_size.height();
-
-		// compute max_scroll depending on direction
-		int max_scroll = 0;
-		if (scroll_text_direction == eScrollConfig::scrollLeft || scroll_text_direction == eScrollConfig::scrollRight)
-			max_scroll = std::max(0, m_text_size.width() - visibleW);
-		else if (scroll_text_direction == eScrollConfig::scrollTop || scroll_text_direction == eScrollConfig::scrollBottom)
-			max_scroll = std::max(0, m_text_size.height() - visibleH);
+		const int max_scroll = computeMaxScroll(scroll_text_direction, m_text_size, m_scroll_size);
 
 		// determine step sign
 		int step = m_listbox->m_scroll_config.stepSize;
@@ -769,8 +804,6 @@ void eListboxPythonStringContent::updateScrollPosition() {
 }
 
 //////////////////////////////////////
-
-RESULT SwigFromPython(ePtr<gPixmap> &res, PyObject *obj);
 
 void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected)
 {
@@ -962,11 +995,16 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 
 				/* CallObject will call __call__ which should return the value tuple */
 				value = PyObject_CallObject(value, args);
+				Py_DECREF(args);
 
 				if (PyErr_Occurred())
+				{
 					PyErr_Print();
+					// Abort rendering this item; value may be null or invalid
+					painter.clippop();
+					return;
+				}
 
-				Py_DECREF(args);
 				/* the PyInt was stolen. */
 				painter.setFont(fnt);
 			}
@@ -1253,9 +1291,6 @@ int eListboxPythonConfigContent::getIndentSize()
 
 //////////////////////////////////////
 
-/* todo: make a real infrastructure here! */
-RESULT SwigFromPython(ePtr<gPixmap> &res, PyObject *obj);
-
 eListboxPythonMultiContent::eListboxPythonMultiContent()
 	: m_clip(gRegion::invalidRegion()), m_old_clip(gRegion::invalidRegion())
 {
@@ -1449,18 +1484,23 @@ static ePyObject lookupColor(ePyObject color, ePyObject data)
 
 int eListboxPythonMultiContent::getMaxItemTextWidth()
 {
+	// Return cached result if already calculated
+	if (m_max_text_width >= 0)
+		return m_max_text_width;
+
 	ePtr<gFont> fnt;
-	eListboxStyle *local_style = 0;
-	int m_text_offset = 1;
+	eListboxStyle *local_style = nullptr;
+	int text_offset = 1;
 	if (m_listbox)
 		local_style = m_listbox->getLocalStyle();
 	if (local_style) {
 		fnt = local_style->m_font;
-		m_text_offset = local_style->m_text_padding.x();
+		text_offset = local_style->m_text_padding.x();
 	}
 	if (!fnt) fnt = new gFont("Regular", 20);
 
 	ePyObject items, buildfunc_ret;
+    int max_width = 0;
 	if (m_list) {
 		for (int k = 0; k < size(); k++)
 		{
@@ -1537,14 +1577,14 @@ int eListboxPythonMultiContent::getMaxItemTextWidth()
 							continue;
 
 						const char *string = (PyUnicode_Check(pstring)) ? PyUnicode_AsUTF8(pstring) : "<not-a-string>";
-						eRect textRect = eRect(0,0, 9999, 100);
+						eRect textRect = eRect(0,0, TEXT_MEASURE_MAX_WIDTH, 100);
 
 						ePtr<eTextPara> para = new eTextPara(textRect);
 						para->setFont(fnt);
 						para->renderString(string);
 						int textWidth = para->getBoundBox().width() + PyLong_AsLong(px);
-						if (textWidth > m_max_text_width) {
-							m_max_text_width = textWidth;
+						if (textWidth > max_width) {
+							max_width = textWidth;
 						}
 						break;
 					}
@@ -1555,7 +1595,9 @@ int eListboxPythonMultiContent::getMaxItemTextWidth()
 
 	}
 
-	return m_max_text_width + (m_text_offset*2);
+	// Store result; cache is invalidated by setList()
+	m_max_text_width = max_width + (text_offset * 2);
+	return m_max_text_width;
 }
 
 

--- a/lib/gui/elistboxcontent.h
+++ b/lib/gui/elistboxcontent.h
@@ -3,6 +3,7 @@
 
 #include <lib/python/python.h>
 #include <lib/gui/elistbox.h>
+#include <unordered_map>
 
 class eListboxPythonStringContent : public virtual iListboxContent
 {
@@ -22,7 +23,7 @@ public:
 	void invalidateEntry(int index);
 	void invalidate();
 	eSize getItemSize() { return m_itemsize; }
-	int getMaxItemTextWidth();
+	int getMaxItemTextWidth() override;
 	uint8_t getOrientation() { return m_orientation; }
 	
 #ifndef SWIG
@@ -51,10 +52,10 @@ protected:
 
 	int getItemHeight() { return m_itemheight; }
 	int getItemWidth() { return m_itemwidth; }
-	int getScollPos() { return m_scroll_pos; }
+	int getScrollPos() override { return m_scroll_pos; } // Returns the current scroll position in pixels.
 
 private:
-	int m_saved_cursor_line;
+	int m_saved_cursor_line = 0;
 	ePtr<gFont> m_font_zoomed;
 	// scroll
 	int m_scroll_pos = 0;
@@ -74,26 +75,26 @@ private:
 	ePtr<eTimer> scrollTimer;
 
 protected:
-	int m_cursor;
-	int m_saved_cursor;
+	int m_cursor = 0;
+	int m_saved_cursor = 0;
 	ePyObject m_list;
 	eSize m_itemsize;
-	int m_itemheight;
-	int m_itemwidth;
-	int m_max_text_width;
-	uint8_t m_orientation;
+	int m_itemheight = 25;
+	int m_itemwidth = 25;
+	int m_max_text_width = -1; // -1 means not yet calculated
+	uint8_t m_orientation = 1;
 #endif
 };
 
 class eListboxPythonConfigContent : public eListboxPythonStringContent
 {
 public:
-	void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected);
+	void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected) override;
 	void setSeperation(int sep) { m_seperation = sep; }
 	int getEntryLeftOffset();
 	int getHeaderLeftOffset();
 	int getIndentSize();
-	int currentCursorSelectable();
+	int currentCursorSelectable() override;
 	void setSlider(int height, int space)
 	{
 		m_slider_height = height;
@@ -102,7 +103,9 @@ public:
 	eSize calculateEntryTextSize(const std::string &string, bool headerFont = true);
 
 private:
-	int m_seperation, m_slider_height, m_slider_space;
+	int m_seperation = 0;   // pixel separation between label and value
+	int m_slider_height = 10; // height of the filled slider bar in pixels
+	int m_slider_space = 2;   // spacing between slider bar and its frame in pixels
 	std::map<int, int> m_text_offset;
 };
 
@@ -129,8 +132,8 @@ public:
 		TYPE_PIXMAP_ALPHABLEND,
 		TYPE_PROGRESS_PIXMAP
 	};
-	void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected);
-	int currentCursorSelectable();
+	void paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected) override;
+	int currentCursorSelectable() override;
 	void setList(SWIG_PYOBJECT(ePyObject) list);
 	void setFont(int fnt, gFont *font);
 	void setBuildFunc(SWIG_PYOBJECT(ePyObject) func);
@@ -140,16 +143,16 @@ public:
 	void resetClip();
 	void entryRemoved(int idx);
 	void setTemplate(SWIG_PYOBJECT(ePyObject) tmplate);
-	int getMaxItemTextWidth();
+	int getMaxItemTextWidth() override;
 protected:
-	virtual void setBuildArgs(int selected) {}
-	virtual bool getIsMarked(int selected) { return false; }
+	virtual void setBuildArgs(int selected) {} // intended extension point for subclasses // NOSONAR
+	virtual bool getIsMarked(int selected) { return false; } // intended extension point for subclasses
 	bool m_servicelist = false;
 	ePyObject m_pArgs;
 
 private:
-	std::map<int, ePtr<gFont>> m_fonts;
-	std::map<int, ePtr<gFont>> m_fonts_zoomed;
+	std::unordered_map<int, ePtr<gFont>> m_fonts;
+	std::unordered_map<int, ePtr<gFont>> m_fonts_zoomed;
 };
 
 #ifdef SWIG


### PR DESCRIPTION
Cache getMaxItemTextWidth() result; invalidate on setList() to avoid O(n) font layout work on every layout pass for large channel lists Change m_fonts and m_fonts_zoomed from std::map to std::unordered_map for O(1) average font lookup in the paint() hot path Bug fixes / safety:

Initialize eListboxPythonConfigContent members (m_seperation=0, m_slider_height=10, m_slider_space=2) to eliminate undefined behavior on first paint when setters have not been called Add pixmap size guard in createScrollPixmap() using a named MAX_SCROLL_PIXMAP_PIXELS constexpr (1,000,000 px); on limit exceeded log a warning, disable cache and fall back to scrollModeNormal to prevent OOM crashes on constrained STB hardware Return early from paint() after PyObject_CallObject() failure and move Py_DECREF(args) before the error check to prevent null-pointer dereference when a config entry's value function raises an exception Add missing local variable; fix typo; fix Sonar warnings API:

Add correctly spelled getScrollPos(); remove misspelled getScollPos() (was missing 'r') — breaking change for any callers of the old name Improve updateScrollPosition()
Code quality (no behavior change):

Add override specifiers to paint(), currentCursorSelectable() and getMaxItemTextWidth() in derived classes for compiler-enforced signature checking Replace magic numbers with named constants: TEXT_MEASURE_MAX_WIDTH (8000), MAX_SCROLL_PIXMAP_PIXELS (1,000,000), SCROLL_ROLL_EXTRA_FACTOR (1.5f); unify inconsistent 8000 vs 9999 values in getMaxItemTextWidth() Fix shadowed local variable (m_text_offset → text_offset) Replace 0 pointer literals with nullptr
Add explicit static_cast where float multiplication feeds an int Remove duplicate SwigFromPython forward declaration Initialize scrollTimer only if needed