### PR TITLE
[OScamInfo] softcam control + dynamic keys + robustness

### DIFF
--- a/lib/python/Screens/OScamInfo.py
+++ b/lib/python/Screens/OScamInfo.py
@@ -11,7 +11,7 @@ from time import time
 from pathlib import Path
 from xml.etree.ElementTree import XML, ParseError
 from ipaddress import ip_address
-from socket import getaddrinfo, gaierror
+from socket import getaddrinfo, gaierror, gethostname
 
 # ENIGMA IMPORTS
 from enigma import eTimer
@@ -21,14 +21,46 @@ from Components.config import config
 from Components.ScrollLabel import ScrollLabel
 from Components.Sources.List import List
 from Components.Sources.StaticText import StaticText
+from Components.About import GetIPsFromNetworkInterfaces
 from Components.SystemInfo import BoxInfo
 from Screens.MessageBox import MessageBox
 from Screens.Screen import Screen
 from Screens.Setup import Setup
 from Tools.BoundFunction import boundFunction
+from Tools.ServiceAction import ServiceAction
 
 # GLOBALS
 MODULE_NAME = __name__.split(".")[-1]
+
+
+def isLoopback(host):
+	if host == "localhost":
+		return True
+	try:
+		return ip_address(host).is_loopback
+	except ValueError:
+		return False
+
+
+def isLocalHost(host):
+	if isLoopback(host):
+		return True
+	if host.lower() == gethostname().lower():
+		return True
+	try:
+		targetIPs = {info[4][0] for info in getaddrinfo(host, None)}
+	except gaierror:
+		return False
+	localIPs = {"127.0.0.1", "::1"}
+	try:
+		localIPs |= {ip for _, ip in GetIPsFromNetworkInterfaces()}
+	except OSError:
+		pass
+	return bool(targetIPs & localIPs)
+
+
+def camDisplayName(text):
+	return "NCam" if "ncam" in (text or "").lower() else "OSCam"
 
 
 class OSCamGlobals():
@@ -63,7 +95,7 @@ class OSCamGlobals():
 												username=str(config.oscaminfo.username.value),
 												password=str(config.oscaminfo.password.value),
 												api=api, fmt="html", part="files", label=verfilename)
-			result = result.decode(encoding="latin-1", errors="ignore")
+			result = result.decode("UTF-8", "ignore")
 			if webifok:
 				try:
 					xml = XML(result).find("file")
@@ -103,7 +135,7 @@ class OSCamGlobals():
 			ip, proto, blocked = "127.0.0.1", "http", False  # Assume that oscam webif is NOT blocking localhost, IPv6 is also configured if it is compiled in, and no user and password are required
 			user = pwd = None
 			conffile = f"{conffile or 'oscam.conf'}"
-			ret = _("OSCam webif disabled") if not error else error
+			ret = _("%s webif disabled") % camDisplayName(api) if not error else error
 			if webif and port is not None:  # oscam reports it got webif support and webif is running (Port != 0)
 				if config.oscaminfo.userDataFromConf.value:  # Find and parse running oscam, ncam (auto)
 					if conffile is not None and exists(conffile):  # If we have a config file, we need to investigate it further
@@ -170,7 +202,7 @@ class OSCamGlobals():
 			else:
 				errmsg = str(error)
 			print(f"[{MODULE_NAME}] ERROR in module 'callApi': Unexpected error accessing WebIF: {errmsg}")
-			return False, url, errmsg.encode(encoding="latin-1", errors="ignore")
+			return False, url, errmsg.encode("UTF-8", "ignore")
 
 	def parseTimestamp(self, value):
 		if not value:
@@ -194,7 +226,7 @@ class OSCamGlobals():
 
 	def updateLog(self):
 		webifok, api, url, signstatus, result = self.openWebIF(log=True)
-		ret, result = False, result.decode(encoding="latin-1", errors="ignore")
+		ret, result = False, result.decode("UTF-8", "ignore")
 		if webifok:
 			try:
 				xml = XML(result).find("log")
