### PR TITLE
MultiBoot: JSON-cached slot state, standalone scanner, SLOTNAMES-based rename

### DIFF
--- a/lib/python/Screens/FlashManager.py
+++ b/lib/python/Screens/FlashManager.py
@@ -386,7 +386,7 @@ class FlashImage(Screen):
 			if slotCode == currentSlotCode:
 				current = currentMsg
 				default = index
-			choices.append((slotMsg % (slotCode, slotType, imageDictionary[slotCode]["imagename"], current), (slotCode, True)))
+			choices.append((slotMsg % (slotCode, slotType, MultiBoot.getSlotDisplayName(slotCode, MultiBoot.getCurrentBootMode()), current), (slotCode, True)))
 		choices.append((_("No, don't flash this image"), False))
 		self.session.openWithCallback(self.checkMedia, MessageBox, _("Do you want to flash the image '%s'?") % self.imageName, list=choices, default=default, windowTitle=self.getTitle())
 
@@ -699,6 +699,9 @@ class FlashImage(Screen):
 				cmdArgs = ["-r"]
 			else:  # Normal non MultiBoot receiver.
 				cmdArgs = ["-r", "-k"]
+			slotCode = getattr(self, "slotCode", None)
+			if slotCode:
+				MultiBoot.clearSlotName(slotCode)
 			self.containerOFGWrite = Console()
 			self.containerOFGWrite.ePopen([OFGWRITE, OFGWRITE] + cmdArgs + ['%s' % imageFiles], callback=self.flashImageDone)
 			fbClass.getInstance().lock()
@@ -710,6 +713,8 @@ class FlashImage(Screen):
 		self.containerOFGWrite = None
 		if retVal == 0:
 			slotCode = getattr(self, "slotCode", None)
+			if slotCode:
+				MultiBoot._refreshJsonSlot(slotCode)
 			if slotCode and BoxInfo.getItem("model") in ("dreamone", "dreamtwo") and BoxInfo.getItem("HasGPT"):
 				MultiBoot.updateDreamBootSection(slotCode)
 			self["header"].setText(_("Flashing image successful"))

--- a/lib/python/Screens/ImageBackup.py
+++ b/lib/python/Screens/ImageBackup.py
@@ -110,12 +110,13 @@ class ImageBackup(Screen):
 						slotText = f'{slotCode} {"eMMC" if "mmcblk" in imageList[slotCode]["device"] else "MTD" if "mtd" in imageList[slotCode]["device"] else "UBI" if "ubi" in imageList[slotCode]["device"] else "USB"}'
 						slotDistro = imageList[slotCode].get("displaydistro") or None
 						slotVersion = imageList[slotCode].get("imgversion") or None
+						displayName = MultiBoot.getSlotDisplayName(slotCode, MultiBoot.getCurrentBootMode())
 						if slotCode == "1" and currentImageSlot == 1 and BoxInfo.getItem("canRecovery"):
-							images.append(ChoiceEntryComponent(None, (_("Slot %s: %s as USB Recovery") % (slotText, imageList[slotCode]["imagename"]), slotCode, True, slotDistro, slotVersion)))
+							images.append(ChoiceEntryComponent(None, (_("Slot %s: %s as USB Recovery") % (slotText, displayName), slotCode, True, slotDistro, slotVersion)))
 						if rootSlot:
-							images.append(ChoiceEntryComponent(None, ((_("Slot %s: %s")) % (slotText, imageList[slotCode]["imagename"]), slotCode, False, slotDistro, slotVersion)))
+							images.append(ChoiceEntryComponent(None, ((_("Slot %s: %s")) % (slotText, displayName), slotCode, False, slotDistro, slotVersion)))
 						else:
-							images.append(ChoiceEntryComponent(None, ((_("Slot %s: %s (Current image)") if slotCode == str(currentImageSlot) else _("Slot %s: %s")) % (slotText, imageList[slotCode]["imagename"]), slotCode, False, slotDistro, slotVersion)))
+							images.append(ChoiceEntryComponent(None, ((_("Slot %s: %s (Current image)") if slotCode == str(currentImageSlot) else _("Slot %s: %s")) % (slotText, displayName), slotCode, False, slotDistro, slotVersion)))
 				if rootSlot:
 					images.append(ChoiceEntryComponent(None, (_("Slot R: Root Slot Image Backup (Current image)"), "R", False, None, None)))
 				elif flashSlot:

--- a/lib/python/Screens/Information.py
+++ b/lib/python/Screens/Information.py
@@ -942,33 +942,36 @@ class MultiBootInformation(InformationBase):
 			slotCode, bootCode = MultiBoot.getCurrentSlotAndBootCodes()
 			slotImageList = sorted(self.slotImages.keys(), key=lambda x: (not x.isnumeric(), int(x) if x.isnumeric() else x))
 			currentMsg = f"  -  {_("Active")}"
-			imageLists = {}
+			modeLists = {}
+			plainLines = []
 			for slot in slotImageList:
-				for boot in self.slotImages[slot]["bootCodes"]:
-					if imageLists.get(boot) is None:
-						imageLists[boot] = []
+				entry = self.slotImages[slot]
+				configs = entry.get("bootCodes") or {}
+				hasBoxMode = len(configs) > 1
+				for boot in configs.keys():
 					active = currentMsg if boot == bootCode and slot == slotCode else ""
-					indent = "P0V" if boot == "" else "P1V"
+					indent = "P1V" if hasBoxMode else "P0V"
 					if active:
 						indent = indent.replace("P", "F").replace("V", "F")
-					device = self.slotImages[slot]["device"]
+					device = entry["device"]
 					slotType = "eMMC" if "mmcblk" in device else "MTD" if "mtd" in device else "UBI" if "ubi" in device else "USB"
-					imageLists[boot].append(formatLine(indent, _("Slot '%s' %s") % (slot, slotType), f"{self.slotImages[slot]["imagename"]}{active}"))
+					line = formatLine(indent, _("Slot '%s' %s") % (slot, slotType), f"{MultiBoot.getSlotDisplayName(slot, boot)}{active}")
+					if hasBoxMode:
+						modeLists.setdefault(boot, []).append(line)
+					else:
+						plainLines.append(line)
 			count = 0
-			for bootCode in sorted(imageLists.keys()):
-				if bootCode == "":
-					continue
+			for boot in sorted(modeLists.keys()):
 				if count:
 					info.append("")
-				info.append(formatLine("S", MultiBoot.getBootCodeDescription(bootCode), None))
+				info.append(formatLine("S", MultiBoot.getBootCodeDescription(boot), None))
 				if self.extraSpacing:
 					info.append("")
-				info.extend(imageLists[bootCode])
+				info.extend(modeLists[boot])
 				count += 1
 			if count:
 				info.append("")
-			if "" in imageLists:
-				info.extend(imageLists[""])
+			info.extend(plainLines)
 		else:
 			info.append(formatLine("P1", _("Retrieving boot slot information...")))
 		self["information"].setText("\n".join(info))

--- a/lib/python/Screens/MultiBootManager.py
+++ b/lib/python/Screens/MultiBootManager.py
@@ -18,7 +18,6 @@ from Screens.MessageBox import MessageBox
 from Screens.Screen import Screen
 from Screens.Setup import Setup
 from Screens.Standby import QUIT_REBOOT, QUIT_RESTART, TryQuitMainloop
-from Screens.VirtualKeyBoard import VirtualKeyBoard
 from Tools.Directories import fileReadLines, fileReadLine, fileWriteLine, fileWriteLines
 from Tools.MultiBoot import MultiBoot
 
@@ -55,9 +54,6 @@ class MultiBootManager(Screen):
 		<widget source="key_blue" render="Label" position="460,e-50" size="140,40" backgroundColor="key_blue" font="Regular;20" conditional="key_blue" foregroundColor="key_text" halign="center" noWrap="1" valign="center">
 			<convert type="ConditionalShowHide" />
 		</widget>
-		<widget source="key_text" render="Label" position="e-200,e-50" size="90,40" backgroundColor="key_back" font="Regular;20" conditional="key_text" foregroundColor="key_text" halign="center" noWrap="1" valign="center">
-			<convert type="ConditionalShowHide" />
-		</widget>
 		<widget source="key_help" render="Label" position="e-100,e-50" size="90,40" backgroundColor="key_back" font="Regular;20" conditional="key_help" foregroundColor="key_text" halign="center" noWrap="1" valign="center">
 			<convert type="ConditionalShowHide" />
 		</widget>
@@ -72,7 +68,6 @@ class MultiBootManager(Screen):
 		self["key_green"] = StaticText(_("Reboot"))
 		self["key_yellow"] = StaticText()
 		self["key_blue"] = StaticText()
-		self["key_text"] = StaticText()
 		actionDescription = _("MultiBoot Manager Actions")
 		self["actions"] = HelpableActionMap(self, ["CancelActions", "NavigationActions"], {
 			"cancel": (self.keyCancel, _("Cancel the slot selection and exit")),
@@ -99,16 +94,11 @@ class MultiBootManager(Screen):
 			"blue": (self.keyRestoreSlot, _("Restore the highlighted slot"))
 		}, prio=0, description=actionDescription)
 		self["restoreActions"].setEnabled(False)
-		self["renameActions"] = HelpableActionMap(self, "VirtualKeyboardActions", {
-			"showVirtualKeyboard": (self.keyRenameSlot, _("Rename the highlighted slot"))
-		}, prio=0, description=actionDescription)
-		self["renameActions"].setEnabled(False)
 		if (BoxInfo.getItem("HasKexecMultiboot") or BoxInfo.getItem("HasGPT") or BoxInfo.getItem("HasChkrootMultiboot")) and not BoxInfo.getItem("hasUBIMB"):
 			self["addActions"] = HelpableActionMap(self, ["ColorActions"], {
 				"blue": (self.keyAddSlots, _("Add more slots"))
 			}, prio=0, description=actionDescription)
 			self["addActions"].setEnabled(False)
-		self.editSlotCode = None
 		self.onLayoutFinish.append(self.layoutFinished)
 		self.initialize = True
 		self.callLater(self.getSlotList)
@@ -213,12 +203,6 @@ class MultiBootManager(Screen):
 				self["restoreActions"].setEnabled(False)
 				self["addActions"].setEnabled(True)
 				self["key_blue"].setText(_("Add slots"))
-		if status == "active" and slot.isdecimal():
-			self["renameActions"].setEnabled(True)
-			self["key_text"].setText("TEXT")
-		else:
-			self["renameActions"].setEnabled(False)
-			self["key_text"].setText("")
 
 	def keyCancel(self):
 		self.close()
@@ -318,29 +302,6 @@ class MultiBootManager(Screen):
 
 		current = self["slotlist"].getCurrent()[0]
 		MultiBoot.restoreSlot(current[1][0], keyRestoreSlotCallback)
-
-	def keyRenameSlot(self):
-		def renameSlotCallback(newName):
-			def renameCallback(result):
-				if result:
-					print(f"[MultiBootManager] Rename of slot failed, status {result}!")
-				self.getSlotList()
-
-			slotCode = self.editSlotCode
-			self.editSlotCode = None
-			if newName is not None and slotCode is not None:
-				MultiBoot.renameSlot(slotCode, newName.strip(), renameCallback)
-
-		current = self["slotlist"].getCurrent()
-		if current and current[0][1]:
-			slotCode, _bootCode, status, _ubi, _current = current[0][1]
-			if status in ("active",) and slotCode.isdecimal():
-				editable = current[0][0].split(": ", 1)[-1].rsplit(" (", 1)[0]
-				index = editable.rfind("  -  ")
-				if index >= 0:
-					editable = editable[:index]
-				self.editSlotCode = slotCode
-				self.session.openWithCallback(renameSlotCallback, VirtualKeyBoard, title=_("Rename slot '%s' (leave empty to reset):") % slotCode, text=editable)
 
 	def keyAddSlots(self):
 		if BoxInfo.getItem("HasGPT"):

--- a/lib/python/Screens/MultiBootManager.py
+++ b/lib/python/Screens/MultiBootManager.py
@@ -18,6 +18,7 @@ from Screens.MessageBox import MessageBox
 from Screens.Screen import Screen
 from Screens.Setup import Setup
 from Screens.Standby import QUIT_REBOOT, QUIT_RESTART, TryQuitMainloop
+from Screens.VirtualKeyBoard import VirtualKeyBoard
 from Tools.Directories import fileReadLines, fileReadLine, fileWriteLine, fileWriteLines
 from Tools.MultiBoot import MultiBoot
 
@@ -54,6 +55,9 @@ class MultiBootManager(Screen):
 		<widget source="key_blue" render="Label" position="460,e-50" size="140,40" backgroundColor="key_blue" font="Regular;20" conditional="key_blue" foregroundColor="key_text" halign="center" noWrap="1" valign="center">
 			<convert type="ConditionalShowHide" />
 		</widget>
+		<widget source="key_text" render="Label" position="e-200,e-50" size="90,40" backgroundColor="key_back" font="Regular;20" conditional="key_text" foregroundColor="key_text" halign="center" noWrap="1" valign="center">
+			<convert type="ConditionalShowHide" />
+		</widget>
 		<widget source="key_help" render="Label" position="e-100,e-50" size="90,40" backgroundColor="key_back" font="Regular;20" conditional="key_help" foregroundColor="key_text" halign="center" noWrap="1" valign="center">
 			<convert type="ConditionalShowHide" />
 		</widget>
@@ -68,6 +72,7 @@ class MultiBootManager(Screen):
 		self["key_green"] = StaticText(_("Reboot"))
 		self["key_yellow"] = StaticText()
 		self["key_blue"] = StaticText()
