### PR TITLE
ImageBackup: match backup ZIP filename to slot name shown in slot list

### DIFF
--- a/lib/python/Screens/ImageBackup.py
+++ b/lib/python/Screens/ImageBackup.py
@@ -102,26 +102,28 @@ class ImageBackup(Screen):
 			flashSlot = currentImageSlot == "F"
 			currentImageSlot = int(currentImageSlot) if currentImageSlot and currentImageSlot.isdecimal() else 1
 			print(f"[ImageBackup] Current slot={currentImageSlot}, rootSlot={rootSlot}.")
-			images = []  # ChoiceEntryComponent(key, (Label, slotCode, recovery))
+			images = []  # ChoiceEntryComponent(key, (Label, slotCode, recovery, slotDistro, slotVersion))
 			if imageList:
 				for slotCode in sorted(imageList.keys()):
 					print(f"[ImageBackup]     Slot {slotCode}: {imageList[slotCode]}")
 					if imageList[slotCode]["status"] == "active" or imageList[slotCode]["status"] == "flash":
 						slotText = f'{slotCode} {"eMMC" if "mmcblk" in imageList[slotCode]["device"] else "MTD" if "mtd" in imageList[slotCode]["device"] else "UBI" if "ubi" in imageList[slotCode]["device"] else "USB"}'
+						slotDistro = imageList[slotCode].get("displaydistro") or None
+						slotVersion = imageList[slotCode].get("imgversion") or None
 						if slotCode == "1" and currentImageSlot == 1 and BoxInfo.getItem("canRecovery"):
-							images.append(ChoiceEntryComponent(None, (_("Slot %s: %s as USB Recovery") % (slotText, imageList[slotCode]["imagename"]), slotCode, True)))
+							images.append(ChoiceEntryComponent(None, (_("Slot %s: %s as USB Recovery") % (slotText, imageList[slotCode]["imagename"]), slotCode, True, slotDistro, slotVersion)))
 						if rootSlot:
-							images.append(ChoiceEntryComponent(None, ((_("Slot %s: %s")) % (slotText, imageList[slotCode]["imagename"]), slotCode, False)))
+							images.append(ChoiceEntryComponent(None, ((_("Slot %s: %s")) % (slotText, imageList[slotCode]["imagename"]), slotCode, False, slotDistro, slotVersion)))
 						else:
-							images.append(ChoiceEntryComponent(None, ((_("Slot %s: %s (Current image)") if slotCode == str(currentImageSlot) else _("Slot %s: %s")) % (slotText, imageList[slotCode]["imagename"]), slotCode, False)))
+							images.append(ChoiceEntryComponent(None, ((_("Slot %s: %s (Current image)") if slotCode == str(currentImageSlot) else _("Slot %s: %s")) % (slotText, imageList[slotCode]["imagename"]), slotCode, False, slotDistro, slotVersion)))
 				if rootSlot:
-					images.append(ChoiceEntryComponent(None, (_("Slot R: Root Slot Image Backup (Current image)"), "R", False)))
+					images.append(ChoiceEntryComponent(None, (_("Slot R: Root Slot Image Backup (Current image)"), "R", False, None, None)))
 				elif flashSlot:
-					images.append(ChoiceEntryComponent(None, (_("Slot F: Flash Slot Image Backup (Current image)"), "F", False)))
+					images.append(ChoiceEntryComponent(None, (_("Slot F: Flash Slot Image Backup (Current image)"), "F", False, None, None)))
 			else:
 				if BoxInfo.getItem("canRecovery"):
-					images.append(ChoiceEntryComponent(None, (_("Internal flash: %s %s as USB Recovery") % (displayDistro, imageVersion), "slotCode", True)))
-				images.append(ChoiceEntryComponent(None, (_("Internal flash:  %s %s ") % (displayDistro, imageVersion), "slotCode", False)))
+					images.append(ChoiceEntryComponent(None, (_("Internal flash: %s %s as USB Recovery") % (displayDistro, imageVersion), "slotCode", True, None, None)))
+				images.append(ChoiceEntryComponent(None, (_("Internal flash:  %s %s ") % (displayDistro, imageVersion), "slotCode", False, None, None)))
 			self["config"].setList(images)
 			for index, item in enumerate(images):
 				if item[0][1] == str(currentImageSlot):
@@ -133,15 +135,17 @@ class ImageBackup(Screen):
 		MultiBoot.getSlotImageList(getImageListCallback)
 
 	def keyStart(self):
-		current = self["config"].getCurrent()  # (label, slotCode, recovery)
+		current = self["config"].getCurrent()  # (label, slotCode, recovery, slotDistro, slotVersion)
+		slotDistro = current[0][3] if len(current[0]) > 3 else None
+		slotVersion = current[0][4] if len(current[0]) > 4 else None
 		targets = []
