### PR TITLE
[EpgList.py] Improve EPG timer service matching

### DIFF
--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -736,7 +736,7 @@ class EPGList(GUIComponent):
 	def getPixmapForEntry(self, service, eventId, beginTime, duration):
 		if not beginTime:
 			return None
-		rec = self.timer.isInTimer(eventId, beginTime, duration, ":".join(service.split(":")[:11]))
+		rec = self.timer.isInTimer(eventId, beginTime, duration, eServiceReference(service).toCompareString())
 		if rec is not None:
 			self.wasEntryAutoTimer = bool(rec[2] & 1)
 			self.wasEntryIceTV = bool(rec[2] & 2)


### PR DESCRIPTION
### Problem

Timer indicators are not displayed in the single and multi EPG when a timer uses an alternative service group.

Alternative group references contain non-zero flags, for example 1:134:.... `RecordTimerEntry` stores its comparison key using `toCompareString()`, which normalizes those flags to 0. However, `EpgList.getPixmapForEntry()` only truncates the EPG service reference to its first eleven colon-separated fields, preserving the original 134 flags.

The subsequent strict comparison therefore uses different representations of the same service:
```
EPG:   1:134:...
Timer: 1:0:...
```
As a result, isInTimer() does not find the timer and no recording or AutoTimer icon is rendered. The timer itself remains valid, can be edited from the EPG, and records correctly because those operations use separate matching paths.

### Solution
Normalize the EPG service reference with `eServiceReference.toCompareString()` before performing the timer lookup. This uses the same canonical representation as `RecordTimerEntry`, allowing timers associated with alternative service groups to be detected and displayed correctly.