### PR TITLE
Add ECMs and EMMs to the pid filters based on the existing local CAIDs

### DIFF
--- a/lib/dvb/csasession.cpp
+++ b/lib/dvb/csasession.cpp
@@ -167,8 +167,6 @@ void eDVBCSASession::startECMMonitor(iDVBDemux *demux, uint16_t ecm_pid, uint16_
 					setActive(true);
 				}
 			}
-
-			return;
 		}
 	}
 
@@ -277,7 +275,10 @@ void eDVBCSASession::ecmDataReceived(const uint8_t *data)
 			eDebug("[eDVBCSASession] ECM analyzed: Not CSA-ALT, hardware descrambling will be used");
 		}
 
-		stopECMMonitor();
+		if (!eSimpleConfig::getBool("config.usage.add_ecm_emm_filters", false))
+		{
+			stopECMMonitor();
+		}
 	}
 }
 

--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -12,6 +12,7 @@
 
 #include <lib/base/eerror.h>
 #include <lib/base/cfile.h>
+#include <lib/base/esimpleconfig.h>
 #include <lib/dvb/idvb.h>
 #include <lib/dvb/demux.h>
 #include <lib/dvb/esection.h>
@@ -287,6 +288,7 @@ RESULT eDVBSectionReader::start(const eDVBSectionFilterMask &mask)
 	memcpy(sct.filter.mask, mask.mask, DMX_FILTER_SIZE);
 	memcpy(sct.filter.mode, mask.mode, DMX_FILTER_SIZE);
 	setBufferSize(8192*8);
+
 
 	res = ::ioctl(fd, DMX_SET_FILTER, &sct);
 	if (!res)

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -52,6 +52,7 @@ eDVBServicePMTHandler::eDVBServicePMTHandler()
 
 	eDVBResourceManager::getInstance(m_resourceManager);
 	CONNECT(m_PAT.tableReady, eDVBServicePMTHandler::PATready);
+	CONNECT(m_CAT.tableReady, eDVBServicePMTHandler::CATready);
 	CONNECT(m_AIT.tableReady, eDVBServicePMTHandler::AITready);
 	CONNECT(m_OC.tableReady, eDVBServicePMTHandler::OCready);
 	CONNECT(m_no_pat_entry_delay->timeout, eDVBServicePMTHandler::sendEventNoPatEntry);
@@ -118,6 +119,8 @@ void eDVBServicePMTHandler::channelStateChanged(iDVBChannel *channel)
 					m_PAT.begin(eApp, eDVBPATSpec(), m_demux);
 				else
 					m_PMT.begin(eApp, eDVBPMTSpec(m_pmt_pid, m_reference.getServiceID().get()), m_demux);
+
+				m_CAT.begin(eApp, eDVBCATSpec(), m_demux);
 			}
 
 			serviceEvent(eventTuned);
@@ -241,6 +244,7 @@ void eDVBServicePMTHandler::PATready(int)
 	ePtr<eTable<ProgramAssociationSection> > ptr;
 	if (!m_PAT.getCurrent(ptr))
 	{
+		m_cached_program.emmPids.clear();
 		int service_id_single = -1;
 		int pmtpid_single = -1;
 		int pmtpid = -1;
@@ -287,6 +291,56 @@ void eDVBServicePMTHandler::PATready(int)
 		}
 	} else
 		serviceEvent(eventNoPAT);
+}
+
+void eDVBServicePMTHandler::CATready(int error)
+{
+	eDebug("[eDVBServicePMTHandler] CATready error %d", error);
+	if (error)
+	{
+		return;
+	}
+
+	ePtr<eTable<ConditionalAccessSection> > ptr;
+	if (!m_CAT.getCurrent(ptr))
+	{
+		eDebug("[eDVBServicePMTHandler] CATready parsed CAT table with %zu sections!", ptr->getSections().size());
+		for (std::vector<ConditionalAccessSection*>::const_iterator i = ptr->getSections().begin(); i != ptr->getSections().end(); ++i)
+		{
+			const ConditionalAccessSection &cat = **i;
+			for (DescriptorConstIterator desc = cat.getDescriptors()->begin(); desc != cat.getDescriptors()->end(); ++desc)
+			{
+				if ((*desc)->getTag() == CA_DESCRIPTOR)
+				{
+					CaDescriptor *ca = (CaDescriptor*)(*desc);
+					uint16_t caid = ca->getCaSystemId();
+					uint16_t emm_pid = ca->getCaPid();
+					eDebug("[eDVBServicePMTHandler] CAT CaDescriptor: CAID 0x%04X, EMM PID %d (0x%04X)", caid, emm_pid, emm_pid);
+
+					eDVBCIInterfaces *ci = eDVBCIInterfaces::getInstance();
+					if (ci && !ci->isCAIDSupported(caid))
+					{
+						eDebug("[eDVBServicePMTHandler] Skipping EMM PID %d (0x%04X) with CAID 0x%04X: not supported by connected CI modules", emm_pid, emm_pid, caid);
+						continue;
+					}
+
+					bool exists = false;
+					for (int p : m_cached_program.emmPids)
+					{
+						if (p == emm_pid) { exists = true; break; }
+					}
+					if (!exists && emm_pid > 0 && emm_pid < 0x1FFF)
+					{
+						m_cached_program.emmPids.push_back(emm_pid);
+					}
+				}
+			}
+		}
+		if (!m_cached_program.emmPids.empty())
+		{
+			serviceEvent(eventNewProgramInfo);
+		}
+	}
 }
 
 static void eraseHbbTVApplications(HbbTVApplicationInfoList  *applications)
