### PR TITLE
[DreamNextGen] MultiBoot: sync with dream embedded boot manager

### DIFF
--- a/lib/python/Screens/FlashManager.py
+++ b/lib/python/Screens/FlashManager.py
@@ -700,6 +700,9 @@ class FlashImage(Screen):
 		fbClass.getInstance().unlock()
 		self.containerOFGWrite = None
 		if retVal == 0:
+			slotCode = getattr(self, "slotCode", None)
+			if slotCode and BoxInfo.getItem("model") in ("dreamone", "dreamtwo") and BoxInfo.getItem("HasGPT"):
+				MultiBoot.updateDreamBootSection(slotCode)
 			self["header"].setText(_("Flashing image successful"))
 			self["summary_header"].setText(self["header"].getText())
 			self["info"].setText("%s\n\n%s\n%s" % (self.imageName, _("Press OK for MultiBoot selection."), _("Press EXIT to close.")))

--- a/lib/python/Tools/MultiBoot.py
+++ b/lib/python/Tools/MultiBoot.py
@@ -154,6 +154,48 @@ class MultiBootClass():
 		if current != sectionIdx:
 			self._writeDreamBoot(defaultIdx=sectionIdx)
 
+	def getDreamBootSectionName(self, slotCode):
+		# Build the "<displaydistro> <imgversion> (<compiledate>)" string for the bootmanager menu.
+		slot = self.bootSlots.get(slotCode) if slotCode else None
+		if not slot:
+			return None
+		device = slot.get("device")
+		if not device or slotCode in ("R", "A", "L", "F"):
+			return None
+		rootSubdir = slot.get("rootsubdir") or ""
+		tempDir = mkdtemp(prefix=PREFIX)
+		name = None
+		opts = ["-t", "ubifs"] if slot.get("ubi") else []
+		self.console.ePopen([MOUNT, MOUNT] + opts + [device, tempDir])
+		try:
+			imageDir = join(tempDir, rootSubdir) if rootSubdir else tempDir
+			for fname in ("usr/lib/enigma.info", "usr/lib/enigma.conf"):
+				path = join(imageDir, fname)
+				if isfile(path):
+					name = self._formatSlotName(self.readSlotInfo(path))
+					if name:
+						break
+		finally:
+			self.console.ePopen([UMOUNT, UMOUNT, tempDir])
+			rmdir(tempDir)
+		return name
+
+	def updateDreamBootSection(self, slotCode, setDefault=False):
+		# Refresh the [Section] header for slotCode in DREAM_BOOT_FILE, optionally also flipping default= to it.
+		sectionIdx = self.getDreamBootSectionIndex(slotCode)
+		if sectionIdx is None and setDefault:
+			if slotCode.isdecimal():
+				sectionIdx = int(slotCode) - 1
+			elif slotCode == "R":
+				cmd_count = sum(1 for _ in self._iterDreamBootSections())
+				if cmd_count:
+					sectionIdx = cmd_count - 1
+		if sectionIdx is None:
+			return
+		sectionName = self.getDreamBootSectionName(slotCode)
+		sectionUpdates = {sectionIdx: sectionName} if sectionName else None
+		self._writeDreamBoot(defaultIdx=sectionIdx if setDefault else None, sectionUpdates=sectionUpdates)
+
 	def getDreamBootSectionIndex(self, slotCode):
 		# Match by root partition (or 'recovery' for slotCode R) — section order is not fixed.
 		isRecovery = slotCode == "R"
@@ -542,15 +584,10 @@ class MultiBootClass():
 			infoFile = join(imageDir, "usr/lib/enigma.info")
 			versionFile = join(imageDir, "etc/image-version")
 			if isfile(infoFile):
-				info = self.readSlotInfo(infoFile)
-				compileDate = str(info.get("compiledate"))
-				revision = info.get("imgrevision")
-				revision = f".{revision:03d}" if info.get("distro") == "openvix" and isinstance(revision, int) else f" {revision}"
-				revision = "" if revision.strip() == compileDate else revision
-				compileDate = f"{compileDate[0:4]}-{compileDate[4:6]}-{compileDate[6:8]}"
+				name = self._formatSlotName(self.readSlotInfo(infoFile))
 				self.imageList[self.slotCode]["detection"] = "Found an enigma information file"
