### PR TITLE
[eHEVCHDRDetector] suppress scan when a CI module is descrambling

### DIFF
--- a/lib/dvb/hevc_hdr_detector.cpp
+++ b/lib/dvb/hevc_hdr_detector.cpp
@@ -2,6 +2,7 @@
 
 #include <lib/base/eerror.h>
 #include <lib/dvb/hevc_hdr_detector.h>
+#include <lib/dvb_ci/dvbci.h>
 
 /*
  * Keep completion outside eDVBPESReader::data().  Stopping the reader from a
@@ -31,6 +32,14 @@ bool eHEVCHDRDetector::start(int pid)
 	stop();
 	if (!m_demux || pid <= 0 || pid >= 0x2000)
 		return false;
+
+	eDVBCIInterfaces *ci = eDVBCIInterfaces::getInstance();
+	if (ci && ci->hasActiveCiRouting())
+	{
+		eDebug("[eHEVCHDRDetector] scan suppressed for PID %04x "
+			"(CI module handles descrambling)", pid);
+		return false;
+	}
 
 	if (!m_reader)
 	{

--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -908,6 +908,14 @@ bool eDVBCIInterfaces::isCiConnected(eDVBServicePMTHandler *pmthandler)
 	return ret;
 }
 
+bool eDVBCIInterfaces::hasActiveCiRouting()
+{
+	for (PMTHandlerList::iterator it = m_pmt_handlers.begin(); it != m_pmt_handlers.end(); ++it)
+		if (it->cislot)
+			return true;
+	return false;
+}
+
 int eDVBCIInterfaces::getMMIState(int slotid)
 {
 	eDVBCISlot *slot;

--- a/lib/dvb_ci/dvbci.h
+++ b/lib/dvb_ci/dvbci.h
@@ -232,6 +232,7 @@ public:
 	void executeRecheckPMTHandlersInMainloop();
 	void gotPMT(eDVBServicePMTHandler *pmthandler);
 	bool isCiConnected(eDVBServicePMTHandler *pmthandler);
+	bool hasActiveCiRouting();
 	void ciRemoved(eDVBCISlot *slot);
 	int getSlotState(int slot);
 


### PR DESCRIPTION
Follow-up to 236583085a ('dvb: add HEVC HDR fallback detection for 4K receivers').

Problem
-------
The HDR fallback detector opens a second PES reader on the running video PID (createPESReader() + reader->start(pid)).

On direct tuner routes the demux broadcasts to both consumers so the tap is harmless: the hardware video decoder keeps receiving all packets and the detector reads its own copy in parallel.

On CI-routed demuxes (setInputSource CI0/CI1, active whenever a CAM is descrambling) the second reader competes with the hardware video decoder for the same descrambled PID. On Hisilicon-based 4K receivers (hd61 / ax61, sf8008, ustym4kpro, viper4k, gbmv200 and other Hi3798 platforms) the CI-return path is single-consumer per descrambled PID and the tap wins the routing — the descrambled TS packets go to the HDR reader instead of DMX_PES_VIDEO0. The hardware video decoder starves after roughly one second of prefill while audio continues on its independent DMX_PES_AUDIO0 filter, producing the well-known 'sound but frozen picture' symptom on 4K CAM services (Tivusat UHD in particular).

Solution
--------
Extend eDVBCIInterfaces with hasActiveCiRouting() — a pmthandler-less variant of isCiConnected() that walks m_pmt_handlers and returns true if any active service currently has a CI slot assigned.

Query it from eHEVCHDRDetector::start() and skip the scan when the answer is true. FTA playback keeps the detector running unchanged and still reports HDR gamma from the SPS/VUI and SEI parsers; CAM playback leaves the video PID exclusively to the hardware decoder, so 4K CAM services no longer freeze.

Same signal as isCiConnected(), just observable from the detector without threading a pmthandler pointer through iTSMPEGDecoder, eDVBVideo and eHEVCHDRDetector.