@@ -609,6 +663,7 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 		return 0;
 	}
 
+	std::vector<int> prevEmmPids = m_cached_program.emmPids;
 	eDVBPMTParser::clearProgramInfo(program);
 
 	for (int m = 0; m < eDVBService::cacheMax; m++)
@@ -1005,6 +1060,11 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 		program.demuxId = demux;
 	}
 
+	if (program.emmPids.empty() && !prevEmmPids.empty())
+	{
+		program.emmPids = prevEmmPids;
+	}
+
 	m_cached_program = program;
 	m_have_cached_program = true;
 	return ret;
@@ -1162,6 +1222,12 @@ int eDVBServicePMTHandler::tuneExt(eServiceReferenceDVB &ref, ePtr<iTsSource> &s
 	RESULT res=0;
 	m_reference = ref;
 	m_reference.name = ""; // clear name, we don't need it
+	// Reset PMT and table state for new service; reset m_last_channel_state so channelStateChanged
+	// properly initializes table readers (PAT/CAT/PMT) even on same-transponder channel switches.
+	m_pmt_ready = false;
+	m_have_cached_program = false;
+	m_cached_program.emmPids.clear();
+	m_last_channel_state = -1;
 
 	/*
 		* We need to m_use decode demux only when we are descrambling (demuxers > ca demuxers)
@@ -1327,6 +1393,7 @@ void eDVBServicePMTHandler::free()
 	m_OC.stop();
 	m_AIT.stop();
 	m_PMT.stop();
+	m_CAT.stop();
 	m_PAT.stop();
 	m_service = 0;
 	m_channel = 0;

--- a/lib/dvb/pmt.h
+++ b/lib/dvb/pmt.h
@@ -11,6 +11,7 @@
 #include <lib/dvb/cahandler.h>
 #include <lib/dvb/pmtparse.h>
 #include <lib/python/python.h>
+#include <dvbsi++/ca_section.h>
 
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -75,6 +76,7 @@ class eDVBServicePMTHandler: public eDVBPMTParser
 	ePtr<eDVBScan> m_dvb_scan; // for sdt scan
 
 	eAUTable<eTable<ProgramAssociationSection> > m_PAT;
+	eAUTable<eTable<ConditionalAccessSection> > m_CAT;
 	eAUTable<eTable<ApplicationInformationSection> > m_AIT;
 	eAUTable<eTable<OCSection> > m_OC;
 
@@ -94,6 +96,7 @@ class eDVBServicePMTHandler: public eDVBPMTParser
 
 	void PMTready(int error);
 	void PATready(int error);
+	void CATready(int error);
 	void AITready(int error);
 	void OCready(int error);
 

--- a/lib/dvb/pmtparse.h
+++ b/lib/dvb/pmtparse.h
@@ -82,6 +82,7 @@ public:
 		std::vector<subtitleStream> subtitleStreams;
 		int defaultSubtitleStream;
 		std::list<capid_pair> caids;
+		std::vector<int> emmPids;
 		int pcrPid;
 		int pmtPid;
 		int textPid;

--- a/lib/dvb/specs.h
+++ b/lib/dvb/specs.h
@@ -7,9 +7,29 @@
 #include <dvbsi++/service_description_section.h>
 #include <dvbsi++/network_information_section.h>
 #include <dvbsi++/bouquet_association_section.h>
+#include <dvbsi++/ca_section.h>
 #include <dvbsi++/program_association_section.h>
 #include <dvbsi++/event_information_section.h>
 #include <dvbsi++/application_information_section.h>
+
+struct eDVBCATSpec
+{
+	eDVBTableSpec m_spec;
+public:
+	eDVBCATSpec(int timeout=20000)
+	{
+		m_spec.pid     = ConditionalAccessSection::PID;
+		m_spec.tid     = ConditionalAccessSection::TID;
+		m_spec.timeout = timeout;
+		m_spec.flags   = eDVBTableSpec::tfAnyVersion |
+			eDVBTableSpec::tfHaveTID | eDVBTableSpec::tfCheckCRC |
+			eDVBTableSpec::tfHaveTimeout;
+	}
+	operator eDVBTableSpec &()
+	{
+		return m_spec;
+	}
+};
 
 struct eDVBPMTSpec
 {

--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -1148,6 +1148,39 @@ PyObject *eDVBCIInterfaces::readCICaIds(int slotid)
 	return 0;
 }
 
+bool eDVBCIInterfaces::isCAIDSupported(uint16_t caid)
+{
+	singleLock s(m_slot_lock);
+	bool has_ci_module = false;
+	for (eSmartPtrList<eDVBCISlot>::iterator i(m_slots.begin()); i != m_slots.end(); ++i)
+	{
+		eDVBCICAManagerSession *ca_manager = i->getCAManager();
+		if (ca_manager)
+		{
+			const std::vector<uint16_t> &ci_caids = ca_manager->getCAIDs();
+			if (!ci_caids.empty())
+			{
+				has_ci_module = true;
+				for (uint16_t c : ci_caids)
+				{
+					if (c == caid)
+						return true;
+				}
+			}
+		}
+		if (!i->possible_caids.empty())
+		{
+			has_ci_module = true;
+			if (i->possible_caids.find(caid) != i->possible_caids.end())
+				return true;
+		}
+	}
+	// Fallback: If no CI module is plugged in or reporting CAIDs, allow all CAIDs
+	if (!has_ci_module)
+		return true;
+	return false;
+}
+
 int eDVBCIInterfaces::setCIEnabled(int slotid, bool enabled)
 {
 	eDVBCISlot *slot = getSlot(slotid);

--- a/lib/dvb_ci/dvbci.h
+++ b/lib/dvb_ci/dvbci.h
@@ -260,6 +260,7 @@ public:
 	RESULT setDescrambleRules(int slotid, SWIG_PYOBJECT(ePyObject));
 	PyObject *readCICaIds(int slotid);
 #ifndef SWIG
+	bool isCAIDSupported(uint16_t caid);
 	struct Message
 	{
 		enum

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -966,6 +966,7 @@ def InitUsageConfig():
 		("(1920, 1080)", "1920x1080")
 	])
 	config.usage.enable_delivery_system_workaround = ConfigYesNo(default=False)
+	config.usage.add_ecm_emm_filters = ConfigYesNo(default=False)
 
 	config.usage.date = ConfigSubsection()
 	config.usage.date.enabled = NoSave(ConfigBoolean(default=False))

--- a/lib/python/enigma_python.i
+++ b/lib/python/enigma_python.i
@@ -39,6 +39,9 @@ is usually caused by not marking PSignals as immutable.
 %{
 
 #define SWIG_COMPILE
+#ifndef t_output_helper
+#define t_output_helper(res, obj) SWIG_Python_AppendOutput(res, obj, 0)
+#endif
 #include <lib/base/ebase.h>
 #include <lib/base/smartptr.h>
 #include <lib/base/eenv.h>

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -43,6 +43,7 @@
 #include <chrono>
 #include <thread>
 #include <lib/dvb_ci/descrambler.h>
+#include <lib/dvb_ci/dvbci.h>
 
 #include <byteswap.h>
 #include <netinet/in.h>
@@ -1334,6 +1335,113 @@ void eDVBServicePlay::serviceEvent(int event)
 		if (m_timeshift_enabled)
 			updateTimeshiftPids();
 
+		/* Register EMM PIDs (parsed dynamically from CAT table) and ECM PIDs (parsed dynamically from PMT table) for SAT>IP / vtuner demux filtering when enabled */
+		if (eSimpleConfig::getBool("config.usage.add_ecm_emm_filters", false))
+		{
+			static const std::vector<int> EXTRA_STATIC_PIDS = {
+				0x0014 // PID 20: TDT / TOT / EIT time synchronization
+			};
+
+			ePtr<iDVBDemux> live_demux;
+			if (m_service_handler.getDataDemux(live_demux) == 0 && live_demux)
+			{
+				for (int extra_pid : EXTRA_STATIC_PIDS)
+				{
+					if (extra_pid > 0 && extra_pid < 0x1FFF)
+					{
+						bool exists = false;
+						for (int existing_pid : m_extra_pids)
+						{
+							if (existing_pid == extra_pid) { exists = true; break; }
+						}
+						if (!exists)
+						{
+							ePtr<iDVBSectionReader> extra_reader;
+							if (live_demux->createSectionReader(eApp, extra_reader) == 0 && extra_reader)
+							{
+								eDVBSectionFilterMask mask = {};
+								mask.pid = extra_pid;
+								mask.data[0] = 0x00;
+								mask.mask[0] = 0x00;
+								extra_reader->start(mask);
+								m_extra_pids_readers.push_back(extra_reader);
+								m_extra_pids.push_back(extra_pid);
+								eDebug("[eDVBServicePlay] Persistent section reader started on extra PID %d (0x%04x)", extra_pid, extra_pid);
+							}
+						}
+					}
+				}
+
+				eDVBServicePMTHandler::program program;
+				if (m_service_handler.getProgramInfo(program) == 0)
+				{
+					// Dynamically register EMM PIDs parsed from CAT table (e.g. 5677 / 0x162D)
+					for (int emm_pid : program.emmPids)
+					{
+						if (emm_pid > 0 && emm_pid < 0x1FFF)
+						{
+							bool exists = false;
+							for (int existing_pid : m_emm_pids)
+							{
+								if (existing_pid == emm_pid) { exists = true; break; }
+							}
+							if (!exists)
+							{
+								ePtr<iDVBSectionReader> emm_reader;
+								if (live_demux->createSectionReader(eApp, emm_reader) == 0 && emm_reader)
+								{
+									eDVBSectionFilterMask mask = {};
+									mask.pid = emm_pid;
+									mask.data[0] = 0x00;
+									mask.mask[0] = 0x00;
+									emm_reader->start(mask);
+									m_emm_readers.push_back(emm_reader);
+									m_emm_pids.push_back(emm_pid);
+									eDebug("[eDVBServicePlay] Dynamic EMM section reader started from CAT on PID %d (0x%04x)", emm_pid, emm_pid);
+								}
+							}
+						}
+					}
+
+					// Dynamically register ECM PIDs parsed from PMT table (e.g. 1030 / 1042)
+					eDVBCIInterfaces *ci = eDVBCIInterfaces::getInstance();
+					for (const auto& ca : program.caids)
+					{
+						int ecm_pid = ca.capid;
+						uint16_t caid = (uint16_t)ca.caid;
+						if (ecm_pid > 0 && ecm_pid < 0x1FFF)
+						{
+							if (ci && !ci->isCAIDSupported(caid))
+							{
+								eDebug("[eDVBServicePlay] Skipping ECM PID %d (0x%04x) with CAID 0x%04x: not supported by connected CI modules", ecm_pid, ecm_pid, caid);
+								continue;
+							}
+							bool exists = false;
+							for (int existing_pid : m_ecm_pids)
+							{
+								if (existing_pid == ecm_pid) { exists = true; break; }
+							}
+							if (!exists)
+							{
+								ePtr<iDVBSectionReader> ecm_reader;
+								if (live_demux->createSectionReader(eApp, ecm_reader) == 0 && ecm_reader)
+								{
+									eDVBSectionFilterMask mask = {};
+									mask.pid = ecm_pid;
+									mask.data[0] = 0x80;
+									mask.mask[0] = 0xFE;
+									ecm_reader->start(mask);
+									m_ecm_readers.push_back(ecm_reader);
+									m_ecm_pids.push_back(ecm_pid);
+									eDebug("[eDVBServicePlay] Dynamic ECM section reader started from PMT on PID %d (0x%04x)", ecm_pid, ecm_pid);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
 		// Re-tuned during an active recovery: let the recovery state machine keep control
 		// and resume playback at the preserved delay. Do not resync the decoder here.
 		if (m_stream_corruption_detected)
@@ -1342,16 +1450,20 @@ void eDVBServicePlay::serviceEvent(int event)
 		if (m_csa_session && !m_csa_session->isEcmAnalyzed())
 		{
 			eDVBServicePMTHandler::program program;
-			if (m_service_handler.getProgramInfo(program) == 0 && !program.caids.empty())
+			if (m_service_handler.getProgramInfo(program) == 0)
 			{
-				uint16_t ecm_pid = program.caids.front().capid;
-				uint16_t caid = program.caids.front().caid;
-				ePtr<iDVBDemux> demux;
-				if (m_service_handler.getDataDemux(demux) == 0 && demux)
+				for (const auto& ca : program.caids)
 				{
-					eDebug("[eDVBServicePlay] Requesting ECM monitor: PID=%d, CAID=0x%04X", ecm_pid, caid);
-					m_csa_session->startECMMonitor(demux, ecm_pid, caid);
-					// Note: If CSA-ALT was cached, session is now active and onSessionActivated() has already been called!
+					if (ca.capid > 0 && ca.capid < 0x1FFF)
+					{
+						ePtr<iDVBDemux> demux;
+						if (m_service_handler.getDataDemux(demux) == 0 && demux)
+						{
+							eDebug("[eDVBServicePlay] Requesting ECM monitor: PID=%d, CAID=0x%04X", ca.capid, ca.caid);
+							m_csa_session->startECMMonitor(demux, ca.capid, ca.caid);
+						}
+						break;
+					}
 				}
 			}
 		}
@@ -1749,6 +1861,29 @@ RESULT eDVBServicePlay::stop()
 	stopTimeshift(); /* in case time shift was enabled, remove buffer etc. */
 
 	cleanupSoftwareDescrambling();
+
+	for (auto& reader : m_extra_pids_readers)
+	{
+		if (reader)
+			reader->stop();
+	}
+	m_extra_pids_readers.clear();
+	m_extra_pids.clear();
+	for (auto& reader : m_ecm_readers)
+	{
+		if (reader)
+			reader->stop();
+	}
+	m_ecm_readers.clear();
+	m_ecm_pids.clear();
+
+	for (auto& reader : m_emm_readers)
+	{
+		if (reader)
+			reader->stop();
+	}
+	m_emm_readers.clear();
+	m_emm_pids.clear();
 
 	m_service_handler_timeshift.free();
 	m_service_handler.free();
@@ -3603,6 +3738,11 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 	eDVBServicePMTHandler::program program;
 	if (h.getProgramInfo(program))
 		eDebug("[eDVBServicePlay] getting program info failed.");
+	else if (program.videoStreams.empty() && program.audioStreams.empty())
+	{
+		eDebug("[eDVBServicePlay] updateDecoder: no streams available yet, skipping decoder reconfig");
+		return;
+	}
 	else
 	{
 		eDebugNoNewLineStart("[eDVBServicePlay] have %zd video stream(s)", program.videoStreams.size());

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -236,6 +236,14 @@ protected:
 	ePtr<eDVBSoftDecoder> m_soft_decoder;
 	bool m_soft_decoder_video_info_valid = false;  // Track if video info is available from SoftDecoder
 
+	// Persistent section readers for Extra PIDs (e.g. PID 20), EMM (from CAT), and ECM (from PMT)
+	std::vector<ePtr<iDVBSectionReader>> m_extra_pids_readers;
+	std::vector<int> m_extra_pids;
+	std::vector<ePtr<iDVBSectionReader>> m_emm_readers;
+	std::vector<int> m_emm_pids;
+	std::vector<ePtr<iDVBSectionReader>> m_ecm_readers;
+	std::vector<int> m_ecm_pids;
+
 	int m_is_primary;
 	int m_decoder_index;
 	int m_have_video_pid;

--- a/lib/service/servicedvbstream.cpp
+++ b/lib/service/servicedvbstream.cpp
@@ -393,12 +393,24 @@ int eDVBServiceStream::doRecord()
 		if (program.textPid != -1)
 			pids_to_record.insert(program.textPid); // Videotext
 
-		if (m_stream_ecm)
+		if (m_stream_ecm || !program.caids.empty())
 		{
 			for (std::list<eDVBServicePMTHandler::program::capid_pair>::const_iterator i(program.caids.begin());
 						i != program.caids.end(); ++i)
 			{
-				if (i->capid >= 0) pids_to_record.insert(i->capid);
+				if (i->capid >= 0)
+				{
+					pids_to_record.insert(i->capid);
+					eDebug("[eDVBServiceStream] ECM PID added for stream: %04x (CAID %04x)", i->capid, i->caid);
+				}
+			}
+			for (std::vector<int>::const_iterator i(program.emmPids.begin()); i != program.emmPids.end(); ++i)
+			{
+				if (*i >= 0)
+				{
+					pids_to_record.insert(*i);
+					eDebug("[eDVBServiceStream] Dynamic EMM PID from CAT added for stream: %04x", *i);
+				}
 			}
 		}
 


### PR DESCRIPTION
The use case for this diff is having local CAMs decrypt channels received over satip.

The diagram in this case would be 

Hotbird -> minisatip -> network -> satipclient -> vtuner -> CI(+) -> enigma2.

The diff was tested successfully with the official Kabelio CI+.

Enabling the ECMs and EMMs is done just for the CAIDs reported by the local CAMs to prevent adding too many filters for channels using multiple decryption systems.