### PR TITLE
[eLabel/eListbox]

### DIFF
--- a/lib/gdi/font.cpp
+++ b/lib/gdi/font.cpp
@@ -611,6 +611,11 @@ void eTextPara::setFont(const gFont *font, int tabwidth)
 	fontRenderClass::getInstance()->getFont(fnt, font->family.c_str(), font->pointSize, tabwidth);
 	if (!fnt)
 		eWarning("[eTextPara] Font '%s' is missing!", font->family.c_str());
+	else if (font->pointWidth > 0 && font->pointWidth < font->pointSize)
+	{
+		fnt->scaler.width = font->pointWidth;
+		fnt->font.width   = font->pointWidth;
+	}
 	fontRenderClass::getInstance()->getFont(replacement, replacement_facename.c_str(), font->pointSize, tabwidth);
 	fontRenderClass::getInstance()->getFont(fallback, fallback_facename.c_str(), font->pointSize, tabwidth);
 	setFont(fnt, replacement, fallback);

--- a/lib/gdi/gfont.h
+++ b/lib/gdi/gfont.h
@@ -17,6 +17,7 @@ public:
 
 	std::string family;
 	int pointSize;
+	int pointWidth = 0; // 0 = same as pointSize (no horizontal compression)
 
 	/**
 	 * \brief Constructs a font with the given name and size.

--- a/lib/gdi/grc.h
+++ b/lib/gdi/grc.h
@@ -318,7 +318,8 @@ public:
 		RT_WRAP = 64,
 		RT_ELLIPSIS = 128,
 		RT_BLEND = 256,
-		RT_UNDERLINE = 512
+		RT_UNDERLINE = 512,
+		RT_SCROLL = 1024
 	};
 	void renderText(const eRect &position, const std::string &string, int flags = 0, gRGB bordercolor = gRGB(), int border = 0, int markedpos = -1, int *offset = 0, int tabwidth = -1);
 

--- a/lib/gui/elabel.cpp
+++ b/lib/gui/elabel.cpp
@@ -1,8 +1,9 @@
 /*
 
 Scroll Text Feature of eLabel
+Font Scale Feature of eLabel
 
-Copyright (c) 2025 jbleyel
+Copyright (c) 2025-2026 jbleyel
 
 This code may be used commercially. Attribution must be given to the original author.
 Licensed under GPLv2.
@@ -170,8 +171,36 @@ int eLabel::event(int event, void* data, void* data2) {
 }
 
 void eLabel::updateTextSize() {
-	if (m_scroll_config.direction == eScrollConfig::scrollNone)
+	if (m_scroll_config.direction == eScrollConfig::scrollNone) {
+		if (m_fontScaleType) {
+			int visibleW = std::max(1, size().width() - m_padding.x() - m_padding.width());
+			int visibleH = std::max(1, size().height() - m_padding.y() - m_padding.height());
+			eSize s = eSize(visibleW, visibleH);
+			m_font->pointSize = m_originalFontSize;
+			m_font->pointWidth = 0;
+			eSize text_size = calculateTextSize(m_font, m_text, s, true); // nowrap at original size
+
+			if (m_fontScaleType == 1) {
+				int newFontSize = m_originalFontSize;
+				if (text_size.width() > visibleW || text_size.height() > visibleH) {
+					int scaleW = text_size.width() > 0 ? m_originalFontSize * visibleW / text_size.width() : m_originalFontSize;
+					int scaleH = text_size.height() > 0 ? m_originalFontSize * visibleH / text_size.height() : m_originalFontSize;
+					newFontSize = std::max(std::min(scaleW, scaleH), m_fontScaleSize);
+				}
+				if (m_font->pointSize != newFontSize)
+					m_font->pointSize = newFontSize;
+			} else if (m_fontScaleType == 2) {
+				int newFontWidth = 0;
+				if (text_size.width() > visibleW && text_size.height() <= visibleH) {
+					int scaleW = m_originalFontSize * visibleW / text_size.width();
+					newFontWidth = std::max(scaleW, m_fontScaleSize);
+				}
+				if (m_font->pointWidth != newFontWidth)
+					m_font->pointWidth = newFontWidth;
+			}
+		}
 		return;
+	}
 
 	stopScroll();
 
@@ -317,6 +346,7 @@ void eLabel::setMarkedPos(int markedPos) {
 
 void eLabel::setFont(gFont* font) {
 	m_font = font;
+	m_originalFontSize = font->pointSize;
 	event(evtChangedFont);
 }
 
@@ -422,6 +452,11 @@ eSize eLabel::calculateTextSize(gFont* font, const std::string& string, eSize ta
 	para.setFont(font);
 	para.renderString(string.empty() ? 0 : string.c_str(), nowrap ? 0 : RS_WRAP);
 	return para.getBoundBox().size();
+}
+
+void eLabel::setFontScale(int scaleType, int size) {
+	m_fontScaleType = scaleType;
+	m_fontScaleSize = size;
 }
 
 void eLabel::setScrollText(int direction, long delay, long startDelay, long endDelay, int repeat, int stepSize, int mode) {

--- a/lib/gui/elabel.h
+++ b/lib/gui/elabel.h
@@ -72,6 +72,9 @@ public:
 	gRGB getForegroundColor(int styleID = 0);
 	eSize calculateSize();
 	static eSize calculateTextSize(gFont* font, const std::string& string, eSize targetSize, bool nowrap = false);
+	
+	/* Set minimum font size or width for auto-scaling depending on scaleType */
+	void setFontScale(int scaleType, int size);
 
 protected:
 	ePtr<gFont> m_font;