+		self["key_text"] = StaticText()
 		actionDescription = _("MultiBoot Manager Actions")
 		self["actions"] = HelpableActionMap(self, ["CancelActions", "NavigationActions"], {
 			"cancel": (self.keyCancel, _("Cancel the slot selection and exit")),
@@ -94,11 +99,17 @@ class MultiBootManager(Screen):
 			"blue": (self.keyRestoreSlot, _("Restore the highlighted slot"))
 		}, prio=0, description=actionDescription)
 		self["restoreActions"].setEnabled(False)
+		self["renameActions"] = HelpableActionMap(self, "VirtualKeyboardActions", {
+			"showVirtualKeyboard": (self.keyRenameSlot, _("Rename the highlighted slot"))
+		}, prio=0, description=actionDescription)
+		self["renameActions"].setEnabled(False)
 		if (BoxInfo.getItem("HasKexecMultiboot") or BoxInfo.getItem("HasGPT") or BoxInfo.getItem("HasChkrootMultiboot")) and not BoxInfo.getItem("hasUBIMB"):
 			self["addActions"] = HelpableActionMap(self, ["ColorActions"], {
 				"blue": (self.keyAddSlots, _("Add more slots"))
 			}, prio=0, description=actionDescription)
 			self["addActions"].setEnabled(False)
+		self.editSlotCode = None
+		self.editBootCode = None
 		self.onLayoutFinish.append(self.layoutFinished)
 		self.initialize = True
 		self.callLater(self.getSlotList)
@@ -113,26 +124,32 @@ class MultiBootManager(Screen):
 				slotCode, bootCode = MultiBoot.getCurrentSlotAndBootCodes()
 				activeMsg = "  -  %s" % _("Active")
 				slotMsg = _("Slot '%s' %s: %s%s")
-				slotData = {}
+				modeSlots = {}
+				plainSlots = []
 				for slot in sorted(slotList.keys(), key=lambda x: (not x.isnumeric(), int(x) if x.isnumeric() else x)):
-					for boot in slotList[slot]["bootCodes"]:
-						if slotData.get(boot) is None:
-							slotData[boot] = []
+					entry = slotList[slot]
+					configs = entry.get("bootCodes") or {}
+					hasBoxMode = len(configs) > 1
+					for boot in configs.keys():
 						active = activeMsg if boot == bootCode and slot == slotCode else ""
-						device = slotList[slot]["device"]
+						device = entry["device"]
 						slotType = "eMMC" if "mmcblk" in device else "MTD" if "mtd" in device else "UBI" if "ubi" in device else "USB"
-						slotData[boot].append(ChoiceEntryComponent("none" if boot else "", (slotMsg % (slot, slotType, slotList[slot]["imagename"], active), (slot, boot, slotList[slot]["status"], slotList[slot]["ubi"], active != ""))))
-				for bootCode in sorted(slotData.keys()):
-					if bootCode == "":
-						continue
-					slots.append(ChoiceEntryComponent("", (MultiBoot.getBootCodeDescription(bootCode), None)))
-					slots.extend(slotData[bootCode])
-				if "" in slotData:
-					slots.extend(slotData[""])
+						displayName = MultiBoot.getSlotDisplayName(slot, boot)
+						item = ChoiceEntryComponent("none" if hasBoxMode else "", (slotMsg % (slot, slotType, displayName, active), (slot, boot, entry["status"], entry["ubi"], active != "")))
+						if hasBoxMode:
+							modeSlots.setdefault(boot, []).append(item)
+						else:
+							plainSlots.append(item)
+				for boot in sorted(modeSlots.keys()):
+					slots.append(ChoiceEntryComponent("", (MultiBoot.getBootCodeDescription(boot), None)))
+					slots.extend(modeSlots[boot])
+				slots.extend(plainSlots)
 				if self.initialize:
 					self.initialize = False
-					for index, item in enumerate(slots):
+					index = 0
+					for i, item in enumerate(slots):
 						if item[0][1] and item[0][1][4]:
+							index = i
 							break
 				else:
 					index = self["slotlist"].getSelectedIndex()
@@ -203,6 +220,12 @@ class MultiBootManager(Screen):
 				self["restoreActions"].setEnabled(False)
 				self["addActions"].setEnabled(True)
 				self["key_blue"].setText(_("Add slots"))
+		if status == "active" and slot.isdecimal():
+			self["renameActions"].setEnabled(True)
+			self["key_text"].setText("TEXT")
+		else:
+			self["renameActions"].setEnabled(False)
+			self["key_text"].setText("")
 
 	def keyCancel(self):
 		self.close()
@@ -302,6 +325,34 @@ class MultiBootManager(Screen):
 
 		current = self["slotlist"].getCurrent()[0]
 		MultiBoot.restoreSlot(current[1][0], keyRestoreSlotCallback)
+
+	def keyRenameSlot(self):
+		def renameSlotCallback(newName):
+			def renameCallback(result):
+				if result:
+					print(f"[MultiBootManager] Rename of slot failed, status {result}!")
+				self.getSlotList()
+
+			slotCode = self.editSlotCode
+			bootCode = self.editBootCode
+			self.editSlotCode = None
+			self.editBootCode = None
+			if newName is not None and slotCode is not None:
+				MultiBoot.setSlotName(slotCode, bootCode, newName.strip(), renameCallback)
+
+		current = self["slotlist"].getCurrent()
+		if current and current[0][1]:
+			slotCode, bootCode, status, _ubi, _current = current[0][1]
+			if status in ("active",) and slotCode.isdecimal():
+				editable = MultiBoot.getSlotName(slotCode, bootCode)
+				if not editable:
+					editable = current[0][0].split(": ", 1)[-1].rsplit(" (", 1)[0]
+					index = editable.rfind("  -  ")
+					if index >= 0:
+						editable = editable[:index]
+				self.editSlotCode = slotCode
+				self.editBootCode = bootCode
+				self.session.openWithCallback(renameSlotCallback, VirtualKeyBoard, title=_("Rename slot '%s' (leave empty to reset):") % slotCode, text=editable)
 
 	def keyAddSlots(self):
 		if BoxInfo.getItem("HasGPT"):

--- a/lib/python/Tools/MultiBoot.py
+++ b/lib/python/Tools/MultiBoot.py
@@ -1,17 +1,18 @@
+#!/usr/bin/env python3
+# Dual-mode: `python3 MultiBoot.py [--slot N | --slotnames]` scans & writes JSON;
+# enigma2 imports MultiBootClass which reads it. stdlib-only above __main__.
 from datetime import datetime
 from glob import glob
 from hashlib import md5
-from os import listdir, mkdir, rename, rmdir, stat
-from os.path import basename, exists, isdir, isfile, ismount, join, islink, realpath
-from re import search
+from json import dump, load
+from os import listdir, makedirs, mkdir, rename, rmdir, stat, unlink
+from os.path import basename, dirname, exists, isdir, isfile, join, islink, realpath
+from re import findall, search
 from struct import calcsize, pack, unpack, error
+from subprocess import run
+from sys import argv as sysArgv, exit as sysExit, stderr
 from tempfile import mkdtemp
-
-# NOTE: This module must not import from SystemInfo.py as this module is
-# used to populate BoxInfo / SystemInfo and will create a boot loop!
-#
-from Components.Console import Console
-from Tools.Directories import SCOPE_CONFIG, copyfile, fileHas, fileReadLine, fileReadLines, resolveFilename
+from time import monotonic
 
 MODULE_NAME = __name__.split(".")[-1]
 
@@ -30,8 +31,33 @@ STARTUP_ANDROID_LINUXSE = "STARTUP_ANDROID_LINUXSE"
 STARTUP_RECOVERY = "STARTUP_RECOVERY"
 STARTUP_FLASH = "STARTUP_FLASH"
 STARTUP_BOXMODE = "BOXMODE"  # This is known as bootCode in this code.
+SLOTNAMES_FILE = "SLOTNAMES"
 BOOT_DEVICE_LIST = ("/dev/mmcblk0p1", "/dev/mmcblk1p1", "/dev/mmcblk0p3", "/dev/mmcblk0p4", "/dev/mtdblock2", "/dev/block/by-name/bootoptions", "/dev/block/by-name/others", "/dev/block/by-name/startup")
 BOOT_DEVICE_LIST_VUPLUS = ("/dev/mmcblk0p4", "/dev/mmcblk0p7", "/dev/mmcblk0p9")  # Kexec kernel Vu+ MultiBoot.
+
+JSON_FILE = "/var/run/multiboot.json"
+SCAN_LOG = "/tmp/multiboot-scan.log"
+
+KNOWN_DISTROS = {
+	"beyonwiz": "Beyonwiz", "blackhole": "Black Hole", "dreambox": "DreamOS",
+	"egami": "EGAMI", "gemini": "GeminiProject", "newnigma2": "Newnigma2",
+	"openatv": "OpenATV", "openbh": "OpenBH", "opendreambox": "OpenDreambox",
+	"opendroid": "OpenDroid", "openeight": "OpenEight", "openhdf": "OpenHDF",
+	"opennfr": "OpenNFR", "openpli": "OpenPLi", "openspa": "OpenSpa",
+	"openvision": "Open Vision", "openvix": "OpenViX", "pure2": "PurE2",
+	"sif": "Sif", "teamblue": "teamBlue", "vti": "VTi",
+}
+
+
+def _naturalKey(key):
+	# Pad every digit run to a fixed width so "STARTUP_10" > "STARTUP_2" as plain string compare.
+	return "".join(f"{int(x):010d}" if x.isdigit() else x for x in findall(r"\d+|\D+", str(key)))
+
+
+def _sortDictNatural(obj):
+	if isinstance(obj, dict):
+		return {k: _sortDictNatural(v) for k, v in sorted(obj.items(), key=lambda kv: _naturalKey(kv[0]))}
+	return obj
 
 
 # STARTUP
@@ -68,6 +94,727 @@ BOOT_DEVICE_LIST_VUPLUS = ("/dev/mmcblk0p4", "/dev/mmcblk0p7", "/dev/mmcblk0p9")
 #
 # root=/dev/mmcblk0p3 rootsubdir=linuxrootfs1 kernel=/dev/mmcblk0p2 rw rootwait h7_4.boxmode=1
 #