@@ -284,6 +316,11 @@ class OSCamInfo(Screen, OSCamGlobals):
 		self.skinName = "OSCamInfo"
 		self.setTitle(_("OSCamInfo: Information"))
 		self.rulist = []
+		self.lastWebifOk = False
+		self.isLocal = False
+		self._isLocalKey = None
+		self._fetchInProgress = False
+		self.camName = camDisplayName(BoxInfo.getItem("CurrentSoftcam"))
 		self["buildinfos"] = StaticText()
 		self["extrainfos"] = StaticText()
 		self["timerinfos"] = StaticText()
@@ -296,8 +333,8 @@ class OSCamInfo(Screen, OSCamGlobals):
 		self["camname"] = StaticText()
 		self["virtuell"] = StaticText()
 		self["resident"] = StaticText()
-		self["key_red"] = StaticText(_("Shutdown OSCam"))
-		self["key_green"] = StaticText(_("Restart OSCam"))
+		self["key_red"] = StaticText(_("Shutdown %s") % self.camName)
+		self["key_green"] = StaticText(_("Restart %s") % self.camName)
 		self["key_yellow"] = StaticText(_("Show Capabilities"))
 		self["key_blue"] = StaticText(_("Show Log"))
 		self["key_OK"] = StaticText()
@@ -308,13 +345,15 @@ class OSCamInfo(Screen, OSCamGlobals):
 			"ok": (self.keyOk, _("Show details")),
 			"cancel": (self.exit, _("Close the screen")),
 			"menu": (self.keyMenu, _("Open Settings")),
-			"red": (self.keyShutdown, _("Shutdown OSCam")),
-			"green": (self.keyRestart, _("Restart OSCam")),
+			"red": (self.keyShutdown, _("Shutdown %s") % self.camName),
+			"green": (self.keyRestart, _("Restart %s") % self.camName),
 			"yellow": (self.keyInfo, _("Open Capability")),
 			"blue": (self.keyBlue, _("Open Log"))
 			}, prio=1, description=_("OSCamInfo Actions"))
 		self.loop = eTimer()
 		self.loop.callback.append(self._triggerDataUpdate)
+		self.actionRefreshTimer = eTimer()
+		self.actionRefreshTimer.callback.append(self._triggerDataUpdate)
 		self.onLayoutFinish.append(self.onLayoutFinished)
 		self.bgColors = parameters.get("OSCamInfoBGcolors", (0x10fcfce1, 0x10f1f6e6, 0x10e2e0ef))
 
@@ -347,10 +386,34 @@ class OSCamInfo(Screen, OSCamGlobals):
 		"""Trigger data fetch in background thread"""
 		callInThread(self._fetchOScamData)
 
+	def _updateIsLocal(self):
+		key = (bool(config.oscaminfo.userDataFromConf.value), str(config.oscaminfo.ip.value))
+		if key != self._isLocalKey:
+			self._isLocalKey = key
+			self.isLocal = key[0] or isLocalHost(key[1])
+
 	def _fetchOScamData(self):
 		"""Fetch data in background thread, then update UI"""
-		webifok, api, url, signstatus, result = self.openWebIF()
-		self._updateMainUI(webifok, api, url, signstatus, result)
+		if self._fetchInProgress:
+			return
+		self._fetchInProgress = True
+		try:
+			self._updateIsLocal()
+			webifok, api, url, signstatus, result = self.openWebIF()
+			self.lastWebifOk = webifok
+			self._updateMainUI(webifok, api, url, signstatus, result)
+			self.updateKeyLabels()
+		finally:
+			self._fetchInProgress = False
+
+	def updateKeyLabels(self):
+		self["key_red"].setText(_("Shutdown %s") % self.camName if self.lastWebifOk else "")
+		if self.lastWebifOk:
+			self["key_green"].setText(_("Restart %s") % self.camName)
+		elif self.isLocal:
+			self["key_green"].setText(_("Start %s") % self.camName)
+		else:
+			self["key_green"].setText("")
 
 	def _updateMainUI(self, webifok, api, url, signstatus, result):
 		"""Update main UI"""