@@ -84,6 +87,11 @@ protected:
 	std::string getClassName() const override { return std::string("eLabel"); }
 
 private:
+	/* Font auto-scaling */
+	int m_fontScaleType = 0;
+	int m_fontScaleSize = 0;
+	int m_originalFontSize = 0;
+	
 	int buildFlags() const {
 		int flags = 0;
 

--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -1,8 +1,9 @@
 /*
 
 Scroll Text Feature of eListBox
+Font Scale Feature of eLabel
 
-Copyright (c) 2025 jbleyel
+Copyright (c) 2025-2026 jbleyel
 
 This code may be used commercially. Attribution must be given to the original author.
 Licensed under GPLv2.

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -89,6 +89,7 @@ struct eListboxStyleSetted
 	bool background_color_rows : 1;
 	bool separator_color : 1;
 	bool header_color : 1;
+	bool wrap : 1;
 };
 
 struct eListboxStyle
@@ -124,7 +125,10 @@ struct eListboxStyle
 		alignBlock
 	};
 	int m_valign, m_halign, m_border_size, m_scrollbarborder_width;
+	int m_wrap = 0;
 	ePtr<gFont> m_font, m_font_zoomed, m_valuefont, m_headerfont;
+	int m_fontScaleType = 0;
+	int m_fontScaleSize = 0;
 	eRect m_text_padding;
 	eRect m_separator_size;
 
@@ -320,11 +324,14 @@ public:
 	void setScrollbarLength(int size) { m_scrollbar_length = size; }
 
 	void setFont(gFont *font);
-	void setEntryFont(gFont *font) {m_style.m_font = font;}
+	void setEntryFont(gFont *font) { m_style.m_font = font; }
 	void setValueFont(gFont *font) { m_style.m_valuefont = font; }
 	void setHeaderFont(gFont *font) { m_style.m_headerfont = font; }
+	void setFontScale(int scaleType, int size) { m_style.m_fontScaleType = scaleType; m_style.m_fontScaleSize = size; }
+
 	void setVAlign(int align) { m_style.m_valign = align; }
 	void setHAlign(int align) { m_style.m_halign = align; }
+	void setWrap(int wrap) { m_style.m_wrap = wrap; m_style.is_set.wrap = true; }
 	void setUseVTIWorkaround(void) { m_style.is_set.use_vti_workaround = 1; }
 
 	void setPadding(const eRect &padding) override { m_style.m_text_padding = padding; }

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -1,8 +1,9 @@
 /*
 
 Scroll Text Feature of eListBox
+Font Scale Feature of eListBox
 
-Copyright (c) 2025 jbleyel
+Copyright (c) 2025-2026 jbleyel
 
 This code may be used commercially. Attribution must be given to the original author.
 Licensed under GPLv2.
@@ -96,6 +97,7 @@ int eListboxPythonStringContent::cursorMove(int count) {
 		cursorHome();
 	else if (m_cursor > size())
 		cursorEnd();
+
 	return 0;
 }
 
@@ -193,6 +195,39 @@ int eListboxPythonStringContent::getMaxItemTextWidth() {
     // Store result; cache is invalidated by setList()
     m_max_text_width = max_width + (text_offset * 2);
 	return m_max_text_width;
+}
+
+static eSize calculateTextSize(gFont* font, const std::string& string, eSize targetSize, bool nowrap) {
+	// Calculate text size for a piece of text without creating an eLabel instance
+	// this avoids the side effect of "invalidate" being called on the parent container
+	// during the setup of the font and text on the eLabel
+	eTextPara para(eRect(0, 0, targetSize.width(), targetSize.height()));
+	para.setFont(font);
+	para.renderString(string.empty() ? 0 : string.c_str(), nowrap ? 0 : RS_WRAP);
+	return para.getBoundBox().size();
+}
+
+/* Returns a new scaled gFont if scaling is needed, null otherwise.
+   Caller must call painter.setFont(result) before and painter.setFont(fnt) after renderText. */
+static ePtr<gFont> makeFontScale(gFont* fnt, const char* text, int visibleW, const eListboxStyle* style)
+{
+	if (!fnt || !style || !style->m_fontScaleType || visibleW <= 0)
+		return nullptr;
+	eSize ts = calculateTextSize(fnt, text ? text : "", eSize(visibleW, 0x7fff), true);
+	if (ts.width() <= visibleW)
+		return nullptr;
+	int origSize = fnt->pointSize;
+	int newSize = origSize, newWidth = 0;
+	int sW = origSize * visibleW / ts.width();
+	if (style->m_fontScaleType == 1)
+		newSize = std::max(sW, style->m_fontScaleSize);
+	else if (style->m_fontScaleType == 2)
+		newWidth = std::max(sW, style->m_fontScaleSize);
+	else
+		return nullptr;
+	ePtr<gFont> scaled = new gFont(fnt->family, newSize);
+	scaled->pointWidth = newWidth;
+	return scaled;
 }
 
 void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, const ePoint &offset, int selected)
