### PR TITLE
[skin] add more skin formula operators

### DIFF
--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -411,6 +411,9 @@ def parseColor(value, default=0x00FFFFFF):
 #
 def parseCoordinate(value, parent, size=0, font=None, scale=(1, 1)):
 	def scaleNumbers(coordinate, scale):
+		# Digits adjacent to "*" or "/", or immediately followed by "%", "w" or "h", are ratio/coefficient
+		# constants (e.g. the "4" in "e/4", the "3" in "3*e", the "25" in "25%") and must be left unscaled -
+		# only additive pixel offsets (e.g. the "48" in "e-48") represent real pixel quantities that need scaling.
 		inNumber = False
 		chars = []
 		digits = []
@@ -420,7 +423,12 @@ def parseCoordinate(value, parent, size=0, font=None, scale=(1, 1)):
 				digits.append(char)
 			elif inNumber:
 				inNumber = False
-				chars.append(str(int(int("".join(digits)) * scale[0] / scale[1])))
+				precededByRatioOp = chars and chars[-1] in ("*", "/")
+				followedByRatioOp = char in ("*", "/", "%", "w", "h")
+				if precededByRatioOp or followedByRatioOp:
+					chars.append("".join(digits))
+				else:
+					chars.append(str(int(int("".join(digits)) * scale[0] / scale[1])))
 				digits = []
 				chars.append(char)
 			else:


### PR DESCRIPTION
currently the only operators that can be used in formulas are + and -, like e-20, e+40.
other operators can't be used because all values are scaled equally but values after e.g. * or / must not be scaled.
this change distiguishes between values that need to be scaled and those that have to be left unscaled.

this code was generated with claude code ai.

i unit tested it with the following skin:

		<widget font="Regular;20" halign="center" name="key_red" position="0,e-48" size="e/4,38" foregroundColor="keyRed" transparent="1" zPosition="2"/>
		<widget font="Regular;20" halign="center" name="key_green" position="1*e/4,e-48" size="e/4,38" foregroundColor="keyGreen" transparent="1" zPosition="2"/>
		<widget font="Regular;20" halign="center" name="key_yellow" position="2*e/4,e-48" size="e/4,38" foregroundColor="keyYellow" transparent="1" zPosition="2"/>
		<widget font="Regular;20" halign="center" name="key_blue" position="3*e/4,e-48" size="e/4,38" foregroundColor="keyBlue" transparent="1" zPosition="2"/>