+
+
+# ============================================================
+# Scanner section — stdlib+subprocess only, no enigma2 deps.
+# Can be executed by `python3 MultiBoot.py [--slot N | --slotnames]`
+# at boot via init script and as an emergency fallback from
+# MultiBootClass.__init__ when the JSON is missing.
+# ============================================================
+
+def _scan_log(msg):
+	try:
+		with open(SCAN_LOG, "a") as fd:
+			fd.write(f"{datetime.now().isoformat(timespec='seconds')} {msg}\n")
+	except OSError:
+		pass
+
+
+def _scan_run(cmd):
+	return run(cmd, capture_output=True).returncode
+
+
+def _scan_read_lines(path):
+	try:
+		with open(path, "r", errors="replace") as fd:
+			return [line.rstrip("\n") for line in fd]
+	except OSError:
+		return []
+
+
+def _scan_read_first_line(path):
+	lines = _scan_read_lines(path)
+	return lines[0] if lines else ""
+
+
+def _scan_file_has(path, needle):
+	return needle in _scan_read_first_line(path)
+
+
+def _scan_resolve_device(device):
+	return realpath(device) if islink(device) else device
+
+
+def _scan_find_existing_mount(device):
+	# /proc/mounts may list the source as a /dev/<symlink> (e.g. /dev/dreambox-data) while our
+	# device is the resolved realdev (e.g. /dev/mmcblk0p4) — resolve both sides to match.
+	resolved = _scan_resolve_device(device)
+	try:
+		with open("/proc/mounts") as fd:
+			for line in fd:
+				parts = line.split()
+				if len(parts) < 2:
+					continue
+				src = parts[0]
+				if src in (device, resolved):
+					return parts[1].replace("\\040", " ")
+				if src.startswith("/dev/") and _scan_resolve_device(src) == resolved:
+					return parts[1].replace("\\040", " ")
+	except OSError:
+		pass
+	return None
+
+
+def _scan_mount_subroot(mount_point):
+	# Return which FS path this mount exposes: "/" for a full mount, "/subdir" when the kernel
+	# bound only a sub-directory.
+	try:
+		with open("/proc/self/mountinfo") as fd:
+			for line in fd:
+				parts = line.split()
+				if len(parts) >= 5 and parts[4] == mount_point:
+					return parts[3]
+	except OSError:
+		pass
+	return "/"
+
+
+class _ScanMount(object):
+	# Reuse the existing mount if it exposes the whole FS; else mount fresh so sibling subdirs
+	# hidden by a subtree-mount become visible.
+	def __init__(self, device, opts=None):
+		self.device = device
+		self.opts = opts or []
+		self.mount_point = None
+		self.owned = False
+
+	def __enter__(self):
+		existing = _scan_find_existing_mount(self.device)
+		if existing and _scan_mount_subroot(existing) == "/":
+			self.mount_point = existing
+			return existing
+		self.mount_point = mkdtemp(prefix=PREFIX)
+		if _scan_run([MOUNT] + self.opts + [self.device, self.mount_point]) == 0:
+			self.owned = True
+			return self.mount_point
+		try:
+			rmdir(self.mount_point)
+		except OSError:
+			pass
+		self.mount_point = None
+		return None
+
+	def __exit__(self, *exc):
+		if self.owned and self.mount_point:
+			_scan_run([UMOUNT, self.mount_point])
+			try:
+				rmdir(self.mount_point)
+			except OSError:
+				pass
+
+
+def _scan_get_param(line, param):
+	return line.replace("userdataroot", "rootuserdata").rsplit(f"{param}=", 1)[1].split(" ", 1)[0]
+
+
+def _scan_uuid_to_device(uuid):
+	if uuid.startswith("UUID="):
+		uuid = uuid[5:]
+	try:
+		for fname in listdir("/dev/uuid"):
+			if _scan_read_first_line(join("/dev/uuid", fname)) == uuid:
+				return f"/dev/{fname}"
+	except OSError:
+		pass
+	return None
+
+
+def _scan_process_value(value):
+	if value is None:
+		return None
+	vt = value.upper() if value else ""
+	if value.startswith(('"', "'")) and value.endswith(value[0]):
+		return value[1:-1]
+	if value.startswith("(") and value.endswith(")"):
+		return tuple(_scan_process_value(x.strip()) for x in value[1:-1].split(","))
+	if value.startswith("[") and value.endswith("]"):
+		return [_scan_process_value(x.strip()) for x in value[1:-1].split(",")]
+	if vt == "NONE":
+		return None
+	if vt in ("FALSE", "NO", "OFF", "DISABLED"):
+		return False
+	if vt in ("TRUE", "YES", "ON", "ENABLED"):
+		return True
+	if value.isdigit() or (value[:1] in ("-", "+") and value[1:].isdigit()):
+		return int(value)
+	for base_val, prefix in ((16, "0X"), (8, "0O"), (2, "0B")):
+		if vt.startswith(prefix):
+			try:
+				return int(value, base_val)
+			except ValueError:
+				pass
+	try:
+		return float(value)
+	except ValueError:
+		pass
+	return value
+
+
+def _scan_check_checksum(lines):
+	value = "Undefined!"
+	data = []
+	for line in lines:
+		if line.startswith("checksum"):
+			_, value = (x.strip() for x in line.split("=", 1))
+		else:
+			data.append(line)
+	data.append("")
+	result = md5(bytearray("\n".join(data), "UTF-8", errors="ignore")).hexdigest()  # NOSONAR
+	return value != result
+
+
+def _scan_read_slot_info(path, slot_code=None):
+	info = {}
+	for src in (path, path.replace(".info", ".conf")):
+		lines = _scan_read_lines(src)
+		if not lines:
+			continue
+		if src.endswith(".info") and _scan_check_checksum(lines):
+			_scan_log(f"warning: slot '{slot_code or '?'}' checksum mismatch in {basename(src)}")
+		for line in lines:
+			if line.startswith("#") or not line.strip():
+				continue
+			if "=" in line:
+				item, val = (x.strip() for x in line.split("=", 1))
+				if item:
+					info[item] = _scan_process_value(val)
+	return info
+
+
+def _scan_get_compile_date(path):
+	status_file = "var/lib/opkg/status"
+	if exists(join(path, "var/lib/dpkg/status")):
+		status_file = "var/lib/dpkg/status"
+	try:
+		date = datetime.fromtimestamp(stat(join(path, status_file)).st_mtime).strftime("%Y%m%d")
+		if date.startswith("1970"):
+			date = datetime.fromtimestamp(stat(join(path, "usr/share/bootlogo.mvi")).st_mtime).strftime("%Y%m%d")
+		date = max(date, datetime.fromtimestamp(stat(join(path, "usr/bin/enigma2")).st_mtime).strftime("%Y%m%d"))
+	except OSError:
+		date = "00000000"
+	return date
+
+
+def _display_distro(distro):
+	key = distro.lower()
+	if key in KNOWN_DISTROS:
+		return KNOWN_DISTROS[key]
+	for match, display in KNOWN_DISTROS.items():
+		if match in key:
+			return display
+	return distro.capitalize()
+
+
+def _scan_enigma2_pkg_version(path):
+	for status_path in ("var/lib/opkg/status", "var/lib/dpkg/status"):
+		lines = _scan_read_lines(join(path, status_path))
+		if not lines:
+			continue
+		in_enigma2 = False
+		for line in lines:
+			if line.startswith("Package: "):
+				in_enigma2 = line[9:].strip() == "enigma2"
+			elif in_enigma2 and line.startswith("Version: "):
+				version = line[9:].strip().split("+", 1)[0]
+				if "-r" in version:
+					version = version.split("-r", 1)[0]
+				return version or None
+	return None
+
+
+def _scan_derive_slot_info(path):
+	info = {"compiledate": _scan_get_compile_date(path)}
+	lines = _scan_read_lines(join(path, "etc/issue"))
+	if lines and "vuplus" not in lines[0] and len(lines) >= 2:
+		data = lines[-2].strip()[:-6].split()
+		info["distro"] = " ".join(data[:-1])
+		info["displaydistro"] = _display_distro(info["distro"])
+		info["imgversion"] = data[-1]
+	else:
+		info["distro"] = "Enigma2"
+		info["displaydistro"] = "Enigma2"
+		info["imgversion"] = "???"
+	if info["imgversion"] in ("", "???"):
+		pkg_version = _scan_enigma2_pkg_version(path)
+		if pkg_version:
+			info["imgversion"] = pkg_version
+	return info
+
+
+def _scan_format_slot_name(info):
+	# Raw imagename "<distro> <version><revision>". compiledate is stored separately and appended
+	# only in displayname; revision is dropped when it equals compiledate to avoid duplications.
+	distro = info.get("displaydistro") or info.get("distro")
+	if not distro:
+		return None
+	compile_date = str(info.get("compiledate", ""))
+	revision = info.get("imgrevision")
+	if revision is not None:
+		revision = f".{revision:03d}" if info.get("distro") == "openvix" and isinstance(revision, int) else f" {revision}"
+		revision = "" if revision.strip() == compile_date else revision
+	else:
+		revision = ""
+	version = info.get("imgversion") or ""
+	return f"{distro} {version}{revision}".rstrip()
+
+
+def _scan_find_boot_device():
+	is_kexec = _scan_file_has("/proc/cmdline", "kexec=1")
+	candidates = BOOT_DEVICE_LIST_VUPLUS if is_kexec else BOOT_DEVICE_LIST
+	for device in candidates:
+		if not exists(device):
+			continue
+		with _ScanMount(device) as mount_point:
+			if not mount_point:
+				continue
+			cmd_file = join(mount_point, COMMAND_FILE)
+			startup_file = join(mount_point, STARTUP_FILE)
+			if isfile(cmd_file) or isfile(startup_file):
+				src = cmd_file if isfile(cmd_file) else startup_file
+				boot_cmd = " ".join(x.strip() for x in _scan_read_lines(src) if x.strip())
+				return _scan_resolve_device(device), boot_cmd
+	return None, ""
+
+
+def _scan_boot_slots(boot_device):
+	# Each slot's "bootCodes" dict maps bootCode (string) → {startupfile, cmdline} — slotname and
+	# displayname get attached later. Non-BOXMODE slots have one entry "1"; h7 has several.
+	boot_slots = {}
+	if not boot_device:
+		return boot_slots
+	with _ScanMount(boot_device) as mount_point:
+		if not mount_point:
+			return boot_slots
+		for path in sorted(glob(join(mount_point, STARTUP_TEMPLATE))):
+			file = basename(path)
+			if "DISABLE" in file:
+				continue
+			if file == STARTUP_ANDROID:
+				boot_code, slot_code = "1", "A"
+			elif file == STARTUP_ANDROID_LINUXSE:
+				boot_code, slot_code = "1", "L"
+			elif file == STARTUP_RECOVERY:
+				boot_code, slot_code = "1", "R"
+			elif file == STARTUP_FLASH:
+				boot_code, slot_code = "1", "F"
+			elif STARTUP_BOXMODE in file:
+				parts = file.rsplit("_", 3)
+				boot_code, slot_code = parts[3], parts[1]
+			else:
+				boot_code, slot_code = "1", file.rsplit("_", 1)[1]
+			if not slot_code:
+				_scan_log(f"error: cannot derive slot code from '{file}'")
+				continue
+			line = " ".join(x.strip() for x in _scan_read_lines(path) if x.strip())
+			slot = boot_slots.setdefault(slot_code, {})
+			if "root=" in line:
+				device = _scan_get_param(line, "root")
+				if "UUID=" in device:
+					uuid_dev = _scan_uuid_to_device(device)
+					if uuid_dev:
+						device = uuid_dev
+				if not (exists(device) or device in ("ubi0:ubifs", "ubi0:rootfs", "ubi0:dreambox-rootfs")):
+					continue
+				slot.setdefault("device", device)
+				slot.setdefault("bootCodes", {})[boot_code] = {"startupfile": file, "cmdline": line}
+				if "ubi.mtd=" in line:
+					slot["ubi"] = True
+				if "UUID=" in line:
+					slot["uuid"] = True
+				if "rescuemode" in line:
+					slot["rootsubdir"] = "rescue"
+				boot_disk = [x for x in ("sda", "sdb", "sdc", "sdd") if x in line]
+				if "rootsubdir" in line:
+					slot["kernel"] = _scan_get_param(line, "kernel")
+					slot["rootsubdir"] = _scan_get_param(line, "rootsubdir")
+				elif "flash=1" in line:
+					slot["kernel"] = _scan_get_param(line, "kernel")
+					slot["rootfs"] = _scan_get_param(line, "root")
+				elif boot_disk:
+					d = boot_disk[0]
+					slot.setdefault("kernel", f"/dev/{d}{line.split(d, 1)[1].split(' ', 1)[0]}")
+				else:
+					parts = device.split("p")
+					try:
+						slot.setdefault("kernel", f"{parts[0]}p{int(parts[1]) - 1}")
+					except (IndexError, ValueError):
+						pass
+			elif "bootcmd=" in line or " recovery " in line:
+				slot.setdefault("bootCodes", {})[boot_code] = {"startupfile": file, "cmdline": line}
+			else:
+				_scan_log(f"error: slot line unidentifiable: {line}")
+	return boot_slots
+
+
+def _scan_slotnames_dict(boot_device):
+	if not boot_device:
+		return {}
+	result = {}
+	with _ScanMount(boot_device) as mount_point:
+		if not mount_point:
+			return result
+		path = join(mount_point, SLOTNAMES_FILE)
+		if not isfile(path):
+			return result
+		for raw in _scan_read_lines(path):
+			line = raw.strip()
+			if not line or line.startswith("#") or "=" not in line:
+				continue
+			key, _sep, val = line.partition("=")
+			key = key.strip()
+			val = val.strip()
+			if key and val:
+				result[key] = val
+	return result
+
+
+def _scan_current_slot(boot_slots, boot_cmd):
+	# /proc/cmdline is the source of truth for what the kernel actually booted; the STARTUP file
+	# can be stale on DreamNextGen after a bootmenu direct-boot.
+	if exists(DUAL_BOOT_FILE):
+		try:
+			with open(DUAL_BOOT_FILE, "rb") as fd:
+				fmt = "B"
+				slot = unpack(fmt, fd.read(calcsize(fmt)))
+				return str(slot[0]), "1"
+		except (OSError, error):
+			return None, "1"
+	running_root = None
+	running_subdir = None
+	running_boxmode = None
+	for tok in _scan_read_first_line("/proc/cmdline").split():
+		if tok.startswith("root="):
+			running_root = tok[5:]
+		elif tok.startswith("rootsubdir="):
+			running_subdir = tok[len("rootsubdir="):]
+		elif "boxmode=" in tok:
+			running_boxmode = tok.rsplit("boxmode=", 1)[1]
+	if running_root:
+		for slot_code in sorted(boot_slots.keys()):
+			slot = boot_slots[slot_code]
+			if slot.get("device") != running_root:
+				continue
+			if running_subdir and slot.get("rootsubdir") != running_subdir:
+				continue
+			configs = slot.get("bootCodes") or {}
+			if running_boxmode and running_boxmode in configs:
+				return slot_code, running_boxmode
+			if configs:
+				return slot_code, min(configs.keys())
+			return slot_code, "1"
+	# Fallback: STARTUP-cmdline match. Handles UUID-boot and other cases where /proc/cmdline
+	# token match doesn't line up with the parsed slot fields.
+	for slot_code in sorted(boot_slots.keys()):
+		for boot_code, cfg in boot_slots[slot_code].get("bootCodes", {}).items():
+			if cfg.get("cmdline") == boot_cmd:
+				return slot_code, boot_code
+	return None, "1"
+
+
+def _scan_analyze_image_dir(image_dir, slot_code=None):
+	# Detect the image in image_dir (enigma.info > image-version > enigma2 > hidden > empty) and
+	# return imagename/compiledate/status/detection. slot_code only labels checksum-mismatch logs.
+	info_file = join(image_dir, "usr/lib/enigma.info")
+	version_file = join(image_dir, "etc/image-version")
+	hidden_marker = join(image_dir, "usr/bin/enigma2x.bin")
+	if isfile(info_file):
+		info = _scan_read_slot_info(info_file, slot_code)
+		name = _scan_format_slot_name(info) or "Unknown"
+		return {
+			"imagename": name,
+			"displaydistro": info.get("displaydistro") or info.get("distro") or "",
+			"imgversion": str(info.get("imgversion") or ""),
+			"imgrevision": str(info.get("imgrevision") or ""),
+			"compiledate": str(info.get("compiledate") or ""),
+			"status": "active",
+			"detection": "Found an enigma information file",
+		}
+	if isfile(version_file):
+		info = _scan_read_slot_info(version_file, slot_code)
+		cd_raw = _scan_get_compile_date(image_dir)
+		version = str(info.get("version") or "")
+		if "." not in version and "-" not in version and version.isdigit():
+			version = f"{int(version[0:2])}.{version[2:3]}.{version[3:5]}" if len(version) == 17 else f"{int(version[0:2])}.{int(version[3:5])}"
+		creator = info.get("creator")
+		base = f"{creator.split()[0]} {version}" if creator else f"Unknown Creator {version}"
+		return {
+			"imagename": base,
+			"compiledate": cd_raw,
+			"status": "active",
+			"detection": "Found an image version file",
+		}
+	if isfile(join(image_dir, "usr/bin/enigma2")):
+		info = _scan_derive_slot_info(image_dir)
+		cd_raw = str(info.get("compiledate") or "")
+		base = f"{info.get('displaydistro', info.get('distro'))} {info.get('imgversion')}"
+		return {
+			"imagename": base,
+			"compiledate": cd_raw,
+			"status": "active",
+			"detection": "Found an enigma2 binary file",
+		}
+	if isfile(hidden_marker):
+		return {
+			"imagename": "Disabled",
+			"status": "hidden",
+			"detection": "Found a disabled enigma2 binary file",
+		}
+	return {
+		"imagename": "Empty",
+		"status": "empty",
+		"detection": "Found no enigma files",
+	}
+
+
+def _scan_analyze_slot(slot_code, slot, running_slot_code):
+	base = {
+		"ubi": slot.get("ubi", False),
+		"uuid": slot.get("uuid", False),
+		"device": slot.get("device", ""),
+		"kernel": slot.get("kernel", "Unknown"),
+		"rootsubdir": slot.get("rootsubdir", ""),
+		"bootCodes": slot.get("bootCodes", {}),
+	}
+	if slot_code == "A":
+		return {**base, "imagename": "Android", "status": "android", "detection": "Found an Android slot"}
+	if slot_code == "L":
+		return {**base, "imagename": "Android Linux SE", "status": "androidlinuxse", "detection": "Found an Android Linux SE slot"}
+	if slot_code == "R":
+		if _scan_file_has("/proc/cmdline", "kexec=1"):
+			return {**base, "imagename": "Root Image", "status": "rootimage", "detection": "Found a Root Image slot"}
+		return {**base, "imagename": "Recovery", "status": "recovery", "detection": "Found a Recovery slot"}
+	if slot_code == "F":
+		return {**base, "imagename": "Flash", "status": "flash", "detection": "Found a Flash Image slot"}
+	device = slot.get("device")
+	if not device:
+		return {**base, "imagename": "Unknown", "status": "unknown", "detection": "Found an unexpected/ill-defined slot"}
+	# Running slot: rootfs already at /; if kernel bound rootsubdir as / then /rootsubdir doesn't exist — use /.
+	if slot_code == running_slot_code:
+		rootsubdir = slot.get("rootsubdir")
+		image_dir = f"/{rootsubdir}" if rootsubdir and isdir(f"/{rootsubdir}") else "/"
+		base.update(_scan_analyze_image_dir(image_dir, slot_code))
+		return base
+	opts = ["-t", "ubifs"] if slot.get("ubi") else []
+	with _ScanMount(device, opts=opts) as mount_point:
+		if not mount_point:
+			_scan_log(f"error: cannot mount slot '{slot_code}' ({device}) for analysis")
+			return {**base, "imagename": "Inaccessible", "status": "unknown", "detection": f"Cannot mount slot '{slot_code}' ({device})"}
+		rootsubdir = slot.get("rootsubdir")
+		image_dir = join(mount_point, rootsubdir) if rootsubdir else mount_point
+		base.update(_scan_analyze_image_dir(image_dir, slot_code))
+		return base
+
+
+def _load_existing_json():
+	try:
+		with open(JSON_FILE) as fd:
+			return load(fd)
+	except (OSError, ValueError):
+		return None
+
+
+def _write_json(data):
+	sorted_data = _sortDictNatural(data)
+	try:
+		d = dirname(JSON_FILE)
+		if d:
+			makedirs(d, exist_ok=True)
+		with open(JSON_FILE, "w") as fd:
+			dump(sorted_data, fd, indent=2, default=str)
+	except OSError as err:
+		_scan_log(f"error writing '{JSON_FILE}': {err}")
+
+
+def _attach_slot_names(slots, slot_names_flat):
+	# Fan the flat SLOTNAMES {startupfile: name} out into per-bootCodes "slotname" fields verbatim
+	# (matches what sits on disk in SLOTNAMES).
+	for entry in slots.values():
+		for cfg in (entry.get("bootCodes") or {}).values():
+			startup = cfg.get("startupfile")
+			if startup and startup in slot_names_flat:
+				cfg["slotname"] = slot_names_flat[startup]
+			else:
+				cfg.pop("slotname", None)
+
+
+def _attach_display_names(slots):
+	# Build cfg.displayname = (slotname or imagename) + " (YYYY-MM-DD)" — pre-formatted so the UI
+	# can render slotname/imagename without knowing about the compile date.
+	for entry in slots.values():
+		imagename = entry.get("imagename") or ""
+		cdate = str(entry.get("compiledate") or "")
+		date_suffix = f" ({cdate[0:4]}-{cdate[4:6]}-{cdate[6:8]})" if len(cdate) == 8 and cdate.isdigit() and cdate != "00000000" else ""
+		for cfg in (entry.get("bootCodes") or {}).values():
+			base = cfg.get("slotname") or imagename
+			cfg["displayname"] = f"{base}{date_suffix}" if base else ""
+
+
+def scan_full():
+	boot_device, boot_cmd = _scan_find_boot_device()
+	boot_slots = _scan_boot_slots(boot_device)
+	slot_names_flat = _scan_slotnames_dict(boot_device)
+	current_slot, current_boot = _scan_current_slot(boot_slots, boot_cmd)
+	slots = {}
+	for slot_code in sorted(boot_slots.keys(), key=_naturalKey):
+		slots[slot_code] = _scan_analyze_slot(slot_code, boot_slots[slot_code], current_slot)
+	_attach_slot_names(slots, slot_names_flat)
+	_attach_display_names(slots)
+	return {
+		"bootDevice": boot_device,
+		"bootCmdLine": boot_cmd,
+		"bootSlot": current_slot,
+		"bootCode": current_boot,
+		"slots": slots,
+	}
+
+
+def scan_slot(slot_code):
+	# Refreshes every slot's slotname too — SLOTNAMES read is cheap once the boot device is mounted.
+	existing = _load_existing_json()
+	if not existing:
+		return scan_full()
+	boot_device = existing.get("bootDevice")
+	if not boot_device:
+		return scan_full()
+	boot_slots = _scan_boot_slots(boot_device)
+	slot_names_flat = _scan_slotnames_dict(boot_device)
+	if slot_code not in boot_slots:
+		# Slot disappeared (STARTUP file gone) — drop from JSON.
+		existing.setdefault("slots", {}).pop(slot_code, None)
+	else:
+		current_slot = existing.get("bootSlot")
+		existing.setdefault("slots", {})[slot_code] = _scan_analyze_slot(slot_code, boot_slots[slot_code], current_slot)
+	_attach_slot_names(existing.get("slots") or {}, slot_names_flat)
+	_attach_display_names(existing.get("slots") or {})
+	return existing
+
+
+def scan_slotnames_only():
+	existing = _load_existing_json()
+	if not existing:
+		return scan_full()
+	boot_device = existing.get("bootDevice")
+	if not boot_device:
+		return scan_full()
+	slot_names_flat = _scan_slotnames_dict(boot_device)
+	_attach_slot_names(existing.get("slots") or {}, slot_names_flat)
+	_attach_display_names(existing.get("slots") or {})
+	return existing
+
+
+def _slotLine(slot_code, entry):
+	status = entry.get("status", "unknown")
+	imagename = entry.get("imagename") or "?"
+	configs = entry.get("bootCodes") or {}
+	startups = ",".join(sorted(cfg.get("startupfile") for cfg in configs.values() if cfg.get("startupfile"))) or "-"
+	line = f"  slot {slot_code:>3} [{status:>14}] {imagename}  ({startups})"
+	overrides = {bc: cfg["slotname"] for bc, cfg in configs.items() if cfg.get("slotname")}
+	if overrides:
+		items = ", ".join(f"{k}={v!r}" for k, v in sorted(overrides.items(), key=lambda kv: _naturalKey(kv[0])))
+		line += f"  overrides={{{items}}}"
+	if status in ("unknown", "empty", "hidden"):
+		reason = entry.get("detection")
+		if reason:
+			line += f"  reason={reason!r}"
+	return line
+
+
+def _log_scan(mode, source, dur_ms, data):
+	slots = data.get("slots") or {}
+	status_counts = {}
+	total_overrides = 0
+	for entry in slots.values():
+		s = entry.get("status", "unknown")
+		status_counts[s] = status_counts.get(s, 0) + 1
+		total_overrides += sum(1 for cfg in (entry.get("bootCodes") or {}).values() if cfg.get("slotname"))
+	status_summary = " ".join(f"{k}={v}" for k, v in sorted(status_counts.items())) or "-"
+	_scan_log(
+		f"[{mode}/{source}] boot={data.get('bootDevice')}"
+		f" current={data.get('bootSlot')}/{data.get('bootCode') or '-'}"
+		f" slots={len(slots)}({status_summary})"
+		f" overrides={total_overrides} dur={dur_ms}ms"
+	)
+	only_slot = mode.split("=", 1)[1] if mode.startswith("slot=") else None
+	for slot_code in sorted(slots.keys(), key=_naturalKey):
+		if only_slot is not None and slot_code != only_slot:
+			continue
+		if mode == "slotnames" and not any(cfg.get("slotname") for cfg in (slots[slot_code].get("bootCodes") or {}).values()):
+			continue
+		_scan_log(_slotLine(slot_code, slots[slot_code]))
+
+
+def _print_help(prog, stream):
+	from shutil import get_terminal_size
+	from textwrap import fill
+	width = max(40, get_terminal_size((80, 24)).columns)
+	pad = "                  "  # matches "  --source LABEL  "
+	def option(flag, text):
+		return fill(text, width=width, initial_indent=f"  {flag:<16}", subsequent_indent=pad)
+	print(f"Usage: {prog} [--slot N | --slotnames] [--source LABEL]", file=stream)
+	print(file=stream)
+	print(fill(f"Scans MultiBoot slots on the boot device and writes {JSON_FILE}, which enigma2's MultiBootClass reads at startup (and reloads on mtime change).", width=width), file=stream)
+	print(file=stream)
+	print("Modes (mutually exclusive, default is a full rescan of every slot):", file=stream)
+	print(option("--slot N", "Refresh only slot N — called after flash or activateSlot."), file=stream)
+	print(option("--slotnames", "Reread SLOTNAMES only, keep every other slot field intact — called after a rename."), file=stream)
+	print(file=stream)
+	print("Options:", file=stream)
+	print(option("--source LABEL", "Short label written to the scanner log line, e.g. 'boot' from the init script or 'write' from an in-process refresh. Purely informational (default: cli)."), file=stream)
+
+
+def main():
+	args = sysArgv[1:]
+	if not args:
+		_print_help(sysArgv[0], stderr)
+		return 0
+	source = "cli"
+	if "--source" in args:
+		idx = args.index("--source")
+		if idx + 1 < len(args):
+			source = args[idx + 1]
+			del args[idx:idx + 2]
+	started = monotonic()
+	try:
+		if not args:
+			data = scan_full()
+			mode = "full"
+		elif args[0] == "--slotnames" and len(args) == 1:
+			data = scan_slotnames_only()
+			mode = "slotnames"
+		elif args[0] == "--slot" and len(args) == 2:
+			data = scan_slot(args[1])
+			mode = f"slot={args[1]}"
+		else:
+			_print_help(sysArgv[0], stderr)
+			return 2
+		_write_json(data)
+		dur_ms = int((monotonic() - started) * 1000)
+		_log_scan(mode, source, dur_ms, data)
+		total_overrides = sum(1 for e in (data.get("slots") or {}).values() for cfg in (e.get("bootCodes") or {}).values() if cfg.get("slotname"))
+		print(f"[MultiBoot] scan mode={mode} source={source} dur={dur_ms}ms slots={len(data.get('slots') or {})} current={data.get('bootSlot')} overrides={total_overrides}")
+		return 0
+	except Exception as err:
+		import traceback
+		_scan_log(f"CRASH source={source}: {err}\n{traceback.format_exc()}")
+		raise
+
+
+if __name__ == "__main__":
+	sysExit(main())
+
+
+# ============================================================
+# enigma2 module — MultiBootClass. These imports live below the __main__
+# dispatch so that shell invocation stays enigma2-independent.
+# NOTE: This module must not import from SystemInfo.py as this module is
+# used to populate BoxInfo / SystemInfo and will create a boot loop!
+# ============================================================
+
+from Components.Console import Console  # noqa: E402
+from Tools.Directories import SCOPE_CONFIG, copyfile, fileHas, fileReadLine, fileReadLines, fileWriteLines, resolveFilename  # noqa: E402
+
+
 class MultiBootClass():
 	def __init__(self):
 		print("[MultiBoot] MultiBoot is initializing.")
