### PR TITLE
[RecordTimer] Fix "Tune failed" for simultaneous timers after GUI res…

### DIFF
--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -837,6 +837,32 @@ class RecordTimerEntry(TimerEntry):
 			if eStreamServer.getInstance().getConnectedClients():
 				eStreamServer.getInstance().stopStream()
 				return False
+			# When two timers share the same begin time, processActivation() processes
+			# them sequentially in one pass. Timer A reserves Tuner 1, Timer B then
+			# finds no free tuner and immediately runs the full escalation (PiP ->
+			# PseudoRec -> Stream -> Live-Zap) in a single activate() call, because
+			# none of those resources are active and each step falls through without
+			# a return. After a GUI restart InfoBar.instance is None, so the live-zap
+			# at escalation step 3 fires as a hard NavigationInstance.playService()
+			# call with no dialog and no settling time -> "Tune failed!".
+			# Fix: if another timer with the same begin is already in StatePrepared
+			# (it won the tuner race in this same processActivation() pass), defer
+			# our escalation by 20 seconds without incrementing first_try_prepare.
+			# On the next activation InfoBar is ready and the escalation runs
+			# normally with a proper dialog that cleanly stops the live service.
+			if self.first_try_prepare == 0:
+				simultaneousPrepared = [
+					x for x in NavigationInstance.instance.RecordTimer.timer_list
+					if x is not self
+					and not x.disabled
+					and x.begin == self.begin
+					and x.state == self.StatePrepared
+				]
+				if simultaneousPrepared:
+					self.log(8, "Simultaneous timer '%s' already prepared; deferring tuner-release escalation by 20 seconds." % simultaneousPrepared[0].name)
+					self.backoff = 0  # Reset backoff
+					self.start_prepare = int(time()) + 20
+					return False
 			if self.first_try_prepare == 0:  # Try to make a tuner available by disabling PiP.
 				self.first_try_prepare += 1
 				if not InfoBar:


### PR DESCRIPTION
…tart

When two timers share the same begin time, processActivation() in timer.py
processes both in a single while-loop pass. Timer A reserves its tuner
successfully. Timer B then calls tryPrepare(), finds no free tuner, and
immediately runs the full first_try_prepare escalation chain (PiP ->
PseudoRec -> Streaming -> Live-Zap) in one activate() call, because none
of those resources are active and each step falls through without a return.

After a GUI restart InfoBar.instance is None. This means the live-zap at
escalation step 3 fires immediately as a hard NavigationInstance.playService()
call with no dialog and no settling time. The current channel (e.g. ARD)
is interrupted while the navigation stack is still initializing, producing
the spurious "Tune failed!" error. Both recordings still complete correctly.

Without a GUI restart InfoBar.instance exists, a "Disable TV and try again?"
dialog is shown, and the live service is cleanly stopped before the tuner
is reassigned. Hence the bug only reproduces after a GUI restart.

Fix: after tryPrepare() fails, and before the first_try_prepare escalation
begins, check whether another non-disabled timer with the same begin time
is already in StatePrepared (meaning it won the tuner race in this same
processActivation() pass). If so, defer this timer's next activation by
20 seconds without incrementing first_try_prepare. On the next tick InfoBar
is fully initialized and the escalation runs normally with a proper dialog.

timer.begin is never modified. No behavior change for any other scenario.
The 20-second deferral only occurs once (first_try_prepare is still 0 on
the next attempt, so the full escalation remains available).

Fixes #3641