-				self.imageList[self.slotCode]["imagename"] = f"{info.get("displaydistro", info.get("distro"))} {info.get("imgversion")}{revision} ({compileDate})"
-				self.imageList[self.slotCode]["imagelogname"] = f"{info.get("displaydistro", info.get("distro"))} {info.get("imgversion")}{revision} ({compileDate})"
+				self.imageList[self.slotCode]["imagename"] = name
+				self.imageList[self.slotCode]["imagelogname"] = name
 				self.imageList[self.slotCode]["status"] = "active"
 			elif isfile(versionFile):
 				info = self.readSlotInfo(versionFile)
@@ -591,6 +628,26 @@ class MultiBootClass():
 			print(f"[MultiBoot] finishSlot Error {retVal}: Unable to unmount slot '{self.slotCode}' (self.device)!")
 		else:
 			self.findSlot()
+
+	def _formatSlotName(self, info):
+		# Format the slot name "<displaydistro> <imgversion>[<revision>] (<compiledate>)" — single source for the UI and the bootmanager menu header.
+		distro = info.get("displaydistro") or info.get("distro")
+		if not distro:
+			return None
+		compileDate = str(info.get("compiledate", ""))
+		revision = info.get("imgrevision")
+		if revision is not None:
+			revision = f".{revision:03d}" if info.get("distro") == "openvix" and isinstance(revision, int) else f" {revision}"
+			revision = "" if revision.strip() == compileDate else revision
+		else:
+			revision = ""
+		if len(compileDate) == 8 and compileDate.isdigit():
+			compileDate = f"{compileDate[0:4]}-{compileDate[4:6]}-{compileDate[6:8]}"
+		else:
+			compileDate = ""
+		version = info.get("imgversion") or ""
+		base = f"{distro} {version}{revision}".rstrip()
+		return f"{base} ({compileDate})" if compileDate else base
 
 	def readSlotInfo(self, path):  # Part of analyzeSlot() within getSlotImageList().
 		info = {}
@@ -748,15 +805,7 @@ class MultiBootClass():
 				with open(DUAL_BOOT_FILE, "wb") as fd:
 					fd.write(pack("B", int(slot)))
 			if exists(DREAM_BOOT_FILE):
-				slot = self.getDreamBootSectionIndex(self.slotCode)
-				if slot is None and self.slotCode.isdecimal():
-					slot = int(self.slotCode) - 1
-				if slot is None and self.slotCode == "R":
-					cmd_count = sum(1 for _ in self._iterDreamBootSections())
-					if cmd_count:
-						slot = cmd_count - 1
-				if slot is not None:
-					self._writeDreamBoot(defaultIdx=slot)
+				self.updateDreamBootSection(self.slotCode, setDefault=True)
 			if self.debugMode:
 				print(f"[MultiBoot] Installing '{startup}' as '{target}'.")
 			self.console.ePopen([UMOUNT, UMOUNT, self.tempDir], self.bootDeviceUnmounted)

--- a/lib/python/Tools/MultiBoot.py
+++ b/lib/python/Tools/MultiBoot.py
@@ -3,6 +3,7 @@ from glob import glob
 from hashlib import md5
 from os import listdir, mkdir, rename, rmdir, stat
 from os.path import basename, exists, isdir, isfile, ismount, join, islink, realpath
+from re import search
 from struct import calcsize, pack, unpack, error
 from tempfile import mkdtemp
 
@@ -97,11 +98,113 @@ class MultiBootClass():
 		else:
 			self.bootSlot, self.bootCode = self.loadCurrentSlotAndBootCodes()
 		if exists(DREAM_BOOT_FILE):