-		choiceList = []  # (label, slotCode, target, recovery)
+		choiceList = []  # (label, slotCode, target, recovery, slotDistro, slotVersion)
 		if current[0][1]:  # The MultiBoot enumeration is complete as we now have slotCodes.
 			for target in [join("/media", x) for x in listdir("/media")] + ([join("/media/net", x) for x in listdir("/media/net")] if isdir("/media/net") else []):
 				if Freespace(target) > 300000:
 					targets.append(target)
-					choiceList.append((target, current[0][1], target, current[0][2]))
-			choiceList.append((_("Do not backup the image"), False, None, False))
+					choiceList.append((target, current[0][1], target, current[0][2], slotDistro, slotVersion))
+			choiceList.append((_("Do not backup the image"), False, None, False, None, None))
 			print(f"[ImageBackup] Potential target{"" if len(targets) == 1 else "s"}: '{"', '".join(targets)}'.")
 			self.session.openWithCallback(self.runImageBackup, ChoiceBox, text=_("Please select the target location to save the backup:"), choiceList=choiceList, windowTitle=self.getTitle())
 
@@ -153,7 +157,7 @@ class ImageBackup(Screen):
 			print("[ImageBackup] Image backup completed.")
 			self.close()
 
-		label, slotCode, target, recovery = answer if answer else (None, None, None, None)
+		label, slotCode, target, recovery, slotDistro, slotVersion = answer if answer else (None, None, None, None, None, None)
 		if slotCode:
 			shutdownOK = config.usage.shutdownOK.value
 			config.usage.shutdownOK.setValue(True)
@@ -255,6 +259,15 @@ class ImageBackup(Screen):
 			cmdLines.append("\tDisplayDistro=Unknown")
 			cmdLines.append("\tImageVersion=Unknown")
 			cmdLines.append("fi")
+			# Prefer the slot's resolved displaydistro/imgversion
+			if slotDistro:
+				safeDistro = "".join(c if c.isalnum() or c in "._+-" else "_" for c in slotDistro).strip("_") or "Unknown"
+				shellDisplayDistro = slotDistro.replace("'", "'\\''")
+				cmdLines.append(f"Distro={safeDistro}")
+				cmdLines.append(f"DisplayDistro='{shellDisplayDistro}'")
+			if slotVersion:
+				safeVersion = "".join(c if c.isalnum() or c in "._+-" else "_" for c in slotVersion).strip("_") or "Unknown"
+				cmdLines.append(f"ImageVersion={safeVersion}")
 			cmdLines.append(f"{self.echoCmd} \"{_("Image version")} $DisplayDistro $ImageVersion.\"")
 			# Build the "imageversion" inventory file.
 			cmdLines.append(f"{self.echoCmd} \"[Image Version]\" > /tmp/imageversion")

--- a/lib/python/Tools/MultiBoot.py
+++ b/lib/python/Tools/MultiBoot.py
@@ -584,10 +584,13 @@ class MultiBootClass():
 			infoFile = join(imageDir, "usr/lib/enigma.info")
 			versionFile = join(imageDir, "etc/image-version")
 			if isfile(infoFile):
-				name = self._formatSlotName(self.readSlotInfo(infoFile))
+				info = self.readSlotInfo(infoFile)
+				name = self._formatSlotName(info)
 				self.imageList[self.slotCode]["detection"] = "Found an enigma information file"
 				self.imageList[self.slotCode]["imagename"] = name
 				self.imageList[self.slotCode]["imagelogname"] = name
+				self.imageList[self.slotCode]["displaydistro"] = info.get("displaydistro") or info.get("distro") or ""
+				self.imageList[self.slotCode]["imgversion"] = info.get("imgversion") or ""
 				self.imageList[self.slotCode]["status"] = "active"
 			elif isfile(versionFile):
 				info = self.readSlotInfo(versionFile)


### PR DESCRIPTION
The slot picker shows a per-slot name built from the slot's displaydistro/imgversion, but the ZIP filename was derived from a separate enigma.info grep in the shell script. As a result the filename could differ from what the user just selected.

- MultiBoot.analyzeSlot exposes the resolved displaydistro/imgversion in imageList next to the existing imagename.
- ImageBackup picker passes those two fields through ChoiceEntryComponent and the ChoiceBox callback into runImageBackup.
- runImageBackup writes them as Distro/DisplayDistro/ImageVersion before the existing enigma.info grep, so the slot's resolved values drive ZipName, the user-facing echo and /tmp/imageversion.
- Filename-bound values are sanitized to [A-Za-z0-9._+-]; the display value is single-quote-escaped for the shell.