### PR TITLE
[DreamNextGen] MultiBoot: sync bootmanager header on slot disable/restore

### DIFF
--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -381,7 +381,7 @@ BoxInfo.setItem("CanMeasureFrontendInputPower", eDVBResourceManager.getInstance(
 BoxInfo.setItem("canMultiBoot", MultiBoot.getBootSlots())
 BoxInfo.setItem("HasKexecMultiboot", fileHas("/proc/cmdline", "kexec=1"))
 BoxInfo.setItem("cankexec", BoxInfo.getItem("kexecmb") and fileExists("/usr/bin/kernel_auto.bin") and fileExists("/usr/bin/STARTUP.cpio.gz") and not BoxInfo.getItem("HasKexecMultiboot"))
-BoxInfo.setItem("HasChkrootMultiboot", MultiBoot.isFat32("/dev/block/by-name/others") or fileExists("/dev/block/by-name/startup"))
+BoxInfo.setItem("HasChkrootMultiboot", (MultiBoot.isFat32("/dev/block/by-name/others") or fileExists("/dev/block/by-name/startup")) and MODEL not in ("dreamone", "dreamtwo"))
 BoxInfo.setItem("canchkroot", (BoxInfo.getItem("hasUBIMB") or fileExists("/dev/block/by-name/others")) and not BoxInfo.getItem("HasChkrootMultiboot") and not fileExists("/etc/.disableChkroot"))
 BoxInfo.setItem("CanNotDoSimultaneousTranscodeAndPIP", MODEL in ("vusolo4k", "gbquad4k", "gbquad4kpro", "gbue4k"))
 BoxInfo.setItem("canRecovery", MODEL in ("hd51", "vs1500", "h7", "8100s") and ("disk.img", "mmcblk0p1") or MODEL in ("xc7439", "osmio4k", "osmio4kplus", "osmini4k") and ("emmc.img", "mmcblk1p1") or MODEL in ("gbmv200", "sf8008", "sf8008m", "sx988", "ip8", "ustym4kpro", "ustym4kottpremium", "ustym4ks2ottx", "beyonwizv2", "viper4k", "og2ott4k", "og2s4k", "sx88v2", "sx888") and ("usb_update.bin", "none"))

--- a/lib/python/Screens/MultiBootManager.py
+++ b/lib/python/Screens/MultiBootManager.py
@@ -304,9 +304,12 @@ class MultiBootManager(Screen):
 			self["deleteActions"].setEnabled(True)
 			self["restoreActions"].setEnabled(False)
 		if (BoxInfo.getItem("HasKexecMultiboot") and slotCode == "R") or BoxInfo.getItem("HasGPT"):
-			self["restoreActions"].setEnabled(False)
-			self["moreSlotActions"].setEnabled(True)
-			self["key_blue"].setText(_("Add more slots"))
+			if status == "empty":
+				self["moreSlotActions"].setEnabled(False)
+			else:
+				self["restoreActions"].setEnabled(False)
+				self["moreSlotActions"].setEnabled(True)
+				self["key_blue"].setText(_("Add more slots"))
 		if status == "active" and slot.isdecimal():
 			self["editActions"].setEnabled(True)
 			self["key_text"].setText("TEXT")

--- a/lib/python/Tools/MultiBoot.py
+++ b/lib/python/Tools/MultiBoot.py
@@ -180,6 +180,8 @@ class MultiBootClass():
 		finally:
 			self.console.ePopen([UMOUNT, UMOUNT, tempDir])
 			rmdir(tempDir)
+		if not name and slotCode.isdecimal():
+			name = f"BuildIn Slot {slotCode}"
 		return name
 
 	def updateDreamBootSection(self, slotCode, setDefault=False):
@@ -947,6 +949,8 @@ class MultiBootClass():
 			self.callback(3)
 		else:
 			rmdir(self.tempDir)
+			if exists(DREAM_BOOT_FILE):
+				self.updateDreamBootSection(self.slotCode)
 			self.callback(0)
 
 	def isFat32(self, device):


### PR DESCRIPTION
Problem: deleting (Disable) a slot through the MultiBoot manager only hid the slot's enigma2 / enigma.info / etc files but did not touch /data/bootconfig.txt's section header — the embedded bootmanager menu kept showing the now-empty slot under its old image name. On top of that, the disabled slot could not be reactivated through the UI at all on GPT boxes, and the chkroot 'Disable' button was shown on dreamone/two where it doesn't apply.

Cause:
- emptySlot/manageSlot/hideSlot/cleanUpSlot ended with a plain callback(0), without refreshing the bootmanager section header.
- getDreamBootSectionName returned None for slots without readable enigma.info/.conf, so a later updateDreamBootSection would no-op on the hidden slot.
- HasChkrootMultiboot keyed off /dev/block/by-name/startup, which exists on dreamone as the recovery GPT partition — false positive.
- selectionChanged's final HasGPT block unconditionally disabled restoreActions and rewrote the blue button to 'Add more slots', overriding the empty-slot branch that had just enabled Restore.

Fix:
- cleanUpSlot now calls updateDreamBootSection(slotCode) after a successful unmount when DREAM_BOOT_FILE is present, so the header is brought in line with the slot's current state (also covers the restore path symmetrically).
- getDreamBootSectionName falls back to 'BuildIn Slot <N>' when no enigma info file is readable and the slotCode is numeric, matching the dream-data.sh factory default. Recovery/Android/Flash slots still short-circuit to None earlier and are untouched.
- HasChkrootMultiboot is now gated on MODEL not being a dreamone/two so the chkroot 'Disable' UI path is no longer false-positive there.
- selectionChanged skips the Add-more-slots override on GPT when status == 'empty', so the Restore action and blue label survive, and disables moreSlotActions there to avoid a double binding on blue.