@@ -428,6 +463,9 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 				else if (local_style->m_halign == eListboxStyle::alignBlock)
 					flags |= gPainter::RT_HALIGN_BLOCK;
 
+				if (local_style->is_set.wrap && local_style->m_wrap == 2)
+					flags |= gPainter::RT_ELLIPSIS;
+
 				int paddingx = local_style->m_text_padding.x();
 				int paddingy = local_style->m_text_padding.y();
 				int paddingw = local_style->m_text_padding.width();
@@ -444,7 +482,7 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 					m_scroll_index = m_cursor;
 					m_scroll_size = eSize(position.width(), position.height());
 					m_scroll_text_str = string;
-					updateTextSize(m_scroll_text_str, fnt, flags, border_color, border_size);
+					updateTextSize(m_scroll_text_str, fnt, flags & ~gPainter::RT_ELLIPSIS, border_color, border_size);
 				}
 				if(m_scroll_text)
 				{
@@ -458,12 +496,19 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 						position.setX(position.x() - m_scroll_pos);
 					else if (scroll_text_direction == eScrollConfig::scrollTop || scroll_text_direction == eScrollConfig::scrollBottom)
 						position.setY(position.y() - m_scroll_pos);
-					painter.renderText(position, m_scroll_text_str.empty() ? string : m_scroll_text_str.c_str(), flags, border_color, border_size);
+					painter.renderText(position, m_scroll_text_str.empty() ? string : m_scroll_text_str.c_str(), flags & ~gPainter::RT_ELLIPSIS, border_color, border_size);
 					painter.clippop();
 					return;
 				}
 			}
-			painter.renderText(position, string, flags, border_color, border_size);
+			{
+				ePtr<gFont> scaledFnt = makeFontScale(fnt, string, position.width(), local_style);
+				if (scaledFnt)
+					painter.setFont(scaledFnt);
+				painter.renderText(position, string, flags, border_color, border_size);
+				if (scaledFnt)
+					painter.setFont(fnt);
+			}
 
 		}
 	}
