### PR TITLE
[Positioner/SatCR] Add Unicable PIN, rotor position tracking, and per…

### DIFF
--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -1708,11 +1708,25 @@ error:
 	return ret;
 }
 
-bool eDVBResourceManager::canMeasureFrontendInputPower()
+int eDVBResourceManager::readFrontendInputPower(int slotid)
 {
 	for (eSmartPtrList<eDVBRegisteredFrontend>::iterator i(m_frontend.begin()); i != m_frontend.end(); ++i)
 	{
-		return i->m_frontend->readInputpower() >= 0;
+		if (i->m_frontend->getSlotID() == slotid)
+			return i->m_frontend->readInputpower();
+	}
+	return -1;
+}
+
+bool eDVBResourceManager::canMeasureFrontendInputPower(int slotid)
+{
+	if (slotid >= 0)
+		return readFrontendInputPower(slotid) >= 0;
+
+	for (eSmartPtrList<eDVBRegisteredFrontend>::iterator i(m_frontend.begin()); i != m_frontend.end(); ++i)
+	{
+		if (i->m_frontend->readInputpower() >= 0)
+			return true;
 	}
 	return false;
 }

--- a/lib/dvb/dvb.h
+++ b/lib/dvb/dvb.h
@@ -246,7 +246,8 @@ public:
 public:
 #endif
 	int canAllocateFrontend(ePtr<iDVBFrontendParameters> &feparm, bool simulate=false);
