### PR TITLE
[ServiceDVB] fix teletext subtitles never being displayed

### DIFF
--- a/lib/dvb/teletext.h
+++ b/lib/dvb/teletext.h
@@ -50,6 +50,7 @@ public:
 	static const int max_id = 26;
 	static const char *const my_country_codes[];
 	int start(int pid);
+	int getPid() const { return m_pid; }
 	void setPageAndMagazine(int page, int magazine, const char *lang);
 	void setMagazine(int magazine);
 	void connectNewStream(const sigc::slot<void()> &slot, ePtr<eConnection> &connection);

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1385,6 +1385,16 @@ void eDVBServicePlay::serviceEvent(int event)
 					}
 				}
 			}
+			else if (m_teletext_parser && m_decoder_index == 0)
+			{
+				// same as in updateDecoder: the text pid may only show up in a later program info
+				eDVBServicePMTHandler::program program;
+				if (!m_service_handler.getProgramInfo(program) && program.textPid >= 0 && program.textPid != m_teletext_parser->getPid())
+				{
+					m_teletext_parser->start(program.textPid);
+					eDebug("[eDVBServicePlay] Teletext parser restarted on PID %04x", program.textPid);
+				}
+			}
 
 			// Late-start case: session is active but SoftDecoder may not be running yet
 			// This happens when we switched to a channel where CSA-ALT was already cached
@@ -3748,6 +3758,12 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 			}
 			m_teletext_parser->start(program.textPid);
 		}
+		else if (m_teletext_parser && m_decoder_index == 0 && tpid >= 0 && tpid != m_teletext_parser->getPid())
+		{
+			/* first program info can come from the service cache without a text pid,
+			   pick it up once the real PMT arrives */
+			m_teletext_parser->start(tpid);
+		}
 
 		/* don't worry about non-existing services, nor pvr services */
 		if (m_dvb_service)
@@ -4151,12 +4167,13 @@ void eDVBServicePlay::newSubtitlePage(const eDVBTeletextSubtitlePage &page)
 		eDVBTeletextSubtitlePage tmppage = page;
 		pts_t diff = tmppage.m_pts - pts;
 
-		if (diff > 0 && diff < (MAX_SUBTITLE_LIFESPAN * 90000))
-		{
-			tmppage.m_pts += (m_is_pvr || m_timeshift_enabled) ? 0 : eSubtitleSettings::subtitle_bad_timing_delay;
-			m_subtitle_pages.push_back(tmppage);
-			m_subtitle_pages.sort(compare_pts);
-		}
+		// No usable timing (PES without PTS, or an absurd diff): show now instead of dropping the page.
+		if (diff <= 0 || diff >= (MAX_SUBTITLE_LIFESPAN * 90000))
+			tmppage.m_pts = pts;
+
+		tmppage.m_pts += (m_is_pvr || m_timeshift_enabled) ? 0 : eSubtitleSettings::subtitle_bad_timing_delay;
+		m_subtitle_pages.push_back(tmppage);
+		m_subtitle_pages.sort(compare_pts);
 
 		checkSubtitleTiming();
 	}


### PR DESCRIPTION
Two independent defects made EBU teletext subtitles unusable on channels that only carry them (RAI 1/2/3, SRF info, TVP Polonia on 13E), while channels with real DVB subtitles were unaffected. Reported as #3862.

1) newSubtitlePage() only queued pages whose PTS was ahead of the decoder
   PTS and silently dropped everything else. Broadcasters that send the
   teletext PES without a PTS end up with m_pts = 0, so every page was
   discarded and nothing was ever displayed. Clamp pages without usable
   timing to the current PTS instead, which is what the code did before
   the timing rework, and keep the ordering and lifespan checks.

2) The first eventNewProgramInfo after a zap can come from the service
   cache, which often has no cached text pid. The teletext parser was
   then started with pid -1 and never set up a PES filter, and since the
   start call sits behind the mustPlay gate the real pid from the PMT
   100ms later was never picked up. Restart the parser whenever a later
   program info brings a text pid that differs from the running one.