@@ -76,42 +823,121 @@ class MultiBootClass():
 		self.debugMode = "config.crash.debugMultiBoot=True" in lines
 		self.bootArgs = fileReadLine("/sys/firmware/devicetree/base/chosen/bootargs", default="", source=MODULE_NAME)
 		self.console = Console()
-		self.loadMultiBoot()
-
-	def loadMultiBoot(self):
-		self.bootDevice, self.startupCmdLine = self.loadBootDevice()
-		self.bootSlots, self.bootSlotsKeys = self.loadBootSlots()
-		if exists(DUAL_BOOT_FILE):
-			try:
-				with open(DUAL_BOOT_FILE, "rb") as fd:
-					structFormat = "B"
-					flag = fd.read(calcsize(structFormat))
-					slot = unpack(structFormat, flag)
-					self.bootSlot = str(slot[0])
-					self.bootCode = ""
-			except OSError as err:
-				print(f"MultiBoot] Error {err.errno}: Unable to read dual boot file '{DUAL_BOOT_FILE}'!  ({err.strerror})")
-				self.bootSlot = None
-				self.bootCode = ""
-			except error as err:
-				print(f"MultiBoot] Unable to interpret dual boot file '{DUAL_BOOT_FILE}' data!  ({err})")
-		else:
-			self.bootSlot, self.bootCode = self.loadCurrentSlotAndBootCodes()
+		self.bootDevice = None
+		self.bootCmdLine = ""
+		self.bootSlot = None
+		self.bootCode = ""
+		self.bootSlots = {}
+		self.bootSlotsKeys = []
+		self._loadStateFromJson()
+		# Boot-time sync tasks: STARTUP file selection and DreamNextGen bootconfig.txt.
 		if exists(DREAM_BOOT_FILE):