-	bool canMeasureFrontendInputPower();
+	bool canMeasureFrontendInputPower(int slotid=-1);
+	int readFrontendInputPower(int slotid);
 	PSignal1<void,int> frontendUseMaskChanged;
 	SWIG_VOID(RESULT) allocateRawChannel(eUsePtr<iDVBChannel> &SWIG_OUTPUT, int slot_index);
 	PyObject *setFrontendSlotInformations(SWIG_PYOBJECT(ePyObject) list);

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -3205,7 +3205,7 @@ RESULT eDVBFrontend::tune(const iDVBFrontendParameters &where, bool blindscan)
 		switch (diction)
 		{
 			case 1:
-				if(pin < 1)
+				if(pin < 0)
 				{
 					diseqc.len = 4;
 					diseqc.data[0] = 0x70;
@@ -3222,7 +3222,7 @@ RESULT eDVBFrontend::tune(const iDVBFrontendParameters &where, bool blindscan)
 				break;
 			case 0:
 			default:
-				if(pin < 1)
+				if(pin < 0)
 				{
 					diseqc.len = 5;
 					diseqc.data[2] = 0x5A;

--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -939,12 +939,12 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 				}
 				eDebugNoSimulate("[eDVBSatelliteEquipmentControl] tune timeout %dms", tunetimeout);
 
-				if((oldSatcr != -1) && (oldSatcr != lnb_param.SatCR_idx))
+				if((oldSatcr != -1) && (oldSatcr != lnb_param.SatCR_idx || oldDiction != lnb_param.SatCR_format || oldPin != lnb_param.SatCR_pin))
 				{
 					switch (oldDiction)
 					{
 						case 1:
-							if(oldPin < 1)
+							if(oldPin < 0)
 							{
 								diseqc.len = 4;
 								diseqc.data[0] = 0x70;
@@ -961,7 +961,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 							break;
 						case 0:
 						default:
-							if(oldPin < 1)
+							if(oldPin < 0)
 							{
 								diseqc.len = 5;
 								diseqc.data[2] = 0x5A;
@@ -989,18 +989,15 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 
 
 				frontend.setData(eDVBFrontend::DICTION, lnb_param.SatCR_format);
-//TODO				frontend.setData(eDVBFrontend::PIN, lnb_param.SatCR_pin);
-
-//>>> HACK adenin20150421
-				long pin = 0;
-//<<<
+				frontend.setData(eDVBFrontend::PIN, lnb_param.SatCR_pin);
+				long pin = lnb_param.SatCR_pin;
 //>>> TODO optimize this
 				if(lnb_param.SatCR_switch_reliable && gfrq && gfrq_a)
 				{
 					switch(lnb_param.SatCR_format)
 					{
 						case 1: //JESS
-							if(pin < 1)
+							if(pin < 0)
 							{
 								diseqc.len = diseqc_a.len = 4;
 								diseqc.data[0] = diseqc_a.data[0] = 0x70;
@@ -1021,7 +1018,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 							break;
 						case 0: //DiSEqC
 						default:
-							if(pin < 1)
+							if(pin < 0)
 							{
 								diseqc.len = diseqc_a.len = 5;
 								diseqc.data[2] = diseqc_a.data[2] = 0x5A;
@@ -1058,7 +1055,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 				switch(lnb_param.SatCR_format)
 				{
 					case 1: //JESS
-						if(pin < 1)
+						if(pin < 0)
 						{
 							diseqc.len = 4;
 							diseqc.data[0] = 0x70;
@@ -1078,7 +1075,7 @@ RESULT eDVBSatelliteEquipmentControl::prepare(iDVBFrontend &frontend, const eDVB
 						break;
 					case 0: //DiSEqC
 					default:
-						if(pin < 1)
+						if(pin < 0)
 						{
 							diseqc.len = 5;
 							diseqc.data[2] = 0x5A;
@@ -1404,7 +1401,7 @@ void eDVBSatelliteEquipmentControl::prepareTurnOffSatCR(iDVBFrontend &frontend)
 	switch (diction)
 	{
 		case 1:
-			if(pin < 1)
+			if(pin < 0)
 			{
 				diseqc.len = 4;
 				diseqc.data[0] = 0x70;
@@ -1421,7 +1418,7 @@ void eDVBSatelliteEquipmentControl::prepareTurnOffSatCR(iDVBFrontend &frontend)
 			break;
 		case 0:
 		default:
-			if(pin < 1)
+			if(pin < 0)
 			{
 				diseqc.len = 5;
 				diseqc.data[2] = 0x5A;
@@ -1491,6 +1488,7 @@ RESULT eDVBSatelliteEquipmentControl::clear()
 		it->m_frontend->setData(eDVBFrontend::ROTOR_POS, -1);
 		it->m_frontend->setData(eDVBFrontend::ROTOR_CMD, -1);
 		it->m_frontend->setData(eDVBFrontend::SATCR, -1);
+		it->m_frontend->setData(eDVBFrontend::PIN, -1);
 
 		if (it->m_frontend->is_FBCTuner())
 		{
@@ -1508,6 +1506,7 @@ RESULT eDVBSatelliteEquipmentControl::clear()
 		it->m_frontend->setData(eDVBFrontend::ROTOR_POS, -1);
 		it->m_frontend->setData(eDVBFrontend::ROTOR_CMD, -1);
 		it->m_frontend->setData(eDVBFrontend::SATCR, -1);
+		it->m_frontend->setData(eDVBFrontend::PIN, -1);
 	}
 
 	return 0;
@@ -1517,7 +1516,10 @@ RESULT eDVBSatelliteEquipmentControl::clear()
 RESULT eDVBSatelliteEquipmentControl::addLNB()
 {
 	if ( (m_lnbidx+1) < (int)(sizeof(m_lnbs) / sizeof(eDVBSatelliteLNBParameters)))
+	{
 		m_curSat=m_lnbs[++m_lnbidx].m_satellites.end();
+		m_lnbs[m_lnbidx].SatCR_pin = -1;
+	}
 	else
 	{
 		eDebug("[eDVBSatelliteEquipmentControl] no more LNB free... cnt is %d", m_lnbidx);
@@ -1807,6 +1809,18 @@ RESULT eDVBSatelliteEquipmentControl::setLNBSatCRvco(int SatCRvco)
 	return 0;
 }
 
+RESULT eDVBSatelliteEquipmentControl::setLNBSatCRpin(int SatCR_pin)
+{
+	eSecDebug("[eDVBSatelliteEquipmentControl] eDVBSatelliteEquipmentControl::setLNBSatCRpin(%d)", SatCR_pin);
+	if (SatCR_pin < -1 || SatCR_pin > 255)
+		return -EPERM;
+	if (currentLNBValid())
+		m_lnbs[m_lnbidx].SatCR_pin = SatCR_pin;
+	else
+		return -ENOENT;
+	return 0;
+}
+
 RESULT eDVBSatelliteEquipmentControl::setLNBSatCRpositions(int SatCR_positions)
 {
 	eSecDebug("[eDVBSatelliteEquipmentControl] eDVBSatelliteEquipmentControl::setLNBSatCRpositions(%d)", SatCR_positions);
@@ -1844,6 +1858,13 @@ RESULT eDVBSatelliteEquipmentControl::getLNBSatCRvco()
 {
 	if ( currentLNBValid() )
 		return m_lnbs[m_lnbidx].SatCRvco;
+	return -ENOENT;
+}
+
+RESULT eDVBSatelliteEquipmentControl::getLNBSatCRpin()
+{
+	if (currentLNBValid())
+		return m_lnbs[m_lnbidx].SatCR_pin;
 	return -ENOENT;
 }
 

--- a/lib/dvb/sec.h
+++ b/lib/dvb/sec.h
@@ -287,6 +287,7 @@ public:
 	int SatCR_positions;
 	int SatCR_idx;
 	int SatCR_format;
+	int SatCR_pin;
 	int SatCR_switch_reliable;
 	int SatCR_RetuneNoPatEntry;
 	int BootUpTime;
@@ -390,10 +391,12 @@ public:
 	RESULT setLNBSatCRformat(int SatCR_format);	//DiSEqc or JESS (or ...)
 	RESULT setLNBSatCR(int SatCR_idx);
 	RESULT setLNBSatCRvco(int SatCRvco);
+	RESULT setLNBSatCRpin(int SatCR_pin);
 	RESULT setLNBSatCRpositions(int SatCR_positions);
 	RESULT getLNBSatCRformat();	//DiSEqc or JESS (or ...)
 	RESULT getLNBSatCR();
 	RESULT getLNBSatCRvco();
+	RESULT getLNBSatCRpin();
 	RESULT getLNBSatCRpositions();
 /* Satellite Specific Parameters */
 	RESULT addSatellite(int orbital_position);

--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import datetime
 from os import F_OK, access
 from os.path import exists
@@ -8,7 +9,7 @@ from enigma import eDVBSatelliteEquipmentControl as secClass, \
 	eDVBSatelliteDiseqcParameters as diseqcParam, \
 	eDVBSatelliteSwitchParameters as switchParam, \
 	eDVBSatelliteRotorParameters as rotorParam, \
-	eDVBResourceManager, eDVBDB, eEnv, iDVBFrontend
+	eDVBResourceManager, eDVBDB, eEnv, getLinkedSlotID, iDVBFrontend, isFBCLink
 
 from Components.config import config, ConfigSubsection, ConfigSelection, ConfigFloat, ConfigSatlist, ConfigYesNo, ConfigInteger, ConfigSubList, ConfigNothing, ConfigSubDict, ConfigOnOff, ConfigDateTime, ConfigText
 from Components.SystemInfo import BoxInfo
@@ -24,8 +25,8 @@ MODULE_NAME = __name__.split(".")[-1]
 # LNB69 3605 Selecting satellites 1 (USALS)
 # LNB70 3606 Selecting satellites 2 (USALS)
 #
-MAX_LNB_WILDCARDS = 6
-MAX_ORBITPOSITION_WILDCARDS = 6
+MAX_LNB_WILDCARDS = 7
+MAX_ORBITPOSITION_WILDCARDS = 7
 ORBITPOSITION_LIMIT = 3600  # Magic number.
 iDVBFrontendDict = {
 	iDVBFrontend.feSatellite: "DVB-S",
@@ -43,6 +44,31 @@ def getConfigSatlist(orbPos, satList):
 			defaultOrbPos = orbPos
 			break
 	return ConfigSatlist(satList, defaultOrbPos)
+
+
+def orbitalPositionInList(orbitalPosition, orbitalPositionList):
+	"""Return whether an orbital position is an exact member of a saved ConfigText list."""
+	positions = str(orbitalPositionList).strip("[]").replace(",", " ").split()
+	return str(orbitalPosition) in positions
+
+
+def inputPowerSlotForNim(slotid, nimmgr=None):
+	if nimmgr is None:
+		nimmgr = nimmanager
+	if isFBCLink(slotid):
+		linkedSlot = getLinkedSlotID(slotid)
+		if linkedSlot >= 0:
+			return linkedSlot
+		if 0 <= slotid < len(nimmgr.nim_slots):
+			rootSlot = nimmgr.nim_slots[slotid].getFBCRootId(nimmgr.nim_slots)
+			if rootSlot is not None:
+				return rootSlot
+	return slotid
+
+
+def canMeasureInputPowerForNim(slotid, nimmgr=None):
+	resourceManager = eDVBResourceManager.getInstance()
+	return bool(resourceManager and resourceManager.canMeasureFrontendInputPower(inputPowerSlotForNim(slotid, nimmgr)))
 
 
 class SecConfigure:
@@ -68,6 +94,7 @@ class SecConfigure:
 			for slot in self.linked[slotid]:
 				tunermask |= (1 << slot)
 		sec.setLNBSatCR(-1)
+		sec.setLNBSatCRpin(-1)
 		sec.setLNBSatCRTuningAlgo(0)
 		sec.setLNBBootupTime(0)
 		sec.setLNBSatCRpositionnumber(1)
@@ -115,10 +142,10 @@ class SecConfigure:
 				user_satList = []
 				if orbpos and isinstance(orbpos, str):
 					for user_sat in self.NimManager.satList:
-						if str(user_sat[0]) in orbpos:
+						if orbitalPositionInList(user_sat[0], orbpos):
 							user_satList.append(user_sat)
 			for x in user_satList:
-				print("[NimManager] Add sat %s" % str(x[0]))
+				print(f"[NimManager] Add sat {str(x[0])}")
 				self.addSatellite(sec, int(x[0]))
 				if diseqc13V:
 					sec.setVoltageMode(switchParam.HV_13)
@@ -130,7 +157,7 @@ class SecConfigure:
 		sec.setLNBSlotMask(tunermask)
 
 	def setSatposDepends(self, sec, nim1, nim2):
-		print("[NimManager] tuner %s depends on satpos of %s" % (nim1, nim2))
+		print(f"[NimManager] tuner {nim1} depends on satpos of {nim2}")
 		sec.setTunerDepends(nim1, nim2)
 
 	def linkInternally(self, slotid):
@@ -139,7 +166,7 @@ class SecConfigure:
 			nim.setInternalLink()
 
 	def linkNIMs(self, sec, nim1, nim2):
-		print("[NimManager] link tuner %s to tuner %s" % (nim1, nim2))
+		print(f"[NimManager] link tuner {nim1} to tuner {nim2}")
 		# for internally connect tuner A to B
 		if BoxInfo.getItem("machinebuild") == 'vusolo2' or nim2 == (nim1 - 1):
 			self.linkInternally(nim1)
@@ -232,13 +259,14 @@ class SecConfigure:
 			x = slot.slot
 			if slot.canBeCompatible("DVB-S"):
 				nim = slot.config.dvbs
-				print("[NimManager] slot: %s configmode: %s" % (str(x), str(nim.configMode.value)))
+				clearLastSatRotorPosition = True
+				print(f"[NimManager] slot: {str(x)} configmode: {str(nim.configMode.value)}")
 				if nim.configMode.value in ("loopthrough", "satposdepends", "nothing"):
 					pass
 				else:
 					sec.setSlotNotLinked(x)
 					if nim.configMode.value == "equal":
-						pass
+						clearLastSatRotorPosition = False
 					elif nim.configMode.value == "simple":		#simple config
 						print("[NimManager] diseqcmode: ", nim.diseqcMode.value)
 						if nim.diseqcMode.value == "single":			#single
@@ -265,6 +293,7 @@ class SecConfigure:
 							self.addLNBSimple(sec, slotid=x, orbpos=nim.diseqcC.orbital_position, toneburstmode=diseqcParam.NO, diseqcmode=diseqcParam.V1_0, diseqcpos=diseqcParam.BA, fastDiSEqC=fastDiSEqC, setVoltageTone=setVoltageTone, diseqc13V=nim.diseqc13V.value)
 							self.addLNBSimple(sec, slotid=x, orbpos=nim.diseqcD.orbital_position, toneburstmode=diseqcParam.NO, diseqcmode=diseqcParam.V1_0, diseqcpos=diseqcParam.BB, fastDiSEqC=fastDiSEqC, setVoltageTone=setVoltageTone, diseqc13V=nim.diseqc13V.value)
 						elif nim.diseqcMode.value in ("positioner", "positioner_select"):		#Positioner
+							clearLastSatRotorPosition = False
 							current_mode = 3
 							sat = 0
 							if nim.diseqcMode.value == "positioner_select":
@@ -281,7 +310,7 @@ class SecConfigure:
 							inputPowerDelta = nim.powerThreshold.value
 							useInputPower = False
 							turning_speed = 0
-							if nim.powerMeasurement.value:
+							if nim.powerMeasurement.value and canMeasureInputPowerForNim(x, self.NimManager):
 								useInputPower = True
 								turn_speed_dict = {"fast": rotorParam.FAST, "slow": rotorParam.SLOW}
 								if nim.turningSpeed.value in turn_speed_dict:
@@ -302,13 +331,17 @@ class SecConfigure:
 								inputPowerDelta=inputPowerDelta,
 								diseqc13V=nim.diseqc13V.value)
 					elif nim.configMode.value == "advanced":  # advanced config
+						clearLastSatRotorPosition = not self.NimManager.getRotorSatListForNim(x, onlyFirst=True)
 						self.updateAdvanced(sec, x)
+				if clearLastSatRotorPosition and nim.lastsatrotorposition.value:
+					nim.lastsatrotorposition.value = ""
+					nim.lastsatrotorposition.save()
 			if slot.canBeCompatible("DVB-T"):
 				nim = slot.config.dvbt
-				print("[NimManager] slot: %s configmode: %s" % (str(x), str(nim.configMode.value)))
+				print(f"[NimManager] slot: {str(x)} configmode: {str(nim.configMode.value)}")
 			if slot.canBeCompatible("DVB-C"):
 				nim = slot.config.dvbc
-				print("[NimManager] slot: %s configmode: %s" % (str(x), str(nim.configMode.value)))
+				print(f"[NimManager] slot: {str(x)} configmode: {str(nim.configMode.value)}")
 
 		for slot in nim_slots:
 			if slot.frontend_id is not None:
@@ -346,46 +379,67 @@ class SecConfigure:
 			pass
 
 		lnbSat = {}
-		for x in list(range(1, 71)):
+		for x in range(1, 72):
 			lnbSat[x] = []
 
-		#wildcard for all satellites ( for rotor )
-		for x in list(range(3601, 3605)):
+		# Wildcard for all satellites ( for rotor )
+		for x in range(3601, 3605):
 			lnb = int(advanced.sat[x].lnb.value)
 			if lnb != 0:
 				for x in self.NimManager.satList:
-					print("[NimManager] add %s to %s" % (x[0], lnb))
+					print(f"[NimManager] add {x[0]} to {lnb}")
 					lnbSat[lnb].append(x[0])
 
-		#wildcard for user satellites ( for rotor )
-		for x in list(range(3605, 3607)):
+		# Wildcard for user satellites ( for rotor )
+		for x in range(3605, 3607):
 			lnb = int(advanced.sat[x].lnb.value)
 			if lnb != 0:
 				for user_sat in self.NimManager.satList:
-					if str(user_sat[0]) in advanced.sat[x].userSatellitesList.value:
-						print("[NimManager] add %s to %s" % (user_sat[0], lnb))
+					if orbitalPositionInList(user_sat[0], advanced.sat[x].userSatellitesList.value):
+						print(f"[NimManager] add {user_sat[0]} to {lnb}")
 						lnbSat[lnb].append(user_sat[0])
 
 		for x in self.NimManager.satList:
 			lnb = int(advanced.sat[x[0]].lnb.value)
 			if lnb != 0:
-				print("[NimManager] add %s to %s" % (x[0], lnb))
+				print(f"[NimManager] add {x[0]} to {lnb}")
 				lnbSat[lnb].append(x[0])
 
-		for x in list(range(1, 71)):
+		# Additional cable from an existing motorized LNB. This tuner inherits
+		# the source rotor's satellite list but never sends motor commands itself.
+		lnb = int(advanced.sat[3607].lnb.value)
+		if lnb != 0:
+			sourceSlot = config.Nims[slotid].dvbs.connectedTo.value
+			rotorSatList = sourceSlot.isdigit() and self.NimManager.getRotorSatListForNim(int(sourceSlot))
+			if rotorSatList:
+				for satellite in rotorSatList:
+					lnbSat[lnb].append(satellite[0])
+			else:
+				advanced.sat[3607].lnb.value = "0"
+				advanced.sat[3607].lnb.save()
+				if not self.NimManager.getSatListForNim(slotid):
+					config.Nims[slotid].dvbs.configMode.value = "nothing"
+					config.Nims[slotid].dvbs.configMode.save()
+					if hasattr(advanced, "unicableconnected") and advanced.unicableconnected.value:
+						advanced.unicableconnected.value = False
+						advanced.unicableconnected.save()
+						advanced.unicableconnectedTo.save_forced = False
+					return
+
+		for x in range(1, 72):
 			if len(lnbSat[x]) > 0:
 				currLnb = advanced.lnb[x]
 				if sec.addLNB():
 					print("[NimManager] No space left on m_lnbs (max No. 144 LNBs exceeded)")
 					return
+				if x == maxFixedLnbPositions + MAX_LNB_WILDCARDS:
+					sourceSlot = int(config.Nims[slotid].dvbs.connectedTo.value)
+					sec.setLNBsatposdepends(sourceSlot)
 
-				posnum = 1
-				#default if LNB movable
-				if x <= maxFixedLnbPositions:
-					posnum = x
-					sec.setLNBSatCRpositionnumber(x)  # LNB has fixed Position
-				else:
-					sec.setLNBSatCRpositionnumber(0)  # or not (movable LNB)
+				posnum = x if x <= maxFixedLnbPositions else 1
+				if x <= maxFixedLnbPositions and currLnb.lof.value == "unicable" and currLnb.unicablePosition.value:
+					posnum = currLnb.unicablePosition.value
+				sec.setLNBSatCRpositionnumber(posnum if x <= maxFixedLnbPositions else 0)
 
 				tunermask = 1 << slotid
 				if slotid in self.equal:
@@ -396,6 +450,7 @@ class SecConfigure:
 						tunermask |= (1 << slot)
 				if currLnb.lof.value != "unicable":
 					sec.setLNBSatCR(-1)
+					sec.setLNBSatCRpin(-1)
 					sec.setLNBSatCRTuningAlgo(0)
 					sec.setLNBBootupTime(0)
 				if currLnb.lof.value == "universal_lnb":
@@ -403,6 +458,15 @@ class SecConfigure:
 					sec.setLNBLOFH(10600000)
 					sec.setLNBThreshold(11700000)
 				elif currLnb.lof.value == "unicable":
+					pinLnb = currLnb
+					if 1 < x <= maxFixedLnbPositions and currLnb.unicableUseLnb1UserBand.value:
+						try:
+							pinLnb = config.Nims[slotid].dvbs.advanced.lnb[1]
+						except (AttributeError, KeyError):
+							pass
+					pin = pinLnb.unicable_pin.value if pinLnb.unicable_use_pin.value else -1
+					sec.setLNBSatCRpin(pin)
+
 					def setupUnicable(configManufacturer, ProductDict):
 						manufacturer_name = configManufacturer.value
 						manufacturer = ProductDict[manufacturer_name]
@@ -424,7 +488,7 @@ class SecConfigure:
 								sec.setLNBLOFH(manufacturer.lofh[product_name][position_idx].value * 1000)
 								sec.setLNBThreshold(manufacturer.loft[product_name][position_idx].value * 1000)
 								sec.setLNBSatCRTuningAlgo(["traditional", "reliable", "traditional_retune", "reliable_retune"].index(currLnb.unicableTuningAlgo.value))
-								sec.setLNBBootupTime(manufacturer.bootuptime[product_name][0].value)
+								sec.setLNBBootupTime(0 if currLnb.powerInserter.value else manufacturer.bootuptime[product_name][0].value)
 								configManufacturer.save_forced = True
 								manufacturer.product.save_forced = True
 								manufacturer.vco[product_name][manufacturer_scr[product_name].index].save_forced = True
@@ -448,7 +512,7 @@ class SecConfigure:
 						sec.setLNBLOFH(currLnb.lofh.value * 1000)
 						sec.setLNBThreshold(currLnb.threshold.value * 1000)
 						sec.setLNBSatCRpositions(64)
-						sec.setLNBBootupTime(currLnb.bootuptimeuser.value)
+						sec.setLNBBootupTime(0 if currLnb.powerInserter.value else currLnb.bootuptimeuser.value)
 					elif currLnb.unicable.value == "unicable_matrix":
 						self.reconstructUnicableData(currLnb.unicableMatrixManufacturer, currLnb.unicableMatrix, currLnb)
 						setupUnicable(currLnb.unicableMatrixManufacturer, currLnb.unicableMatrix)
@@ -478,6 +542,8 @@ class SecConfigure:
 					sec.setLNBIncreasedVoltage(False)
 
 				dm = currLnb.diseqcMode.value
+				if self.NimManager.nim_slots[slotid].isFBCLink() and dm == "1_2":
+					dm = "none"
 				if dm == "none":
 					sec.setDiSEqCMode(diseqcParam.NONE)
 				elif dm == "1_0":
@@ -543,9 +609,9 @@ class SecConfigure:
 					sec.setCommandOrder(order_map[currCO])
 
 				if dm == "1_2":
-					latitude = currLnb.latitude.float
+					latitude = currLnb.latitude.float if isinstance(currLnb.latitude, ConfigFloat) else 50.767
 					sec.setLatitude(latitude)
-					longitude = currLnb.longitude.float
+					longitude = currLnb.longitude.float if isinstance(currLnb.longitude, ConfigFloat) else 5.1
 					sec.setLongitude(longitude)
 					if currLnb.latitudeOrientation.value == "north":
 						sec.setLaDirection(rotorParam.NORTH)
@@ -556,7 +622,7 @@ class SecConfigure:
 					else:
 						sec.setLoDirection(rotorParam.WEST)
 
-					if currLnb.powerMeasurement.value:
+					if currLnb.powerMeasurement.value and canMeasureInputPowerForNim(slotid, self.NimManager):
 						sec.setUseInputpower(True)
 						sec.setInputpowerDelta(currLnb.powerThreshold.value)
 						turn_speed_dict = {"fast": rotorParam.FAST, "slow": rotorParam.SLOW}
@@ -616,11 +682,11 @@ class SecConfigure:
 			SDict = val.get('unicableMatrix', None)
 		else:
 			return
-		# print "[reconstructUnicableData] SDict %s" % SDict
+		# print(f"[reconstructUnicableData] SDict {SDict}")
 		if SDict is None:
 			return
 
-		print("[NimManager] [reconstructUnicableData] ManufacturerName %s" % ManufacturerName)
+		print(f"[NimManager] [reconstructUnicableData] ManufacturerName {ManufacturerName}")
 
 		PDict = SDict.get(ManufacturerName, None)			#dict contained last stored device data
 		if PDict is None:
@@ -635,7 +701,7 @@ class SecConfigure:
 			if PN in tmp.product.choices.choices:
 				return
 		else:  # if manufacture not in list, then generate new ConfigSubsection
-			print("[NimManager] [reconstructUnicableData] Manufacturer %s not in unicable.xml" % ManufacturerName)
+			print(f"[NimManager] [reconstructUnicableData] Manufacturer {ManufacturerName} not in unicable.xml")
 			tmp = ConfigSubsection()
 			tmp.scr = ConfigSubDict()
 			tmp.vco = ConfigSubDict()
@@ -649,7 +715,7 @@ class SecConfigure:
 			tmp.positionsoffset = ConfigSubDict()
 
 		if PN not in tmp.product.choices.choices:
-			print("[NimManager] [reconstructUnicableData] Product %s not in unicable.xml" % PN)
+			print(f"[NimManager] [reconstructUnicableData] Product {PN} not in unicable.xml")
 			scrlist = []
 			SatCR = int(PDict.get('scr', {PN: 1}).get(PN, 1)) - 1
 			vco = int(PDict.get('vco', {PN: 0}).get(PN, 0).get(str(SatCR), 1))
@@ -670,12 +736,12 @@ class SecConfigure:
 			tmp.vco[PN] = ConfigSubList()
 
 			for cnt in range(0, SatCR + 1):
-				vcofreq = (cnt == SatCR) and vco or 0		# equivalent to vcofreq = (cnt == SatCR) ? vco : 0
+				vcofreq = (cnt == SatCR) and vco or 0  # equivalent to vcofreq = (cnt == SatCR) ? vco : 0
 				if vcofreq == 0:
 					scrlist.append(("%d" % (cnt + 1), "SCR %d " % (cnt + 1) + _("not used")))
 				else:
 					scrlist.append(("%d" % (cnt + 1), "SCR %d" % (cnt + 1)))
-				print("[NimManager] vcofreq %d" % vcofreq)
+				print(f"[NimManager] vcofreq {vcofreq}")
 				tmp.vco[PN].append(ConfigInteger(default=vcofreq, limits=(vcofreq, vcofreq)))
 
 			tmp.scr[PN] = ConfigSelection(choices=scrlist, default=scrlist[SatCR][0])
@@ -683,7 +749,7 @@ class SecConfigure:
 			tmp.lofl[PN] = ConfigSubList()
 			tmp.lofh[PN] = ConfigSubList()
 			tmp.loft[PN] = ConfigSubList()
-			for cnt in list(range(1, positions + 1)):
+			for cnt in range(1, positions + 1):
 				lofl = int(positionslist[cnt][0])
 				lofh = int(positionslist[cnt][1])
 				loft = int(positionslist[cnt][2])
@@ -817,15 +883,15 @@ class NIM:
 
 	def setInternalLink(self):
 		if self.internally_connectable is not None:
-			print("[NimManager] setting internal link on frontend id %s" % self.frontend_id)
-			f = open("/proc/stb/frontend/%d/rf_switch" % self.frontend_id, "w")
+			print(f"[NimManager] setting internal link on frontend id {self.frontend_id}")
+			f = open(f"/proc/stb/frontend/{self.frontend_id}/rf_switch", "w")
 			f.write("internal")
 			f.close()
 
 	def removeInternalLink(self):
 		if self.internally_connectable is not None:
-			print("[NimManager] removing internal link on frontend id %s" % self.frontend_id)
-			f = open("/proc/stb/frontend/%d/rf_switch" % self.frontend_id, "w")
+			print(f"[NimManager] removing internal link on frontend id {self.frontend_id}")
+			f = open(f"/proc/stb/frontend/{self.frontend_id}/rf_switch", "w")
 			f.write("external")
 			f.close()
 
@@ -1101,9 +1167,9 @@ class NimManager:
 					elif lamedb[0].find("/4/") != -1:
 						version = 4
 					else:
-						print("[NimManager] unknown lamedb version: %s" % lamedb[0])
+						print(f"[NimManager] unknown lamedb version: {lamedb[0]}")
 						return False
-					print("[NimManager] import version %d" % version)
+					print(f"[NimManager] import version {version}")
 
 					collect = False
 					transponders = []
@@ -1159,9 +1225,9 @@ class NimManager:
 						if freq[0] == "s" or freq[0] == "S":
 							if ((version == 3) and len(x[1]) > len(t2_sv3)) or ((version == 4) and len(x[1]) > len(t2_sv4)):
 								continue
-							for y in list(range(0, len(x[0]))):
+							for y in range(0, len(x[0])):
 								tp.update({t1[y]: x[0][y]})
-							for y in list(range(0, len(x[1]))):
+							for y in range(0, len(x[1])):
 								if version == 3:
 									tp.update({t2_sv3[y]: x[1][y]})
 								elif version == 4:
@@ -1360,7 +1426,7 @@ class NimManager:
 					fbc_number = 0
 					fbc_tuner += 1
 
-			# print("[NimManager] DEBUG create NIM %s" % entry)
+			# print(f"[NimManager] DEBUG create NIM {entry}")
 			self.nim_slots.append(NIM(slot=id, description=entry["name"], nimtype=entry["type"], has_outputs=entry["has_outputs"], internally_connectable=entry["internally_connectable"], multi_type=entry["multi_type"], frontend_id=entry["frontend_device"], i2c=entry["i2c"], is_empty=entry["isempty"], input_name=entry.get("input_name", None), supports_blind_scan=entry["supports_blind_scan"], is_fbc=entry["fbc"], number_of_slots=self.number_of_slots))
 
 	def hasNimType(self, chktype):
@@ -1469,7 +1535,7 @@ class NimManager:
 					nimList.remove(nim)
 		return nimList
 
-	def canDependOn(self, slotid):
+	def canDependOn(self, slotid, advancedSatposdepends=""):
 		tunertype = self.getNimType(slotid)
 		tunertype = tunertype[:5]  # DVB-S2X --> DVB-S2 --> DVB-S, DVB-T2 --> DVB-T, DVB-C2 --> DVB-C
 		nimList = self.getNimListOfType(tunertype, slotid)
@@ -1492,14 +1558,18 @@ class NimManager:
 								nimHaveRotor = True
 								break
 				if nimHaveRotor:
-					alreadyConnected = False
-					for testnim in nimList:
-						testmode = self.getNimConfig(testnim).dvbs
-						if testmode.configMode.value == "satposdepends" and int(testmode.connectedTo.value) == int(nim):
-							alreadyConnected = True
-							break
-					if not alreadyConnected:
-						positionerList.append(nim)
+					if advancedSatposdepends:
+						if advancedSatposdepends == "all" or self.nim_slots[nim].isFBCRoot():
+							positionerList.append(nim)
+					else:
+						alreadyConnected = False
+						for testnim in nimList:
+							testmode = self.getNimConfig(testnim).dvbs
+							if testmode.configMode.value == "satposdepends" and int(testmode.connectedTo.value) == int(nim):
+								alreadyConnected = True
+								break
+						if not alreadyConnected:
+							positionerList.append(nim)
 		return positionerList
 
 	def getNimConfig(self, slotid):
@@ -1516,7 +1586,7 @@ class NimManager:
 	def somethingConnected(self, slotid=-1):
 		if slotid == -1:
 			connected = False
-			for id in list(range(self.getSlotCount())):
+			for id in range(self.getSlotCount()):
 				if self.somethingConnected(id):
 					connected = True
 			return connected
@@ -1575,10 +1645,10 @@ class NimManager:
 						result.append(x)
 				if dm == "positioner_select":
 					for x in self.satList:
-						if str(x[0]) in nim.userSatellitesList.value:
+						if orbitalPositionInList(x[0], nim.userSatellitesList.value):
 							result.append(x)
 			elif configMode == "advanced":
-				for x in list(range(3601, 3605)):
+				for x in range(3601, 3605):
 					if int(nim.advanced.sat[x].lnb.value) != 0:
 						for x in self.satList:
 							result.append(x)
@@ -1589,14 +1659,20 @@ class NimManager:
 				for x in range(3605, 3607):
 					if int(nim.advanced.sat[x].lnb.value) != 0:
 						for user_sat in self.satList:
-							if str(user_sat[0]) in nim.advanced.sat[x].userSatellitesList.value and user_sat not in result:
+							if orbitalPositionInList(user_sat[0], nim.advanced.sat[x].userSatellitesList.value) and user_sat not in result:
 								result.append(user_sat)
+				if int(nim.advanced.sat[3607].lnb.value) != 0 and nim.connectedTo.value.isdigit():
+					sourceSlot = int(nim.connectedTo.value)
+					if sourceSlot != slotid:
+						for sourceSatellite in self.getRotorSatListForNim(sourceSlot):
+							if sourceSatellite not in result:
+								result.append(sourceSatellite)
 		return result
 
 	def getNimListForSat(self, orb_pos):
 		return [nim.slot for nim in self.nim_slots if nim.canBeCompatible("DVB-S") and not nim.isFBCLink() and orb_pos in [sat[0] for sat in self.getSatListForNim(nim.slot)]]
 
-	def getRotorSatListForNim(self, slotid):
+	def getRotorSatListForNim(self, slotid, onlyFirst=False):
 		result = []
 		if self.nim_slots[slotid].canBeCompatible("DVB-S"):
 			nim = config.Nims[slotid].dvbs
@@ -1604,15 +1680,21 @@ class NimManager:
 			if configMode == "simple":
 				if nim.diseqcMode.value == "positioner":
 					for x in self.satList:
+						if onlyFirst:
+							return True
 						result.append(x)
 				elif nim.diseqcMode.value == "positioner_select":
 					for x in self.satList:
-						if str(x[0]) in nim.userSatellitesList.value:
+						if orbitalPositionInList(x[0], nim.userSatellitesList.value):
+							if onlyFirst:
+								return True
 							result.append(x)
 			elif configMode == "advanced":
-				for x in list(range(3601, 3605)):
+				for x in range(3601, 3605):
 					if int(nim.advanced.sat[x].lnb.value) != 0:
 						for x in self.satList:
+							if onlyFirst:
+								return True
 							result.append(x)
 				if not result:
 					for x in self.satList:
@@ -1620,13 +1702,30 @@ class NimManager:
 						if lnbnum != 0:
 							lnb = nim.advanced.lnb[lnbnum]
 							if lnb.diseqcMode.value == "1_2":
+								if onlyFirst:
+									return True
 								result.append(x)
-				for x in list(range(3605, 3607)):
+				for x in range(3605, 3607):
 					if int(nim.advanced.sat[x].lnb.value) != 0:
 						for user_sat in self.satList:
-							if str(user_sat[0]) in nim.advanced.sat[x].userSatellitesList.value and user_sat not in result:
+							if orbitalPositionInList(user_sat[0], nim.advanced.sat[x].userSatellitesList.value) and user_sat not in result:
+								if onlyFirst:
+									return True
 								result.append(user_sat)
 		return result
+
+	def rotorLastPositionForNim(self, slotid, number=True):
+		if not 0 <= slotid < len(self.nim_slots):
+			return 9999 if number else _("Not a valid tuner")
+		if not self.getRotorSatListForNim(slotid, onlyFirst=True):
+			return 9998 if number else _("Rotor is not configured")
+		lastRotorPosition = secClass.getInstance().frontendLastRotorOrbitalPosition(slotid)
+		if lastRotorPosition == -1:
+			return -1 if number else _("Unknown")
+		if number:
+			return lastRotorPosition
+		from Tools.Transponder import orbpos
+		return orbpos(lastRotorPosition)
 
 
 def InitSecParams():
@@ -1770,9 +1869,9 @@ def InitNimManager(nimmgr, update_slots=None):
 			scr = []
 			scr_append = scr.append
 			scr_pop = scr.pop
-			for i in list(range(len(lscr))):
+			for i in range(len(lscr)):
 				scr_append(product.get(lscr[i], "0"))
-			for i in list(range(len(lscr))):
+			for i in range(len(lscr)):
 				if scr[len(lscr) - i - 1] == "0":
 					scr_pop()
 				else:
@@ -1839,8 +1938,8 @@ def InitNimManager(nimmgr, update_slots=None):
 	UnicableMatrixManufacturers = list(unicablematrixproducts.keys())
 	UnicableMatrixManufacturers.sort()
 	unicable_choices_default = "unicable_lnb"
-	advanced_lnb_satcr_user_choicesEN50494 = [(f"{i}", f"SatCR {i}") for i in list(range(1, 9))]
-	advanced_lnb_satcr_user_choicesEN50607 = [(f"{i}", f"SatCR {i}") for i in list(range(1, 33))]
+	advanced_lnb_satcr_user_choicesEN50494 = [(f"{i}", f"SatCR {i}") for i in range(1, 9)]
+	advanced_lnb_satcr_user_choicesEN50607 = [(f"{i}", f"SatCR {i}") for i in range(1, 33)]
 	advanced_lnb_diction_user_choices = [("EN50494", "Unicable(EN50494)"), ("EN50607", "JESS(EN50607)")]
 	prio_list = [("-1", _("Auto"))]
 	for prio in list(range(65)) + list(range(14000, 14065)) + list(range(19000, 19065)):
@@ -1855,7 +1954,7 @@ def InitNimManager(nimmgr, update_slots=None):
 			description = _(" (higher than any auto)")
 		prio_list.append((str(prio), str(prio) + description))
 	advanced_lnb_csw_choices = [("none", _("None")), ("AA", _("Port A")), ("AB", _("Port B")), ("BA", _("Port C")), ("BB", _("Port D"))]
-	advanced_lnb_ucsw_choices = [("0", _("None"))] + [(str(y), _("Input ") + str(y)) for y in list(range(1, 17))]
+	advanced_lnb_ucsw_choices = [("0", _("None"))] + [(str(y), _("Input ") + str(y)) for y in range(1, 17)]
 	diseqc_mode_choices = [
 		("single", _("Single")), ("toneburst_a_b", _("Tone burst A/B")),
 		("diseqc_a_b", "DiSEqC A/B"), ("diseqc_a_b_c_d", "DiSEqC A/B/C/D"),
@@ -1874,11 +1973,12 @@ def InitNimManager(nimmgr, update_slots=None):
 		(3605, _("Selecting satellites 1 (USALS)"), 1),
 		(3606, _("Selecting satellites 2 (USALS)"), 1)
 	]
-	advanced_lnb_choices = [("0", _("Not configured"))] + [(str(y), "LNB " + str(y)) for y in list(range(1, (maxFixedLnbPositions + 1)))]
+	advanced_lnb_choices = [("0", _("Not configured"))] + [(str(y), "LNB " + str(y)) for y in range(1, (maxFixedLnbPositions + 1))]
 	advanced_voltage_choices = [("polarization", _("Polarization")), ("13V", _("13 V")), ("18V", _("18 V"))]
 	advanced_tonemode_choices = [("band", _("Band")), ("on", _("On")), ("off", _("Off"))]
 	advanced_lnb_toneburst_choices = [("none", _("None")), ("A", _("A")), ("B", _("B"))]
 	advanced_lnb_allsat_diseqcmode_choices = [("1_2", _("1.2"))]
+	advanced_lnb_satposdepends_diseqcmode_choices = [("none", _("None")), ("1_0", _("1.0")), ("1_1", _("1.1"))]
 	advanced_lnb_diseqcmode_choices = [("none", _("None")), ("1_0", _("1.0")), ("1_1", _("1.1")), ("1_2", _("1.2"))]
 	advanced_lnb_commandOrder1_0_choices = [("ct", "DiSEqC 1.0, toneburst"), ("tc", "toneburst, DiSEqC 1.0")]
 	advanced_lnb_commandOrder_choices = [
@@ -1898,6 +1998,38 @@ def InitNimManager(nimmgr, update_slots=None):
 	advanced_lnb_fast_turning_btime = mktime(datetime(1970, 1, 1, 7, 0).timetuple())
 	advanced_lnb_fast_turning_etime = mktime(datetime(1970, 1, 1, 19, 0).timetuple())
 
+	def lnbTemplateValue(template, name, default):
+		if isinstance(template, ConfigSubsection):
+			configElement = template.content.items.get(name)
+			if configElement is not None and not isinstance(configElement, ConfigNothing) and hasattr(configElement, "value"):
+				return deepcopy(configElement.value)
+		return deepcopy(default)
+
+	def lnbTemplateSequenceValue(template, name, default, limits):
+		value = lnbTemplateValue(template, name, default)
+		if not isinstance(value, (list, tuple)) or len(value) != len(limits):
+			return deepcopy(default)
+		try:
+			return [min(max(int(item), limits[index][0]), limits[index][1]) for index, item in enumerate(value)]
+		except (TypeError, ValueError):
+			return deepcopy(default)
+
+	def lnbTemplateListValue(template, name, index, default):
+		if isinstance(template, ConfigSubsection):
+			configList = template.content.items.get(name)
+			if isinstance(configList, ConfigSubList) and index < len(configList) and hasattr(configList[index], "value"):
+				return deepcopy(configList[index].value)
+		return deepcopy(default)
+
+	def lnbTemplateProduct(template, configName, manufacturer):
+		if isinstance(template, ConfigSubsection):
+			manufacturerDict = template.content.items.get(configName)
+			manufacturerConfig = manufacturerDict.get(manufacturer) if isinstance(manufacturerDict, ConfigSubDict) else None
+			product = manufacturerConfig.content.items.get("product") if isinstance(manufacturerConfig, ConfigSubsection) else None
+			if product is not None and hasattr(product, "value"):
+				return product.value
+		return None
+
 	def configLOFChanged(configElement):
 		if configElement.value == "unicable":
 			x = configElement.slot_id
@@ -1905,11 +2037,16 @@ def InitNimManager(nimmgr, update_slots=None):
 			nim = config.Nims[x].dvbs
 			lnbs = nim.advanced.lnb
 			section = lnbs[lnb]
+			template = getattr(configElement, "lnb_template", None)
 			if isinstance(section.unicable, ConfigNothing):
 				if lnb == 1 or lnb > maxFixedLnbPositions:
-					section.unicable = ConfigSelection(UNICABLE_CHOICES(), unicable_choices_default)
+					unicableChoices = UNICABLE_CHOICES()
 				else:
-					section.unicable = ConfigSelection(choices={"unicable_matrix": _("Unicable Matrix"), "unicable_user": "Unicable " + _("User defined")}, default="unicable_matrix")
+					unicableChoices = {"unicable_matrix": _("Unicable Matrix"), "unicable_user": "Unicable " + _("User defined")}
+				defaultUnicable = lnbTemplateValue(template, "unicable", unicable_choices_default)
+				if defaultUnicable not in unicableChoices:
+					defaultUnicable = "unicable_matrix" if lnb != 1 and lnb <= maxFixedLnbPositions else unicable_choices_default
+				section.unicable = ConfigSelection(unicableChoices, defaultUnicable)
 
 			def fillUnicableConf(sectionDict, unicableproducts, vco_null_check, defaultProduct=None, defaultSlot=0):
 				for manufacturer in unicableproducts:
@@ -1961,7 +2098,7 @@ def InitNimManager(nimmgr, update_slots=None):
 							tmp_lofl_article_append = tmp.lofl[article].append
 							tmp_lofh_article_append = tmp.lofh[article].append
 							tmp_loft_article_append = tmp.loft[article].append
-							for cnt in list(range(1, positions + 1)):
+							for cnt in range(1, positions + 1):
 								lofl = int(positionslist[cnt][0])
 								lofh = int(positionslist[cnt][1])
 								loft = int(positionslist[cnt][2])
@@ -1971,40 +2108,43 @@ def InitNimManager(nimmgr, update_slots=None):
 							products_valide_append(article)
 					if len(products_valide) == 0:
 						products_valide_append("None")
-					tmp.product = ConfigSelection(choices=products_valide, default=products_valide[0])
+					productDefault = defaultProduct if defaultProduct in products_valide else products_valide[0]
+					tmp.product = ConfigSelection(choices=products_valide, default=productDefault)
 					sectionDict[manufacturer] = tmp
-					if defaultProduct and defaultProduct in products_valide:
-						tmp.product.value = defaultProduct
-						# default scr needs to be fixed
-						#if defaultSlot and len(tmp.vco[defaultProduct]) >= int(defaultSlot):
-						#	tmp.scr[defaultProduct].value = str(defaultSlot)
+					# default scr needs to be fixed
+					#if defaultSlot and len(tmp.vco[productDefault]) >= int(defaultSlot):
+					#	tmp.scr[productDefault].value = str(defaultSlot)
 
 			print("[NimManager] MATRIX")
 			section.unicableMatrix = ConfigSubDict()
 			defaultSlot = rootDefaults.get("slotnr", None)
-			default = rootDefaults.get("unicable_matrix_manufacturer_default", UnicableMatrixManufacturers[0]) if defaultSlot else UnicableMatrixManufacturers[0]
-			defaultProduct = rootDefaults.get("unicable_matrix_product", None) if defaultSlot else None
+			default = rootDefaults.get("unicable_matrix_manufacturer_default", UnicableMatrixManufacturers[0]) if defaultSlot else lnbTemplateValue(template, "unicableMatrixManufacturer", UnicableMatrixManufacturers[0])
+			if default not in UnicableMatrixManufacturers:
+				default = UnicableMatrixManufacturers[0]
+			defaultProduct = rootDefaults.get("unicable_matrix_product", None) if defaultSlot else lnbTemplateProduct(template, "unicableMatrix", default)
 			section.unicableMatrixManufacturer = ConfigSelection(UnicableMatrixManufacturers, default)
 			fillUnicableConf(section.unicableMatrix, unicablematrixproducts, True, defaultProduct, defaultSlot)
 			print("[NimManager] LNB")
 			section.unicableLnb = ConfigSubDict()
 			defaultSlot = rootDefaults.get("slotnr", None)
-			default = rootDefaults.get("unicable_lnb_manufacturer_default", UnicableLnbManufacturers[0]) if defaultSlot else UnicableLnbManufacturers[0]
-			defaultProduct = rootDefaults.get("unicable_lnb_product", None) if defaultSlot else None
+			default = rootDefaults.get("unicable_lnb_manufacturer_default", UnicableLnbManufacturers[0]) if defaultSlot else lnbTemplateValue(template, "unicableLnbManufacturer", UnicableLnbManufacturers[0])
+			if default not in UnicableLnbManufacturers:
+				default = UnicableLnbManufacturers[0]
+			defaultProduct = rootDefaults.get("unicable_lnb_product", None) if defaultSlot else lnbTemplateProduct(template, "unicableLnb", default)
 			section.unicableLnbManufacturer = ConfigSelection(UnicableLnbManufacturers, default)
 			fillUnicableConf(section.unicableLnb, unicablelnbproducts, False, defaultProduct, defaultSlot)
 			# TODO satpositions for satcruser
-			section.bootuptimeuser = ConfigInteger(default=2700, limits=(0, 15000))
-			section.dictionuser = ConfigSelection(advanced_lnb_diction_user_choices, default="EN50494")
-			section.satcruserEN50494 = ConfigSelection(advanced_lnb_satcr_user_choicesEN50494, default="1")
-			section.satcruserEN50607 = ConfigSelection(advanced_lnb_satcr_user_choicesEN50607, default="1")
+			section.bootuptimeuser = ConfigInteger(default=lnbTemplateValue(template, "bootuptimeuser", 2700), limits=(0, 15000))
+			section.dictionuser = ConfigSelection(advanced_lnb_diction_user_choices, default=lnbTemplateValue(template, "dictionuser", "EN50494"))
+			section.satcruserEN50494 = ConfigSelection(advanced_lnb_satcr_user_choicesEN50494, default=lnbTemplateValue(template, "satcruserEN50494", "1"))
+			section.satcruserEN50607 = ConfigSelection(advanced_lnb_satcr_user_choicesEN50607, default=lnbTemplateValue(template, "satcruserEN50607", "1"))
 			tmpEN50494 = ConfigSubList()
-			for i in (1284, 1400, 1516, 1632, 1748, 1864, 1980, 2096):
-				tmpEN50494.append(ConfigInteger(default=i, limits=(950, 2150)))
+			for index, frequency in enumerate((1284, 1400, 1516, 1632, 1748, 1864, 1980, 2096)):
+				tmpEN50494.append(ConfigInteger(default=lnbTemplateListValue(template, "satcrvcouserEN50494", index, frequency), limits=(950, 2150)))
 			section.satcrvcouserEN50494 = tmpEN50494
 			tmpEN50607 = ConfigSubList()
-			for i in (1210, 1420, 1680, 2040, 984, 1020, 1056, 1092, 1128, 1164, 1256, 1292, 1328, 1364, 1458, 1494, 1530, 1566, 1602, 1638, 1716, 1752, 1788, 1824, 1860, 1896, 1932, 1968, 2004, 2076, 2112, 2148):
-				tmpEN50607.append(ConfigInteger(default=i, limits=(950, 2150)))
+			for index, frequency in enumerate((1210, 1420, 1680, 2040, 984, 1020, 1056, 1092, 1128, 1164, 1256, 1292, 1328, 1364, 1458, 1494, 1530, 1566, 1602, 1638, 1716, 1752, 1788, 1824, 1860, 1896, 1932, 1968, 2004, 2076, 2112, 2148)):
+				tmpEN50607.append(ConfigInteger(default=lnbTemplateListValue(template, "satcrvcouserEN50607", index, frequency), limits=(950, 2150)))
 			section.satcrvcouserEN50607 = tmpEN50607
 			nim.advanced.unicableconnected = ConfigYesNo(default=False)
 			nim.advanced.unicableconnectedTo = ConfigSelection([(str(id), nimmgr.getNimDescription(id)) for id in nimmgr.getNimListOfType("DVB-S") if id != x])
@@ -2019,26 +2159,28 @@ def InitNimManager(nimmgr, update_slots=None):
 				# txt = _("Misconfigured unicable connection from tuner %(tuner1)s to tuner %(tuner2)s!\nTuner %(tuner1)s option \"connected to\" are disabled now") % locals()
 				txt = _("Misconfigured unicable connection from tuner %s to tuner %s!\nTuner %s option \"connected to\" are disabled now") % (chr(int(x) + ord("A")), chr(int(nim.advanced.unicableconnectedTo.saved_value) + ord("A")), chr(int(x) + ord("A")),)
 				Notifications.AddPopup(txt, type=MessageBox.TYPE_ERROR, timeout=0, id="UnicableConnectionFailed")
-			section.unicableTuningAlgo = ConfigSelection([("reliable", _("reliable")), ("traditional", _("traditional (fast)")), ("reliable_retune", _("reliable, retune")), ("traditional_retune", _("traditional (fast), retune"))], default="reliable_retune")
+			section.unicableTuningAlgo = ConfigSelection([("reliable", _("reliable")), ("traditional", _("traditional (fast)")), ("reliable_retune", _("reliable, retune")), ("traditional_retune", _("traditional (fast), retune"))], default=lnbTemplateValue(template, "unicableTuningAlgo", "reliable_retune"))
+			section.powerInserter = ConfigYesNo(default=lnbTemplateValue(template, "powerInserter", False))
 			if rootDefaults.get("slotnr", None):
 				section.unicable.value = rootDefaults.get("unicable_choices_default", unicable_choices_default)
 
 	def configDiSEqCModeChanged(configElement):
 		section = configElement.section
+		template = getattr(configElement, "lnb_template", None)
 		if configElement.value == "1_2" and isinstance(section.longitude, ConfigNothing):
-			section.longitude = ConfigFloat(default=[5, 100], limits=[(0, 359), (0, 999)])
-			section.longitudeOrientation = ConfigSelection(longitude_orientation_choices, "east")
-			section.latitude = ConfigFloat(default=[50, 767], limits=[(0, 359), (0, 999)])
-			section.latitudeOrientation = ConfigSelection(latitude_orientation_choices, "north")
-			section.tuningstepsize = ConfigFloat(default=[0, 360], limits=[(0, 9), (0, 999)])
-			section.rotorPositions = ConfigInteger(default=99, limits=[1, 999])
-			section.turningspeedH = ConfigFloat(default=[2, 3], limits=[(0, 9), (0, 9)])
-			section.turningspeedV = ConfigFloat(default=[1, 7], limits=[(0, 9), (0, 9)])
-			section.powerMeasurement = ConfigYesNo(default=True)
-			section.powerThreshold = ConfigInteger(default=15, limits=(0, 100))
-			section.turningSpeed = ConfigSelection(turning_speed_choices, "fast")
-			section.fastTurningBegin = ConfigDateTime(default=advanced_lnb_fast_turning_btime, formatstring=_("%H:%M"), increment=600)
-			section.fastTurningEnd = ConfigDateTime(default=advanced_lnb_fast_turning_etime, formatstring=_("%H:%M"), increment=600)
+			section.longitude = ConfigFloat(default=lnbTemplateSequenceValue(template, "longitude", [5, 100], [(0, 359), (0, 999)]), limits=[(0, 359), (0, 999)])
+			section.longitudeOrientation = ConfigSelection(longitude_orientation_choices, lnbTemplateValue(template, "longitudeOrientation", "east"))
+			section.latitude = ConfigFloat(default=lnbTemplateSequenceValue(template, "latitude", [50, 767], [(0, 359), (0, 999)]), limits=[(0, 359), (0, 999)])
+			section.latitudeOrientation = ConfigSelection(latitude_orientation_choices, lnbTemplateValue(template, "latitudeOrientation", "north"))
+			section.tuningstepsize = ConfigFloat(default=lnbTemplateSequenceValue(template, "tuningstepsize", [0, 360], [(0, 9), (0, 999)]), limits=[(0, 9), (0, 999)])
+			section.rotorPositions = ConfigInteger(default=lnbTemplateValue(template, "rotorPositions", 99), limits=[1, 999])
+			section.turningspeedH = ConfigFloat(default=lnbTemplateSequenceValue(template, "turningspeedH", [2, 3], [(0, 9), (0, 9)]), limits=[(0, 9), (0, 9)])
+			section.turningspeedV = ConfigFloat(default=lnbTemplateSequenceValue(template, "turningspeedV", [1, 7], [(0, 9), (0, 9)]), limits=[(0, 9), (0, 9)])
+			section.powerMeasurement = ConfigYesNo(default=lnbTemplateValue(template, "powerMeasurement", True))
+			section.powerThreshold = ConfigInteger(default=lnbTemplateValue(template, "powerThreshold", 15), limits=(0, 100))
+			section.turningSpeed = ConfigSelection(turning_speed_choices, lnbTemplateValue(template, "turningSpeed", "fast"))
+			section.fastTurningBegin = ConfigDateTime(default=lnbTemplateValue(template, "fastTurningBegin", advanced_lnb_fast_turning_btime), formatstring=_("%H:%M"), increment=600)
+			section.fastTurningEnd = ConfigDateTime(default=lnbTemplateValue(template, "fastTurningEnd", advanced_lnb_fast_turning_etime), formatstring=_("%H:%M"), increment=600)
 
 	def configLNBChanged(configElement):
 		x = configElement.slot_id
@@ -2046,36 +2188,58 @@ def InitNimManager(nimmgr, update_slots=None):
 		lnb = int(configElement.value[0] if isinstance(configElement.value, tuple) else configElement.value)
 		lnbs = nim.advanced.lnb
 		if lnb and lnb not in lnbs:
+			# LNB 1 is a better starting point than the generic defaults for another position
+			# on the same installation. A saved LNB remains independent and is never migrated.
+			useLnb1Template = 1 < lnb <= maxFixedLnbPositions and str(configElement.saved_value) != str(lnb) and str(lnb) not in lnbs.stored_values
+			template = lnbs.get(1) if useLnb1Template and isinstance(lnbs.get(1), ConfigSubsection) else None
+			if template is not None:
+				print(f"[NimManager] Using LNB 1 as initial settings template for LNB {lnb}.")
 			section = lnbs[lnb] = ConfigSubsection()
-			section.lofl = ConfigInteger(default=9750, limits=(0, 99999))
-			section.lofh = ConfigInteger(default=10600, limits=(0, 99999))
-			section.threshold = ConfigInteger(default=11700, limits=(0, 99999))
-			section.increased_voltage = ConfigYesNo(False)
+			section.lofl = ConfigInteger(default=lnbTemplateValue(template, "lofl", 9750), limits=(0, 99999))
+			section.lofh = ConfigInteger(default=lnbTemplateValue(template, "lofh", 10600), limits=(0, 99999))
+			section.threshold = ConfigInteger(default=lnbTemplateValue(template, "threshold", 11700), limits=(0, 99999))
+			section.increased_voltage = ConfigYesNo(default=lnbTemplateValue(template, "increased_voltage", False))
 			section.toneburst = ConfigSelection(advanced_lnb_toneburst_choices, "none")
 			section.longitude = ConfigNothing()
-			if lnb > maxFixedLnbPositions:
+			if maxFixedLnbPositions < lnb < maxFixedLnbPositions + MAX_LNB_WILDCARDS:
 				tmp = ConfigSelection(advanced_lnb_allsat_diseqcmode_choices, "1_2")
 				tmp.section = section
+				tmp.lnb_template = template
 				configDiSEqCModeChanged(tmp)
 			else:
-				tmp = ConfigSelection(advanced_lnb_diseqcmode_choices, "none")
+				diseqcChoices = advanced_lnb_satposdepends_diseqcmode_choices if lnb == maxFixedLnbPositions + MAX_LNB_WILDCARDS else advanced_lnb_diseqcmode_choices
+				diseqcDefault = lnbTemplateValue(template, "diseqcMode", "none")
+				if diseqcDefault not in {choice[0] for choice in diseqcChoices}:
+					diseqcDefault = "none"
+				tmp = ConfigSelection(diseqcChoices, diseqcDefault)
 				tmp.section = section
+				tmp.lnb_template = template
 				tmp.addNotifier(configDiSEqCModeChanged)
 			section.diseqcMode = tmp
 			section.commitedDiseqcCommand = ConfigSelection(advanced_lnb_csw_choices)
-			section.fastDiseqc = ConfigYesNo(False)
-			section.sequenceRepeat = ConfigYesNo(False)
-			section.commandOrder1_0 = ConfigSelection(advanced_lnb_commandOrder1_0_choices, "ct")
-			section.commandOrder = ConfigSelection(advanced_lnb_commandOrder_choices, "ct")
+			section.fastDiseqc = ConfigYesNo(default=lnbTemplateValue(template, "fastDiseqc", False))
+			section.sequenceRepeat = ConfigYesNo(default=lnbTemplateValue(template, "sequenceRepeat", False))
+			section.commandOrder1_0 = ConfigSelection(advanced_lnb_commandOrder1_0_choices, lnbTemplateValue(template, "commandOrder1_0", "ct"))
+			section.commandOrder = ConfigSelection(advanced_lnb_commandOrder_choices, lnbTemplateValue(template, "commandOrder", "ct"))
 			section.uncommittedDiseqcCommand = ConfigSelection(advanced_lnb_ucsw_choices)
-			section.diseqcRepeats = ConfigSelection(advanced_lnb_diseqc_repeat_choices, "none")
-			section.prio = ConfigSelection(prio_list, "-1")
+			section.diseqcRepeats = ConfigSelection(advanced_lnb_diseqc_repeat_choices, lnbTemplateValue(template, "diseqcRepeats", "none"))
+			section.prio = ConfigSelection(prio_list, lnbTemplateValue(template, "prio", "-1"))
 			section.unicable = ConfigNothing()
-			tmp = ConfigSelection(LNB_CHOICES(), lnb_choices_default)
+			section.unicableUseLnb1UserBand = ConfigYesNo(default=False)
+			section.unicable_use_pin = ConfigYesNo(default=lnbTemplateValue(template, "unicable_use_pin", False))
+			section.unicable_pin = ConfigInteger(default=lnbTemplateValue(template, "unicable_pin", 0), limits=(0, 255))
+			section.unicablePosition = ConfigInteger(default=0, limits=(0, 64))
+			lofDefault = lnbTemplateValue(template, "lof", lnb_choices_default)
+			if lofDefault not in LNB_CHOICES():
+				lofDefault = lnb_choices_default
+			tmp = ConfigSelection(LNB_CHOICES(), lofDefault)
 			tmp.slot_id = x
 			tmp.lnb_id = lnb
+			tmp.lnb_template = template
 			tmp.addNotifier(configLOFChanged, initial_call=False)
 			section.lof = tmp
+			if tmp.value == "unicable" and isinstance(section.unicable, ConfigNothing):
+				configLOFChanged(tmp)
 			if rootDefaults.get("slotnr", None):
 				section.lof.value = rootDefaults.get("lnb_choices_default", lnb_choices_default)
 
@@ -2139,7 +2303,7 @@ def InitNimManager(nimmgr, update_slots=None):
 				nim.advanced.sat[x[0]] = tmp
 				if oldlnbval is not None and sat == x[0]:
 					nim.advanced.sat[x[0]].lnb.value = oldlnbval
-			for x in range(3601, 3607):
+			for x in range(3601, 3608):
 				tmp = ConfigSubsection()
 				tmp.voltage = ConfigSelection(advanced_voltage_choices, "polarization")
 				tmp.tonemode = ConfigSelection(advanced_tonemode_choices, "band")
@@ -2206,6 +2370,8 @@ def InitNimManager(nimmgr, update_slots=None):
 			nim.simpleDiSEqCSetVoltageTone = ConfigYesNo(True)
 			nim.simpleDiSEqCOnlyOnSatChange = ConfigYesNo(False)
 			nim.simpleDiSEqCSetCircularLNB = ConfigYesNo(True)
+			nim.autoDiSEqCOrderSingle = ConfigSelection([("all", _("All")), ("astra", _("Central Europe")), ("east", _("Eastern satellites")), ("west", _("Western satellites")), ("circular", _("Circular LNB"))], "all")
+			nim.autoDiSEqCOrder = ConfigSelection([("all", _("All")), ("astra", _("Central Europe")), ("east", _("Eastern satellites")), ("west", _("Western satellites"))], "all")
 			nim.diseqcA = ConfigSatlist(list=diseqc_satlist_choices)
 			nim.diseqcB = ConfigSatlist(list=diseqc_satlist_choices)
 			nim.diseqcC = ConfigSatlist(list=diseqc_satlist_choices)
@@ -2219,9 +2385,10 @@ def InitNimManager(nimmgr, update_slots=None):
 			nim.latitudeOrientation = ConfigSelection(latitude_orientation_choices, "north")
 			nim.tuningstepsize = ConfigFloat(default=[0, 360], limits=[(0, 9), (0, 999)])
 			nim.rotorPositions = ConfigInteger(default=99, limits=[1, 999])
+			nim.lastsatrotorposition = ConfigText()
 			nim.turningspeedH = ConfigFloat(default=[2, 3], limits=[(0, 9), (0, 9)])
 			nim.turningspeedV = ConfigFloat(default=[1, 7], limits=[(0, 9), (0, 9)])
-			nim.powerMeasurement = ConfigYesNo(False)
+			nim.powerMeasurement = ConfigYesNo(True)
 			nim.powerThreshold = ConfigInteger(default=BoxInfo.getItem("machinebuild") == "dm8000" and 15 or 50, limits=(0, 100))
 			nim.turningSpeed = ConfigSelection(turning_speed_choices, "fast")
 			btime = datetime(1970, 1, 1, 7, 0)
@@ -2264,6 +2431,8 @@ def InitNimManager(nimmgr, update_slots=None):
 			nim.scan_sr_6875 = ConfigYesNo(default=True)
 			nim.scan_sr_ext1 = ConfigInteger(default=0, limits=(0, 7230))
 			nim.scan_sr_ext2 = ConfigInteger(default=0, limits=(0, 7230))
+		if not hasattr(nim, "settingsConfigured"):
+			nim.settingsConfigured = ConfigYesNo(default=False)
 
 	def createTerrestrialConfig(nim, x):
 		try:
@@ -2272,6 +2441,8 @@ def InitNimManager(nimmgr, update_slots=None):
 			items = [(x[0], x[0]) for x in nimmgr.terrestrialsList]
 			nim.terrestrial = ConfigSelection(choices=items)
 			nim.terrestrial_5V = ConfigOnOff()
+		if not hasattr(nim, "settingsConfigured"):
+			nim.settingsConfigured = ConfigYesNo(default=False)
 
 	def createATSCConfig(nim, x):
 		try:

--- a/lib/python/Components/Sources/FrontendInfo.py
+++ b/lib/python/Components/Sources/FrontendInfo.py
@@ -1,4 +1,7 @@
-from enigma import iPlayableService, eDVBResourceManager, iServiceInformation
+from enigma import iPlayableService, eDVBResourceManager, eDVBSatelliteEquipmentControl, iServiceInformation
+
+from Components.config import config
+from Components.NimManager import nimmanager
 from Components.PerServiceDisplay import PerServiceBase
 from Components.Sources.Source import Source
 
@@ -19,6 +22,9 @@ class FrontendInfo(Source, PerServiceBase):
 		self.service_source = service_source
 		self.frontend_source = frontend_source
 		self.tuner_mask = 0
+		sec = eDVBSatelliteEquipmentControl.getInstance()
+		if sec:
+			sec.slotRotorSatPosChanged.get().append(self.updateSlotRotorSatPosition)
 		self.updateFrontendData()
 
 	def serviceEnd(self):
@@ -44,6 +50,18 @@ class FrontendInfo(Source, PerServiceBase):
 		if mask:
 			self.updateFrontendData()
 		self.changed((self.CHANGED_ALL, ))
+
+	def updateSlotRotorSatPosition(self, slot, orbitalPosition):
+		for nim in nimmanager.nim_slots:
+			if nim.slot == slot:
+				nimConfig = nim.config.dvbs
+				nimConfig.lastsatrotorposition.value = str(orbitalPosition)
+				nimConfig.lastsatrotorposition.save()
+				if hasattr(config.misc, "lastrotorposition"):
+					config.misc.lastrotorposition.value = orbitalPosition
+					config.misc.lastrotorposition.save()
+				self.changed((self.CHANGED_ALL, ))
+				break
 
 	def getFrontendData(self):
 		if self.frontend_source:
@@ -84,4 +102,7 @@ class FrontendInfo(Source, PerServiceBase):
 		res_mgr = eDVBResourceManager.getInstance()
 		if res_mgr:
 			res_mgr.frontendUseMaskChanged.get().remove(self.updateTunerMask)
+		sec = eDVBSatelliteEquipmentControl.getInstance()
+		if sec:
+			sec.slotRotorSatPosChanged.get().remove(self.updateSlotRotorSatPosition)
 		Source.destroy(self)

--- a/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/PositionerSetup/plugin.py
@@ -1,13 +1,15 @@
-from time import sleep
+from time import sleep, time
 from operator import mul
 from random import SystemRandom
 from threading import Thread
 from threading import Event
 
-from enigma import eDVBDiseqcCommand, eDVBFrontendParametersSatellite, eDVBResourceManager, eTimer, iDVBFrontend
+from enigma import eDVBDiseqcCommand, eDVBFrontendParametersSatellite, eDVBResourceManager, eDVBSatelliteEquipmentControl, eTimer, iDVBFrontend
 
 from Screens.Screen import Screen
 from Screens.MessageBox import MessageBox
+from Screens.ChoiceBox import ChoiceBox
+from Screens.Satconfig import NimSetup
 from Plugins.Plugin import PluginDescriptor
 
 from Components.Label import Label
@@ -16,10 +18,10 @@ from Components.ConfigList import ConfigList
 from Components.ConfigList import ConfigListScreen
 from Components.TunerInfo import TunerInfo
 from Components.ActionMap import ActionMap, NumberActionMap
-from Components.NimManager import nimmanager
+from Components.NimManager import inputPowerSlotForNim, nimmanager
 from Components.MenuList import MenuList
 from Components.ScrollLabel import ScrollLabel
-from Components.config import config, ConfigFloat, ConfigInteger, ConfigNothing, ConfigSatlist, ConfigSelection, ConfigSubsection, KEY_LEFT, KEY_RIGHT, KEY_0, getConfigListEntry
+from Components.config import config, ConfigFloat, ConfigInteger, ConfigNothing, ConfigSatlist, ConfigSelection, ConfigSubsection, KEY_LEFT, KEY_RIGHT, KEY_0, NoSave, getConfigListEntry
 from Components.TuneTest import Tuner
 from Tools.Transponder import ConvertToHumanReadable
 
@@ -55,7 +57,15 @@ class PositionerSetup(Screen):
 	def latitude2orbital(position):
 		return (position, "north") if position >= 0 else (-position, "south")
 
+	@staticmethod
+	def orbitalPositionToString(position):
+		if position > 1800:
+			position = 3600 - position
+			return f"{position // 10}.{position % 10}° W"
+		return f"{position // 10}.{position % 10}° E"
+
 	UPDATE_INTERVAL = 50					# milliseconds
+	INPUT_POWER_UPDATE_INTERVAL = 500			# milliseconds
 	STATUS_MSG_TIMEOUT = 2					# seconds
 	LOG_SIZE = 16 * 1024					# log buffer size
 
@@ -63,15 +73,24 @@ class PositionerSetup(Screen):
 		Screen.__init__(self, session)
 		self.setTitle(_("Positioner setup"))
 		self.feid = feid
+		self.inputPowerSlot = inputPowerSlotForNim(feid)
+		self.resourceManager = eDVBResourceManager.getInstance()
+		self.canMeasureInputPower = self.resourceManager and self.resourceManager.canMeasureFrontendInputPower(self.inputPowerSlot)
+		self.inputPowerUpdateTicks = 0
 		self.oldref = None
+		self.sec = eDVBSatelliteEquipmentControl.getInstance()
+		self.rotorPositionSignalConnected = False
+		self.checkingTsidOnid = False
+		self.tsid = self.onid = 0
+		self.fineSteps = 0
 		log.open(self.LOG_SIZE)
 		if config.Nims[self.feid].dvbs.configMode.value == 'advanced':
 			self.advanced = True
 			self.advancedconfig = config.Nims[self.feid].dvbs.advanced
 			self.advancedsats = self.advancedconfig.sat
-			self.availablesats = [x[0] for x in nimmanager.getRotorSatListForNim(self.feid)]
 		else:
 			self.advanced = False
+		self.availablesats = [x[0] for x in nimmanager.getRotorSatListForNim(self.feid)]
 
 		cur = {}
 		if not self.openFrontend():
@@ -147,13 +166,20 @@ class PositionerSetup(Screen):
 		self["fec_value"] = Label("")
 		self["polarisation"] = Label("")
 		self["status_bar"] = Label("")
+		self["rotorstatus"] = Label("")
+		self["inputpower"] = Label("")
+		self.updateInputPower()
+		if self.sec:
+			self.sec.slotRotorSatPosChanged.get().append(self.rotorPositionChanged)
+			self.rotorPositionSignalConnected = True
+		self.updateRotorStatus()
 		self.statusMsgTimeoutTicks = 0
 		self.statusMsgBlinking = False
 		self.statusMsgBlinkCount = 0
 		self.statusMsgBlinkRate = 500 / self.UPDATE_INTERVAL  # milliseconds
 		self.tuningChangedTo(tp)
 
-		self["actions"] = NumberActionMap(["DirectionActions", "OkCancelActions", "ColorActions", "TimerEditActions", "InputActions"],
+		self["actions"] = NumberActionMap(["DirectionActions", "OkCancelActions", "ColorActions", "TimerEditActions", "InputActions", "InfobarMenuActions"],
 		{
 			"ok": self.keyOK,
 			"cancel": self.keyCancel,
@@ -166,6 +192,7 @@ class PositionerSetup(Screen):
 			"yellow": self.yellowKey,
 			"blue": self.blueKey,
 			"log": self.showLog,
+			"mainMenu": self.furtherOptions,
 			"1": self.keyNumberGlobal,
 			"2": self.keyNumberGlobal,
 			"3": self.keyNumberGlobal,
@@ -189,11 +216,65 @@ class PositionerSetup(Screen):
 
 		self.createConfig()
 		self.createSetup()
+		if not self.frontend:
+			self.frontendErrorTimer = eTimer()
+			self.frontendErrorTimer.callback.append(self.showFrontendError)
+			self.frontendErrorTimer.start(0, True)
 
 	def __onClose(self):
 		self.statusTimer.stop()
+		if hasattr(self, "onidTsidTimer"):
+			self.onidTsidTimer.stop()
+		if self.checkingTsidOnid and hasattr(self, "raw_channel") and self.raw_channel:
+			self.raw_channel.receivedTsidOnid.get().remove(self.gotTsidOnid)
+			self.checkingTsidOnid = False
+		if self.rotorPositionSignalConnected:
+			self.sec.slotRotorSatPosChanged.get().remove(self.rotorPositionChanged)
+			self.rotorPositionSignalConnected = False
 		log.close()
-		self.session.nav.playService(self.oldref)
+		if self.oldref:
+			self.session.nav.playService(self.oldref)
+
+	def showFrontendError(self):
+		self.session.openWithCallback(
+			lambda answer: self.close(),
+			MessageBox,
+			_("The positioner tuner is currently unavailable. Stop recordings or other services using this tuner and try again."),
+			MessageBox.TYPE_ERROR
+		)
+
+	def getCurrentRotorPosition(self):
+		position = self.sec and self.sec.frontendLastRotorOrbitalPosition(self.feid)
+		if position is not None and position >= 0:
+			return position
+		savedPosition = config.Nims[self.feid].dvbs.lastsatrotorposition.value
+		if savedPosition.isdigit():
+			return int(savedPosition)
+		if hasattr(config.misc, "lastrotorposition") and config.misc.lastrotorposition.value in self.availablesats:
+			return config.misc.lastrotorposition.value
+		return None
+
+	def updateRotorStatus(self, position=None):
+		position = self.getCurrentRotorPosition() if position is None else position
+		if position is None or position not in self.availablesats:
+			text = _("Current rotor position: unknown")
+		else:
+			text = f"{_('Current rotor position:')} {self.orbitalPositionToString(position)}"
+		self["rotorstatus"].setText(text)
+
+	def rotorPositionChanged(self, slot, position):
+		if slot == self.feid:
+			self.updateRotorStatus(position)
+
+	def updateInputPower(self):
+		if not self.canMeasureInputPower:
+			self["inputpower"].setText("")
+			return
+		power = self.resourceManager.readFrontendInputPower(self.inputPowerSlot)
+		if power >= 0:
+			self["inputpower"].setText(f"{_('LNB current:')} {power} mA")
+		else:
+			self["inputpower"].setText(_("LNB current: not available"))
 
 	def restartPrevService(self, yesno):
 		if yesno:
@@ -205,6 +286,8 @@ class PositionerSetup(Screen):
 		self.close(None)
 
 	def keyCancel(self):
+		if self.frontend and self.isMoving:
+			self.stopMoving()
 		if self.oldref:
 			self.session.openWithCallback(self.restartPrevService, MessageBox, _("Zap back to service before positioner setup?"), MessageBox.TYPE_YESNO)
 		else:
@@ -284,9 +367,10 @@ class PositionerSetup(Screen):
 		else:  # it is advanced
 			self.printMsg("Configuration mode: advanced")
 			fe_data = {}
-			self.frontend.getFrontendData(fe_data)
-			self.frontend.getTransponderData(fe_data, True)
-			orb_pos = fe_data.get("orbital_position", None)
+			if self.frontend:
+				self.frontend.getFrontendData(fe_data)
+				self.frontend.getTransponderData(fe_data, True)
+			orb_pos = fe_data.get("orbital_position", self.availablesats[0] if self.availablesats else 0)
 			if orb_pos in self.availablesats:
 				rotorposition = int(self.advancedsats[orb_pos].rotorposition.value)
 			self.setLNB(self.getLNBfromConfig(orb_pos))
@@ -311,7 +395,15 @@ class PositionerSetup(Screen):
 		self["list"].l.setList(self.list)
 
 	def keyOK(self):
-		pass
+		if self.getCurrentConfigPath() == "finemove":
+			self.statusMsg(_("Fine movement") + self.fineStepCourse(), timeout=self.STATUS_MSG_TIMEOUT)
+
+	def fineStepCourse(self):
+		if self.fineSteps > 0:
+			return "  >| %s %d" % ("." * min(self.fineSteps // 10, 10), self.fineSteps)
+		if self.fineSteps < 0:
+			return "  %d %s |<" % (abs(self.fineSteps), "." * min(abs(self.fineSteps) // 10, 10))
+		return "  >|<"
 
 	def getCurrentConfigPath(self):
 		return self["list"].getCurrent()[2]
@@ -393,7 +485,11 @@ class PositionerSetup(Screen):
 		self.statusMsg(_("Stopped"), timeout=self.STATUS_MSG_TIMEOUT)
 
 	def redKey(self):
+		if not self.frontend:
+			return
 		entry = self.getCurrentConfigPath()
+		if entry != "finemove":
+			self.fineSteps = 0
 		if entry == "move":
 			if self.isMoving:
 				self.stopMoving()
@@ -417,7 +513,11 @@ class PositionerSetup(Screen):
 			self.session.openWithCallback(self.tune, TunerScreen, self.feid, fe_data)
 
 	def greenKey(self):
+		if not self.frontend:
+			return
 		entry = self.getCurrentConfigPath()
+		if entry != "finemove":
+			self.fineSteps = 0
 		if entry == "tune":
 			# Auto focus
 			self.printMsg("Auto focus")
@@ -437,9 +537,10 @@ class PositionerSetup(Screen):
 				self.statusMsg(_("Searching west ..."), blinking=True)
 			self.updateColors("move")
 		elif entry == "finemove":
+			self.fineSteps += 1
 			self.printMsg("Step west")
 			self.diseqccommand("moveWest", 0xFF)  # one step
-			self.statusMsg(_("Stepped west"), timeout=self.STATUS_MSG_TIMEOUT)
+			self.statusMsg(_("Stepped west") + self.fineStepCourse(), timeout=self.STATUS_MSG_TIMEOUT)
 		elif entry == "storage":
 			self.printMsg("Store at index")
 			index = int(self.positioner_storage.value)
@@ -455,7 +556,11 @@ class PositionerSetup(Screen):
 			self.statusMsg(_("Moved to position 0"), timeout=self.STATUS_MSG_TIMEOUT)
 
 	def yellowKey(self):
+		if not self.frontend:
+			return
 		entry = self.getCurrentConfigPath()
+		if entry != "finemove":
+			self.fineSteps = 0
 		if entry == "move":
 			if self.isMoving:
 				self.stopMoving()
@@ -467,9 +572,10 @@ class PositionerSetup(Screen):
 				self.statusMsg(_("Searching east ..."), blinking=True)
 			self.updateColors("move")
 		elif entry == "finemove":
+			self.fineSteps -= 1
 			self.printMsg("Step east")
 			self.diseqccommand("moveEast", 0xFF)  # one step
-			self.statusMsg(_("Stepped east"), timeout=self.STATUS_MSG_TIMEOUT)
+			self.statusMsg(_("Stepped east") + self.fineStepCourse(), timeout=self.STATUS_MSG_TIMEOUT)
 		elif entry == "storage":
 			self.printMsg("Goto index position")
 			index = int(self.positioner_storage.value)
@@ -497,7 +603,11 @@ class PositionerSetup(Screen):
 			Thread(target=self.gotoXcalibration).start()
 
 	def blueKey(self):
+		if not self.frontend:
+			return
 		entry = self.getCurrentConfigPath()
+		if entry != "finemove":
+			self.fineSteps = 0
 		if entry == "move":
 			if self.isMoving:
 				self.stopMoving()
@@ -585,6 +695,67 @@ class PositionerSetup(Screen):
 				self.allocatedIndices = []
 			self.setLNB(self.getLNBfromConfig(orb_pos))
 
+	def furtherOptions(self):
+		menu = [(_("Open tuner setup"), self.openTunerSetup)]
+		if not self.checkingTsidOnid and self.frontend and self.isLocked() and not self.isMoving:
+			menu.append((_("Check ONID/TSID"), self.openONIDTSIDScreen))
+
+		def openAction(choice):
+			if choice:
+				choice[1]()
+
+		self.session.openWithCallback(openAction, ChoiceBox, title=_("Positioner actions"), list=menu)
+
+	def openTunerSetup(self):
+		if self.checkingTsidOnid:
+			self.finishTsidOnidCheck()
+		if self.frontend and self.isMoving:
+			self.stopMoving()
+		if self.frontend:
+			self.frontend = None
+			self.diseqc.frontend = None
+			self.tuner.frontend = None
+			if hasattr(self, "raw_channel"):
+				del self.raw_channel
+		self.session.openWithCallback(self.closeTunerSetup, NimSetup, self.feid)
+
+	def closeTunerSetup(self, *args):
+		self.close()
+
+	def openONIDTSIDScreen(self):
+		self.tsid = self.onid = 0
+		self.session.openWithCallback(self.startCheckTsidOnid, ONIDTSIDScreen)
+
+	def startCheckTsidOnid(self, tsidOnid=None):
+		if tsidOnid is None or not self.frontend or not self.isLocked() or self.isMoving or not hasattr(self, "raw_channel") or not self.raw_channel:
+			return
+		self.onid, self.tsid = tsidOnid
+		self.checkingTsidOnid = True
+		self.raw_channel.receivedTsidOnid.get().append(self.gotTsidOnid)
+		self.raw_channel.requestTsidOnid()
+		self.statusMsg(_("Checking ONID/TSID ..."), blinking=True)
+		self.onidTsidTimer = eTimer()
+		self.onidTsidTimer.callback.append(self.onidTsidTimeout)
+		self.onidTsidTimer.start(10000, True)
+
+	def gotTsidOnid(self, tsid, onid):
+		if hasattr(self, "onidTsidTimer"):
+			self.onidTsidTimer.stop()
+		valid = tsid == self.tsid and onid == self.onid
+		self.statusMsg(_("ONID/TSID valid") if valid else _("ONID/TSID does not match"), blinking=not valid, timeout=10)
+		self.finishTsidOnidCheck()
+
+	def onidTsidTimeout(self):
+		self.statusMsg(_("ONID/TSID check timed out"), timeout=5)
+		self.finishTsidOnidCheck()
+
+	def finishTsidOnidCheck(self):
+		if hasattr(self, "onidTsidTimer"):
+			self.onidTsidTimer.stop()
+		if self.checkingTsidOnid and hasattr(self, "raw_channel") and self.raw_channel:
+			self.raw_channel.receivedTsidOnid.get().remove(self.gotTsidOnid)
+		self.checkingTsidOnid = False
+
 	def isLocked(self):
 		return self.frontendStatus.get("tuner_locked", 0) == 1
 
@@ -593,10 +764,14 @@ class PositionerSetup(Screen):
 		if not blinking:
 			self["status_bar"].visible = True
 		self["status_bar"].setText(msg)
-		self.statusMsgTimeoutTicks = (timeout * 1000 + self.UPDATE_INTERVAL / 2) / self.UPDATE_INTERVAL
+		self.statusMsgTimeoutTicks = (timeout * 1000 + self.UPDATE_INTERVAL // 2) // self.UPDATE_INTERVAL
 
 	def updateStatus(self):
 		self.statusTimer.start(self.UPDATE_INTERVAL, True)
+		if self.inputPowerUpdateTicks <= 0:
+			self.updateInputPower()
+			self.inputPowerUpdateTicks = self.INPUT_POWER_UPDATE_INTERVAL // self.UPDATE_INTERVAL
+		self.inputPowerUpdateTicks -= 1
 		if self.frontend:
 			self.frontend.getFrontendStatus(self.frontendStatus)
 		self["snr_db"].update()
@@ -1070,6 +1245,38 @@ class PositionerSetupLog(Screen):
 		self.close(False)
 
 
+class ONIDTSIDScreen(ConfigListScreen, Screen):
+	skin = """
+		<screen position="center,center" size="520,250" title="ONID/TSID">
+			<widget name="config" position="20,15" size="480,170" scrollbarMode="showOnDemand" />
+			<widget name="introduction" position="20,200" size="480,30" font="Regular;20" />
+		</screen>"""
+
+	def __init__(self, session):
+		Screen.__init__(self, session)
+		self.setTitle(_("Enter expected ONID/TSID"))
+		self.transponderOnid = NoSave(ConfigInteger(default=0, limits=(0, 65535)))
+		self.transponderTsid = NoSave(ConfigInteger(default=0, limits=(0, 65535)))
+		self.list = [
+			getConfigListEntry(_("ONID"), self.transponderOnid),
+			getConfigListEntry(_("TSID"), self.transponderTsid)
+		]
+		ConfigListScreen.__init__(self, self.list)
+		self["introduction"] = Label(_("OK checks the currently tuned transponder."))
+		self["actions"] = NumberActionMap(["SetupActions"], {
+			"ok": self.keyGo,
+			"cancel": self.keyCancel
+		}, -2)
+
+	def keyGo(self):
+		onid = int(self.transponderOnid.value)
+		tsid = int(self.transponderTsid.value)
+		self.close((onid, tsid) if onid or tsid else None)
+
+	def keyCancel(self):
+		self.close(None)
+
+
 class TunerScreen(ConfigListScreen, Screen):
 	skin = """
 		<screen position="90,100" size="520,400" title="Tune">
@@ -1325,14 +1532,12 @@ class RotorNimSelection(Screen):
 			<widget name="nimlist" position="20,10" size="360,100" />
 		</screen>"""
 
-	def __init__(self, session):
+	def __init__(self, session, nimList):
 		Screen.__init__(self, session)
 
-		nimlist = nimmanager.getNimListOfType("DVB-S")
 		nimMenuList = []
-		for x in nimlist:
-			if len(nimmanager.getRotorSatListForNim(x)) != 0:
-				nimMenuList.append((nimmanager.nim_slots[x].friendly_full_description, x))
+		for slot in nimList:
+			nimMenuList.append((nimmanager.nim_slots[slot].friendly_full_description, slot))
 
 		self["nimlist"] = MenuList(nimMenuList)
 
@@ -1344,7 +1549,18 @@ class RotorNimSelection(Screen):
 
 	def okbuttonClick(self):
 		selection = self["nimlist"].getCurrent()
-		self.session.open(PositionerSetup, selection[1])
+		if selection:
+			self.session.openWithCallback(self.close, PositionerSetup, selection[1])
+
+
+def getUsableRotorNims(onlyFirst=False):
+	usableNims = []
+	for slot in nimmanager.getNimListOfType("DVB-S"):
+		if not nimmanager.nim_slots[slot].isFBCLink() and nimmanager.getRotorSatListForNim(slot, onlyFirst=onlyFirst):
+			usableNims.append(slot)
+			if onlyFirst:
+				break
+	return usableNims
 
 
 def PositionerMain(session, **kwargs):
@@ -1352,22 +1568,19 @@ def PositionerMain(session, **kwargs):
 	if session.nav.isCurrentServiceStreamRelay:
 		messageText = _("Stream Relay is active, please switch to a none Stream Relay channel.")
 	else:
-		nimList = nimmanager.getNimListOfType("DVB-S")
-		if len(nimList) == 0:
+		if not nimmanager.getNimListOfType("DVB-S"):
 			messageText = _("No positioner capable frontend found.")
 		else:
-			if session.nav.getAnyRecordingsCount():
-				messageText = _("A recording is currently running. Please stop the recording before trying to configure the positioner.")
+			nextRecording = session.nav.RecordTimer.getNextRecordingTime()
+			secondsUntilRecording = nextRecording - time() if nextRecording and nextRecording > 0 else -1
+			if session.nav.getAnyRecordingsCount() or 0 <= secondsUntilRecording < 360:
+				messageText = _("A recording is running or will start within six minutes. Please try the positioner setup later.")
 			else:
-				usableNims = []
-				for x in nimList:
-					configured_rotor_sats = nimmanager.getRotorSatListForNim(x)
-					if len(configured_rotor_sats) != 0:
-						usableNims.append(x)
+				usableNims = getUsableRotorNims()
 				if len(usableNims) == 1:
 					session.open(PositionerSetup, usableNims[0])
 				elif len(usableNims) > 1:
-					session.open(RotorNimSelection)
+					session.open(RotorNimSelection, usableNims)
 				else:
 					messageText = _("No tuner is configured for use with a DiSEqC positioner!")
 	if messageText:
@@ -1375,10 +1588,9 @@ def PositionerMain(session, **kwargs):
 
 
 def PositionerSetupStart(menuid, **kwargs):
-	if menuid == "scan":
+	if menuid == "scan" and getUsableRotorNims(onlyFirst=True):
 		return [(_("Positioner setup"), PositionerMain, "positioner_setup", None)]
-	else:
-		return []
+	return []
 
 
 def Plugins(**kwargs):

--- a/lib/python/Screens/AutoDiseqc.py
+++ b/lib/python/Screens/AutoDiseqc.py
@@ -144,6 +144,86 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			706,
 			1536,
 			"Thor 5/6/7 0.8w"),
+		# Astra 4A 4.8E
+		(
+			11785,
+			27500,
+			eDVBFrontendParametersSatellite.Polarisation_Vertical,
+			eDVBFrontendParametersSatellite.FEC_5_6,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			48,
+			eDVBFrontendParametersSatellite.System_DVB_S2,
+			eDVBFrontendParametersSatellite.Modulation_8PSK,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			201,
+			85,
+			"Astra 4A 4.8e"),
+		# Eutelsat 9B 9.0E
+		(
+			11996,
+			27500,
+			eDVBFrontendParametersSatellite.Polarisation_Vertical,
+			eDVBFrontendParametersSatellite.FEC_3_4,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			90,
+			eDVBFrontendParametersSatellite.System_DVB_S,
+			eDVBFrontendParametersSatellite.Modulation_Auto,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			1,
+			1,
+			"Eutelsat 9B 9.0e"),
+		# Eutelsat 16A 16.0E
+		(
+			11595,
+			30000,
+			eDVBFrontendParametersSatellite.Polarisation_Horizontal,
+			eDVBFrontendParametersSatellite.FEC_3_4,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			160,
+			eDVBFrontendParametersSatellite.System_DVB_S2,
+			eDVBFrontendParametersSatellite.Modulation_8PSK,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			2,
+			64,
+			"Eutelsat 16A 16.0e"),
+		# Eutelsat 5 West B 5.0W
+		(
+			11054,
+			29950,
+			eDVBFrontendParametersSatellite.Polarisation_Vertical,
+			eDVBFrontendParametersSatellite.FEC_2_3,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			3550,
+			eDVBFrontendParametersSatellite.System_DVB_S2,
+			eDVBFrontendParametersSatellite.Modulation_8PSK,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			20500,
+			1375,
+			"Eutelsat 5 West B 5.0w"),
 	]
 
 	circular_sat_frequencies = [
@@ -167,6 +247,26 @@ class AutoDiseqc(ConfigListScreen, Screen):
 			11,
 			112,
 			"Express AMU1 36.0e"),
+		# Express AT1 56.0E
+		(
+			12054,
+			27500,
+			eDVBFrontendParametersSatellite.Polarisation_CircularRight,
+			eDVBFrontendParametersSatellite.FEC_3_4,
+			eDVBFrontendParametersSatellite.Inversion_Off,
+			560,
+			eDVBFrontendParametersSatellite.System_DVB_S2,
+			eDVBFrontendParametersSatellite.Modulation_8PSK,
+			eDVBFrontendParametersSatellite.RollOff_auto,
+			eDVBFrontendParametersSatellite.Pilot_Unknown,
+			eDVBFrontendParametersSatellite.No_Stream_Id_Filter,
+			eDVBFrontendParametersSatellite.PLS_Gold,
+			eDVBFrontendParametersSatellite.PLS_Default_Gold_Code,
+			eDVBFrontendParametersSatellite.No_T2MI_PLP_Id,
+			eDVBFrontendParametersSatellite.T2MI_Default_Pid,
+			566,
+			112,
+			"Express AT1 56.0e"),
 	]
 
 	SAT_TABLE_FREQUENCY = 0
@@ -188,7 +288,7 @@ class AutoDiseqc(ConfigListScreen, Screen):
 	SAT_TABLE_ONID = 16
 	SAT_TABLE_NAME = 17
 
-	def __init__(self, session, feid, nr_of_ports, simple_tone, simple_sat_change):
+	def __init__(self, session, feid, nr_of_ports, simple_tone, simple_sat_change, order="all"):
 		Screen.__init__(self, session)
 
 		self["statusbar"] = StaticText(" ")
@@ -211,15 +311,20 @@ class AutoDiseqc(ConfigListScreen, Screen):
 		self.simple_sat_change = simple_sat_change
 		self.found_sats = []
 		self.circular_setup = False
-		sat_found = False
-		for x in self.sat_frequencies:
-			if x[self.SAT_TABLE_ORBPOS] == 360:
-				sat_found = True
-		if self.nr_of_ports == 1:
-			if not sat_found:
-				self.sat_frequencies += self.circular_sat_frequencies
-		elif sat_found:
-			self.sat_frequencies.remove(x)
+		centralPositions = {130, 192, 235, 282}
+		eastPositions = centralPositions | {48, 90, 160}
+		westPositions = {3592, 3550, 3300}
+		allUniversal = list(self.sat_frequencies)
+		if order == "astra":
+			self.sat_frequencies = [sat for sat in allUniversal if sat[self.SAT_TABLE_ORBPOS] in centralPositions]
+		elif order == "east":
+			self.sat_frequencies = [sat for sat in allUniversal if sat[self.SAT_TABLE_ORBPOS] in eastPositions]
+		elif order == "west":
+			self.sat_frequencies = [sat for sat in allUniversal if sat[self.SAT_TABLE_ORBPOS] in westPositions]
+		elif order == "circular":
+			self.sat_frequencies = list(self.circular_sat_frequencies)
+		else:
+			self.sat_frequencies = allUniversal + (list(self.circular_sat_frequencies) if self.nr_of_ports == 1 else [])
 		if not self.openFrontend():
 			self.oldref = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 			self.session.nav.stopService()
@@ -345,7 +450,7 @@ class AutoDiseqc(ConfigListScreen, Screen):
 				config.Nims[self.feid].dvbs.diseqcMode.value = "diseqc_a_b"
 			else:
 				config.Nims[self.feid].dvbs.diseqcMode.value = "single"
-				if self.sat_frequencies[self.index][self.SAT_TABLE_ORBPOS] == 360 and not self.found_sats:
+				if self.sat_frequencies[self.index][self.SAT_TABLE_ORBPOS] in (360, 560) and not self.found_sats:
 					config.Nims[self.feid].dvbs.simpleDiSEqCSetCircularLNB.value = True
 					self.circular_setup = True
 

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -1,16 +1,17 @@
+from copy import deepcopy
 from datetime import datetime
 from os.path import exists
-from time import localtime, mktime
+from time import localtime, mktime, time
 
-from enigma import eDVBDB, eDVBResourceManager, getLinkedSlotID, isFBCLink
+from enigma import eDVBDB, eDVBResourceManager, eStreamServer, eTimer, getLinkedSlotID, isFBCLink
 
 from Components.ActionMap import ActionMap
 from Components.Button import Button
-from Components.config import ConfigNothing, ConfigYesNo, ConfigSelection, config, configfile, getConfigListEntry
+from Components.config import ConfigBoolean, ConfigNothing, ConfigSelection, config, configfile, getConfigListEntry
 from Components.ConfigList import ConfigListScreen
 from Components.International import international
 from Components.Label import Label
-from Components.NimManager import InitNimManager, LNB_CHOICES, UNICABLE_CHOICES, nimmanager
+from Components.NimManager import InitNimManager, LNB_CHOICES, MAX_LNB_WILDCARDS, UNICABLE_CHOICES, inputPowerSlotForNim, maxFixedLnbPositions, nimmanager
 from Components.SelectionList import SelectionEntryComponent, SelectionList
 from Components.SystemInfo import BoxInfo
 from Components.Sources.List import List
@@ -24,6 +25,20 @@ from Tools.BoundFunction import boundFunction
 from Tools.BugHunting import printCallSequence
 
 
+class ConfigReadOnlyValue(ConfigSelection):
+	def __init__(self):
+		ConfigSelection.__init__(self, choices=[("", "")], default="")
+
+	def isChanged(self):
+		return False
+
+	def save(self):  # Overwrite to force read only
+		pass
+
+	def cancel(self):  # Overwrite to force read only
+		pass
+
+
 class ServiceStopScreen:
 	def __init__(self):
 		try:
@@ -31,6 +46,8 @@ class ServiceStopScreen:
 		except Exception:
 			print("[SatConfig] ServiceStopScreen ERROR: No self.session set!")
 		self.oldref = None
+		self.oldAlternativeRef = None
+		self.serviceSlot = -1
 		self.onClose.append(self.__onClose)
 
 	def pipAvailable(self):  # PiP isn't available in every state of Enigma2.
@@ -41,19 +58,37 @@ class ServiceStopScreen:
 			pipavailable = False
 		return pipavailable
 
+	def getServiceSlot(self):
+		service = self.session.nav.getCurrentService()
+		frontendInfo = service and service.frontendInfo()
+		frontendData = frontendInfo and frontendInfo.getFrontendData()
+		return frontendData.get("tuner_number", -1) if frontendData else -1
+
 	def stopService(self):
-		self.oldref = self.session.nav.getCurrentlyPlayingServiceOrGroup()
-		self.session.nav.stopService()
-		if self.pipAvailable() and self.session.pipshown:  # Try to disable PiP.
-			if hasattr(self.session, "infobar"):
-				if self.session.infobar.servicelist and self.session.infobar.servicelist.dopipzap:
-					self.session.infobar.servicelist.togglePipzap()
-			if hasattr(self.session, "pip"):
-				del self.session.pip
-			self.session.pipshown = False
+		if self.oldref is None:
+			serviceRef = self.session.nav.getCurrentlyPlayingServiceOrGroup()
+			if serviceRef:
+				serviceRefString = serviceRef.toString()
+				servicePath = serviceRefString.rsplit(":", 1)[-1]
+				if "%3a//" not in serviceRefString.lower() and not servicePath.startswith("/"):
+					self.serviceSlot = self.getServiceSlot()
+					self.oldref = serviceRef
+					self.oldAlternativeRef = self.session.nav.getCurrentlyPlayingServiceReference()
+					self.session.nav.stopService()
+			if self.pipAvailable() and self.session.pipshown:  # Try to disable PiP.
+				if hasattr(self.session, "infobar"):
+					if self.session.infobar.servicelist and self.session.infobar.servicelist.dopipzap:
+						self.session.infobar.servicelist.togglePipzap()
+				if hasattr(self.session, "pip"):
+					del self.session.pip
+				self.session.pipshown = False
+			streamServer = eStreamServer.getInstance()
+			if streamServer and streamServer.getConnectedClients():
+				streamServer.stopStream()
 
 	def __onClose(self):
-		self.session.nav.playService(self.oldref)
+		if self.oldref:
+			self.session.nav.playService(self.oldref)
 
 	def restoreService(self, msg=_("Zap back to previously tuned service?")):
 		if self.oldref:
@@ -61,10 +96,18 @@ class ServiceStopScreen:
 		else:
 			self.restartPrevService(False)
 
-	def restartPrevService(self, yesno):
+	def restartPrevService(self, yesno=True, close=True):
 		if not yesno:
 			self.oldref = None
-		self.close()
+			self.oldAlternativeRef = None
+			self.serviceSlot = -1
+		if close:
+			self.close()
+		else:
+			self.__onClose()
+			self.oldref = None
+			self.oldAlternativeRef = None
+			self.serviceSlot = -1
 
 
 class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
@@ -75,7 +118,6 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 		self.slotid = slotid
 		self.list = []
 		ServiceStopScreen.__init__(self)
-		self.stopService()
 		ConfigListScreen.__init__(self, self.list, on_change=self.changedEntry)
 		self["key_red"] = Label(_("Close"))
 		self["key_green"] = Label(_("Save"))
@@ -95,7 +137,21 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 		self.nimCountries = international.getNIMCountries()
 		self.nim = nimmanager.nim_slots[slotid]
 		self.nimConfig = self.nim.config
+		self.tunerTemplateSource = None
+		self.tunerTemplateSnapshot = []
+		self.applyCableTerrestrialTemplate()
+		self.inputPowerSlot = inputPowerSlotForNim(slotid)
+		self.resourceManager = eDVBResourceManager.getInstance()
+		self.canMeasureInputPower = self.resourceManager and self.resourceManager.canMeasureFrontendInputPower(self.inputPowerSlot)
+		self.inputPowerValue = ConfigReadOnlyValue()
+		self.inputPowerEntry = None
+		self.inputPowerTimer = eTimer()
+		self.inputPowerTimer.callback.append(self.updateInputPowerStatus)
+		self.onClose.append(self.stopInputPowerTimer)
 		self.createSetup()
+		if self.canMeasureInputPower:
+			self.updateInputPowerStatus()
+			self.inputPowerTimer.start(500, False)
 		self.onLayoutFinish.append(self.layoutFinished)
 
 	def layoutFinished(self):
@@ -107,6 +163,243 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 
 	def selectionChanged(self):
 		self["description"].setText(self["config"].getCurrent() and len(self["config"].getCurrent()) > 2 and self["config"].getCurrent()[2] or "")
+
+	@staticmethod
+	def cableTerrestrialTypes(nim):
+		return tuple(receptionType for receptionType in ("DVB-C", "DVB-T") if nim.canBeCompatible(receptionType))
+
+	@staticmethod
+	def configWasSaved(configElement):
+		return getattr(configElement, "saved_value", None) is not None
+
+	def sectionWasConfigured(self, section):
+		return section.settingsConfigured.value or any(self.configWasSaved(configElement) for configElement in section.content.items.values() if configElement is not section.settingsConfigured)
+
+	def copyTemplateElement(self, sourceElement, targetElement):
+		if not hasattr(sourceElement, "value") or not hasattr(targetElement, "value"):
+			return
+		if not any(snapshot[0] is targetElement for snapshot in self.tunerTemplateSnapshot):
+			self.tunerTemplateSnapshot.append((targetElement, deepcopy(targetElement.value), deepcopy(targetElement.saved_value), deepcopy(targetElement.loadValue)))
+		targetElement.setValue(deepcopy(sourceElement.value))
+
+	def copyTemplateSection(self, sourceSection, targetSection):
+		for name, sourceElement in sourceSection.content.items.items():
+			targetElement = targetSection.content.items.get(name)
+			if targetElement is not None:
+				self.copyTemplateElement(sourceElement, targetElement)
+
+	def applyCableTerrestrialTemplate(self):
+		templateTypes = self.cableTerrestrialTypes(self.nim)
+		if not templateTypes or self.nim.isFBCLink():
+			return
+		if any(self.sectionWasConfigured(getattr(self.nimConfig, receptionType.lower().replace("-", ""))) for receptionType in templateTypes):
+			return
+		for sourceNim in nimmanager.nim_slots[:self.slotid]:
+			if sourceNim.isFBCLink() or sourceNim.description != self.nim.description or self.cableTerrestrialTypes(sourceNim) != templateTypes:
+				continue
+			sourceConfig = sourceNim.config
+			if not any(self.sectionWasConfigured(getattr(sourceConfig, receptionType.lower().replace("-", ""))) for receptionType in templateTypes):
+				continue
+			for name in ("force_legacy_signal_stats",):
+				sourceElement = sourceConfig.content.items.get(name)
+				targetElement = self.nimConfig.content.items.get(name)
+				if sourceElement is not None and targetElement is not None and self.configWasSaved(sourceElement) and not self.configWasSaved(targetElement):
+					self.copyTemplateElement(sourceElement, targetElement)
+			for receptionType in templateTypes:
+				sectionName = receptionType.lower().replace("-", "")
+				self.copyTemplateSection(getattr(sourceConfig, sectionName), getattr(self.nimConfig, sectionName))
+			self.tunerTemplateSource = sourceNim.slot
+			sourceName = sourceNim.slot_name
+			print(f"[SatConfig] Using {sourceName} as DVB-C/T settings template for {self.nim.slot_name}.")
+			break
+
+	def restoreCableTerrestrialTemplate(self):
+		for configElement, value, savedValue, loadValue in reversed(self.tunerTemplateSnapshot):
+			configElement.saved_value = savedValue
+			configElement.loadValue = loadValue
+			configElement.setValue(deepcopy(value))
+		self.tunerTemplateSnapshot = []
+
+	def saveCableTerrestrialTemplate(self):
+		if self.tunerTemplateSource is None:
+			return
+		for snapshot in self.tunerTemplateSnapshot:
+			snapshot[0].save()
+		self.tunerTemplateSnapshot = []
+		self.tunerTemplateSource = None
+
+	def markCableTerrestrialConfigured(self):
+		templateTypes = self.cableTerrestrialTypes(self.nim)
+		activeTypes = [receptionType for receptionType in templateTypes if self.nim.isCompatible(receptionType)]
+		if self.isCableTerrestrialHybrid() and self.nimConfig.hybridTunerMode.value == "switch":
+			activeTypes = templateTypes
+		for receptionType in activeTypes:
+			section = getattr(self.nimConfig, receptionType.lower().replace("-", ""))
+			section.settingsConfigured.value = True
+			section.settingsConfigured.save()
+		configfile.save()
+
+	def stopInputPowerTimer(self):
+		self.inputPowerTimer.stop()
+
+	def updateInputPowerStatus(self):
+		if not self.canMeasureInputPower or not self.inputPowerEntry:
+			return
+		power = self.resourceManager.readFrontendInputPower(self.inputPowerSlot)
+		value = _("Not available") if power < 0 else f"{power} mA"
+		if self.inputPowerValue.value != value:
+			self.inputPowerValue.setChoices([(value, value)], default=value)
+			self["config"].invalidate(self.inputPowerEntry)
+
+	def addInputPowerEntry(self):
+		self.inputPowerEntry = getConfigListEntry(_("Measured current"), self.inputPowerValue, _("Current supplied to the LNB and positioner."))
+		self.list.append(self.inputPowerEntry)
+
+	def getUnicableUserBand(self, lnb, requireFrequency=True):
+		if isinstance(lnb, ConfigNothing) or lnb.lof.value != "unicable" or isinstance(lnb.unicable, ConfigNothing):
+			return None, _("is not configured for Unicable")
+		deviceType = lnb.unicable.value
+		try:
+			if deviceType == "unicable_user":
+				diction = lnb.dictionuser.value
+				if diction == "EN50607":
+					scr = lnb.satcruserEN50607
+					vco = lnb.satcrvcouserEN50607
+				else:
+					scr = lnb.satcruserEN50494
+					vco = lnb.satcrvcouserEN50494
+				userDefined = True
+				positions = 64 if diction == "EN50607" else 2
+				positionsOffset = 0
+			elif deviceType in ("unicable_matrix", "unicable_lnb"):
+				if deviceType == "unicable_matrix":
+					configManufacturer = lnb.unicableMatrixManufacturer
+					productDict = lnb.unicableMatrix
+				else:
+					configManufacturer = lnb.unicableLnbManufacturer
+					productDict = lnb.unicableLnb
+				nimmanager.sec.reconstructUnicableData(configManufacturer, productDict, lnb)
+				manufacturerName = configManufacturer.value.decode(encoding="UTF-8", errors="strict") if isinstance(configManufacturer.value, bytes) else configManufacturer.value
+				manufacturer = productDict[manufacturerName]
+				productName = manufacturer.product.value.decode(encoding="UTF-8", errors="strict") if isinstance(manufacturer.product.value, bytes) else manufacturer.product.value
+				if productName not in manufacturer.scr:
+					return None, _("has no valid Unicable product")
+				scr = manufacturer.scr[productName]
+				vco = manufacturer.vco[productName]
+				diction = manufacturer.diction[productName].value
+				userDefined = False
+				positions = int(manufacturer.positions[productName][0].value)
+				positionsOffset = int(manufacturer.positionsoffset[productName][0].value)
+			else:
+				return None, _("has no supported Unicable device type")
+			index = scr.index
+			if index < 0 or index >= len(vco):
+				return None, _("has no valid User Band channel")
+			frequency = int(vco[index].value)
+			if requireFrequency and frequency <= 0:
+				return None, _("uses an unavailable User Band frequency")
+		except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+			return None, _("has incomplete Unicable settings")
+		return {
+			"diction": diction,
+			"frequency": frequency,
+			"index": index,
+			"pin": int(lnb.unicable_pin.value) if lnb.unicable_use_pin.value else -1,
+			"positions": positions,
+			"positionsOffset": positionsOffset,
+			"scr": scr,
+			"userDefined": userDefined,
+			"vco": vco,
+		}, None
+
+	def validateUnicablePositions(self):
+		for lnbnum, lnb in self.nimConfig.dvbs.advanced.lnb.items():
+			if not isinstance(lnbnum, int) or not 0 < lnbnum <= maxFixedLnbPositions or isinstance(lnb, ConfigNothing) or lnb.lof.value != "unicable" or not lnb.unicablePosition.value:
+				continue
+			device, error = self.getUnicableUserBand(lnb, requireFrequency=False)
+			if error:
+				return _("Unable to validate the Unicable position for LNB %d: %s.") % (lnbnum, error)
+			firstPosition = device["positionsOffset"] + 1
+			lastPosition = device["positionsOffset"] + device["positions"]
+			if not firstPosition <= lnb.unicablePosition.value <= lastPosition:
+				return _("Unicable position %d is not supported by the selected device for LNB %d. Valid positions are %d to %d; use 'User defined' for a reprogrammed device.") % (lnb.unicablePosition.value, lnbnum, firstPosition, lastPosition)
+		return None
+
+	def getInheritedUnicableUserBand(self, lnbnum, source=None):
+		lnbs = self.nimConfig.dvbs.advanced.lnb
+		if source is None:
+			try:
+				source, error = self.getUnicableUserBand(lnbs[1])
+			except KeyError:
+				source, error = None, _("is not configured")
+			if error:
+				return None, "%s %s" % (_("LNB 1"), error)
+		try:
+			targetLnb = lnbs[lnbnum]
+		except KeyError:
+			return None, _("the target LNB is not configured")
+		target, error = self.getUnicableUserBand(targetLnb, requireFrequency=False)
+		if error:
+			return None, "%s %s" % (_("the target LNB"), error)
+		if source["diction"] != target["diction"]:
+			return None, _("LNB 1 and the target LNB use different Unicable protocols")
+		index = source["index"]
+		if index >= len(target["vco"]) or index >= len(target["scr"].choices.choices):
+			return None, _("the User Band channel from LNB 1 is not available")
+		targetFrequency = int(target["vco"][index].value)
+		if not target["userDefined"] and targetFrequency != source["frequency"]:
+			return None, _("the selected device does not use the LNB 1 frequency on this User Band channel")
+		return {
+			"frequency": source["frequency"],
+			"index": index,
+			"link": targetLnb.unicableUseLnb1UserBand,
+			"pin": source["pin"],
+			"pinConfig": targetLnb.unicable_pin,
+			"scr": target["scr"],
+			"scrValue": target["scr"].choices.choices[index][0],
+			"usePin": targetLnb.unicable_use_pin,
+			"vco": target["vco"][index] if target["userDefined"] else None,
+		}, None
+
+	def appendInheritedUnicableUserBand(self, lnbnum):
+		inherited, error = self.getInheritedUnicableUserBand(lnbnum)
+		value = _("Unavailable") if error else "SCR %d / %d MHz" % (inherited["index"] + 1, inherited["frequency"])
+		if not error and inherited["pin"] >= 0:
+			value += " / PIN %d" % inherited["pin"]
+		description = error if error else _("The User Band channel, frequency and optional PIN are inherited from LNB 1 and cannot be changed here.")
+		self.advancedInheritedSCR = getConfigListEntry(_("Inherited channel / frequency"), ConfigSelection(choices=[("inherited", value)], default="inherited"), description)
+		self.list.append(self.advancedInheritedSCR)
+
+	def synchronizeInheritedUnicableUserBands(self):
+		lnbs = self.nimConfig.dvbs.advanced.lnb
+		try:
+			source, error = self.getUnicableUserBand(lnbs[1])
+		except KeyError:
+			source, error = None, _("is not configured")
+		plans = []
+		for lnbnum in sorted(key for key in lnbs.keys() if isinstance(key, int) and 1 < key < 65):
+			lnb = lnbs[lnbnum]
+			if isinstance(lnb, ConfigNothing) or lnb.lof.value != "unicable" or not lnb.unicableUseLnb1UserBand.value:
+				continue
+			if error:
+				return _("Unable to inherit the User Band for LNB %d: LNB 1 %s.") % (lnbnum, error)
+			plan, planError = self.getInheritedUnicableUserBand(lnbnum, source)
+			if planError:
+				return _("Unable to inherit the User Band for LNB %d: %s.") % (lnbnum, planError)
+			plans.append(plan)
+		for plan in plans:
+			plan["scr"].setValue(plan["scrValue"])
+			plan["scr"].save()
+			if plan["vco"] is not None:
+				plan["vco"].setValue(plan["frequency"])
+				plan["vco"].save()
+			plan["usePin"].setValue(plan["pin"] >= 0)
+			plan["usePin"].save()
+			if plan["pin"] >= 0:
+				plan["pinConfig"].setValue(plan["pin"])
+				plan["pinConfig"].save()
+			plan["link"].save()
+		return None
 
 	def keyMenuCallback(self, answer):
 		if answer:
@@ -164,12 +457,12 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 		self.newConfig()
 
 	def keyCancel(self):
-		if self["config"].isChanged():
+		if self["config"].isChanged() or self.tunerTemplateSource is not None:
 			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), default=False)
 		else:
 			self.restoreService(_("Zap back to service before tuner setup?"))
 
-	def saveAll(self, validateSat=True):
+	def saveAll(self, validateSat=True, reopen=False):
 		if self.isCableTerrestrialHybrid():
 			self.nimConfig.hybridTunerMode.save()
 			self.nimConfig.dvbc.configMode.save()
@@ -188,6 +481,27 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 			# Sanity check for empty sat list.
 			if validateSat and self.nimConfig.dvbs.configMode.value != "satposdepends" and len(nimmanager.getSatListForNim(self.slotid)) < 1:
 				self.nimConfig.dvbs.configMode.value = "nothing"
+		if self.nim.isCompatible("DVB-C") and self.nim.isFBCRoot():
+			rootMode = self.nimConfig.dvbc.configMode.value
+			for slot in nimmanager.nim_slots:
+				if slot.isFBCLink() and slot.is_fbc[2] == self.nim.is_fbc[2]:
+					slot.config.dvbc.configMode.value = rootMode
+					slot.config.dvbc.configMode.save()
+		if reopen and self.oldref and self.serviceSlot == self.slotid and self.oldAlternativeRef:
+			serviceType = self.oldAlternativeRef.getUnsignedData(4) >> 16
+			forceReopen = serviceType == 0xEEEE and self.nim.canBeCompatible("DVB-T") and self.nimConfig.dvbt.configMode.value == "nothing"
+			forceReopen |= serviceType == 0xFFFF and (
+				self.nim.canBeCompatible("DVB-C") and self.nimConfig.dvbc.configMode.value == "nothing"
+				or self.nim.canBeCompatible("ATSC") and self.nimConfig.atsc.configMode.value == "nothing"
+			)
+			if forceReopen:
+				rawChannel = eDVBResourceManager.getInstance().allocateRawChannel(self.slotid)
+				if rawChannel:
+					frontend = rawChannel.getFrontend()
+					if frontend:
+						frontend.closeFrontend()
+						frontend.reopenFrontend()
+				del rawChannel
 		for x in self["config"].list:
 			x[1].save()
 		if self.isSatelliteCableTerrestrialHybrid():
@@ -199,6 +513,10 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 			return
 		for x in self["config"].list:
 			x[1].cancel()
+		if self.tunerTemplateSource is not None:
+			self.restoreCableTerrestrialTemplate()
+			self.restoreService(_("Zap back to service before tuner setup?"))
+			return
 		if hasattr(self, "originalTerrestrialRegion"):
 			self.nimConfig.dvbt.terrestrial.value = self.originalTerrestrialRegion
 			self.nimConfig.dvbt.terrestrial.save()
@@ -251,6 +569,16 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 			if mode != "toneburst_a_b":
 				self.list.append(getConfigListEntry(_("Set voltage and 22KHz"), nim.simpleDiSEqCSetVoltageTone, _("Leave this set to 'Yes' unless you fully understand why you are adjusting it.")))
 				self.list.append(getConfigListEntry(_("Send DiSEqC only on satellite change"), nim.simpleDiSEqCOnlyOnSatChange, _("Select 'Yes' to only send the DiSEqC command when changing from one satellite to another, or select 'No' for the DiSEqC command to be resent on every zap.")))
+		if mode in ("single", "diseqc_a_b", "diseqc_a_b_c_d"):
+			automaticSelected = nim.diseqcA.orbital_position == 3600
+			if mode in ("diseqc_a_b", "diseqc_a_b_c_d"):
+				automaticSelected |= nim.diseqcB.orbital_position == 3600
+			if mode == "diseqc_a_b_c_d":
+				automaticSelected |= nim.diseqcC.orbital_position == 3600 or nim.diseqcD.orbital_position == 3600
+			if automaticSelected:
+				autoOrder = nim.autoDiSEqCOrderSingle if mode == "single" else nim.autoDiSEqCOrder
+				self.autoDiseqcOrderEntry = getConfigListEntry(_("Auto DiSEqC search order"), autoOrder, _("Limit the search to the satellite group normally used by this installation."))
+				self.list.append(self.autoDiseqcOrderEntry)
 
 	def createPositionerSetup(self):
 		nim = self.nimConfig.dvbs
@@ -261,11 +589,12 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 		self.list.append(getConfigListEntry(" ", nim.longitudeOrientation, _("Enter if you are in the East or West hemisphere.")))
 		self.list.append(getConfigListEntry(_("Latitude"), nim.latitude, _("Enter your current latitude. This is the number of degrees you are from the equator as a decimal.")))
 		self.list.append(getConfigListEntry(" ", nim.latitudeOrientation, _("Enter if you are North or South of the equator.")))
-		if BoxInfo.getItem("CanMeasureFrontendInputPower"):
-			self.advancedPowerMeasurement = getConfigListEntry(_("Use power measurement"), nim.powerMeasurement, _("Consult your receiver's manual for more information on power management."))  # Should this be "measurement" or "management"?
+		if self.canMeasureInputPower:
+			self.addInputPowerEntry()
+			self.advancedPowerMeasurement = getConfigListEntry(_("Use power measurement"), nim.powerMeasurement, _("Detect positioner movement by its current consumption."))
 			self.list.append(self.advancedPowerMeasurement)
 			if nim.powerMeasurement.value:
-				self.list.append(getConfigListEntry(_("Power threshold in mA"), nim.powerThreshold, _("Consult your receiver's manual for more information on power threshold.")))
+				self.list.append(getConfigListEntry(_("Power threshold in mA"), nim.powerThreshold, _("Minimum difference between idle and moving current.")))
 				self.turningSpeed = getConfigListEntry(_("Rotor turning speed"), nim.turningSpeed, _("Select how quickly the dish should move between satellites."))
 				self.list.append(self.turningSpeed)
 				if nim.turningSpeed.value == "fast epoch":
@@ -278,7 +607,8 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				nim.powerMeasurement.value = False
 				nim.powerMeasurement.save()
 		if not hasattr(self, "additionalMotorOptions"):
-			self.additionalMotorOptions = ConfigYesNo(False)
+			customMotorValues = any(x.value != x.default for x in (nim.turningspeedH, nim.turningspeedV, nim.tuningstepsize, nim.rotorPositions))
+			self.additionalMotorOptions = ConfigBoolean(default=customMotorValues, descriptions={False: _("Show sub-menu"), True: _("Hide sub-menu")})
 		self.showAdditionalMotorOptions = getConfigListEntry(_("Extra motor options"), self.additionalMotorOptions, _("Additional motor options allow you to enter details from your motor's specifications so Enigma can work out how long it will take to move the dish from one satellite to another."))
 		self.list.append(self.showAdditionalMotorOptions)
 		if self.additionalMotorOptions.value:
@@ -369,6 +699,8 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 		self.advancedUsalsEntry = None
 		self.advancedLof = None
 		self.advancedPowerMeasurement = None
+		self.inputPowerEntry = None
+		self.autoDiseqcOrderEntry = None
 		self.turningSpeed = None
 		self.turnFastEpochBegin = None
 		self.turnFastEpochEnd = None
@@ -379,12 +711,16 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 		self.cableScanType = None
 		self.have_advanced = False
 		self.advancedUnicable = None
+		self.advancedUnicableUseLnb1 = None
+		self.advancedUnicableUsePin = None
 		self.advancedType = None
 		self.advancedManufacturer = None
 		self.advancedSCR = None
+		self.advancedInheritedSCR = None
 		self.advancedDiction = None
 		self.advancedConnected = None
 		self.advancedUnicableTuningAlgo = None
+		self.advancedPowerInserter = None
 		self.showAdditionalMotorOptions = None
 		self.selectSatsEntry = None
 		self.advancedSelectSatsEntry = None
@@ -449,13 +785,29 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 			elif nimConfig.configMode.value == "nothing":
 				pass
 			elif nimConfig.configMode.value == "advanced":  # Advanced SATs.
+				additionalRotorCable = (3607, _("Additional cable of motorized LNB"))
+				advancedSatChoices = [choice for choice in nimConfig.advanced.sats.choices.choices if int(choice[0]) != 3607]
+				if isFBCLink(self.nim.slot):
+					advancedSatChoices = [choice for choice in advancedSatChoices if int(choice[0]) < 3600]
+				rotorSources = nimmanager.canDependOn(self.slotid, advancedSatposdepends="fbc" if isFBCLink(self.nim.slot) else "all")
+				if rotorSources:
+					advancedSatChoices.append(additionalRotorCable)
+				currentAdvancedSat = int(nimConfig.advanced.sats.value)
+				if currentAdvancedSat not in {int(choice[0]) for choice in advancedSatChoices}:
+					currentAdvancedSat = 192 if any(int(choice[0]) == 192 for choice in advancedSatChoices) else int(advancedSatChoices[0][0])
+				nimConfig.advanced.sats.setChoices(advancedSatChoices, default=currentAdvancedSat)
 				self.advancedSatsEntry = getConfigListEntry(_("Satellite"), nimConfig.advanced.sats, _("Select the satellite you want to configure. Once configured you can select and configure other satellites that will be accessed using this same tuner."))
 				self.list.append(self.advancedSatsEntry)
-				current_config_sats = nimConfig.advanced.sats.value
+				current_config_sats = int(nimConfig.advanced.sats.value)
+				if current_config_sats == 3607:
+					nimConfig.connectedTo.setChoices([(str(slot), nimmanager.getNimDescription(slot)) for slot in rotorSources])
+					self.list.append(getConfigListEntry(_("Tuner"), nimConfig.connectedTo, _("Select the tuner that controls the motorized dish.")))
 				if current_config_sats in (3605, 3606):
 					self.advancedSelectSatsEntry = getConfigListEntry(_("Press OK to select satellites"), nimConfig.pressOKtoList, _("Selecting this option allows you to configure a group of satellites in one block."))
 					self.list.append(self.advancedSelectSatsEntry)
 					self.fillListWithAdvancedSatEntrys(nimConfig.advanced.sat[int(current_config_sats)])
+				elif current_config_sats == 3607:
+					self.fillListWithAdvancedSatEntrys(nimConfig.advanced.sat[3607])
 				else:
 					cur_orb_pos = nimConfig.advanced.sats.orbital_position
 					satlist = nimConfig.advanced.sat.keys()
@@ -474,7 +826,10 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				self.list.append(getConfigListEntry(_("Connector"), nimConfig.input, _("Select the input connector you want to use.")))
 
 		elif self.nim.isCompatible("DVB-C"):
-			self.configMode = getConfigListEntry(_("Configuration mode"), self.nimConfig.dvbc.configMode, _("Select 'Enabled' if this tuner has a signal cable connected, otherwise select 'Nothing connected'."))
+			warningText = ""
+			if "Vuplus DVB-C NIM(BCM3148)" in (self.nim.description or "") and self.nim.isFBCRoot() and self.nim.is_fbc[2] != 1:
+				warningText = _("Warning: This FBC-C V1 tuner should be installed in the first slot. In the second slot only 2 of 8 demodulators may be available. ")
+			self.configMode = getConfigListEntry(_("Configuration mode"), self.nimConfig.dvbc.configMode, warningText + _("Select 'Enabled' if this tuner has a signal cable connected, otherwise select 'Nothing connected'."))
 			self.list.append(self.configMode)
 			if self.nimConfig.dvbc.configMode.value == "enabled":
 				self.list.append(getConfigListEntry(_("Network ID"), self.nimConfig.dvbc.scan_networkid, _("This setting depends on your cable provider and location. If you don't know the correct setting refer to the menu in the official cable receiver, or get it from your cable provider, or seek help via Internet forum.")))
@@ -589,9 +944,9 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 			self.configMode, self.diseqcModeEntry, self.advancedSatsEntry,
 			self.advancedLnbsEntry, self.advancedDiseqcMode, self.advancedUsalsEntry,
 			self.advancedLof, self.advancedPowerMeasurement, self.turningSpeed,
-			self.advancedType, self.advancedSCR, self.advancedDiction, self.advancedManufacturer, self.advancedUnicable, self.advancedConnected, self.advancedUnicableTuningAlgo,
+			self.advancedType, self.advancedSCR, self.advancedDiction, self.advancedManufacturer, self.advancedUnicable, self.advancedUnicableUseLnb1, self.advancedUnicableUsePin, self.advancedConnected, self.advancedUnicableTuningAlgo, self.advancedPowerInserter,
 			self.toneburst, self.committedDiseqcCommand, self.uncommittedDiseqcCommand, self.singleSatEntry,
-			self.commandOrder, self.showAdditionalMotorOptions, self.cableScanType, self.terrestrialCountriesEntry, self.cableCountriesEntry, self.hybridTunerMode, self.multiType
+			self.commandOrder, self.showAdditionalMotorOptions, self.autoDiseqcOrderEntry, self.cableScanType, self.terrestrialCountriesEntry, self.cableCountriesEntry, self.hybridTunerMode, self.multiType
 		)
 		if self["config"].getCurrent() in (self.hybridTunerMode, self.multiType) and (self.hybridTunerMode or self.multiType):
 			update_slots = [self.slotid]
@@ -617,7 +972,8 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					if self.nimConfig.dvbs.diseqcA.orbital_position == 3600 or self.nimConfig.dvbs.diseqcB.orbital_position == 3600 or self.nimConfig.dvbs.diseqcC.orbital_position == 3600 or self.nimConfig.dvbs.diseqcD.orbital_position == 3600:
 						autodiseqc_ports = 4
 				if autodiseqc_ports:
-					self.autoDiseqcRun(autodiseqc_ports)
+					autoOrder = self.nimConfig.dvbs.autoDiSEqCOrderSingle.value if self.nimConfig.dvbs.diseqcMode.value == "single" else self.nimConfig.dvbs.autoDiSEqCOrder.value
+					self.autoDiseqcRun(autodiseqc_ports, autoOrder)
 					return False
 			if self.have_advanced and self.nimConfig.dvbs.configMode.value == "advanced":
 				self.saveAll()  # Save any unsaved data before self.list entries are gone.
@@ -630,17 +986,19 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				x[1].value = int(mktime(dt.timetuple()))
 			x[1].save()
 		nimmanager.sec.update()
-		self.saveAll()
+		self.saveAll(reopen=True)
 		return True
 
-	def autoDiseqcRun(self, ports):
-		self.session.openWithCallback(self.autoDiseqcCallback, AutoDiseqc, self.slotid, ports, self.nimConfig.dvbs.simpleDiSEqCSetVoltageTone, self.nimConfig.dvbs.simpleDiSEqCOnlyOnSatChange)
+	def autoDiseqcRun(self, ports, order="all"):
+		self.stopService()
+		self.session.openWithCallback(self.autoDiseqcCallback, AutoDiseqc, self.slotid, ports, self.nimConfig.dvbs.simpleDiSEqCSetVoltageTone, self.nimConfig.dvbs.simpleDiSEqCOnlyOnSatChange, order)
 
 	def autoDiseqcCallback(self, result):
 		from Screens.Wizard import Wizard
 		if Wizard.instance is not None:
 			Wizard.instance.back()
 		else:
+			self.restartPrevService(close=False)
 			self.createSetup()
 
 	def fillListWithAdvancedSatEntrys(self, Sat):
@@ -668,8 +1026,19 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				self.list.append(getConfigListEntry(_("LOF/H"), currLnb.lofh, _("Enter your high band local oscillator frequency. For more information consult the specifications of your LNB.")))
 				self.list.append(getConfigListEntry(_("Threshold"), currLnb.threshold, _("Enter the frequency at which you LNB switches between low band and high band. For more information consult the specifications of your LNB.")))
 			if currLnb.lof.value == "unicable":
-				self.advancedUnicable = getConfigListEntry("%s%s" % (_("Unicable "), _("Type of device")), currLnb.unicable, _("Select the type of Single Cable Reception device you are using."))
+				warningText = ""
+				if "Vuplus DVB-S NIM(AVL6222)" in (self.nim.description or "") and self.nim.internallyConnectableTo() is not None:
+					warningText = _("Warning: The second input of this dual tuner may not support Unicable devices. ")
+				self.advancedUnicable = getConfigListEntry("%s%s" % (_("Unicable "), _("Type of device")), currLnb.unicable, warningText + _("Select the type of Single Cable Reception device you are using."))
 				self.list.append(self.advancedUnicable)
+				self.advancedPowerInserter = getConfigListEntry(_("Externally powered"), currLnb.powerInserter, _("Enable this when a power inserter or external supply powers the Unicable device."))
+				self.list.append(self.advancedPowerInserter)
+				if lnbnum <= maxFixedLnbPositions:
+					self.list.append(getConfigListEntry(_("Unicable position"), currLnb.unicablePosition, _("Leave this at 0 to derive the position from the LNB number and device profile. Enter 1 to 64 only for a reprogrammed Unicable device.")))
+				inheritUserBand = 1 < lnbnum < 65 and currLnb.unicableUseLnb1UserBand.value
+				if 1 < lnbnum < 65:
+					self.advancedUnicableUseLnb1 = getConfigListEntry(_("Use LNB 1 User Band"), currLnb.unicableUseLnb1UserBand, _("Select 'Yes' to use the same User Band channel and frequency as LNB 1. This is intended for multiple satellite positions delivered by the same Unicable system."))
+					self.list.append(self.advancedUnicableUseLnb1)
 				if currLnb.unicable.value == "unicable_user":
 					self.advancedDiction = getConfigListEntry(_("Diction"), currLnb.dictionuser, _("Select the protocol used by your SCR device. Choices are 'SCR Unicable' (Unicable), or 'SCR JESS' (JESS, also known as Unicable II)."))
 					self.list.append(self.advancedDiction)
@@ -679,13 +1048,17 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					elif currLnb.dictionuser.value == "EN50607":
 						satcr = currLnb.satcruserEN50607
 						stcrvco = currLnb.satcrvcouserEN50607[currLnb.satcruserEN50607.index]
-					self.advancedSCR = getConfigListEntry(_("Channel"), satcr, _("Select the Unicable channel to be assigned to this tuner. This is a unique value. Be certain that no other device connected to this same Unicable system is allocated to the same Unicable channel."))
-					self.list.append(self.advancedSCR)
-					self.list.append(getConfigListEntry(_("Frequency"), stcrvco, _("Select the User Band frequency to be assigned to this tuner. This is the frequency the SCR switch or SCR LNB uses to pass the requested transponder to the tuner.")))
+					if inheritUserBand:
+						self.appendInheritedUnicableUserBand(lnbnum)
+					else:
+						self.advancedSCR = getConfigListEntry(_("Channel"), satcr, _("Select the Unicable channel to be assigned to this tuner. This is a unique value. Be certain that no other device connected to this same Unicable system is allocated to the same Unicable channel."))
+						self.list.append(self.advancedSCR)
+						self.list.append(getConfigListEntry(_("Frequency"), stcrvco, _("Select the User Band frequency to be assigned to this tuner. This is the frequency the SCR switch or SCR LNB uses to pass the requested transponder to the tuner.")))
 					self.list.append(getConfigListEntry(_("LOF/L"), currLnb.lofl, _("Consult your SCR device specifications for this information.")))
 					self.list.append(getConfigListEntry(_("LOF/H"), currLnb.lofh, _("Consult your SCR device specifications for this information.")))
 					self.list.append(getConfigListEntry(_("Threshold"), currLnb.threshold, _("Consult your SCR device specifications for this information.")))
-					self.list.append(getConfigListEntry(_("LNB/Switch Bootup time [ms]"), currLnb.bootuptimeuser))
+					if not currLnb.powerInserter.value:
+						self.list.append(getConfigListEntry(_("LNB/Switch Bootup time [ms]"), currLnb.bootuptimeuser))
 				elif currLnb.unicable.value == "unicable_matrix":
 					nimmanager.sec.reconstructUnicableData(currLnb.unicableMatrixManufacturer, currLnb.unicableMatrix, currLnb)
 					manufacturer_name = ensure_text(currLnb.unicableMatrixManufacturer.value)
@@ -696,10 +1069,13 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					if product_name in manufacturer.scr:
 						diction = manufacturer.diction[product_name].value
 						self.advancedType = getConfigListEntry(_("Model"), manufacturer.product, _("Select the model number of your Unicable device. If the model number is not listed, set 'SCR' to 'User defined' and enter the device parameters manually according to its specifications."))
-						self.advancedSCR = getConfigListEntry(_("Channel"), manufacturer.scr[product_name], _("Select the User Band channel to be assigned to this tuner. This is an index into the table of frequencies the SCR switch uses to pass the requested transponder to the tuner."))
 						self.list.append(self.advancedType)
-						self.list.append(self.advancedSCR)
-						self.list.append(getConfigListEntry(_("Frequency"), manufacturer.vco[product_name][manufacturer.scr[product_name].index], _("Select the User Band frequency to be assigned to this tuner. This is the frequency the SCR switch uses to pass the requested transponder to the tuner.")))
+						if inheritUserBand:
+							self.appendInheritedUnicableUserBand(lnbnum)
+						else:
+							self.advancedSCR = getConfigListEntry(_("Channel"), manufacturer.scr[product_name], _("Select the User Band channel to be assigned to this tuner. This is an index into the table of frequencies the SCR switch uses to pass the requested transponder to the tuner."))
+							self.list.append(self.advancedSCR)
+							self.list.append(getConfigListEntry(_("Frequency"), manufacturer.vco[product_name][manufacturer.scr[product_name].index], _("Select the User Band frequency to be assigned to this tuner. This is the frequency the SCR switch uses to pass the requested transponder to the tuner.")))
 				elif currLnb.unicable.value == "unicable_lnb":
 					nimmanager.sec.reconstructUnicableData(currLnb.unicableLnbManufacturer, currLnb.unicableLnb, currLnb)
 					manufacturer_name = ensure_text(currLnb.unicableLnbManufacturer.value)
@@ -710,10 +1086,18 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					if product_name in manufacturer.scr:
 						diction = manufacturer.diction[product_name].value
 						self.advancedType = getConfigListEntry(_("Model"), manufacturer.product, _("Select the model number of your Unicable device. If the model number is not listed, set 'SCR' to 'User defined' and enter the device parameters manually according to its specifications."))
-						self.advancedSCR = getConfigListEntry(_("Channel"), manufacturer.scr[product_name], _("Select the User Band channel to be assigned to this tuner. This is an index into the table of frequencies the SCR LNB uses to pass the requested transponder to the tuner."))
 						self.list.append(self.advancedType)
-						self.list.append(self.advancedSCR)
-						self.list.append(getConfigListEntry(_("Frequency"), manufacturer.vco[product_name][manufacturer.scr[product_name].index], _("Select the User Band frequency to be assigned to this tuner. This is the frequency the SCR LNB uses to pass the requested transponder to the tuner.")))
+						if inheritUserBand:
+							self.appendInheritedUnicableUserBand(lnbnum)
+						else:
+							self.advancedSCR = getConfigListEntry(_("Channel"), manufacturer.scr[product_name], _("Select the User Band channel to be assigned to this tuner. This is an index into the table of frequencies the SCR LNB uses to pass the requested transponder to the tuner."))
+							self.list.append(self.advancedSCR)
+							self.list.append(getConfigListEntry(_("Frequency"), manufacturer.vco[product_name][manufacturer.scr[product_name].index], _("Select the User Band frequency to be assigned to this tuner. This is the frequency the SCR LNB uses to pass the requested transponder to the tuner.")))
+				if not inheritUserBand:
+					self.advancedUnicableUsePin = getConfigListEntry(_("Use PIN"), currLnb.unicable_use_pin, _("Enable this when the User Band is protected by a PIN in a multi-dwelling Unicable installation."))
+					self.list.append(self.advancedUnicableUsePin)
+					if currLnb.unicable_use_pin.value:
+						self.list.append(getConfigListEntry(_("PIN"), currLnb.unicable_pin, _("Enter the PIN from 0 to 255 assigned to this User Band by the installer or building operator.")))
 				self.advancedUnicableTuningAlgo = getConfigListEntry(_("Tuning algorithm"), currLnb.unicableTuningAlgo, _("SCR timing adjustment, in conjunction with SCR socket and operation of several SCR devices with one cable."))
 				self.list.append(self.advancedUnicableTuningAlgo)
 				choices = []
@@ -733,7 +1117,13 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				self.list.append(getConfigListEntry(_("Voltage mode"), Sat.voltage, _("Select 'Polarization' if using a 'Universal' LNB, otherwise consult your LNB specifications.")))
 				self.list.append(getConfigListEntry(_("Tone mode"), Sat.tonemode, _("Select 'Band' if using a 'Universal' LNB, otherwise consult your LNB specifications.")))
 			self.list.append(getConfigListEntry(_("Increased voltage"), currLnb.increased_voltage, _("Use increased voltage '14/18V' if there are problems when switching the LNB.")))
-			if lnbnum < 65 and diction != "EN50607":
+			additionalRotorLnb = maxFixedLnbPositions + MAX_LNB_WILDCARDS
+			if (lnbnum < 65 and diction != "EN50607") or lnbnum == additionalRotorLnb:
+				if isFBCLink(self.nim.slot):
+					diseqcChoices = [choice for choice in currLnb.diseqcMode.choices.choices if choice[0] != "1_2"]
+					if currLnb.diseqcMode.value == "1_2":
+						currLnb.diseqcMode.value = "none"
+					currLnb.diseqcMode.setChoices(diseqcChoices, default="none")
 				self.advancedDiseqcMode = getConfigListEntry(_("DiSEqC mode"), currLnb.diseqcMode, _("Select '1.0' for standard committed switches, '1.1' for uncommitted switches, and '1.2' for systems using a positioner."))
 				self.list.append(self.advancedDiseqcMode)
 			if currLnb.diseqcMode.value != "none":
@@ -762,11 +1152,12 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 						self.list.append(getConfigListEntry(_("DiSEqC 1.1 repeats"), currLnb.diseqcRepeats, _("If using multiple uncommitted switches the DiSEqC commands must be sent multiple times. Set to the number of uncommitted switches in the chain minus one.")))
 				self.list.append(getConfigListEntry(_("Sequence repeat"), currLnb.sequenceRepeat, _("Set sequence repeats if your aerial system requires this. Normally if the aerial system has been configured correctly sequence repeats will not be necessary. If yours does, recheck you have command order set correctly.")))
 				if currLnb.diseqcMode.value == "1_2":
-					if BoxInfo.getItem("CanMeasureFrontendInputPower"):
-						self.advancedPowerMeasurement = getConfigListEntry(_("Use power measurement"), currLnb.powerMeasurement, _("Consult your receiver's manual for more information on power management."))  # Should this be "measurement" or "management"?
+					if self.canMeasureInputPower:
+						self.addInputPowerEntry()
+						self.advancedPowerMeasurement = getConfigListEntry(_("Use power measurement"), currLnb.powerMeasurement, _("Detect positioner movement by its current consumption."))
 						self.list.append(self.advancedPowerMeasurement)
 						if currLnb.powerMeasurement.value:
-							self.list.append(getConfigListEntry(_("Power threshold in mA"), currLnb.powerThreshold, _("Consult your receiver's manual for more information on power threshold.")))
+							self.list.append(getConfigListEntry(_("Power threshold in mA"), currLnb.powerThreshold, _("Minimum difference between idle and moving current.")))
 							self.turningSpeed = getConfigListEntry(_("Rotor turning speed"), currLnb.turningSpeed, _("Select how quickly the dish should move between satellites."))
 							self.list.append(self.turningSpeed)
 							if currLnb.turningSpeed.value == "fast epoch":
@@ -789,7 +1180,8 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 					else:
 						self.list.append(getConfigListEntry(_("Stored position"), Sat.rotorposition, _("Enter the number stored in the positioner that corresponds to this satellite.")))
 					if not hasattr(self, 'additionalMotorOptions'):
-						self.additionalMotorOptions = ConfigYesNo(False)
+						customMotorValues = any(x.value != x.default for x in (currLnb.turningspeedH, currLnb.turningspeedV, currLnb.tuningstepsize, currLnb.rotorPositions))
+						self.additionalMotorOptions = ConfigBoolean(default=customMotorValues, descriptions={False: _("Show sub-menu"), True: _("Hide sub-menu")})
 					self.showAdditionalMotorOptions = getConfigListEntry(_("Extra motor options"), self.additionalMotorOptions, _("Additional motor options allow you to enter details from your motor's specifications so Enigma can work out how long it will take to move to another satellite."))
 					self.list.append(self.showAdditionalMotorOptions)
 					if self.additionalMotorOptions.value:
@@ -887,7 +1279,20 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 			conf.value = val
 			conf.save()
 
-	def keySave(self):
+	def keySave(self, recordingConfirmed=False):
+		if not recordingConfirmed:
+			nextRecording = self.session.nav.RecordTimer.getNextRecordingTime()
+			secondsUntilRecording = nextRecording - time() if nextRecording and nextRecording > 0 else -1
+			recordingSoon = 0 <= secondsUntilRecording < 360
+			if self.session.nav.getAnyRecordingsCount() or recordingSoon:
+				self.session.openWithCallback(
+					self.keySaveRecordingConfirmed,
+					MessageBox,
+					_("A recording is running or will start within six minutes. Changing the tuner configuration can interrupt it. Save anyway?"),
+					MessageBox.TYPE_YESNO,
+					default=False
+				)
+				return
 		if self.nim.canBeCompatible("DVB-S"):
 			if not self.unicableconnection():
 				self.session.open(MessageBox, _("The unicable connection setting is wrong.\nMaybe recursive connection of tuners."), MessageBox.TYPE_ERROR, timeout=10)
@@ -895,13 +1300,25 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 			if not self.checkLoopthrough():
 				self.session.open(MessageBox, _("The loopthrough setting is wrong."), MessageBox.TYPE_ERROR, timeout=10)
 				return
+			if self.nimConfig.dvbs.configMode.value == "advanced":
+				error = self.validateUnicablePositions() or self.synchronizeInheritedUnicableUserBands()
+				if error:
+					self.session.open(MessageBox, error, MessageBox.TYPE_ERROR, timeout=15)
+					return
+		self.stopService()
 		old_configured_sats = nimmanager.getConfiguredSats()
 		if not self.run():
 			return
+		self.saveCableTerrestrialTemplate()
+		self.markCableTerrestrialConfigured()
 		new_configured_sats = nimmanager.getConfiguredSats()
 		self.unconfed_sats = old_configured_sats - new_configured_sats
 		self.satpos_to_remove = None
 		self.deleteConfirmed((None, "no"))
+
+	def keySaveRecordingConfirmed(self, answer):
+		if answer:
+			self.keySave(recordingConfirmed=True)
 
 	def deleteConfirmed(self, confirmed):
 		if confirmed is None:
@@ -1012,6 +1429,8 @@ class NimSelection(Screen):
 	def okbuttonClick(self):
 		nim = self["nimlist"].getCurrent()
 		nim = nim and nim[3]
+		if nim is None:
+			return
 		if isFBCLink(nim.slot):
 			if nim.isCompatible("DVB-S"):
 				nimConfig = nimmanager.getNimConfig(nim.slot).dvbs
@@ -1021,7 +1440,7 @@ class NimSelection(Screen):
 				nimConfig = nimmanager.getNimConfig(nim.slot).dvbt
 			if nimConfig.configMode.value == "loopthrough":
 				return
-		if nim is not None and not nim.empty and nim.isSupported():
+		if not nim.empty and nim.isSupported():
 			self.session.openWithCallback(boundFunction(self.NimSetupCB, self["nimlist"].getIndex()), self.resultclass, nim.slot)
 
 	def NimSetupCB(self, index=None):
@@ -1031,6 +1450,13 @@ class NimSelection(Screen):
 
 	def showNim(self, nim):
 		return not (nim.isEmpty() or (nim.isCompatible("DVB-C") and nim.isFBCTuner() and not nim.isFBCRoot()))
+
+	@staticmethod
+	def orbitalPositionToString(position):
+		if position > 1800:
+			position = 3600 - position
+			return f"{position // 10}.{position % 10}W"
+		return f"{position // 10}.{position % 10}E"
 
 	def updateList(self, index=None):
 		self.list = []
@@ -1071,7 +1497,11 @@ class NimSelection(Screen):
 						if fbc_text:
 							text += "\n" + fbc_text
 					elif nimConfig.configMode.value == "nothing":
-						text = _("Not configured")
+						if isFBCLink(x.slot):
+							linkedSlot = getLinkedSlotID(x.slot)
+							text = _("FBC automatic: inactive") if linkedSlot < 0 else _("FBC automatic: connected to %s") % nimmanager.getNimDescription(linkedSlot)
+						else:
+							text = _("Not configured")
 						if fbc_text:
 							text += "\n" + fbc_text
 					elif nimConfig.configMode.value == "simple":
@@ -1120,9 +1550,22 @@ class NimSelection(Screen):
 										text += " / " + UNICABLE_CHOICES().get(uni, uni)
 								except AttributeError:
 									pass
+						unicableConnected = nimConfig.advanced.content.items.get("unicableconnected")
+						unicableConnectedTo = nimConfig.advanced.content.items.get("unicableconnectedTo")
+						if unicableConnected is not None and unicableConnectedTo is not None and unicableConnected.value and unicableConnectedTo.value.isdigit():
+							text += " / " + _("Connected to") + " " + nimmanager.getNimDescription(int(unicableConnectedTo.value))
+						configuredSatellites = nimmanager.getSatListForNim(slotid)
+						rotorSatellites = nimmanager.getRotorSatListForNim(slotid)
+						if int(nimConfig.advanced.sat[3607].lnb.value) != 0 and nimConfig.connectedTo.value.isdigit():
+							text += "\n" + _("Additional rotor cable from %s") % nimmanager.getNimDescription(int(nimConfig.connectedTo.value))
+						elif rotorSatellites:
+							text += "\n" + _("Rotor: %d satellites") % len(rotorSatellites)
+						elif configuredSatellites:
+							positions = [self.orbitalPositionToString(satellite[0]) for satellite in configuredSatellites]
+							text += "\n" + _("Sats") + ": " + ", ".join(positions[:8]) + (", …" if len(positions) > 8 else "")
 						if fbc_text:
 							text += "\n" + fbc_text
-					if isFBCLink(x.slot) and nimConfig.configMode.value != "advanced":
+					if isFBCLink(x.slot) and nimConfig.configMode.value not in ("advanced", "loopthrough", "nothing"):
 						text += _("\n<This tuner is configured automatically>")
 				elif x.isCompatible("DVB-T"):
 					nimConfig = nimmanager.getNimConfig(x.slot).dvbt
@@ -1130,6 +1573,8 @@ class NimSelection(Screen):
 						text = _("nothing connected")
 					elif nimConfig.configMode.value == "enabled":
 						text = _("Enabled")
+						if hasattr(nimConfig, "terrestrial_5V") and nimConfig.terrestrial_5V.value:
+							text += _(" (+5 volt terrestrial)")
 				elif x.isCompatible("DVB-C"):
 					nimConfig = nimmanager.getNimConfig(x.slot).dvbc
 					if nimConfig.configMode.value == "nothing":


### PR DESCRIPTION
…-slot input power

- Add eDVBSatelliteEquipmentControl SatCR_pin support end-to-end (sec, NimManager, Satconfig) so PIN-protected Unicable/JESS User Bands work; fix pin<1 checks to pin<0 since PIN 0 is valid, and clear PIN on sec clear()/new LNB.
- Allow LNB1's User Band channel/frequency/PIN to be inherited by other LNBs on the same Unicable system ("Use LNB 1 User Band"), with validation before save.
- Make canMeasureFrontendInputPower/readFrontendInputPower slot-aware instead of returning the first frontend found; surface live LNB current in PositionerSetup and NimSetup.
- Track and persist the last known rotor orbital position per tuner (lastsatrotorposition, slotRotorSatPosChanged signal) and show it in PositionerSetup and FrontendInfo.
- Add "Additional cable of motorized LNB" (advanced sat 3607) so a second tuner can share a rotor's satellite list without sending its own motor commands.
- PositionerSetup: fine-movement step counter, ONID/TSID verification screen, "further options" menu (open tuner setup), frontend-unavailable handling, and block setup while a recording is imminent (not just running).
- NimSetup: copy DVB-C/T settings from an identical tuner as a template for newly enabled tuners, restrict DiSEqC 1.2 on FBC links, add power-inserter and Unicable-position options, and confirm before saving if a recording is running or due within 6 minutes.
- Fix orbital-position list matching (str(pos) in listValue) that could match substrings; add exact orbitalPositionInList() helper.
- AutoDiseqc: add several new satellites and a search-order filter (Astra Central Europe / East / West / Circular).