-			with open(DREAM_BOOT_FILE, "r") as fd:
-				lines = fd.readlines()
-				for line in lines:
-					if line.startswith("default="):
-						self.bootSlot = str(int(line.strip().split("=")[1]) + 1)
+			runningRoot = None
+			for token in fileReadLine("/proc/cmdline", default="", source=MODULE_NAME).split():
+				if token.startswith("root="):
+					runningRoot = token[5:]
+					break
+			if runningRoot:
+				for slotCode, slot in self.bootSlots.items():
+					if slot.get("device") == runningRoot:
+						self.bootSlot = slotCode
+						break
+			self.syncStartupFileFromBootSlot()
+			self._syncDreamBootDefault()
+
+	def syncStartupFileFromBootSlot(self):
+		# Embedded bootmanager picks the slot without updating /data/STARTUP, so copy STARTUP_<N> over /data/STARTUP here.
+		if not self.bootDevice or not self.bootSlot:
+			return
+		bootSlot = self.bootSlots.get(self.bootSlot)
+		if not bootSlot:
+			return
+		cmdLine = bootSlot.get("cmdline", {}).get(self.bootCode)
+		startupName = bootSlot.get("startupfile", {}).get(self.bootCode)
+		if not cmdLine or not startupName or cmdLine == self.startupCmdLine:
+			return
+		tempDir = mkdtemp(prefix=PREFIX)
+		self.console.ePopen([MOUNT, MOUNT, self.bootDevice, tempDir])
+		try:
+			src = join(tempDir, startupName)
+			dst = join(tempDir, STARTUP_FILE)
+			if isfile(src):
+				copyfile(src, dst)
+				self.startupCmdLine = cmdLine
+				print(f"[MultiBoot] Synced '{STARTUP_FILE}' to '{startupName}' to match '/proc/cmdline'.")
+		finally:
+			self.console.ePopen([UMOUNT, UMOUNT, tempDir])
+			rmdir(tempDir)
+
+	def _syncDreamBootDefault(self):
+		# Align /data/bootconfig.txt's default= with the running slot so a plain reboot (no embedded menu) stays in the same slot.
+		if not self.bootSlot:
+			return
+		sectionIdx = self.getDreamBootSectionIndex(self.bootSlot)
+		if sectionIdx is None:
+			return
+		current = None
+		with open(DREAM_BOOT_FILE, "r") as fd:
+			for line in fd:
+				if line.startswith("default="):
+					try:
+						current = int(line.strip().split("=")[1])
+					except (ValueError, IndexError):
+						pass
+					break
+		if current != sectionIdx:
+			self._writeDreamBoot(defaultIdx=sectionIdx)
+
+	def getDreamBootSectionIndex(self, slotCode):
+		# Match by root partition (or 'recovery' for slotCode R) — section order is not fixed.
+		isRecovery = slotCode == "R"
+		targetPart = None
+		if not isRecovery:
+			match = search(r"p(\d+)$", self.bootSlots.get(slotCode, {}).get("device", ""))
+			if not match:
+				return None
+			targetPart = match.group(1)
+		for cur, cmd in self._iterDreamBootSections():
+			if isRecovery:
+				if "recovery" in cmd.lower():
+					return cur
+			else:
+				match = search(r"\b\d+:(\d+)\b", cmd)
+				if match and match.group(1) == targetPart:
+					return cur
+		return None
+
+	def _iterDreamBootSections(self):
+		# Yield (sectionIdx, cmdLine) for each [Section] / cmd= pair in DREAM_BOOT_FILE.
+		if not exists(DREAM_BOOT_FILE):
+			return
+		cur = -1
+		with open(DREAM_BOOT_FILE, "r") as fd:
+			for line in fd:
+				stripped = line.strip()
+				if stripped.startswith("[") and stripped.endswith("]"):
+					cur += 1
+				elif stripped.startswith("cmd=") and cur >= 0:
+					yield cur, stripped
+
+	def _writeDreamBoot(self, defaultIdx=None, sectionUpdates=None):
+		# Rewrite DREAM_BOOT_FILE; optionally set default= and rename [Section] headers via {idx: name}.
+		if not exists(DREAM_BOOT_FILE):
+			return
+		sectionUpdates = sectionUpdates or {}
+		with open(DREAM_BOOT_FILE, "r+") as fd:
+			lines = fd.readlines()
+			fd.seek(0)
+			cur = -1
+			for line in lines:
+				stripped = line.strip()
+				if defaultIdx is not None and line.startswith("default="):
+					line = f"default={defaultIdx}\n"
+				elif stripped.startswith("[") and stripped.endswith("]"):
+					cur += 1
+					if cur in sectionUpdates:
+						line = f"[{sectionUpdates[cur]}]\n"
+				fd.write(line)
+			fd.truncate()
 
 	def loadBootDevice(self):
 		bootDeviceList = BOOT_DEVICE_LIST_VUPLUS if fileHas("/proc/cmdline", "kexec=1") else BOOT_DEVICE_LIST
@@ -645,23 +748,15 @@ class MultiBootClass():
 				with open(DUAL_BOOT_FILE, "wb") as fd:
 					fd.write(pack("B", int(slot)))
 			if exists(DREAM_BOOT_FILE):
