### PR TITLE
[skin.py] Use parseBoolean to process replacement font activation.

### DIFF
--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -1448,7 +1448,7 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_GUISKIN
 			name = font.attrib.get("name", "Regular")
 			scale = font.attrib.get("scale")
 			scale = int(scale) if scale and scale.isdigit() else 100
-			isReplacement = font.attrib.get("replacement") and True or False
+			isReplacement = parseBoolean("replacement", font.attrib.get("replacement", "false"))
 			render = font.attrib.get("render")
 			render = int(render) if render and render.isdigit() else 0
 			resolved = resolveFilename(SCOPE_FONTS, filename, path_prefix=pathSkin)


### PR DESCRIPTION
The old font replacement code did not follow the standardised Boolean evaluation of Boolean logic.  It used a limited numeric evaluation.