@@ -358,6 +421,8 @@ class OSCamInfo(Screen, OSCamGlobals):
 		currtime = "Protocol Time: %s - %s" % (ctime.strftime("%x"), ctime.strftime("%X"))
 		na = _("n/a")
 		tag, camname = {"oscamapi": ("oscam", "OSCam"), "ncamapi": ("ncam", "NCam"), None: (na, na)}.get(api)
+		if camname != na:
+			self.camName = camname
 		if webifok and result:
 			jsonData = loads(result).get(tag, {})
 			sysinfo = jsonData.get("sysinfo", {})
@@ -433,9 +498,12 @@ class OSCamInfo(Screen, OSCamGlobals):
 			self["outlist"].updateList(outlist)
 			self.displayLog()
 		else:
-			self.loop.stop()
 			self["buildinfos"].setText(url)
-			self["extrainfos"].setText(_("Unexpected error accessing WebIF: %s") % result.decode(encoding="latin-1", errors="ignore"))
+			errtext = result.decode("UTF-8", "ignore")
+			if self.isLocal:
+				self["extrainfos"].setText(_("%s is currently stopped or unreachable. Press GREEN to start it.") % self.camName)
+			else:
+				self["extrainfos"].setText(_("Unexpected error accessing WebIF: %s") % errtext)
 			self["timerinfos"].setText(currtime)  # set at least one element just for having the attribute 'activeComponents'
 
 	def strf_delta(self, td):  # converts deltatime-format in hours (e.g. '2 days, 01:00' in '49:00:00')
@@ -455,7 +523,6 @@ class OSCamInfo(Screen, OSCamGlobals):
 			self["logtext"].setText(result)
 			self["logtext"].moveBottom()
 		else:
-			self.loop.stop()
 			self["extrainfos"].setText(_("Unexpected error accessing WebIF: %s") % result)
 
 	def showHideKeyOk(self):
@@ -485,10 +552,21 @@ class OSCamInfo(Screen, OSCamGlobals):
 		self.session.openWithCallback(self.menuCallback, OSCamInfoSetup)
 
 	def keyShutdown(self):
-		self.session.openWithCallback(boundFunction(self.msgboxCB, "shutdown"), MessageBox, _("Do you really want to shut down OSCam?\n\nATTENTION: To reactivate OSCam, a complete receiver restart must be carried out!"), MessageBox.TYPE_YESNO, timeout=10, default=False)
+		if not self.lastWebifOk:
+			return
+		if self.isLocal:
+			msg = _("Do you really want to stop %s?") % self.camName
+		else:
+			msg = _("Do you really want to shut down %s?\n\nATTENTION: To reactivate %s, a complete receiver restart must be carried out!") % (self.camName, self.camName)
+		self.session.openWithCallback(boundFunction(self.msgboxCB, "shutdown"), MessageBox, msg, MessageBox.TYPE_YESNO, timeout=10, default=False)
 
 	def keyRestart(self):
-		self.session.openWithCallback(boundFunction(self.msgboxCB, "restart"), MessageBox, _("Do you really want to restart OSCam?\n\nHINT: This will take about 5 seconds!"), MessageBox.TYPE_YESNO, timeout=10, default=False)
+		if not self.lastWebifOk and not self.isLocal:
+			return
+		if not self.lastWebifOk:
+			self.session.openWithCallback(boundFunction(self.msgboxCB, "start"), MessageBox, _("%s is currently not running.\n\nDo you want to start it?") % self.camName, MessageBox.TYPE_YESNO, timeout=10, default=True)
+		else:
+			self.session.openWithCallback(boundFunction(self.msgboxCB, "restart"), MessageBox, _("Do you really want to restart %s?") % self.camName, MessageBox.TYPE_YESNO, timeout=10, default=False)
 
 	def keyInfo(self):
 		self.loop.stop()