-			runningRoot = None
-			for token in fileReadLine("/proc/cmdline", default="", source=MODULE_NAME).split():
-				if token.startswith("root="):
-					runningRoot = token[5:]
-					break
-			if runningRoot:
-				for slotCode, slot in self.bootSlots.items():
-					if slot.get("device") == runningRoot:
-						self.bootSlot = slotCode
-						break
 			self.syncStartupFileFromBootSlot()
 			self._syncDreamBootDefault()
 			if self.bootSlot:
 				self.updateDreamBootSection(self.bootSlot)
+
+	def _loadStateFromJson(self):
+		# If the JSON is missing we call the scanner inline once, then re-read. Hard-fail if it
+		# still isn't there — the scan must succeed before enigma2 has usable MultiBoot state.
+		data = self._readJson()
+		if data is None:
+			print(f"[MultiBoot] {JSON_FILE} missing, invoking inline scanner subprocess.")
+			try:
+				run(["/usr/bin/python3", __file__, "--source", "fallback"], check=False)
+			except Exception as err:
+				print(f"[MultiBoot] Emergency scanner call failed: {err}")
+			data = self._readJson()
+		if data is None:
+			raise RuntimeError(f"[MultiBoot] {JSON_FILE} unavailable and scanner did not produce it")
+		self.bootDevice = data.get("bootDevice")
+		self.bootCmdLine = data.get("bootCmdLine") or ""
+		self.bootSlot = data.get("bootSlot")
+		self.bootCode = data.get("bootCode") or "1"  # "1" is the non-BOXMODE index.
+		slots = dict(data.get("slots") or {})
+		self.bootSlots = slots
+		self.bootSlotsKeys = sorted(slots.keys(), key=_naturalKey)
+		try:
+			self._jsonMtime = stat(JSON_FILE).st_mtime_ns
+		except OSError:
+			self._jsonMtime = 0
+		if self.debugMode:
+			print(f"[MultiBoot] Loaded from JSON: bootDevice={self.bootDevice} bootSlot={self.bootSlot} slots={len(slots)}")
+
+	def _collectSlotNames(self):
+		# {startupfile: rawname} — pulled straight from cfg.slotname (already raw, matches
+		# SLOTNAMES on disk). Used by set/clearSlotName to rewrite the file.
+		names = {}
+		for entry in self.bootSlots.values():
+			for cfg in (entry.get("bootCodes") or {}).values():
+				startup = cfg.get("startupfile")
+				name = cfg.get("slotname")
+				if startup and name:
+					names[startup] = name
+		return names
+
+	def _reloadIfStale(self):
+		# Cheap stat() on every read entry point — pick up JSON changes written by external
+		# scanner invocations (init.d/multiboot-scan, manual `--source ...` runs) without a reboot.
+		try:
+			mtime = stat(JSON_FILE).st_mtime_ns
+		except OSError:
+			return
+		if mtime != getattr(self, "_jsonMtime", 0):
+			self._loadStateFromJson()
+
+	def _readJson(self):
+		try:
+			with open(JSON_FILE) as fd:
+				return load(fd)
+		except (OSError, ValueError) as err:
+			if self.debugMode:
+				print(f"[MultiBoot] _readJson: {err}")
+			return None
+
+	def _refreshJsonSlotNames(self):
+		try:
+			run(["/usr/bin/python3", __file__, "--slotnames", "--source", "write"], check=False)
+		except Exception as err:
+			print(f"[MultiBoot] scanner --slotnames failed: {err}")
+		data = self._readJson()
+		if not data:
+			return
+		for slotCode, entry in (data.get("slots") or {}).items():
+			target = self.bootSlots.get(slotCode)
+			if target is None:
+				continue
+			for bootCode, freshCfg in (entry.get("bootCodes") or {}).items():
+				targetCfg = (target.get("bootCodes") or {}).get(bootCode)
+				if targetCfg is None:
+					continue
+				if freshCfg.get("slotname"):
+					targetCfg["slotname"] = freshCfg["slotname"]
+				else:
+					targetCfg.pop("slotname", None)
+				if freshCfg.get("displayname"):
+					targetCfg["displayname"] = freshCfg["displayname"]
+				else:
+					targetCfg.pop("displayname", None)
+
+	def _refreshJsonSlot(self, slotCode):
+		# Spawn the scanner for this one slot, then reload it into self.bootSlots so subsequent
+		# reads see the fresh state without a reboot.
+		if not slotCode:
+			return
+		try:
+			run(["/usr/bin/python3", __file__, "--slot", str(slotCode), "--source", "write"], check=False)
+		except Exception as err:
+			print(f"[MultiBoot] scanner --slot {slotCode} failed: {err}")
+		data = self._readJson()
+		if not data:
+			return
+		slots = data.get("slots") or {}
+		if slotCode in slots:
+			self.bootSlots[slotCode] = slots[slotCode]
+		else:
+			self.bootSlots.pop(slotCode, None)
+		self.bootSlotsKeys = sorted(self.bootSlots.keys(), key=_naturalKey)
 
 	def syncStartupFileFromBootSlot(self):
 		# Embedded bootmanager picks the slot without updating /data/STARTUP, so copy STARTUP_<N> over /data/STARTUP here.
@@ -120,9 +946,10 @@ class MultiBootClass():
 		bootSlot = self.bootSlots.get(self.bootSlot)
 		if not bootSlot:
 			return
-		cmdLine = bootSlot.get("cmdline", {}).get(self.bootCode)
-		startupName = bootSlot.get("startupfile", {}).get(self.bootCode)
-		if not cmdLine or not startupName or cmdLine == self.startupCmdLine:
+		cfg = bootSlot.get("bootCodes", {}).get(self.bootCode) or {}
+		cmdLine = cfg.get("cmdline")
+		startupName = cfg.get("startupfile")
+		if not cmdLine or not startupName or cmdLine == self.bootCmdLine:
 			return
 		tempDir = mkdtemp(prefix=PREFIX)
 		self.console.ePopen([MOUNT, MOUNT, self.bootDevice, tempDir])
@@ -131,14 +958,14 @@ class MultiBootClass():
 			dst = join(tempDir, STARTUP_FILE)
 			if isfile(src):
 				copyfile(src, dst)
-				self.startupCmdLine = cmdLine
+				self.bootCmdLine = cmdLine
 				print(f"[MultiBoot] Synced '{STARTUP_FILE}' to '{startupName}' to match '/proc/cmdline'.")
 		finally:
 			self.console.ePopen([UMOUNT, UMOUNT, tempDir])
 			rmdir(tempDir)
 
 	def _syncDreamBootDefault(self):
-		# Align /data/bootconfig.txt's default= with the running slot so a plain reboot (no embedded menu) stays in the same slot.
+		# Align /data/bootconfig.txt's default= with the running slot so a plain reboot stays in the same slot.
 		if not self.bootSlot:
 			return
 		sectionIdx = self.getDreamBootSectionIndex(self.bootSlot)
@@ -157,29 +984,15 @@ class MultiBootClass():
 			self._writeDreamBoot(defaultIdx=sectionIdx)
 
 	def getDreamBootSectionName(self, slotCode):
-		# Build the "<displaydistro> <imgversion> (<compiledate>)" string for the bootmanager menu.
+		# Returns the pre-formatted displayname that DreamNextGen shows in its bootmanager menu
+		self._reloadIfStale()
 		slot = self.bootSlots.get(slotCode) if slotCode else None
-		if not slot:
+		if not slot or slotCode in ("R", "A", "L", "F"):
 			return None
-		device = slot.get("device")
-		if not device or slotCode in ("R", "A", "L", "F"):
+		if not slot.get("device"):
 			return None
-		rootSubdir = slot.get("rootsubdir") or ""
-		tempDir = mkdtemp(prefix=PREFIX)
-		opts = ["-t", "ubifs"] if slot.get("ubi") else []
-		self.console.ePopen([MOUNT, MOUNT] + opts + [device, tempDir])
-		try:
-			imageDir = join(tempDir, rootSubdir) if rootSubdir else tempDir
-			name = self._readSectionNameFromImageDir(imageDir, slotCode)
-		finally:
-			self.console.ePopen([UMOUNT, UMOUNT, tempDir])
-			rmdir(tempDir)
-		return name
-
-	def _readSectionNameFromImageDir(self, imageDir, slotCode):
-		if slotCode in ("R", "A", "L", "F"):
-			return None
-		name = self._formatSlotName(self.readSlotInfo(join(imageDir, "usr/lib/enigma.info")))
+		cfg = (slot.get("bootCodes") or {}).get(self.bootCode) or {}
+		name = cfg.get("displayname") or slot.get("imagename")
 		if name:
 			return name
 		if slotCode and slotCode.isdecimal():
@@ -255,208 +1068,40 @@ class MultiBootClass():
 			with open(DREAM_BOOT_FILE, "w") as fd:
 				fd.writelines(out)
 
-	def loadBootDevice(self):
-		bootDeviceList = BOOT_DEVICE_LIST_VUPLUS if fileHas("/proc/cmdline", "kexec=1") else BOOT_DEVICE_LIST
-		for device in bootDeviceList:
-			bootDevice = None
-			startupCmdLine = None
-			if exists(device):
-				tempDir = mkdtemp(prefix=PREFIX)
-				self.console.ePopen([MOUNT, MOUNT, device, tempDir])
-				cmdFile = join(tempDir, COMMAND_FILE)
-				startupFile = join(tempDir, STARTUP_FILE)
-				if isfile(cmdFile) or isfile(startupFile):
-					file = cmdFile if isfile(cmdFile) else startupFile
-					startupCmdLine = " ".join(x.strip() for x in fileReadLines(file, default=[], source=MODULE_NAME) if x.strip())
-					bootDevice = self.resolveDevice(device)
-				self.console.ePopen([UMOUNT, UMOUNT, tempDir])
-				rmdir(tempDir)
-			if bootDevice:
-				print(f"[MultiBoot] Startup device identified as '{device}'.")
-			if startupCmdLine:
-				print(f"[MultiBoot] Startup command line '{startupCmdLine}'.")
-				break
-		return bootDevice, startupCmdLine
 
-	def loadBootSlots(self):
-		def saveKernel(bootSlots, slotCode, kernel):
-			value = bootSlots[slotCode].get("kernel")
-			if value is None:
-				bootSlots[slotCode]["kernel"] = kernel
-			elif value != kernel:
-				print(f"[MultiBoot] Error: Inconsistent kernels found for slot '{slotCode}'!  ('{value}' != '{kernel}')")
+	def _getSlotNameOverride(self, slotCode, bootCode):
+		slot = self.bootSlots.get(slotCode) if slotCode else None
+		if not slot:
+			return None
+		cfg = (slot.get("bootCodes") or {}).get(bootCode) or {}
+		return cfg.get("slotname")
 
