### PR TITLE
MultiBootManager: rename slots via TXT/VirtualKeyBoard

### DIFF
--- a/lib/python/Screens/MultiBootManager.py
+++ b/lib/python/Screens/MultiBootManager.py
@@ -6,7 +6,7 @@ from shlex import split
 
 from Components.ActionMap import HelpableActionMap
 from Components.ChoiceList import ChoiceEntryComponent, ChoiceList
-from Components.config import ConfigInteger, ConfigSelection
+from Components.config import config, ConfigInteger, ConfigSelection
 from Components.Console import Console
 from Components.Harddisk import harddiskmanager
 from Components.Label import Label
@@ -18,6 +18,7 @@ from Screens.MessageBox import MessageBox
 from Screens.Screen import Screen
 from Screens.Setup import Setup
 from Screens.Standby import QUIT_REBOOT, QUIT_RESTART, TryQuitMainloop
+from Screens.VirtualKeyBoard import VirtualKeyBoard
 from Tools.Directories import fileReadLines, fileReadLine, fileWriteLine, fileWriteLines
 from Tools.MultiBoot import MultiBoot
 
@@ -54,6 +55,9 @@ class MultiBootManager(Screen):
 		<widget source="key_blue" render="Label" position="460,e-50" size="140,40" backgroundColor="key_blue" font="Regular;20" conditional="key_blue" foregroundColor="key_text" halign="center" noWrap="1" valign="center">
 			<convert type="ConditionalShowHide" />
 		</widget>
+		<widget source="key_text" render="Label" position="610,e-50" size="140,40" backgroundColor="key_back" font="Regular;20" conditional="key_text" foregroundColor="key_text" halign="center" noWrap="1" valign="center">
+			<convert type="ConditionalShowHide" />
+		</widget>
 		<widget source="key_help" render="Label" position="e-100,e-50" size="90,40" backgroundColor="key_back" font="Regular;20" conditional="key_help" foregroundColor="key_text" halign="center" noWrap="1" valign="center">
 			<convert type="ConditionalShowHide" />
 		</widget>
@@ -68,6 +72,12 @@ class MultiBootManager(Screen):
 		self["key_green"] = StaticText(_("Reboot"))
 		self["key_yellow"] = StaticText()
 		self["key_blue"] = StaticText()