@@ -498,20 +576,44 @@ class OSCamInfo(Screen, OSCamGlobals):
 		self.loop.stop()
 		self.session.openWithCallback(self.keyCallback, OSCamInfoLog)
 
+	def _afterAction(self, action, exitCode=None):
+		if exitCode:
+			messages = {
+				"start": _("Starting %s failed (exit code %s)"),
+				"stop": _("Stopping %s failed (exit code %s)"),
+				"restart": _("Restarting %s failed (exit code %s)"),
+			}
+			self._showActionError(messages.get(action, _("%s action failed (exit code %s)")) % (self.camName, exitCode))
+		self.actionRefreshTimer.start(3000, True)
+		self.updateKeyLabels()
+		if config.oscaminfo.autoUpdate.value:
+			self.loop.start(config.oscaminfo.autoUpdate.value * 1000, False)
+
+	def _localAction(self, action):
+		sa = ServiceAction("softcam")
+		{"start": sa.start, "stop": sa.stop, "restart": sa.restart}[action](boundFunction(self._afterAction, action))
+
+	def _remoteAction(self, action):
+		def doAction():
+			webifok, api, url, signstatus, result = self.openWebIF(part=action)
+			if not webifok:
+				self._showActionError(result)
+			self._afterAction(action)
+		callInThread(doAction)
+
 	def msgboxCB(self, action, answer):
 		if answer:
 			self.loop.stop()
-			# Execute shutdown/restart in background to avoid blocking
-			def doAction():
-				webifok, api, url, signstatus, result = self.openWebIF(part=action)
-				if not webifok:
-					self._showActionError(result)
-			callInThread(doAction)
+			localAction = {"shutdown": "stop", "restart": "restart", "start": "start"}[action]
+			if self.isLocal:
+				self._localAction(localAction)
+			else:
+				self._remoteAction(action)
 
 	def _showActionError(self, result):
 		"""Show action error"""
 		print("[%s] ERROR in module 'msgboxCB': %s" % (MODULE_NAME, "Unexpected error accessing WebIF: %s" % result))
-		self.session.open(MessageBox, _("Unexpected error accessing WebIF: %s" % result), MessageBox.TYPE_ERROR, timeout=3, close_on_any_key=True)
+		self.session.open(MessageBox, _("Unexpected error accessing WebIF: %s") % result, MessageBox.TYPE_ERROR, timeout=3, close_on_any_key=True)
 
 	def exit(self):
 		self.loop.stop()


### PR DESCRIPTION
- Cam-name aware everywhere: labels, dialogs and 'webif disabled' message use the actually detected softcam (OSCam or NCam) via camDisplayName(); no more hardcoded 'OSCam'.
- Local softcam control via ServiceAction('softcam') over the socketdaemon socket (same path SoftcamSetup and InfoBarGenerics use); remote OSCam control continues via WebIF shutdown.html. A non-zero ServiceAction exit code surfaces a context-aware error ('Starting/Stopping/Restarting <cam> failed') so a failed local action is visible.
- isLocal detection covers loopback, the box's own hostname and any local interface IP (isLocalHost resolves the configured host and intersects it with the local addresses from GetIPsFromNetworkInterfaces); auto mode is always local. Result is cached and only re-resolved when the relevant config changes.
- Red = 'Shutdown <cam>' only when WebIF is reachable. Green = 'Restart <cam>' when reachable, 'Start <cam>' when local and unreachable, hidden when remote and unreachable (WebIF can't wake a dead OSCam).
- Post-action refresh delayed by 3s via eTimer single-shot so the screen doesn't flash 'unreachable' while OSCam is still coming up.
- Auto-update loop keeps running through transient WebIF failures (removed loop.stop() from the error branches), so recovery after a restart happens automatically; a _fetchInProgress guard prevents overlapping fetches piling up on a slow/hanging socket.
- Friendlier error text for local dead WebIF instead of the raw urllib message.
- Byte decoding switched to UTF-8 with errors='ignore', matching the enigma2 convention.
- Fix pre-existing i18n bug in _showActionError: % interpolation was inside _() which broke translation lookup.