-		bootSlots = {}
-		bootSlotsKeys = []
-		if self.bootDevice:
-			tempDir = mkdtemp(prefix=PREFIX)
-			self.console.ePopen([MOUNT, MOUNT, self.bootDevice, tempDir])
-			for path in sorted(glob(join(tempDir, STARTUP_TEMPLATE))):
-				file = basename(path)
-				if "DISABLE" in file:
-					if self.debugMode:
-						print(f"[MultiBoot] Skipping disabled boot file '{file}'.")
-					continue
-				elif file == STARTUP_ANDROID:
-					bootCode = ""
-					slotCode = "A"
-				elif file == STARTUP_ANDROID_LINUXSE:
-					bootCode = ""
-					slotCode = "L"
-				elif file == STARTUP_RECOVERY:
-					bootCode = ""
-					slotCode = "R"
-				elif file == STARTUP_FLASH:
-					bootCode = ""
-					slotCode = "F"
-				elif STARTUP_BOXMODE in file:
-					parts = file.rsplit("_", 3)
-					bootCode = parts[3]
-					slotCode = parts[1]
-				else:
-					bootCode = ""
-					slotCode = file.rsplit("_", 1)[1]
-				if self.debugMode:
-					print(f"[MultiBoot] Processing boot file '{file}' as slot code '{slotCode if slotCode else ""}', boot mode '{bootCode if bootCode else ""}'.")
-				if slotCode:
-					line = " ".join(x.strip() for x in fileReadLines(path, default=[], source=MODULE_NAME) if x.strip())
-					if "root=" in line:
-						# print("[MultiBoot] loadBootSlots DEBUG: 'root=' found.")
-						device = self.getParam(line, "root")
-						if "UUID=" in device:
-							uuidDevice = self.getUUIDtoDevice(device)
-							# print(f"[MultiBoot] loadBootSlots DEBUG: 'UUID=' found for device '{uuidDevice}'.")
-							if uuidDevice:
-								device = uuidDevice
-						if exists(device) or device in ("ubi0:ubifs", "ubi0:rootfs", "ubi0:dreambox-rootfs"):
-							if slotCode not in bootSlots:
-								bootSlots[slotCode] = {}
-								# print(f"[MultiBoot] Root dictionary entry in slot '{slotCode}' created.")
-							value = bootSlots[slotCode].get("device")
-							if value is None:
-								bootSlots[slotCode]["device"] = device
-							elif value != device:
-								print(f"[MultiBoot] Error: Inconsistent root devices found for slot '{slotCode}'!  ('{value}' != '{device}')")
-							value = bootSlots[slotCode].get("bootCodes")
-							if value is None:
-								bootSlots[slotCode]["bootCodes"] = [bootCode]
-							else:
-								bootSlots[slotCode]["bootCodes"].append(bootCode)
-							value = bootSlots[slotCode].get("startupfile")
-							if value is None:
-								bootSlots[slotCode]["startupfile"] = {}
-							bootSlots[slotCode]["startupfile"][bootCode] = file
-							value = bootSlots[slotCode].get("cmdline")
-							if value is None:
-								bootSlots[slotCode]["cmdline"] = {}
-							bootSlots[slotCode]["cmdline"][bootCode] = line
-							if "ubi.mtd=" in line:
-								bootSlots[slotCode]["ubi"] = True
-							if "UUID=" in line:
-								bootSlots[slotCode]["uuid"] = True
-							if "rescuemode" in line:
-								bootSlots[slotCode]["rootsubdir"] = "rescue"
-							bootDevice = [x for x in ("sda", "sdb", "sdc", "sdd") if x in line]
-							if "rootsubdir" in line:
-								bootSlots[slotCode]["kernel"] = self.getParam(line, "kernel")
-								bootSlots[slotCode]["rootsubdir"] = self.getParam(line, "rootsubdir")
-							elif "flash=1" in line:
-								bootSlots[slotCode]["kernel"] = self.getParam(line, "kernel")
-								bootSlots[slotCode]["rootfs"] = self.getParam(line, "root")
-							elif bootDevice:
-								device = bootDevice[0]
-								saveKernel(bootSlots, slotCode, f"/dev/{device}{line.split(device, 1)[1].split(" ", 1)[0]}")
-							else:
-								parts = device.split("p")
-								saveKernel(bootSlots, slotCode, f"{parts[0]}p{int(parts[1]) - 1}")
-					elif "bootcmd=" in line or " recovery " in line:
-						# print("[MultiBoot] loadBootSlots DEBUG: 'bootcmd=' or ' recovery ' text found.")
-						if slotCode not in bootSlots:
-							bootSlots[slotCode] = {}
-							# print(f"[MultiBoot] Boot Command/Recovery dictionary entry in slot '{slotCode}' created.")
-						value = bootSlots[slotCode].get("bootCodes")
-						if value is None:
-							bootSlots[slotCode]["bootCodes"] = [bootCode]
-						else:
-							bootSlots[slotCode]["bootCodes"].append(bootCode)
-						value = bootSlots[slotCode].get("startupfile")
-						if value is None:
-							bootSlots[slotCode]["startupfile"] = {}
-						bootSlots[slotCode]["startupfile"][bootCode] = file
-						value = bootSlots[slotCode].get("cmdline")
-						if value is None:
-							bootSlots[slotCode]["cmdline"] = {}
-						bootSlots[slotCode]["cmdline"][bootCode] = line
-					else:
-						print(f"[MultiBoot] Error: Slot can't be identified.  ({line})")
-				else:
-					print(f"[MultiBoot] Error: Slot code can not be determined from '{file}'!")
-			self.console.ePopen([UMOUNT, UMOUNT, tempDir])
-			rmdir(tempDir)
-			bootSlotsKeys = sorted(bootSlots.keys())
-			if self.debugMode:
-				for slotCode in bootSlotsKeys:
-					# print(f"[MultiBoot] loadBootSlots DEBUG: Boot slot '{slotCode}': {bootSlots[slotCode]}")
-					print(f"[MultiBoot] Slot '{slotCode}':")
-					modes = bootSlots[slotCode].get("bootCodes")
-					if modes and modes != [""]:
-						print(f"[MultiBoot]     Boot modes: '{"', '".join(modes)}'.")
-					startupFile = bootSlots[slotCode].get("startupfile")
-					if startupFile:
-						if isinstance(startupFile, dict):
-							if "" in startupFile:
-								print(f"[MultiBoot]     Startup file: '{startupFile[""]}'.")
-							else:
-								print("[MultiBoot]     Startup files:")
-								for key in sorted(startupFile.keys()):
-									print(f"[MultiBoot]         Mode '{key}': '{startupFile[key]}'.")
-						else:
-							print(f"[MultiBoot]     Startup file: '{startupFile}'.")
-					commandLine = bootSlots[slotCode].get("cmdline")
-					if commandLine:
-						if isinstance(commandLine, dict):
-							if "" in startupFile:
-								print(f"[MultiBoot]     Command line: '{startupFile[""]}'.")
-							else:
-								print("[MultiBoot]     Command lines:")
-								for key in sorted(commandLine.keys()):
-									print(f"[MultiBoot]         Mode '{key}': '{commandLine[key]}'.")
-						else:
-							print(f"[MultiBoot]     Command line: '{startupFile}'.")
-					print(f"[MultiBoot]     Kernel device: '{bootSlots[slotCode].get("kernel", "Unknown")}'.")
-					print(f"[MultiBoot]     Root device: '{bootSlots[slotCode].get("device", "Unknown")}'.")
-					print(f"[MultiBoot]     Root directory: '{bootSlots[slotCode].get("rootsubdir", "Unknown")}'.")
-					print(f"[MultiBoot]     UBI device: '{"Yes" if bootSlots[slotCode].get("ubi", False) else "No"}'.")
-					print(f"[MultiBoot]     UUID device: '{"Yes" if bootSlots[slotCode].get("uuid", False) else "No"}'.")
-				print(f"[MultiBoot] {len(bootSlots)} boot slots detected.")
-		return bootSlots, bootSlotsKeys
+	def getSlotName(self, slotCode, bootCode):
+		# Raw user name for the rename dialog — matches what sits in SLOTNAMES on disk.
+		self._reloadIfStale()
+		return self._getSlotNameOverride(slotCode, bootCode)
 
-	def getParam(self, line, param):
-		return line.replace("userdataroot", "rootuserdata").rsplit(f"{param}=", 1)[1].split(" ", 1)[0]
-
-	def getUUIDtoDevice(self, UUID):  # Returns None on failure.
-		if UUID.startswith("UUID="):  # Remove the "UUID=" from startup files that have it.
-			UUID = UUID[5:]
-		result = None
-		for file in listdir("/dev/uuid"):
-			if fileReadLine(join("/dev/uuid", file)) == UUID:
-				result = f"/dev/{file}"
-				break
-		return result
-
-	def loadCurrentSlotAndBootCodes(self):
-		if self.bootSlots and self.bootSlotsKeys:
-			for slotCode in self.bootSlotsKeys:
-				cmdLines = self.bootSlots[slotCode]["cmdline"]
-				bootCodes = sorted(self.bootSlots[slotCode]["cmdline"].keys())
-				for bootCode in bootCodes:
-					if cmdLines[bootCode] == self.startupCmdLine:
-						if self.debugMode:
-							print(f"[MultiBoot] Startup slot code is '{slotCode}' and boot mode is '{bootCode if bootCode else ""}'.")
-						return slotCode, bootCode
-		return None, ""
+	def getSlotDisplayName(self, slotCode, bootCode):
+		# UI-facing: scanner-formatted displayname (slotname or imagename plus date), plus a
+		# localisation pass for the fixed English placeholders (Recovery/Android/Empty/…).
+		self._reloadIfStale()
+		slot = self.bootSlots.get(slotCode) if slotCode else None
+		cfg = (slot.get("bootCodes") if slot else {}).get(bootCode) or {}
+		name = cfg.get("displayname") or (slot.get("imagename") if slot else "") or ""
+		return {
+			"Android":          _("Android"),
+			"Android Linux SE": _("Android Linux SE"),
+			"Recovery":         _("Recovery"),
+			"Root Image":       _("Root Image"),
+			"Flash":            _("Flash"),
+			"Empty":            _("Empty"),
+			"Disabled":         _("Disabled"),
+			"Unknown":          _("Unknown"),
+			"Inaccessible":     _("Inaccessible"),
+		}.get(name, name)
 
 	def canMultiBoot(self):
+		self._reloadIfStale()
 		if not self.bootSlots:
 			return False
 		if exists(DREAM_BOOT_FILE):
@@ -465,26 +1110,32 @@ class MultiBootClass():
 		return True
 
 	def getBootDevice(self):
+		self._reloadIfStale()
 		return self.bootDevice
 
 	def getBootSlots(self):
+		self._reloadIfStale()
 		return self.bootSlots
 
 	def getCurrentSlotAndBootCodes(self):
+		self._reloadIfStale()
 		return self.bootSlot, self.bootCode
 
 	def getCurrentSlotCode(self):
+		self._reloadIfStale()
 		return self.bootSlot
 
 	def getCurrentBootMode(self):
+		self._reloadIfStale()
 		return self.bootCode
 
 	def hasRecovery(self):
+		self._reloadIfStale()
 		return "R" in self.bootSlots
 
 	def getBootCodeDescription(self, bootCode=None):
+		# Only meaningful for slots with more than one bootCodes entry (h7 BOXMODE).
 		bootCodeDescriptions = {
-			"": _("Normal: No boot modes required."),
 			"1": _("Mode 1: Supports Kodi but PiP may not work"),
 			"12": _("Mode 12: Supports PiP but Kodi may not work")
 		}
@@ -493,313 +1144,19 @@ class MultiBootClass():
 		return bootCodeDescriptions.get(bootCode, "")
 
 	def getStartupFile(self, slotCode=None):
+		self._reloadIfStale()
 		slotCode = slotCode if slotCode in self.bootSlots else self.bootSlot
-		return self.bootSlots[slotCode]["startupfile"][self.bootCode]
+		return self.bootSlots[slotCode]["bootCodes"][self.bootCode]["startupfile"]
 
 	def hasRootSubdir(self, slotCode=None):
+		self._reloadIfStale()
 		if slotCode is None:
 			slotCode = slotCode if slotCode in self.bootSlots else self.bootSlot
 		return "rootsubdir" in self.bootSlots[slotCode]
 
 	def getSlotImageList(self, callback):