@@ -542,16 +587,6 @@ void eListboxPythonStringContent::invalidate() {
 	}
 }
 
-static eSize calculateTextSize(gFont* font, const std::string& string, eSize targetSize, bool nowrap) {
-	// Calculate text size for a piece of text without creating an eLabel instance
-	// this avoids the side effect of "invalidate" being called on the parent container
-	// during the setup of the font and text on the eLabel
-	eTextPara para(eRect(0, 0, targetSize.width(), targetSize.height()));
-	para.setFont(font);
-	para.renderString(string.empty() ? 0 : string.c_str(), nowrap ? 0 : RS_WRAP);
-	return para.getBoundBox().size();
-}
-
 void eListboxPythonStringContent::updateTextSize(std::string& text, gFont* font, int flags, gRGB& border_color, int border_size) {
 	if (m_scroll_text)
 		stopScroll();
@@ -560,6 +595,8 @@ void eListboxPythonStringContent::updateTextSize(std::string& text, gFont* font,
 		const int scroll_text_direction = m_listbox->m_scroll_config.direction;
 
 		if (scroll_text_direction == eScrollConfig::scrollLeft || scroll_text_direction == eScrollConfig::scrollRight) {
+			if (m_scroll_size.width() <= 0)
+				return;
 			m_text_size = calculateTextSize(font, text, m_scroll_size, true); // nowrap
 
 
@@ -582,6 +619,8 @@ void eListboxPythonStringContent::updateTextSize(std::string& text, gFont* font,
 				*/
 			}
 		} else if (scroll_text_direction == eScrollConfig::scrollTop || scroll_text_direction == eScrollConfig::scrollBottom) {
+			if (m_scroll_size.height() <= 0)
+				return;
 			m_text_size = calculateTextSize(font, text, m_scroll_size, false); // allow wrap
 			if (m_text_size.height() > m_scroll_size.height()) {
 				m_text_size.setHeight(m_text_size.height() + font->pointSize / 10); // avoid issues with rounding
@@ -624,6 +663,9 @@ void eListboxPythonStringContent::createScrollPixmap(std::string& text, gFont* f
 
 	int w = std::max(m_text_size.width(), m_scroll_size.width());
 	int h = std::max(m_text_size.height(), m_scroll_size.height());
+
+	if (w <= 0 || h <= 0)
+		return;
 
 	// Guard against excessively large pixmap allocations
 	if (w * h > MAX_SCROLL_PIXMAP_PIXELS)
@@ -1055,8 +1097,75 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 			}
 
 
-			eRect labelrect(ePoint(offset.x() + leftOffset + indent, offset.y()), m_itemsize);
-			painter.renderText(labelrect, string, alphablendflag | gPainter::RT_HALIGN_LEFT | gPainter::RT_VALIGN_CENTER, border_color, border_size);
+			/* Pre-measure value text width for dynamic label/value split.
+			   Value is measured first so the label knows how much space it has. */
+			int scroll_text_direction = (m_listbox) ? m_listbox->m_scroll_config.direction : 0;
+			int valueAreaWidth = 0;
+			if (!value_alignment_left && value && PyTuple_Check(value))
+			{
+				ePyObject preType = PyTuple_GET_ITEM(value, 0);
+				const char *preAtype = (preType && PyUnicode_Check(preType)) ? PyUnicode_AsUTF8(preType) : 0;
+				if (preAtype && (!strcmp(preAtype, "text") || !strcmp(preAtype, "mtext")))
+				{
+					ePyObject preVal = PyTuple_GET_ITEM(value, 1);
+					const char *valStr = (preVal && PyUnicode_Check(preVal)) ? PyUnicode_AsUTF8(preVal) : "";
+					if (*valStr)
+					{
+						ePtr<eTextPara> para = new eTextPara(eRect(0, 0, m_itemsize.width(), m_itemsize.height()));
+						para->setFont(fnt2);
+						para->renderString(valStr, 0);
+						valueAreaWidth = para->getBoundBox().width() + leftOffset;
+					}
+				}
+			}
+
+			/* Label area: left side of item, capped to leave room for value. */
+			int labelMaxWidth = m_itemsize.width() - leftOffset - indent - valueAreaWidth;
+			if (labelMaxWidth < 0) labelMaxWidth = 0;
+			eRect labelrect(ePoint(offset.x() + leftOffset + indent, offset.y()),
+			                eSize(labelMaxWidth > 0 ? labelMaxWidth : m_itemsize.width(), m_itemsize.height()));
+
+			/* Render label — scroll it when selected and it doesn't fit. */
+			int labelflags = alphablendflag | gPainter::RT_HALIGN_LEFT | gPainter::RT_VALIGN_CENTER;
+			if (local_style && local_style->is_set.wrap && local_style->m_wrap == 2)
+				labelflags |= gPainter::RT_ELLIPSIS;
+
+			if (selected && scroll_text_direction && labelMaxWidth > 0)
+			{
+				if (m_scroll_index != m_cursor)
+				{
+					m_listbox->m_scroll_rect = labelrect;
+					m_scroll_index = m_cursor;
+					m_scroll_size = eSize(labelrect.width(), labelrect.height());
+					m_scroll_text_str = string;
+					updateTextSize(m_scroll_text_str, fnt ? fnt : fnt3, labelflags & ~gPainter::RT_ELLIPSIS, border_color, border_size);
+				}
+				if (m_scroll_text)
+				{
+					if (!scrollTimer->isActive())
+						scrollTimer->start(m_listbox->m_scroll_config.startDelay);
+					eRect scrolledLabel = labelrect;
+					if (scroll_text_direction == eScrollConfig::scrollLeft || scroll_text_direction == eScrollConfig::scrollRight)
+						scrolledLabel.setX(scrolledLabel.x() - m_scroll_pos);
+					else if (scroll_text_direction == eScrollConfig::scrollTop || scroll_text_direction == eScrollConfig::scrollBottom)
+						scrolledLabel.setY(scrolledLabel.y() - m_scroll_pos);
+					painter.renderText(scrolledLabel, m_scroll_text_str.c_str(), labelflags & ~gPainter::RT_ELLIPSIS, border_color, border_size);
+				}
+				else
+				{
+					ePtr<gFont> scaledFnt = makeFontScale(fnt, string, labelrect.width(), local_style);
+					if (scaledFnt) painter.setFont(scaledFnt);
+					painter.renderText(labelrect, string, labelflags, border_color, border_size);
+					if (scaledFnt) painter.setFont(fnt);
+				}
+			}
+			else
+			{
+				ePtr<gFont> scaledFnt = makeFontScale(fnt, string, labelrect.width(), local_style);
+				if (scaledFnt) painter.setFont(scaledFnt);
+				painter.renderText(labelrect, string, labelflags, border_color, border_size);
+				if (scaledFnt) painter.setFont(fnt);
+			}
 
 			/*  check if this is really a tuple */
 			if (value && PyTuple_Check(value))
@@ -1101,20 +1210,12 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 								/* plist is 0 or borrowed */
 							}
 						}
-						/* find the width of the label, to prevent the value overwriting it. */
-						ePoint valueoffset = offset;
-						eSize valuesize = m_itemsize;
-						int labelwidth = 0;
-						if (*string)
-						{
-							ePtr<eTextPara> para = new eTextPara(labelrect);
-							para->setFont(fnt);
-							para->renderString(string, 0);
-							labelwidth = para->getBoundBox().width() + leftOffset;
-						}
-						valueoffset.setX(valueoffset.x() + leftOffset + labelwidth);
-						valuesize.setWidth(valuesize.width() - leftOffset - labelwidth - leftOffset);
-						painter.renderText(eRect(valueoffset, valuesize), text, alphablendflag | flags | gPainter::RT_VALIGN_CENTER, border_color, border_size, markedpos, &m_text_offset[cursor]);
+
+						/* Value: render in full item width; flags (RT_HALIGN_LEFT/RIGHT) control alignment.
+						   Label is already clipped to labelMaxWidth so there is no overlap. */
+						eRect valueRect(ePoint(offset.x() + leftOffset, offset.y()),
+						                eSize(m_itemsize.width() - 2 * leftOffset, m_itemsize.height()));
+						painter.renderText(valueRect, text, alphablendflag | flags | gPainter::RT_VALIGN_CENTER, border_color, border_size, markedpos, &m_text_offset[cursor]);
 						/* pvalue is borrowed */
 					}
 					else if (!strcmp(atype, "slider"))
@@ -2140,7 +2241,43 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 
 				eRect textRect = eRect(rect.x() + paddingLeft, rect.y() + paddingTop, rect.width() - paddingLeft - paddingRight, rect.height() - paddingTop - paddingBottom);
 
-				if (pTextBorderColor && btwidth)
+				/* scrollText: if RT_SCROLL is set and this is the selected item,
+				   scroll this text element. Only the first RT_SCROLL element per
+				   row scrolls; subsequent ones are rendered normally. */
+				int scroll_text_direction = (m_listbox) ? m_listbox->m_scroll_config.direction : 0;
+				bool do_scroll = selected && scroll_text_direction && (flags & gPainter::RT_SCROLL);
+				flags &= ~gPainter::RT_SCROLL; // strip flag before passing to renderText
+
+				if (do_scroll && m_scroll_index != m_cursor)
+				{
+					// first time we see this cursor position — set up scroll
+					m_listbox->m_scroll_rect = textRect;
+					m_scroll_index = m_cursor;
+					m_scroll_size = eSize(textRect.width(), textRect.height());
+					m_scroll_text_str = string;
+					gRGB bcolor = (pTextBorderColor && btwidth) ? gRGB(PyLong_AsUnsignedLongMask(pTextBorderColor)) : border_color;
+					int bsize = (pTextBorderColor && btwidth) ? btwidth : border_size;
+					updateTextSize(m_scroll_text_str, m_fonts[fnt], flags & ~gPainter::RT_ELLIPSIS, bcolor, bsize);
+					/* Discard any cached pixmap: createScrollPixmap uses listbox-style colors,
+					   not the per-item pbackColorSelected, so blitting it would show the wrong
+					   background. Force a full-item repaint on each scroll tick instead. */
+					m_listbox->m_textPixmap = nullptr;
+				}
+
+				if (do_scroll && m_scroll_text)
+				{
+					if (!scrollTimer->isActive())
+						scrollTimer->start(m_listbox->m_scroll_config.startDelay);
+					eRect scrollRect = textRect;
+					if (scroll_text_direction == eScrollConfig::scrollLeft || scroll_text_direction == eScrollConfig::scrollRight)
+						scrollRect.setX(scrollRect.x() - m_scroll_pos);
+					else if (scroll_text_direction == eScrollConfig::scrollTop || scroll_text_direction == eScrollConfig::scrollBottom)
+						scrollRect.setY(scrollRect.y() - m_scroll_pos);
+					gRGB bcolor = (pTextBorderColor && btwidth) ? gRGB(PyLong_AsUnsignedLongMask(pTextBorderColor)) : border_color;
+					int bsize = (pTextBorderColor && btwidth) ? btwidth : border_size;
+					painter.renderText(scrollRect, m_scroll_text_str.c_str(), flags & ~gPainter::RT_ELLIPSIS, bcolor, bsize);
+				}
+				else if (pTextBorderColor && btwidth)
 				{
 					uint32_t textBColor = PyLong_AsUnsignedLongMask(pTextBorderColor);
 					painter.renderText(textRect, string, flags, gRGB(textBColor), btwidth);

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -496,7 +496,7 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 						position.setX(position.x() - m_scroll_pos);
 					else if (scroll_text_direction == eScrollConfig::scrollTop || scroll_text_direction == eScrollConfig::scrollBottom)
 						position.setY(position.y() - m_scroll_pos);
-					painter.renderText(position, m_scroll_text_str.empty() ? string : m_scroll_text_str.c_str(), flags & ~gPainter::RT_ELLIPSIS, border_color, border_size);
+					painter.renderText(position, m_scroll_text_str.empty() ? string : m_scroll_text_str, flags & ~gPainter::RT_ELLIPSIS, border_color, border_size);
 					painter.clippop();
 					return;
 				}
@@ -1104,7 +1104,7 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 			if (!value_alignment_left && value && PyTuple_Check(value))
 			{
 				ePyObject preType = PyTuple_GET_ITEM(value, 0);
-				const char *preAtype = (preType && PyUnicode_Check(preType)) ? PyUnicode_AsUTF8(preType) : 0;
+				const char *preAtype = (preType && PyUnicode_Check(preType)) ? PyUnicode_AsUTF8(preType) : nullptr;
 				if (preAtype && (!strcmp(preAtype, "text") || !strcmp(preAtype, "mtext")))
 				{
 					ePyObject preVal = PyTuple_GET_ITEM(value, 1);
@@ -1149,7 +1149,7 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 						scrolledLabel.setX(scrolledLabel.x() - m_scroll_pos);
 					else if (scroll_text_direction == eScrollConfig::scrollTop || scroll_text_direction == eScrollConfig::scrollBottom)
 						scrolledLabel.setY(scrolledLabel.y() - m_scroll_pos);
-					painter.renderText(scrolledLabel, m_scroll_text_str.c_str(), labelflags & ~gPainter::RT_ELLIPSIS, border_color, border_size);
+					painter.renderText(scrolledLabel, m_scroll_text_str, labelflags & ~gPainter::RT_ELLIPSIS, border_color, border_size);
 				}
 				else
 				{
@@ -1172,7 +1172,7 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 			{
 				/* convert type to string */
 				ePyObject type = PyTuple_GET_ITEM(value, 0);
-				const char *atype = (type && PyUnicode_Check(type)) ? PyUnicode_AsUTF8(type) : 0;
+				const char *atype = (type && PyUnicode_Check(type)) ? PyUnicode_AsUTF8(type) : nullptr;
 
 				if (atype)
 				{
@@ -2275,7 +2275,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 						scrollRect.setY(scrollRect.y() - m_scroll_pos);
 					gRGB bcolor = (pTextBorderColor && btwidth) ? gRGB(PyLong_AsUnsignedLongMask(pTextBorderColor)) : border_color;
 					int bsize = (pTextBorderColor && btwidth) ? btwidth : border_size;
-					painter.renderText(scrollRect, m_scroll_text_str.c_str(), flags & ~gPainter::RT_ELLIPSIS, bcolor, bsize);
+					painter.renderText(scrollRect, m_scroll_text_str, flags & ~gPainter::RT_ELLIPSIS, bcolor, bsize);
 				}
 				else if (pTextBorderColor && btwidth)
 				{

--- a/lib/gui/elistboxcontent.h
+++ b/lib/gui/elistboxcontent.h
@@ -58,21 +58,6 @@ private:
 	int m_saved_cursor_line = 0;
 	ePtr<gFont> m_font_zoomed;
 	// scroll
-	int m_scroll_pos = 0;
-	bool m_scroll_text = false;
-	bool m_scroll_started = false;
-	int m_repeat_count = 0;
-	bool m_scroll_swap = false;
-	bool m_end_delay_active = false;
-	eSize m_text_size;
-	eSize m_scroll_size;
-	void updateScrollPosition();
-	void stopScroll();
-	void updateTextSize(std::string& text, gFont* font, int flags, gRGB& border_color, int border_size);
-	std::string m_scroll_text_str;
-	int m_scroll_index = -1;
-	void createScrollPixmap(std::string& text, gFont* font, int flags, gRGB& border_color, int border_size);
-	ePtr<eTimer> scrollTimer;
 
 protected:
 	int m_cursor = 0;
@@ -83,6 +68,25 @@ protected:
 	int m_itemwidth = 25;
 	int m_max_text_width = -1; // -1 means not yet calculated
 	uint8_t m_orientation = 1;
+
+	// scroll
+	std::string m_scroll_text_str;
+	int m_scroll_index = -1;
+	ePtr<eTimer> scrollTimer;
+	eSize m_text_size;
+	eSize m_scroll_size;
+
+	int m_scroll_pos = 0;
+	bool m_scroll_text = false;
+	bool m_scroll_started = false;
+	int m_repeat_count = 0;
+	bool m_scroll_swap = false;
+	bool m_end_delay_active = false;
+	void updateScrollPosition();
+	void stopScroll();
+	void updateTextSize(std::string& text, gFont* font, int flags, gRGB& border_color, int border_size);
+	void createScrollPixmap(std::string& text, gFont* font, int flags, gRGB& border_color, int border_size);
+
 #endif
 };
 
@@ -168,6 +172,7 @@ private:
 #define RT_ELLIPSIS 128
 #define RT_BLEND 256
 #define RT_UNDERLINE 512
+#define RT_SCROLL 1024
 #define BT_ALPHATEST 1
 #define BT_ALPHABLEND 2
 #define BT_SCALE 4

--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -481,6 +481,31 @@ def parseFont(value, scale=((1, 1), (1, 1))):
 	return gFont(name, int(size * scale[1][0] / scale[1][1]))
 
 
+def parseFontScale(value, scale=((1, 1), (1, 1))):
+	if ";" in value:
+		scaleType, size = value.split(";")
+		try:
+			size = int(size)
+		except ValueError:
+			val = size.replace("f", f"{getSkinFactor()}")
+			try:
+				size = int(eval(val))
+			except Exception as err:
+				print(f"[Skin] Error ({type(err).__name__} - {err}): Font scale size in '{value}', evaluated to '{val}', can't be processed!")
+				size = None
+		if scaleType not in ("size", "width"):
+			print(f"[Skin] Error: Font scale size must be in 'size/width', value:'{value}', can't be processed!")
+			size = None
+			scaleType = 0
+		if size:
+			size = int(size * scale[1][0] / scale[1][1])
+			scaleType = 1 if scaleType == "size" else 2
+	else:
+		scaleType = 0
+		size = None
+	return scaleType, size
+
+
 def parseGradient(value):
 	def validColor(value):
 		if value[0] == "#" and len(value) in (9, 7):
@@ -1059,6 +1084,11 @@ class AttributeParser:
 	def font(self, value):
 		self.guiObject.setFont(parseFont(value, self.scaleTuple))
 
+	def fontScale(self, value):
+		scaleType, size = parseFontScale(value, self.scaleTuple)
+		if size and scaleType:
+			self.guiObject.setFontScale(scaleType, size)
+
 	def foregroundColor(self, value):
 		if "," in value:
 			self.guiObject.setForegroundGradient(*parseGradient(value))  # Only for eSlider.
@@ -1597,6 +1627,12 @@ def loadSingleSkinData(desktop, screenID, domSkin, pathSkin, scope=SCOPE_GUISKIN
 				style.setValueFont(parseFont(configList.attrib.get("valueFont", "Regular;18"), ((1, 1), (1, 1))))
 			if "headerFont" in configList.attrib:
 				style.setHeaderFont(parseFont(configList.attrib.get("headerFont", "Regular;20"), ((1, 1), (1, 1))))
+			if "entryFontScale" in configList.attrib:
+				value = configList.attrib.get("entryFontScale")
+				if value:
+					scaleType, size = parseFontScale(value, ((1, 1), (1, 1)))
+					if size and scaleType:
+						style.guiObject.setFontScale(scaleType, size)
 			style.setValue(eWindowStyleSkinned.valueEntryLeftOffset, parseInteger(configList.attrib.get("entryLeftOffset", "15")))
 			style.setValue(eWindowStyleSkinned.valueHeaderLeftOffset, parseInteger(configList.attrib.get("headerLeftOffset", "15")))
 			style.setValue(eWindowStyleSkinned.valueIndentSize, parseInteger(configList.attrib.get("indentSize", "20")))


### PR DESCRIPTION
[eLabel/eListbox] add font auto-scaling and RT_SCROLL flag for multicontent

- gFont: add pointWidth for horizontal font compression
- eLabel: setFontScale(type, minSize) — type 1 shrinks pointSize, type 2 compresses horizontally via pointWidth
- eListbox: propagate fontScaleType/fontScaleSize through style; makeFontScale() applies scaling per rendered item in string and config content
- eListboxStyle: add m_wrap flag; RT_ELLIPSIS applied when wrap==2
- eListboxPythonConfigContent: pre-measure value width so label and value never overlap; value rendered right-aligned in full item width
- eListboxPythonMultiContent: new RT_SCROLL flag (1024) enables per-element scroll text on selected row
- skin.py: parseFontScale() parses "size;<n>" / "width;<n>"; fontScale attribute for widgets, entryFontScale for configList style
- elistboxcontent.h: promote scroll state members to protected so multi-content subclass can share scroll infrastructure
- Guard zero-size scroll pixmap allocation in updateTextSize / createScrollPixmap