### PR TITLE
[pmt] Fix crash on empty audioStreams with active default subtitle st…

### DIFF
--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -869,7 +869,13 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 			else if (allow_hearingimpaired && autosub_dvb_hearing != -1)
 				program.defaultSubtitleStream = autosub_dvb_hearing;
 		}
-		if (program.defaultSubtitleStream != -1 && (program.audioStreams[program.defaultAudioStream].language_code.empty() || ((equallanguagemask & (1<<(autosub_level-1))) == 0 && compareAudioSubtitleCode(program.subtitleStreams[program.defaultSubtitleStream].language_code, program.audioStreams[program.defaultAudioStream].language_code) == 0)))
+		if (program.defaultSubtitleStream != -1
+			&& (program.audioStreams.empty()
+				|| program.defaultAudioStream < 0
+				|| program.defaultAudioStream >= (int)program.audioStreams.size()
+				|| program.audioStreams[program.defaultAudioStream].language_code.empty()
+				|| ((equallanguagemask & (1<<(autosub_level-1))) == 0
+					&& compareAudioSubtitleCode(program.subtitleStreams[program.defaultSubtitleStream].language_code, program.audioStreams[program.defaultAudioStream].language_code) == 0)))
 			program.defaultSubtitleStream = -1;
 
 		ret = 0;


### PR DESCRIPTION
…ream

Fault address 0x14 on ARM32: program.audioStreams[0] on empty vector dereferences nullptr, then .language_code.empty() reads _M_string_length at offset 4 of std::string at audioStream offset 16 (pid+rdsPid+type+component_tag) = 0x14.

Trigger seen on Eutelsat 9B 11958V (MTVA) after several minutes: a PMT update with a matched-language subtitle stream but no audio ES recognized by the parser's stream_type switch causes the crash on the next eventNewProgramInfo dispatch through eDVBServicePlay::serviceEvent.

Bounds-check audioStreams before accessing defaultAudioStream index; fall back to clearing defaultSubtitleStream when no valid audio exists.