-		self.imageList = {}
-		if self.bootSlots:
-			self.callback = callback
-			self.tempDir = mkdtemp(prefix=PREFIX)
-			self.slotCodes = self.bootSlotsKeys[:]
-			self.findSlot()
-		else:
-			callback(self.imageList)
-
-	def findSlot(self):  # Part of getSlotImageList().
-		if self.slotCodes:
-			self.slotCode = self.slotCodes.pop(0)
-			hasMultiBootMTD = self.bootSlots[self.slotCode].get("ubi", False)
-			self.imageList[self.slotCode] = {
-				"ubi": hasMultiBootMTD,
-				"bootCodes": self.bootSlots[self.slotCode].get("bootCodes", [""]),
-				"device": self.bootSlots[self.slotCode].get("device", _("Unknown")),
-				"devicelog": self.bootSlots[self.slotCode].get("device", "Unknown"),
-				"root": self.bootSlots[self.slotCode].get("rootsubdir", _("Not required")),
-				"rootlog": self.bootSlots[self.slotCode].get("rootsubdir", "Not required")
-			}
-			if self.slotCode == "A":
-				self.imageList[self.slotCode]["detection"] = "Found an Android slot"
-				self.imageList[self.slotCode]["imagename"] = _("Android")
-				self.imageList[self.slotCode]["imagelogname"] = "Android"
-				self.imageList[self.slotCode]["status"] = "android"
-				self.findSlot()
-			elif self.slotCode == "L":
-				self.imageList[self.slotCode]["detection"] = "Found an Android Linux SE slot"
-				self.imageList[self.slotCode]["imagename"] = _("Android Linux SE")
-				self.imageList[self.slotCode]["imagelogname"] = "Android Linux SE"
-				self.imageList[self.slotCode]["status"] = "androidlinuxse"
-				self.findSlot()
-			elif self.slotCode == "R" and fileHas("/proc/cmdline", "kexec=1"):
-				self.imageList[self.slotCode]["detection"] = "Found a Root Image slot"
-				self.imageList[self.slotCode]["imagename"] = _("Root Image")
-				self.imageList[self.slotCode]["imagelogname"] = "Root Image"
-				self.imageList[self.slotCode]["status"] = "rootimage"
-				self.findSlot()
-			elif self.slotCode == "R":
-				self.imageList[self.slotCode]["detection"] = "Found a Recovery slot"
-				self.imageList[self.slotCode]["imagename"] = _("Recovery")
-				self.imageList[self.slotCode]["imagelogname"] = "Recovery"
-				self.imageList[self.slotCode]["status"] = "recovery"
-				self.findSlot()
-			elif self.slotCode == "F":
-				self.imageList[self.slotCode]["detection"] = "Found a Flash Image slot"
-				self.imageList[self.slotCode]["imagename"] = _("Flash")
-				self.imageList[self.slotCode]["imagelogname"] = "Flash"
-				self.imageList[self.slotCode]["status"] = "flash"
-				self.findSlot()
-			elif self.bootSlots[self.slotCode].get("device"):
-				self.device = self.bootSlots[self.slotCode]["device"]
-				# print(f"[MultiBoot] DEBUG: Analyzing slot='{self.slotCode}' ({self.device}).")
-				if hasMultiBootMTD:
-					self.console.ePopen([MOUNT, MOUNT, "-t", "ubifs", self.device, self.tempDir], self.analyzeSlot)
-				else:
-					self.console.ePopen([MOUNT, MOUNT, self.device, self.tempDir], self.analyzeSlot)
-			else:
-				self.imageList[self.slotCode]["detection"] = "Found an unexpected/ill-defined slot"
-				self.imageList[self.slotCode]["imagename"] = _("Unknown")
-				self.imageList[self.slotCode]["imagelogname"] = "Unknown"
-				self.imageList[self.slotCode]["status"] = "unknown"
-				self.findSlot()
-		else:
-			rmdir(self.tempDir)
-			if self.debugMode:
-				for slotCode in sorted(self.imageList.keys()):
-					# print(f"[MultiBoot] findSlot DEBUG: Image slot '{slotCode}': {self.imageList[slotCode]}")
-					print(f"[MultiBoot] Slot '{slotCode}' content: '{self.imageList[slotCode].get("imagelogname", "Unknown")}'.")
-					print(f"[MultiBoot]     Device: '{self.imageList[slotCode].get("devicelog", "Unknown")}'.")
-					print(f"[MultiBoot]     Root: '{self.imageList[slotCode].get("rootlog", "Unknown")}'.")
-					print(f"[MultiBoot]     Detection: '{self.imageList[slotCode].get("detection", "Unknown")}'.")
-					print(f"[MultiBoot]     Status: '{self.imageList[slotCode].get("status", "Unknown").capitalize()}'.")
-					modes = self.imageList[slotCode].get("bootCodes")
-					if modes and modes != [""]:
-						print(f"[MultiBoot]     Boot modes: '{"', '".join(modes)}'.")
-					print(f"[MultiBoot]     UBI device: '{"Yes" if self.imageList[slotCode].get("ubi", False) else "No"}'.")
-					print(f"[MultiBoot]     UUID device: '{"Yes" if self.imageList[slotCode].get("uuid", False) else "No"}'.")
-				print(f"[MultiBoot] {len(self.imageList)} boot slots detected.")
-			self.callback(self.imageList)
-
-	def analyzeSlot(self, data, retVal, extraArgs):  # Part of getSlotImageList().
-		if retVal:
-			self.imageList[self.slotCode]["detection"] = f"Error {retVal}: Unable to mount slot '{self.slotCode}' ({self.device}) for analysis"
-			self.imageList[self.slotCode]["imagename"] = _("Inaccessible")
-			self.imageList[self.slotCode]["imagelogname"] = "Inaccessible"
-			self.imageList[self.slotCode]["status"] = "unknown"
-		else:
-			rootDir = self.bootSlots[self.slotCode].get("rootsubdir")
-			imageDir = join(self.tempDir, rootDir) if rootDir else self.tempDir
-			infoFile = join(imageDir, "usr/lib/enigma.info")
-			versionFile = join(imageDir, "etc/image-version")
-			if isfile(infoFile):
-				info = self.readSlotInfo(infoFile)
-				name = self._formatSlotName(info)
-				self.imageList[self.slotCode]["detection"] = "Found an enigma information file"
-				self.imageList[self.slotCode]["imagename"] = name
-				self.imageList[self.slotCode]["imagelogname"] = name
-				self.imageList[self.slotCode]["displaydistro"] = info.get("displaydistro") or info.get("distro") or ""
-				self.imageList[self.slotCode]["imgversion"] = info.get("imgversion") or ""
-				self.imageList[self.slotCode]["compiledate"] = str(info.get("compiledate", ""))
-				self.imageList[self.slotCode]["status"] = "active"
-			elif isfile(versionFile):
-				info = self.readSlotInfo(versionFile)
-				compileDate = self.getCompileDate(imageDir)
-				self.imageList[self.slotCode]["compiledate"] = compileDate
-				compileDate = f"{compileDate[0:4]}-{compileDate[4:6]}-{compileDate[6:8]}"
-				version = str(info.get("version"))
-				if "." not in version and "-" not in version and version.isdigit():
-					version = f"{int(version[0:2])}.{version[2:3]}.{version[3:5]}" if len(version) == 17 else f"{int(version[0:2])}.{int(version[3:5])}"
-				self.imageList[self.slotCode]["detection"] = "Found an image version file"
-				creator = info.get("creator")
-				if creator is not None:
-					self.imageList[self.slotCode]["imagename"] = f"{creator.split()[0]} {version} ({compileDate})"
-					self.imageList[self.slotCode]["imagelogname"] = f"{creator.split()[0]} {version} ({compileDate})"
-				else:
-					self.imageList[self.slotCode]["imagename"] = f"Unknown Creator {version} ({compileDate})"
-					self.imageList[self.slotCode]["imagelogname"] = f"Unknown Creator {version} ({compileDate})"
-				self.imageList[self.slotCode]["status"] = "active"
-			elif isfile(join(imageDir, "usr/bin/enigma2")):
-				info = self.deriveSlotInfo(imageDir)
-				compileDate = str(info.get("compiledate"))
-				self.imageList[self.slotCode]["compiledate"] = compileDate
-				compileDate = f"{compileDate[0:4]}-{compileDate[4:6]}-{compileDate[6:8]}"
-				self.imageList[self.slotCode]["detection"] = "Found an enigma2 binary file"
-				self.imageList[self.slotCode]["imagename"] = f"{info.get("displaydistro", info.get("distro"))} {info.get("imgversion")} ({compileDate})"
-				self.imageList[self.slotCode]["imagelogname"] = f"{info.get("displaydistro", info.get("distro"))} {info.get("imgversion")} ({compileDate})"
-				self.imageList[self.slotCode]["status"] = "active"
-			elif isfile(join(imageDir, "usr/bin/enigma2x.bin")):
-				self.imageList[self.slotCode]["detection"] = "Found a disabled enigma2 binary file"
-				self.imageList[self.slotCode]["imagename"] = _("Disabled")
-				self.imageList[self.slotCode]["imagelogname"] = "Disabled"
-				self.imageList[self.slotCode]["status"] = "hidden"
-			else:
-				self.imageList[self.slotCode]["detection"] = "Found no enigma files"
-				self.imageList[self.slotCode]["imagename"] = _("Empty")
-				self.imageList[self.slotCode]["imagelogname"] = "Empty"
-				self.imageList[self.slotCode]["status"] = "empty"
-		if ismount(self.tempDir):
-			self.console.ePopen([UMOUNT, UMOUNT, self.tempDir], self.finishSlot)
-		else:
-			self.findSlot()
-
-	def finishSlot(self, data, retVal, extraArgs):  # Part of getSlotImageList().
-		if retVal:
-			print(f"[MultiBoot] finishSlot Error {retVal}: Unable to unmount slot '{self.slotCode}' (self.device)!")
-		else:
-			self.findSlot()
-
-	def _formatSlotName(self, info):
-		# Format the slot name "<displaydistro> <imgversion>[<revision>] (<compiledate>)" — single source for the UI and the bootmanager menu header.
-		distro = info.get("displaydistro") or info.get("distro")
-		if not distro:
-			return None
-		compileDate = str(info.get("compiledate", ""))
-		revision = info.get("imgrevision")
-		if revision is not None:
-			revision = f".{revision:03d}" if info.get("distro") == "openvix" and isinstance(revision, int) else f" {revision}"
-			revision = "" if revision.strip() == compileDate else revision
-		else:
-			revision = ""
-		if len(compileDate) == 8 and compileDate.isdigit():
-			compileDate = f"{compileDate[0:4]}-{compileDate[4:6]}-{compileDate[6:8]}"
-		else:
-			compileDate = ""
-		version = info.get("imgversion") or ""
-		base = f"{distro} {version}{revision}".rstrip()
-		return f"{base} ({compileDate})" if compileDate else base
-
-	def readSlotInfo(self, path):  # Part of analyzeSlot() within getSlotImageList().
-		info = {}
-		lines = fileReadLines(path, source=MODULE_NAME)
-		if lines:
-			if self.checkChecksum(lines):
-				print("[MultiBoot] WARNING: Enigma information file found but checksum is incorrect!")
-			for line in lines:
-				if line.startswith("#") or line.strip() == "":
-					continue
-				if "=" in line:
-					item, value = (x.strip() for x in line.split("=", 1))
-					if item:
-						info[item] = self.processValue(value)
-		lines = fileReadLines(path.replace(".info", ".conf"), source=MODULE_NAME)
-		if lines:
-			for line in lines:
-				if line.startswith("#") or line.strip() == "":
-					continue
-				if "=" in line:
-					item, value = (x.strip() for x in line.split("=", 1))
-					if item:
-						if item in info:
-							print(f"[MultiBoot] Note: Enigma information value '{item}' with value '{info[item]}' being overridden to '{value}'.")
-						info[item] = self.processValue(value)
-		return info
-
-	def checkChecksum(self, lines):  # Part of readSlotInfo() within analyzeSlot() within getSlotImageList().
-		value = "Undefined!"
-		data = []
-		for line in lines:
-			if line.startswith("checksum"):
-				item, value = (x.strip() for x in line.split("=", 1))
-			else:
-				data.append(line)
-		data.append("")
-		result = md5(bytearray("\n".join(data), "UTF-8", errors="ignore")).hexdigest()  # NOSONAR
-		return value != result
-
-	def processValue(self, value):  # Part of readSlotInfo() within analyzeSlot() within getSlotImageList().
-		valueTest = value.upper() if value else ""
-		if value is None:
-			pass
-		elif (value.startswith("\"") or value.startswith("'")) and value.endswith(value[0]):
-			value = value[1:-1]
-		elif value.startswith("(") and value.endswith(")"):
-			data = []
-			for item in [x.strip() for x in value[1:-1].split(",")]:
-				data.append(self.processValue(item))
-			value = tuple(data)
-		elif value.startswith("[") and value.endswith("]"):
-			data = []
-			for item in [x.strip() for x in value[1:-1].split(",")]:
-				data.append(self.processValue(item))
-			value = list(data)
-		elif valueTest == "NONE":
-			value = None
-		elif valueTest in ("FALSE", "NO", "OFF", "DISABLED"):
-			value = False
-		elif valueTest in ("TRUE", "YES", "ON", "ENABLED"):
-			value = True
-		elif value.isdigit() or (value[0:1] in ("-", "+") and value[1:].isdigit()):
-			value = int(value)
-		elif valueTest.startswith("0X"):
-			try:
-				value = int(value, 16)
-			except ValueError:
-				pass
-		elif valueTest.startswith("0O"):
-			try:
-				value = int(value, 8)
-			except ValueError:
-				pass
-		elif valueTest.startswith("0B"):
-			try:
-				value = int(value, 2)
-			except ValueError:
-				pass
-		else:
-			try:
-				value = float(value)
-			except ValueError:
-				pass
-		return value
-
-	def getCompileDate(self, path):
-		statusfile = "var/lib/opkg/status"
-		if exists(join(path, "var/lib/dpkg/status")):
-			statusfile = "var/lib/dpkg/status"
-		try:
-			date = datetime.fromtimestamp(stat(join(path, statusfile)).st_mtime).strftime("%Y%m%d")
-			if date.startswith("1970"):
-				date = datetime.fromtimestamp(stat(join(path, "usr/share/bootlogo.mvi")).st_mtime).strftime("%Y%m%d")
-			date = max(date, datetime.fromtimestamp(stat(join(path, "usr/bin/enigma2")).st_mtime).strftime("%Y%m%d"))
-		except OSError:
-			date = "00000000"
-		return date
-
-	def deriveSlotInfo(self, path):  # Part of analyzeSlot() within getSlotImageList().
-		info = {}
-		info["compiledate"] = self.getCompileDate(path)
-		lines = fileReadLines(join(path, "etc/issue"), source=MODULE_NAME)
-		if lines and "vuplus" not in lines[0] and len(lines) >= 2:
-			data = lines[-2].strip()[:-6].split()
-			info["distro"] = " ".join(data[:-1])
-			info["displaydistro"] = {
-				"beyonwiz": "Beyonwiz",
-				"blackhole": "Black Hole",
-				"egami": "EGAMI",
-				"openatv": "OpenATV",
-				"openbh": "OpenBH",
-				"opendroid": "OpenDroid",
-				"openeight": "OpenEight",
-				"openhdf": "OpenHDF",
-				"opennfr": "OpenNFR",
-				"openpli": "OpenPLi",
-				"openspa": "OpenSpa",
-				"openvision": "Open Vision",
-				"openvix": "OpenViX",
-				"sif": "Sif",
-				"teamblue": "teamBlue",
-				"vti": "VTi"
-			}.get(info["distro"].lower(), info["distro"].capitalize())
-			info["imgversion"] = data[-1]
-		else:
-			info["distro"] = "Enigma2"
-			info["displaydistro"] = "Enigma2"
-			info["imgversion"] = "???"
-		return info
+		self._reloadIfStale()
+		callback(self.bootSlots)
 
 	def activateSlot(self, slotCode, bootCode, callback):
 		self.slotCode = slotCode
@@ -814,7 +1171,7 @@ class MultiBootClass():
 			self.callback(1)
 		else:
 			bootSlot = self.bootSlots[self.slotCode]
