### PR TITLE
[Config] Fix config notifier not triggered when changing a value back

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -149,6 +149,7 @@ class ConfigElement:
 		self.saved_value = None if self.save_disabled or (self.value == self.default and not self.saveForced) else self.toString(self.value)
 		if self.value != self.loadValue:
 			self.changedFinal()  # Call non-immediate_feedback notifiers, immediate_feedback notifiers are called as the values chanage.
+		self.loadValue = self.value
 
 	def setReadOnly(self, value):
 		self.readOnly = value

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -146,8 +146,11 @@ class ConfigElement:
 		if self.loadValue is None:
 			self.loadValue = self.default if self.saved_value is None else self.fromString(self.saved_value)
 		# print(f"[Config] save DEBUG: Load='{self.loadValue}', Value='{self.value}'.")
-		self.saved_value = None if self.save_disabled or (self.value == self.default and not self.saveForced) else self.toString(self.value)
-		if self.value != self.loadValue:
+		value = self.value
+		self.saved_value = None if self.save_disabled or (value == self.default and not self.saveForced) else self.toString(value)
+		changed = value != self.loadValue
+		self.loadValue = value
+		if changed:
 			self.changedFinal()  # Call non-immediate_feedback notifiers, immediate_feedback notifiers are called as the values chanage.
 
 	def setReadOnly(self, value):


### PR DESCRIPTION
[Config] Fix config notifier not triggered when changing a value back

Problem:
When a config element was changed from its default value and saved, then changed back to the default and saved again, the final notifiers (changedFinal) were not triggered on the second save.

Example: config.usage.tuxtxt_CleanAlgo
- Initial state:  value = 0 (default), loadValue = 0, saved_value = None
- Change to 1, save:  value(1) != loadValue(0) -> changedFinal fires But loadValue was never updated -- it remained 0.
- Change back to 0, save:  value(0) == loadValue(0) -> changedFinal does NOT fire

The guard condition "if self.value != self.loadValue" in save() is intended to detect whether the value actually changed since the last load/save. However, loadValue was only initialized once (when None) at the start of save() and was never updated afterwards. After the first save, loadValue drifted out of sync with the actually saved value, causing the notifier to be silently skipped on any subsequent save that happened to match the stale loadValue.

Fix:
Update loadValue = self.value unconditionally at the end of save(), so that it always reflects the value as it was last persisted. The next call to save() then correctly compares against the most recently saved value rather than the value from the initial load().

This change does not affect cancel(), which always recalculates loadValue independently from saved_value.

Fixes: https://github.com/openatv/enigma2/issues/3615