+		self["key_text"] = StaticText()
+		self.editSlotCode = None
+		self["editActions"] = HelpableActionMap(self, "VirtualKeyboardActions", {
+			"showVirtualKeyboard": (self.keyEdit, _("Rename the selected slot"))
+		}, prio=0, description=_("MultiBoot Manager Actions"))
+		self["editActions"].setEnabled(False)
 		self["actions"] = HelpableActionMap(self, ["CancelActions", "NavigationActions"], {
 			"cancel": (self.cancel, _("Cancel the slot selection and exit")),
 			"close": (self.closeRecursive, _("Cancel the slot selection and exit all menus")),
@@ -104,6 +114,32 @@ class MultiBootManager(Screen):
 
 	def layoutFinished(self):
 		self["slotlist"].enableAutoNavigation(False)
+
+	def keyEdit(self):
+		currentSelected = self["slotlist"].l.getCurrentSelection()
+		if not currentSelected or not currentSelected[0][1]:
+			return
+		slotCode, _bootCode, status, _ubi, _current = currentSelected[0][1]
+		if status not in ("active",) or not slotCode.isdecimal():
+			return
+		editable = currentSelected[0][0].split(": ", 1)[-1].rsplit(" (", 1)[0]
+		idx = editable.rfind("  -  ")
+		if idx >= 0:
+			editable = editable[:idx]
+		self.editSlotCode = slotCode
+		self.session.openWithCallback(self.renameSlotCallback, VirtualKeyBoard, title=_("Rename slot '%s' (leave empty to reset):") % slotCode, text=editable)
+
+	def renameSlotCallback(self, newName):
+		slotCode = self.editSlotCode
+		self.editSlotCode = None
+		if newName is None or slotCode is None:
+			return
+		MultiBoot.renameSlot(slotCode, newName.strip(), self.renameCallback)
+
+	def renameCallback(self, result):
+		if result:
+			print(f"[MultiBootManager] Rename of slot failed, status {result}!")
+		self.getImagesList()
 
 	def getImagesList(self):
 		MultiBoot.getSlotImageList(self.getSlotImageListCallback)
@@ -271,6 +307,12 @@ class MultiBootManager(Screen):
 			self["restoreActions"].setEnabled(False)
 			self["moreSlotActions"].setEnabled(True)
 			self["key_blue"].setText(_("Add more slots"))
+		if status == "active" and slot.isdecimal():
+			self["editActions"].setEnabled(True)
+			self["key_text"].setText(_("Rename"))
+		else:
+			self["editActions"].setEnabled(False)
+			self["key_text"].setText("")
 
 	def keyTop(self):
 		self["slotlist"].instance.moveSelection(self["slotlist"].instance.moveTop)

--- a/lib/python/Tools/MultiBoot.py
+++ b/lib/python/Tools/MultiBoot.py
@@ -11,7 +11,7 @@ from tempfile import mkdtemp
 # used to populate BoxInfo / SystemInfo and will create a boot loop!
 #
 from Components.Console import Console
-from Tools.Directories import SCOPE_CONFIG, copyfile, fileHas, fileReadLine, fileReadLines, resolveFilename
+from Tools.Directories import SCOPE_CONFIG, copyfile, fileHas, fileReadLine, fileReadLines, fileWriteLines, resolveFilename
 
 MODULE_NAME = __name__.split(".")[-1]
 
@@ -817,6 +817,49 @@ class MultiBootClass():
 		else:
 			rmdir(self.tempDir)
 			self.callback(0)
+
+	def renameSlot(self, slotCode, newName, callback):
+		# Override the slot's displaydistro/imgversion via <slot>/usr/lib/enigma.conf.
+        # Empty newName drops those keys so the image's own enigma.info takes over again.
+		if not self.bootSlots or slotCode not in self.bootSlots:
+			callback(1)
+			return
+		device = self.bootSlots[slotCode].get("device")
+		if not device:
+			callback(1)
+			return
+		self.slotCode = slotCode
+		self.newName = (newName or "").strip()
+		self.callback = callback
+		self.tempDir = mkdtemp(prefix=PREFIX)
+		opts = ["-t", "ubifs"] if self.bootSlots[slotCode].get("ubi") else []
+		self.console.ePopen([MOUNT, MOUNT] + opts + [device, self.tempDir], self._renameSlotMounted)
+
+	def _renameSlotMounted(self, data, retVal, extraArgs):
+		if retVal:
+			rmdir(self.tempDir)
+			self.callback(2)
+			return
+		rootSubdir = self.bootSlots[self.slotCode].get("rootsubdir") or ""
+		imageDir = join(self.tempDir, rootSubdir) if rootSubdir else self.tempDir
+		confPath = join(imageDir, "usr/lib/enigma.conf")
+		lines = fileReadLines(confPath, default=[], source=MODULE_NAME) or []
+		stripped = [line.rstrip("\n") for line in lines]
+		out = [line for line in stripped if not line.startswith(("displaydistro=", "imgversion="))]
+		if self.newName:
+			parts = self.newName.rsplit(" ", 1)
+			distro, version = (parts[0], parts[1]) if len(parts) > 1 else (parts[0], "")
+			out.append(f"displaydistro='{distro}'")
+			out.append(f"imgversion='{version}'")
+		if out != stripped:
+			fileWriteLines(confPath, out, source=MODULE_NAME)
+		self.console.ePopen([UMOUNT, UMOUNT, self.tempDir], self._renameSlotUnmounted)
+
+	def _renameSlotUnmounted(self, data, retVal, extraArgs):
+		rmdir(self.tempDir)
+		if exists(DREAM_BOOT_FILE):
+			self.updateDreamBootSection(self.slotCode)
+		self.callback(0 if not retVal else 3)
 
 	def emptySlot(self, slotCode, callback):
 		self.manageSlot(slotCode, callback, self.hideSlot)


### PR DESCRIPTION
Problem: the e2 MultiBoot manager had no built-in way to give a slot a custom display name.

Fix:
- MultiBoot.renameSlot(slotCode, newName, callback) mounts the slot, rewrites displaydistro/imgversion in <slot>/usr/lib/enigma.conf (the override layer that readSlotInfo / SystemInfo already consume), unmounts. Empty newName resets the override. enigma.info is left alone so a reset cleanly falls back to the image's own metadata.
- MultiBootManager binds TXT (KEY_TEXT via VirtualKeyboardActions / showVirtualKeyboard) on active, numeric slots. It opens the standard VirtualKeyBoard prefilled with the editable portion of the slot name (no 'Slot N Type:' prefix, no '(date)' suffix) and feeds the result to MultiBoot.renameSlot, then reloads the slot list.
- key_text label set to 'Rename' in selectionChanged when applicable, cleared otherwise.