-				if self.slotCode == "R":
-					cmd_count = 0
-					with open(DREAM_BOOT_FILE, "r") as fd:
-						lines = fd.readlines()
-						for line in lines:
-							if line.startswith("cmd="):
-								cmd_count += 1
-					self.slotCode = str(cmd_count)
-				slot = int(self.slotCode) - 1
-				with open(DREAM_BOOT_FILE, "r+") as fd:
-					lines = fd.readlines()
-					fd.seek(0)
-					for line in lines:
-						if line.startswith("default="):
-							line = f"default={slot}\n"
-						fd.write(line)
-					fd.truncate()
+				slot = self.getDreamBootSectionIndex(self.slotCode)
+				if slot is None and self.slotCode.isdecimal():
+					slot = int(self.slotCode) - 1
+				if slot is None and self.slotCode == "R":
+					cmd_count = sum(1 for _ in self._iterDreamBootSections())
+					if cmd_count:
+						slot = cmd_count - 1
+				if slot is not None:
+					self._writeDreamBoot(defaultIdx=slot)
 			if self.debugMode:
 				print(f"[MultiBoot] Installing '{startup}' as '{target}'.")
 			self.console.ePopen([UMOUNT, UMOUNT, self.tempDir], self.bootDeviceUnmounted)


### PR DESCRIPTION
++++ DO NOT SQUASH BOTH COMMITS ++++

* [DreamNextGen] MultiBoot: use /proc/cmdline as source of truth at boot

Problem: on dreamone/dreamtwo the current slot is detected as the wrong
one after a switch through the embedded bootmanager, and a plain
Reboot/Shutdown afterwards reverts to the previous slot at next auto
boot.

Cause: loadCurrentSlotAndBootCodes() identifies the slot by matching
/boot/STARTUP against the STARTUP_<N> cmdlines, but /boot/STARTUP is
written by e2 on slot switch — not by the bootloader. When the user
overrides the boot selection in the embedded menu, the box boots that
slot once without updating either /boot/STARTUP or
/data/bootconfig.txt's default=N, so both go stale. The previous
default=N override also assumed 'section index N <-> slotCode N+1',
which only holds when bootconfig sections are sequential.

Fix: parse /proc/cmdline (the only reliable record of what actually
booted) for root=<device>, look it up in self.bootSlots to override
self.bootSlot. Then sync both stale sources of truth so subsequent
plain reboots and external tooling stay correct:

- syncStartupFileFromBootSlot copies the matching STARTUP_<N> over
  /boot/STARTUP and refreshes self.startupCmdLine.
- _syncDreamBootDefault rewrites /data/bootconfig.txt's default= to
  the matching bootmanager section index.

Section index is resolved by content (root partition match, or the
'recovery' substring in cmd= for slotCode 'R') via the new helpers
getDreamBootSectionIndex / _iterDreamBootSections / _writeDreamBoot.
The slot-switch write path in bootDeviceMounted is updated to use the
same lookup, dropping the silent 'self.slotCode = str(cmd_count)'
mutation that previously turned slotCode 'R' into a number.

* [DreamNextGen] MultiBoot: refresh bootconfig.txt section header on slot switch and after flash

Problem: the embedded bootmanager's pre-boot menu lists slots by their
factory section headers (e.g. 'BuildIn Slot 1', 'DreamOS OE 2.6') even
after the slot has been reflashed or a different image installed, so
the menu is misleading. Also the existing slot-switch path only
rewrote default=N and silently mutated self.slotCode for Recovery.

Cause: section headers were never written. The slot-switch path didn't
even know which section belonged to which slotCode beyond a blind
'slotCode N -> section N-1' assumption.

Fix: introduce updateDreamBootSection(slotCode, setDefault=) which
resolves the section index, mounts the slot, reads enigma.info/.conf
and rewrites the matching [Section] header to a uniformly formatted
'<displaydistro> <imgversion>[<revision>] (<compiledate>)' string in
one pass over /data/bootconfig.txt. Pull the format itself into a
shared _formatSlotName(info) helper so the MultiBoot manager UI and
the bootmanager menu header always render the same value.

Wire it up:

- bootDeviceMounted (e2 slot switch): updateDreamBootSection(setDefault
  =True) — default= and header in one write.
- FlashManager.flashImageDone (post-flash): updateDreamBootSection()
  without setDefault — only the header, since the slot the user just
  flashed is not necessarily the one to boot next. Gated on dreamone/
  dreamtwo + HasGPT to mirror the existing ofgwrite branching.