### PR TITLE
[DreamNextGen] Audio settings: AC4 downmix/passthrough selector

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -12,6 +12,7 @@
 			</if>
 		</if>
 		<item level="1" text="AC3 plus transcoding" description="Select whether AC3 Plus audio tracks should be transcoded to AC3." requires="CanAC3plusTranscode">config.av.transcodeac3plus</item>
+		<item level="1" text="AC4" description="Select whether AC4 (Dolby Atmos) audio tracks should be passed through to the AVR, downmixed to stereo, or auto-routed based on HDMI sink capability." requires="CanAC4">config.av.ac4</item>
 		<item level="1" text="DTS downmix" description="Select whether DTS channel audio tracks should be downmixed to stereo." requires="CanDownmixDTS">config.av.downmix_dts</item>
 		<item level="1" text="DTS/DTS-HD HR/DTS-HD MA/DTS:X" description="Select whether DTS channel audio tracks should be downmixed or transcoded." requires="CanDTSHD">config.av.dtshd</item>
 		<item level="1" text="Dolby TrueHD" description="Select whether Dolby TrueHD audio tracks should be passed through or decoded." requires="CanTrueHD">config.av.truehd</item>

--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -652,6 +652,16 @@ def InitAVSwitch():
 		config.av.transcodeac3plus = ConfigSelection(default="force_ac3", choices=choiceList)
 		if MACHINEBUILD not in ("dreamone", "dreamtwo"):
 			config.av.transcodeac3plus.addNotifier(setAC3plusTranscode)
+	AC4 = MACHINEBUILD in ("dreamone", "dreamtwo")
+	BoxInfo.setItem("CanAC4", AC4)
+	if AC4:
+		config.av.ac4 = ConfigSelection(default="hdmi_best", choices=[
+			("hdmi_best", _("Use best / Controlled by HDMI")),
+			("passthrough", _("Pass-through")),
+			("downmix", _("Downmix"))
+		])
+	else:
+		config.av.ac4 = ConfigNothing()
 	dtsHD = fileReadLine("/proc/stb/audio/dtshd_choices", default=None, source=MODULE_NAME)
 	dtsHD = dtsHD.split() if dtsHD else False
 	if not dtsHD and MACHINEBUILD in ("dreamone", "dreamtwo"):

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -193,6 +193,12 @@ class AudioSelection(ConfigListScreen, Screen):
 				self.settings.transcodeac3plus.addNotifier(self.setAC3plusTranscode, initial_call=False)
 				conflist.append(getConfigListEntry(_("AC3plus transcoding"), self.settings.transcodeac3plus, None))
 
+			if BoxInfo.getItem("CanAC4"):
+				choice_list = [("hdmi_best", _("Use best / Controlled by HDMI")), ("passthrough", _("Pass-through")), ("downmix", _("Downmix"))]
+				self.settings.ac4 = ConfigSelection(choices=choice_list, default=config.av.ac4.value)
+				self.settings.ac4.addNotifier(self.setAC4, initial_call=False)
+				conflist.append(getConfigListEntry("AC4", self.settings.ac4, None))
+
 			if BoxInfo.getItem("CanPcmMultichannel"):
 				if BoxInfo.getItem("machinebuild") in ("dm900", "dm920", "dm7080", "dm820", "dm520"):
 					choice_list = [("downmix", _("Downmix")), ("passthrough", _("Pass-through")), ("multichannel", _("Convert to multi-channel PCM")), ("hdmi_best", _("Use best / Controlled by HDMI"))]
@@ -491,6 +497,10 @@ class AudioSelection(ConfigListScreen, Screen):
 	def setTrueHD(self, downmix):
 		config.av.truehd.setValue(downmix.value)
 		config.av.truehd.save()
+
+	def setAC4(self, downmix):
+		config.av.ac4.setValue(downmix.value)
+		config.av.ac4.save()
 
 	def changeDTSDownmix(self, downmix):
 		if downmix.value:


### PR DESCRIPTION
Adds config.av.ac4 (Downmix / Pass-through) with a CanAC4 BoxInfo gate for dreamone/dreamtwo, exposed in the Audio settings screen right after the AC3+ transcoding entry. Pass-through is the UI hook for the future IEC 61937 AC-4 burst path; the current backend always uses the PCM downmix path.