-			startup = bootSlot["startupfile"][self.bootCode]
+			startup = bootSlot["bootCodes"][self.bootCode]["startupfile"]
 			if (fileHas("/proc/cmdline", "kexec=1") or self.bootSlots[self.slotCode].get("rootsubdir") == "rescue") and startup == STARTUP_RECOVERY:
 				target = STARTUP_FILE
 			else:
@@ -839,7 +1196,79 @@ class MultiBootClass():
 			self.callback(2)
 		else:
 			rmdir(self.tempDir)
+			self._refreshJsonSlot(self.slotCode)
 			self.callback(0)
+
+	def clearSlotName(self, slotCode):
+		if not self.bootSlots or slotCode not in self.bootSlots or not self.bootDevice:
+			return
+		slot = self.bootSlots[slotCode]
+		removed = False
+		for cfg in (slot.get("bootCodes") or {}).values():
+			if cfg.pop("slotname", None) is not None:
+				removed = True
+		if not removed:
+			return
+		tempDir = mkdtemp(prefix=PREFIX)
+		self.console.ePopen([MOUNT, MOUNT, self.bootDevice, tempDir])
+		try:
+			self._writeSlotNamesFile(join(tempDir, SLOTNAMES_FILE), "clearSlotName")
+		finally:
+			self.console.ePopen([UMOUNT, UMOUNT, tempDir])
+			rmdir(tempDir)
+		self._refreshJsonSlotNames()
+
+	def _writeSlotNamesFile(self, path, caller):
+		# Rewrite SLOTNAMES from the current in-memory bootCodes[*].slotname entries
+		names = self._collectSlotNames()
+		if names:
+			lines = [f"{key}={names[key]}" for key in sorted(names.keys(), key=_naturalKey)]
+			fileWriteLines(path, lines, source=MODULE_NAME)
+		elif isfile(path):
+			try:
+				unlink(path)
+			except OSError as err:
+				print(f"[MultiBoot] {caller}: unable to remove '{path}': {err.strerror}")
+
+	def setSlotName(self, slotCode, bootCode, name, callback):
+		if not self.bootSlots or slotCode not in self.bootSlots:
+			callback(1)
+			return
+		if not self.bootDevice:
+			callback(1)
+			return
+		cfg = (self.bootSlots[slotCode].get("bootCodes") or {}).get(bootCode) or {}
+		startupFile = cfg.get("startupfile")
+		if not startupFile:
+			callback(1)
+			return
+		self.slotCode = slotCode
+		self.renameBootCode = bootCode
+		self.renameStartupFile = startupFile
+		self.newName = (name or "").strip()
+		self.callback = callback
+		self.tempDir = mkdtemp(prefix=PREFIX)
+		self.console.ePopen([MOUNT, MOUNT, self.bootDevice, self.tempDir], self._setSlotNameMounted)
+
+	def _setSlotNameMounted(self, data, retVal, extraArgs):
+		if retVal:
+			rmdir(self.tempDir)
+			self.callback(2)
+			return
+		cfg = ((self.bootSlots.get(self.slotCode, {}).get("bootCodes") or {}).get(self.renameBootCode)) or {}
+		if self.newName:
+			cfg["slotname"] = self.newName
+		else:
+			cfg.pop("slotname", None)
+		self._writeSlotNamesFile(join(self.tempDir, SLOTNAMES_FILE), "setSlotName")
+		self.console.ePopen([UMOUNT, UMOUNT, self.tempDir], self._setSlotNameUnmounted)
+
+	def _setSlotNameUnmounted(self, data, retVal, extraArgs):
+		rmdir(self.tempDir)
+		self._refreshJsonSlotNames()
+		if exists(DREAM_BOOT_FILE):
+			self.updateDreamBootSection(self.slotCode)
+		self.callback(0 if not retVal else 3)
 
 	def emptySlot(self, slotCode, callback):
 		self.manageSlot(slotCode, callback, self.hideSlot)
@@ -923,6 +1352,7 @@ class MultiBootClass():
 			rmdir(self.tempDir)
 			if exists(DREAM_BOOT_FILE):
 				self.updateDreamBootSection(self.slotCode)
+			self._refreshJsonSlot(self.slotCode)
 			self.callback(0)
 
 	def isFat32(self, device):

--- a/lib/python/Tools/MultiBoot.py
+++ b/lib/python/Tools/MultiBoot.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from glob import glob
 from hashlib import md5
-from os import listdir, mkdir, rename, rmdir, stat, unlink
+from os import listdir, mkdir, rename, rmdir, stat
 from os.path import basename, exists, isdir, isfile, ismount, join, islink, realpath
 from re import search
 from struct import calcsize, pack, unpack, error
@@ -11,7 +11,7 @@ from tempfile import mkdtemp
 # used to populate BoxInfo / SystemInfo and will create a boot loop!
 #
 from Components.Console import Console
-from Tools.Directories import SCOPE_CONFIG, copyfile, fileHas, fileReadLine, fileReadLines, fileWriteLines, resolveFilename
+from Tools.Directories import SCOPE_CONFIG, copyfile, fileHas, fileReadLine, fileReadLines, resolveFilename
 
 MODULE_NAME = __name__.split(".")[-1]
 
@@ -840,63 +840,6 @@ class MultiBootClass():
 		else:
 			rmdir(self.tempDir)
 			self.callback(0)
-
-	def renameSlot(self, slotCode, newName, callback):
-		# Override the slot's displaydistro/imgversion via <slot>/usr/lib/enigma.conf.
-        # Empty newName drops those keys so the image's own enigma.info takes over again.
-		if not self.bootSlots or slotCode not in self.bootSlots:
-			callback(1)
-			return
-		device = self.bootSlots[slotCode].get("device")
-		if not device:
-			callback(1)
-			return
-		self.slotCode = slotCode
-		self.newName = (newName or "").strip()
-		self.callback = callback
-		self.tempDir = mkdtemp(prefix=PREFIX)
-		opts = ["-t", "ubifs"] if self.bootSlots[slotCode].get("ubi") else []
-		self.console.ePopen([MOUNT, MOUNT] + opts + [device, self.tempDir], self._renameSlotMounted)
-
-	def _renameSlotMounted(self, data, retVal, extraArgs):
-		if retVal:
-			rmdir(self.tempDir)
-			self.callback(2)
-			return
-		rootSubdir = self.bootSlots[self.slotCode].get("rootsubdir") or ""
-		imageDir = join(self.tempDir, rootSubdir) if rootSubdir else self.tempDir
-		infoPath = join(imageDir, "usr/lib/enigma.info")
-		confPath = join(imageDir, "usr/lib/enigma.conf")
-		lines = fileReadLines(confPath, default=[], source=MODULE_NAME) or []
-		stripped = [line.rstrip("\n") for line in lines]
-		out = [line for line in stripped if not line.startswith(("displaydistro=", "imgversion="))]
-		if self.newName:
-			parts = self.newName.rsplit(" ", 1)
-			distro, version = (parts[0], parts[1]) if len(parts) > 1 else (parts[0], "")
-			out.append(f"displaydistro='{distro}'")
-			out.append(f"imgversion='{version}'")
-			if not isfile(infoPath):
-				open(infoPath, "w").close()
-				compiledate = (self.imageList.get(self.slotCode) or {}).get("compiledate") or ""
-				if compiledate:
-					out.append(f"compiledate='{compiledate}'")
-		elif isfile(infoPath) and stat(infoPath).st_size == 0:
-			out = [line for line in out if not line.startswith("compiledate=")]
-			try:
-				unlink(infoPath)
-			except OSError:
-				pass
-		if out != stripped:
-			fileWriteLines(confPath, out, source=MODULE_NAME)
-		self._pendingSectionName = self._readSectionNameFromImageDir(imageDir, self.slotCode) if exists(DREAM_BOOT_FILE) else None
-		self.console.ePopen([UMOUNT, UMOUNT, self.tempDir], self._renameSlotUnmounted)
-
-	def _renameSlotUnmounted(self, data, retVal, extraArgs):
-		rmdir(self.tempDir)
-		if exists(DREAM_BOOT_FILE):
-			self.updateDreamBootSection(self.slotCode, sectionName=self._pendingSectionName)
-		self._pendingSectionName = None
-		self.callback(0 if not retVal else 3)
 
 	def emptySlot(self, slotCode, callback):
 		self.manageSlot(slotCode, callback, self.hideSlot)

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -2,11 +2,11 @@ bin_SCRIPTS = enigma2.sh
 lib_LTLIBRARIES = libopen.la
 
 initddir = $(sysconfdir)/init.d
-initd_SCRIPTS = netrestarter
+initd_SCRIPTS = netrestarter multiboot-scan
 
 AM_CFLAGS = -DLIBC_SO=\"$(base_libdir)/libc.so.6\"
 
 libopen_la_SOURCES = libopen.c
 libopen_la_LIBADD = @LIBDL_LIBS@
 
-EXTRA_DIST = enigma2.sh.in netrestarter
+EXTRA_DIST = enigma2.sh.in netrestarter multiboot-scan

--- a/tools/multiboot-scan
+++ b/tools/multiboot-scan
@@ -1,0 +1,36 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          multiboot-scan
+# Required-Start:    $local_fs udev
+# Required-Stop:
+# Default-Start:     S
+# Default-Stop:
+# Short-Description: Scan MultiBoot slots and dump /var/run/multiboot.json.
+# Description:       Runs before enigma2 to populate the MultiBoot state file
+#                    that MultiBootClass reads at startup.
+### END INIT INFO
+
+MULTIBOOT_DIR=/usr/lib/enigma2/python/Tools
+
+do_scan() {
+	script="$MULTIBOOT_DIR/MultiBoot.py"
+	[ -f "$script" ] || script="$MULTIBOOT_DIR/MultiBoot.pyc"
+	[ -f "$script" ] && python3 "$script" --source boot >/dev/null 2>&1
+}
+
+case "$1" in
+	start|"")
+		do_scan
+		;;
+	stop)
+		;;
+	restart|force-reload)
+		do_scan
+		;;
+	*)
+		echo "usage: $0 {start|stop|restart}" >&2
+		exit 1
+		;;
+esac
+
+exit 0


### PR DESCRIPTION
## Summary

Two-part rework of the MultiBoot code:

1. **Standalone scanner** — the slot inventory (STARTUP files, SLOTNAMES,
   per-slot rootfs analysis) now runs out-of-process and writes a JSON
   state file. `enigma2` reads that file at startup; the SysV init script
   populates it before `enigma2` is spawned.
2. **Slot rename** — a dedicated `SLOTNAMES` file on the boot device maps
   each STARTUP file to a user-chosen name. The slot's rootfs is never
   touched, so a re-flashed slot drops its override automatically.

## Scanner

- CLI: `python3 MultiBoot.py [--slot N | --slotnames] [--source LABEL]`
- Writes `/var/run/multiboot.json` with the full slot state.
- `enigma2-multiboot-scan` — new sub-package (RDEPENDS `enigma2`) ships
  `/etc/init.d/multiboot-scan`, which runs at boot before enigma2.
- `MultiBootClass.__init__` calls the scanner inline as an emergency
  fallback when the JSON is missing.

## `MultiBootClass` (in-process)

- Loads state from `/var/run/multiboot.json`; no scan or mount logic in
  the enigma2 process anymore.
- Auto-reload: every public read stats the JSON — if `mtime` changed the
  state is reloaded. External scanner invocations (init script, manual
  `--source ...`) become visible without restarting enigma2.

## Slot rename

Format of `SLOTNAMES` (lives next to the STARTUP files on the boot device):

```
STARTUP_1=My Box Image (Produktion)
STARTUP_LINUX_1_BOXMODE_1=My Box Image (Kodi)
STARTUP_LINUX_1_BOXMODE_12=My Box Image (PiP)
```

- One entry per STARTUP file — h7 BOXMODE variants of the same slot can
  be renamed independently.
- `setSlotName(slot, bootCode, name)` rewrites the entry.
- `clearSlotName(slot)` drops all entries for a slot; `FlashManager`
  calls it before `ofgwrite` so a freshly flashed image starts with a
  clean name.
- `MultiBootManager` (TXT-key) edits the raw user name only — no date
  suffix in the virtual keyboard field.

## JSON schema

- Top-level: `bootCmdLine`, `bootCode`, `bootDevice`, `bootSlot`, `slots`.
- Per slot: `imagename` (raw, no date), `imgversion`, `imgrevision`,
  `displaydistro`, `compiledate`, `device`, `kernel`, `rootsubdir`,
  `status`, `detection`, `bootCodes`.
- Per bootCode: `startupfile`, `cmdline`, optionally `slotname` (raw)
  and `displayname` (`"<slotname or imagename> (YYYY-MM-DD)"` — the
  string the UI renders verbatim).

## Breaking changes

For code outside this PR that imports `Tools.MultiBoot`:

- `bootSlots[slot]["bootCodes"]` is now a `dict` mapping
  `bootCode → {startupfile, cmdline, slotname, displayname}`, replacing
  the previous `list` of bootCode strings. The per-bootCode
  `startupfile` and `cmdline` fields now live inside this dict.
- `MultiBoot.imageList` — removed. Use `MultiBoot.bootSlots` or
  `MultiBoot.getSlotImageList(callback)`.
- Slot `imagename` no longer carries the compile date. Use
  `MultiBoot.getSlotDisplayName(slot, bootCode)` or read
  `bootCodes[bc]["displayname"]` for the date-suffixed UI string.
  `imagename` and `compiledate` remain available as separate fields.

In-tree consumers (`FlashManager`, `ImageBackup`) migrated to
`getSlotDisplayName(slot, getCurrentBootMode())`.