### PR TITLE
[eConsoleAppContainer] add setLineMode() for line-buffered process ou…

### DIFF
--- a/lib/base/console.cpp
+++ b/lib/base/console.cpp
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <fcntl.h>
+#include <vector>
 
 int bidirpipe(int pfd[], const char *cmd , const char * const argv[], const char *cwd)
 {
@@ -95,17 +96,31 @@ void eConsoleAppContainer::setBufferSize(int size)
 
 int eConsoleAppContainer::execute( const char *cmd )
 {
-	int argc = 3;
-	const char *argv[argc + 1];
-	argv[0] = "/bin/sh";
-	argv[1] = "-c";
-	argv[2] = cmd;
-	argv[argc] = NULL;
-
-	return execute(argv[0], argv);
+	// setLineMode is intentionally not applied to the shell form: stdbuf
+	// wrapping /bin/sh only affects the shell's own buffering, not the
+	// child process it spawns via -c.
+	const char *argv[] = { "/bin/sh", "-c", cmd, nullptr };
+	return startProcess(argv[0], argv);
 }
 
 int eConsoleAppContainer::execute(const char *cmdline, const char * const argv[])
+{
+	if (m_line_mode && access("/usr/bin/stdbuf", X_OK) == 0)
+	{
+		std::vector<const char *> wrapped;
+		wrapped.push_back("/usr/bin/stdbuf");
+		wrapped.push_back("-oL");
+		wrapped.push_back("-eL");
+		wrapped.push_back(cmdline);
+		for (int i = 0; argv[i]; ++i)
+			wrapped.push_back(argv[i]);
+		wrapped.push_back(nullptr);
+		return startProcess("/usr/bin/stdbuf", (const char * const *)wrapped.data());
+	}
+	return startProcess(cmdline, argv);
+}
+
+int eConsoleAppContainer::startProcess(const char *cmdline, const char * const argv[])
 {
 	if (running())
 		return -1;

--- a/lib/base/console.h
+++ b/lib/base/console.h
@@ -32,6 +32,8 @@ class eConsoleAppContainer: public sigc::trackable, public iObject
 	std::vector<char> buffer;
 	int m_nice = -1;
 	int m_ionice = -1;
+	bool m_line_mode = false;
+	int startProcess(const char *cmdline, const char * const argv[]);
 	void readyRead(int what);
 	void readyErrRead(int what);
 	void readyWrite(int what);
@@ -43,6 +45,7 @@ public:
 	void setBufferSize(int size);
 	void setNice(int nice) { m_nice = nice;}
 	void setIONice(int ionice) { m_ionice = ionice;}
+	void setLineMode(bool enable) { m_line_mode = enable; }
 	int execute( const char *str );
 	int execute( const char *cmdline, const char *const argv[] );
 	int getPID() { return pid; }

--- a/lib/python/python_console.i
+++ b/lib/python/python_console.i
@@ -184,6 +184,16 @@ extern "C" {
 	}
 
 	static PyObject *
+	eConsolePy_setLineMode(eConsolePy* self, PyObject *args)
+	{
+		int enable = 0;
+		if (!PyArg_ParseTuple(args, "i", &enable))
+			return NULL;
+		self->cont->setLineMode(enable != 0);
+		Py_RETURN_NONE;
+	}
+
+	static PyObject *
 	eConsolePy_write(eConsolePy* self, PyObject *args)
 	{
 		char *data;
@@ -338,6 +348,9 @@ extern "C" {
 		},
 		{(char*)"setIONice", (PyCFunction)eConsolePy_setIONice, METH_VARARGS,
 		(char*)"set ionice"
+		},
+		{(char*)"setLineMode", (PyCFunction)eConsolePy_setLineMode, METH_VARARGS,
+		(char*)"enable line-buffered stdout/stderr via /usr/bin/stdbuf"
 		},
 		{(char*)"setCWD", (PyCFunction)eConsolePy_setCWD, METH_VARARGS,
 		(char*)"set working dir"


### PR DESCRIPTION
…tput

- Add m_line_mode flag and setLineMode(bool) to eConsoleAppContainer
- When line mode is enabled and /usr/bin/stdbuf is available, wrap the execute(cmdline, argv) call with stdbuf -oL -eL to force line-buffered stdout/stderr — useful for processes that block-buffer when not attached to a tty
- Refactor internal execute() overloads: extract startProcess() as the single entry point that calls bidirpipe(); the public execute() methods handle argument preparation and optional stdbuf wrapping
- Note: setLineMode has no effect on the shell form execute(cmd) because stdbuf only affects the shell itself, not the child spawned via -c
- Expose setLineMode() to Python via python_console.i