### PR TITLE
[servicemp3] add PGS subtitle support and fix subtitle switch/seek races

### DIFF
--- a/lib/dvb/Makefile.inc
+++ b/lib/dvb/Makefile.inc
@@ -26,6 +26,7 @@ dvb_libenigma_dvb_a_SOURCES = \
 	dvb/metaparser.cpp \
 	dvb/opentv.cpp \
 	dvb/pesparse.cpp \
+	dvb/pgssubtitle.cpp \
 	dvb/pmt.cpp \
 	dvb/pvrparse.cpp \
 	dvb/radiotext.cpp \
@@ -77,6 +78,7 @@ dvbinclude_HEADERS = \
 	dvb/metaparser.h \
 	dvb/opentv.h \
 	dvb/pesparse.h \
+	dvb/pgssubtitle.h \
 	dvb/pmt.h \
 	dvb/pvrparse.h \
 	dvb/radiotext.h \

--- a/lib/dvb/pgssubtitle.cpp
+++ b/lib/dvb/pgssubtitle.cpp
@@ -1,0 +1,357 @@
+#include <algorithm>
+#include <cstring>
+#include <lib/base/eerror.h>
+#include <lib/dvb/pgssubtitle.h>
+
+DEFINE_REF(ePGSSubtitleParser);
+
+ePGSSubtitleParser::ePGSSubtitleParser() {
+	clearPalette();
+}
+
+/* enigma2 gRGB stores transparency in .a: 0x00 opaque, 0xFF invisible.
+   Zeroed entries would render as opaque black boxes, so start fully clear. */
+void ePGSSubtitleParser::clearPalette() {
+	std::fill(m_palette, m_palette + 256, gRGB(0, 0, 0, 0xFF));
+}
+
+void ePGSSubtitleParser::reset() {
+	m_objects.clear();
+	m_composition_objects.clear();
+	clearPalette();
+	m_palette_id = 0;
+	m_composition_state = 0;
+	m_display_size = eSize(1920, 1080);
+	m_pts = 0;
+}
+
+void ePGSSubtitleParser::connectNewPage(const sigc::slot<void(const eDVBSubtitlePage&)>& slot, ePtr<eConnection>& connection) {
+	connection = new eConnection(this, m_new_subtitle_page.connect(slot));
+}
+
+bool ePGSSubtitleParser::isSegmentType(uint8_t type) {
+	return type == PGS_PDS || type == PGS_ODS || type == PGS_PCS || type == PGS_WDS || type == PGS_END;
+}
+
+void ePGSSubtitleParser::processBuffer(const uint8_t* data, size_t len, pts_t pts) {
+	if (len < 3)
+		return;
+
+	m_pts = pts;
+	size_t pos = 0;
+
+	/* SUP format prefixes every segment with "PG" + PTS(4) + DTS(4). Some
+	   pipelines deliver that instead of bare segments; require a valid segment
+	   type behind the header so a raw segment starting with 0x50 is not
+	   mistaken for it. */
+	bool sup_format = len >= 13 && data[0] == 0x50 && data[1] == 0x47 && isSegmentType(data[10]);
+
+	if (sup_format) {
+		while (pos + 13 <= len) {
+			if (data[pos] != 0x50 || data[pos + 1] != 0x47) {
+				eTrace("[ePGSSubtitleParser] SUP sync lost at pos %zd", pos);
+				break;
+			}
+
+			uint8_t segment_type = data[pos + 10];
+			uint16_t segment_size = (data[pos + 11] << 8) | data[pos + 12];
+			pos += 13;
+
+			if (pos + segment_size > len) {
+				eWarning("[ePGSSubtitleParser] SUP segment truncated, %zu of %d bytes dropped (type=0x%02x)", len - pos, segment_size, segment_type);
+				break;
+			}
+
+			processSegment(segment_type, data + pos, segment_size);
+			pos += segment_size;
+		}
+	} else {
+		while (pos + 3 <= len) {
+			uint8_t segment_type = data[pos];
+			uint16_t segment_size = (data[pos + 1] << 8) | data[pos + 2];
+			pos += 3;
+
+			if (pos + segment_size > len) {
+				eWarning("[ePGSSubtitleParser] segment truncated, %zu of %d bytes dropped (type=0x%02x)", len - pos, segment_size, segment_type);
+				break;
+			}
+
+			processSegment(segment_type, data + pos, segment_size);
+			pos += segment_size;
+		}
+	}
+}
+
+void ePGSSubtitleParser::processSegment(uint8_t segment_type, const uint8_t* data, int len) {
+	switch (segment_type) {
+		case PGS_PCS:
+			processPCS(data, len);
+			break;
+		case PGS_PDS:
+			processPDS(data, len);
+			break;
+		case PGS_ODS:
+			processODS(data, len);
+			break;
+		case PGS_WDS:
+			/* Window Definition Segment - position info handled via PCS */
+			break;
+		case PGS_END:
+			processEND();
+			break;
+		default:
+			eTrace("[ePGSSubtitleParser] unknown segment type 0x%02x", segment_type);
+			break;
+	}
+}
+
+void ePGSSubtitleParser::processPCS(const uint8_t* data, int len) {
+	if (len < 11)
+		return;
+
+	int width = (data[0] << 8) | data[1];
+	int height = (data[2] << 8) | data[3];
+	/* data[4] = frame rate id, ignored */
+	/* data[5..6] = composition number */
+	m_composition_state = data[7];
+	/* data[8] = palette update flag */
+	m_palette_id = data[9];
+	int num_objects = data[10];
+
+	/* eSubtitleWidget scales by these, they must not become 0 */
+	if (width > 0 && height > 0)
+		m_display_size = eSize(width, height);
+
+	eTrace("[ePGSSubtitleParser] PCS: %dx%d state=0x%02x palette=%d objects=%d pts=%lld", width, height, m_composition_state, m_palette_id, num_objects, (long long)m_pts);
+
+	/* epoch start: nothing from the previous epoch stays valid */
+	if (m_composition_state == 0x80) {
+		m_objects.clear();
+		clearPalette();
+	}
+
+	m_composition_objects.clear();
+
+	int pos = 11;
+	for (int i = 0; i < num_objects && pos + 8 <= len; i++) {
+		PGSCompositionObject comp;
+		comp.object_id = (data[pos] << 8) | data[pos + 1];
+		comp.window_id = data[pos + 2];
+		uint8_t flags = data[pos + 3];
+		comp.x = (data[pos + 4] << 8) | data[pos + 5];
+		comp.y = (data[pos + 6] << 8) | data[pos + 7];
+		comp.cropped = (flags & 0x80) != 0;
+		comp.crop_x = comp.crop_y = comp.crop_w = comp.crop_h = 0;
+		pos += 8;
+
+		if (comp.cropped && pos + 8 <= len) {
+			comp.crop_x = (data[pos] << 8) | data[pos + 1];
+			comp.crop_y = (data[pos + 2] << 8) | data[pos + 3];
+			comp.crop_w = (data[pos + 4] << 8) | data[pos + 5];
+			comp.crop_h = (data[pos + 6] << 8) | data[pos + 7];
+			pos += 8;
+		}
+
+		m_composition_objects.push_back(comp);
+	}
+}
+
+void ePGSSubtitleParser::processPDS(const uint8_t* data, int len) {
+	if (len < 2)
+		return;
+
+	if (uint8_t palette_id = data[0]; palette_id != m_palette_id) {
+		eTrace("[ePGSSubtitleParser] PDS: palette ID %d does not match current palette ID %d", palette_id, m_palette_id);
+		return;
+	}
+
+	/* data[0] = palette ID, data[1] = palette version */
+	int pos = 2;
+	while (pos + 5 <= len) {
+		uint8_t index = data[pos];
+		uint8_t Y = data[pos + 1];
+		uint8_t Cr = data[pos + 2];
+		uint8_t Cb = data[pos + 3];
+		uint8_t A = data[pos + 4];
+		pos += 5;
+
+		/* Convert YCbCr to RGB using the same formula as DVB subtitles */
+		int r, g, b;
+		if (Y == 0) {
+			r = g = b = 0;
+		} else {
+			int y = Y - 16;
+			int cr = Cr - 128;
+			int cb = Cb - 128;
+			r = std::max(0, std::min(255, (298 * y + 460 * cr) / 256));
+			g = std::max(0, std::min(255, (298 * y - 55 * cb - 137 * cr) / 256));
+			b = std::max(0, std::min(255, (298 * y + 543 * cb) / 256));
+		}
+
+		/* PGS alpha is opacity, gRGB .a is transparency */
+		m_palette[index] = gRGB(r, g, b, 255 - A);
+	}
+}
+
+void ePGSSubtitleParser::processODS(const uint8_t* data, int len) {
+	if (len < 4)
+		return;
+
+	int object_id = (data[0] << 8) | data[1];
+	uint8_t seq_flag = data[3];
+
+	if (seq_flag & 0x80) { /* first segment */
+		if (len < 11)
+			return;
+		if (m_objects.size() >= MAX_OBJECTS && m_objects.find(object_id) == m_objects.end()) {
+			eTrace("[ePGSSubtitleParser] ODS: too many objects, ignoring %d", object_id);
+			return;
+		}
+		PGSObject& obj = m_objects[object_id];
+		obj.width = (data[7] << 8) | data[8];
+		obj.height = (data[9] << 8) | data[10];
+		obj.rle_data.clear();
+		obj.overflow = false;
+		obj.complete = (seq_flag & 0x40) != 0;
+		obj.rle_data.insert(obj.rle_data.end(), data + 11, data + len);
+		if (obj.complete)
+			eTrace("[ePGSSubtitleParser] ODS: object %d complete %dx%d rle=%zd bytes", object_id, obj.width, obj.height, obj.rle_data.size());
+	} else { /* continuation segment */
+		auto it = m_objects.find(object_id);
+		if (it == m_objects.end() || it->second.width == 0) {
+			eTrace("[ePGSSubtitleParser] ODS: continuation for object %d without valid first segment", object_id);
+			return;
+		}
+		PGSObject& obj = it->second;
+		if (obj.rle_data.size() + (len - 4) > MAX_OBJECT_RLE) {
+			if (!obj.overflow) {
+				eWarning("[ePGSSubtitleParser] ODS: object %d exceeds %zu bytes, dropping", object_id, MAX_OBJECT_RLE);
+				obj.overflow = true;
+				obj.rle_data.clear();
+				obj.complete = false;
+			}
+			return;
+		}
+		obj.rle_data.insert(obj.rle_data.end(), data + 4, data + len);
+		if (seq_flag & 0x40) {
+			obj.complete = true;
+			eTrace("[ePGSSubtitleParser] ODS: object %d complete %dx%d rle=%zd bytes", object_id, obj.width, obj.height, obj.rle_data.size());
+		}
+	}
+}
+
+void ePGSSubtitleParser::emitPage(std::list<eDVBSubtitleRegion>&& regions) {
+	eDVBSubtitlePage page;
+	page.m_show_time = m_pts;
+	page.m_display_size = m_display_size;
+	page.m_regions = std::move(regions);
+	m_new_subtitle_page(page);
+}
+
+void ePGSSubtitleParser::processEND() {
+	if (m_composition_objects.empty()) {
+		/* empty composition = clear the display */
+		eTrace("[ePGSSubtitleParser] END: clear screen");
+		emitPage({});
+		return;
+	}
+
+	std::list<eDVBSubtitleRegion> regions;
+
+	for (const auto& comp : m_composition_objects) {
+		auto it = m_objects.find(comp.object_id);
+		if (it == m_objects.end() || !it->second.complete) {
+			eTrace("[ePGSSubtitleParser] END: object %d not found or incomplete", comp.object_id);
+			continue;
+		}
+
+		const PGSObject& obj = it->second;
+		ePtr<gPixmap> pixmap;
+
+		if (!decodeRLE(obj, pixmap)) {
+			eTrace("[ePGSSubtitleParser] END: RLE decode failed for object %d (%dx%d)", comp.object_id, obj.width, obj.height);
+			continue;
+		}
+
+		eDVBSubtitleRegion region;
+		region.m_pixmap = pixmap;
+		region.m_position = ePoint(comp.x, comp.y);
+		regions.push_back(region);
+	}
+
+	eTrace("[ePGSSubtitleParser] END: %zd regions, show_time=%lld", regions.size(), (long long)m_pts);
+
+	/* an empty result still has to reach the widget, otherwise the previous
+	   subtitle stays on screen until its hide timer expires */
+	emitPage(std::move(regions));
+}
+
+bool ePGSSubtitleParser::decodeRLE(const PGSObject& obj, ePtr<gPixmap>& pixmap) const {
+	if (obj.width <= 0 || obj.height <= 0 || obj.width > 3840 || obj.height > 2160)
+		return false;
+
+	pixmap = new gPixmap(eSize(obj.width, obj.height), 8, 1);
+	memset(pixmap->surface->data, 0, obj.height * pixmap->surface->stride);
+
+	/* Set up the 256-entry palette on the pixmap */
+	pixmap->surface->clut.colors = 256;
+	pixmap->surface->clut.data = new gRGB[256]; //NOSONAR
+	memcpy(static_cast<void*>(pixmap->surface->clut.data), m_palette, 256 * sizeof(gRGB));
+
+	const uint8_t* rle = obj.rle_data.data();
+	size_t rle_size = obj.rle_data.size();
+	size_t pos = 0;
+	int x = 0, y = 0;
+
+	while (pos < rle_size && y < obj.height) {
+		uint8_t* line = (uint8_t*)pixmap->surface->data + y * pixmap->surface->stride;
+
+		uint8_t byte = rle[pos++];
+
+		if (byte != 0) {
+			/* Single pixel with palette index */
+			if (x < obj.width)
+				line[x] = byte;
+			x++;
+		} else {
+			/* Control byte follows */
+			if (pos >= rle_size)
+				break;
+
+			uint8_t flags = rle[pos++];
+
+			if (flags == 0) {
+				/* End of line */
+				x = 0;
+				y++;
+				continue;
+			}
+
+			int run_length;
+			uint8_t color;
+
+			if (flags & 0x40) { /* long run length */
+				if (pos >= rle_size)
+					break;
+				run_length = ((flags & 0x3F) << 8) | rle[pos++];
+			} else { /* short run length */
+				run_length = flags & 0x3F;
+			}
+
+			if (flags & 0x80) { /* non-zero color */
+				if (pos >= rle_size)
+					break;
+				color = rle[pos++];
+			} else {
+				color = 0;
+			}
+
+			/* Fill run */
+			int end = std::min(x + run_length, obj.width);
+			while (x < end)
+				line[x++] = color;
+		}
+	}
+
+	return true;
+}

--- a/lib/dvb/pgssubtitle.cpp
+++ b/lib/dvb/pgssubtitle.cpp
@@ -12,7 +12,7 @@ ePGSSubtitleParser::ePGSSubtitleParser() {
 /* enigma2 gRGB stores transparency in .a: 0x00 opaque, 0xFF invisible.
    Zeroed entries would render as opaque black boxes, so start fully clear. */
 void ePGSSubtitleParser::clearPalette() {
-	std::fill(m_palette, m_palette + 256, gRGB(0, 0, 0, 0xFF));
+	m_palette.fill(gRGB(0, 0, 0, 0xFF));
 }
 
 void ePGSSubtitleParser::reset() {
@@ -46,39 +46,26 @@ void ePGSSubtitleParser::processBuffer(const uint8_t* data, size_t len, pts_t pt
 	   mistaken for it. */
 	bool sup_format = len >= 13 && data[0] == 0x50 && data[1] == 0x47 && isSegmentType(data[10]);
 
-	if (sup_format) {
-		while (pos + 13 <= len) {
-			if (data[pos] != 0x50 || data[pos + 1] != 0x47) {
-				eTrace("[ePGSSubtitleParser] SUP sync lost at pos %zd", pos);
-				break;
-			}
+	const size_t header = sup_format ? 13 : 3;
 
-			uint8_t segment_type = data[pos + 10];
-			uint16_t segment_size = (data[pos + 11] << 8) | data[pos + 12];
-			pos += 13;
-
-			if (pos + segment_size > len) {
-				eWarning("[ePGSSubtitleParser] SUP segment truncated, %zu of %d bytes dropped (type=0x%02x)", len - pos, segment_size, segment_type);
-				break;
-			}
-
-			processSegment(segment_type, data + pos, segment_size);
-			pos += segment_size;
+	while (pos + header <= len) {
+		if (sup_format && (data[pos] != 0x50 || data[pos + 1] != 0x47)) {
+			eWarning("[ePGSSubtitleParser] SUP sync lost at pos %zu", pos);
+			return;
 		}
-	} else {
-		while (pos + 3 <= len) {
-			uint8_t segment_type = data[pos];
-			uint16_t segment_size = (data[pos + 1] << 8) | data[pos + 2];
-			pos += 3;
 
-			if (pos + segment_size > len) {
-				eWarning("[ePGSSubtitleParser] segment truncated, %zu of %d bytes dropped (type=0x%02x)", len - pos, segment_size, segment_type);
-				break;
-			}
+		uint8_t segment_type = data[pos + header - 3];
+		uint16_t segment_size = (data[pos + header - 2] << 8) | data[pos + header - 1];
+		pos += header;
 
-			processSegment(segment_type, data + pos, segment_size);
-			pos += segment_size;
+		if (pos + segment_size > len) {
+			eWarning("[ePGSSubtitleParser] %ssegment truncated, %zu of %d bytes dropped (type=0x%02x)",
+					 sup_format ? "SUP " : "", len - pos, segment_size, segment_type);
+			return;
 		}
+
+		processSegment(segment_type, data + pos, segment_size);
+		pos += segment_size;
 	}
 }
 
@@ -133,7 +120,9 @@ void ePGSSubtitleParser::processPCS(const uint8_t* data, int len) {
 	m_composition_objects.clear();
 
 	int pos = 11;
-	for (int i = 0; i < num_objects && pos + 8 <= len; i++) {
+	int parsed = 0;
+	while (parsed < num_objects && pos + 8 <= len) {
+		parsed++;
 		PGSCompositionObject comp;
 		comp.object_id = (data[pos] << 8) | data[pos + 1];
 		comp.window_id = data[pos + 2];
@@ -141,7 +130,6 @@ void ePGSSubtitleParser::processPCS(const uint8_t* data, int len) {
 		comp.x = (data[pos + 4] << 8) | data[pos + 5];
 		comp.y = (data[pos + 6] << 8) | data[pos + 7];
 		comp.cropped = (flags & 0x80) != 0;
-		comp.crop_x = comp.crop_y = comp.crop_w = comp.crop_h = 0;
 		pos += 8;
 
 		if (comp.cropped && pos + 8 <= len) {
@@ -176,10 +164,8 @@ void ePGSSubtitleParser::processPDS(const uint8_t* data, int len) {
 		pos += 5;
 
 		/* Convert YCbCr to RGB using the same formula as DVB subtitles */
-		int r, g, b;
-		if (Y == 0) {
-			r = g = b = 0;
-		} else {
+		int r = 0, g = 0, b = 0;
+		if (Y != 0) {
 			int y = Y - 16;
 			int cr = Cr - 128;
 			int cb = Cb - 128;
@@ -203,7 +189,7 @@ void ePGSSubtitleParser::processODS(const uint8_t* data, int len) {
 	if (seq_flag & 0x80) { /* first segment */
 		if (len < 11)
 			return;
-		if (m_objects.size() >= MAX_OBJECTS && m_objects.find(object_id) == m_objects.end()) {
+		if (m_objects.size() >= MAX_OBJECTS && !m_objects.contains(object_id)) {
 			eTrace("[ePGSSubtitleParser] ODS: too many objects, ignoring %d", object_id);
 			return;
 		}
@@ -240,7 +226,7 @@ void ePGSSubtitleParser::processODS(const uint8_t* data, int len) {
 	}
 }
 
-void ePGSSubtitleParser::emitPage(std::list<eDVBSubtitleRegion>&& regions) {
+void ePGSSubtitleParser::emitPage(std::list<eDVBSubtitleRegion>&& regions) const {
 	eDVBSubtitlePage page;
 	page.m_show_time = m_pts;
 	page.m_display_size = m_display_size;
@@ -296,7 +282,7 @@ bool ePGSSubtitleParser::decodeRLE(const PGSObject& obj, ePtr<gPixmap>& pixmap) 
 	/* Set up the 256-entry palette on the pixmap */
 	pixmap->surface->clut.colors = 256;
 	pixmap->surface->clut.data = new gRGB[256]; //NOSONAR
-	memcpy(static_cast<void*>(pixmap->surface->clut.data), m_palette, 256 * sizeof(gRGB));
+	memcpy(static_cast<void*>(pixmap->surface->clut.data), m_palette.data(), m_palette.size() * sizeof(gRGB));
 
 	const uint8_t* rle = obj.rle_data.data();
 	size_t rle_size = obj.rle_data.size();
@@ -313,44 +299,54 @@ bool ePGSSubtitleParser::decodeRLE(const PGSObject& obj, ePtr<gPixmap>& pixmap) 
 			if (x < obj.width)
 				line[x] = byte;
 			x++;
-		} else {
-			/* Control byte follows */
-			if (pos >= rle_size)
-				break;
-
-			uint8_t flags = rle[pos++];
-
-			if (flags == 0) {
-				/* End of line */
-				x = 0;
-				y++;
-				continue;
-			}
-
-			int run_length;
-			uint8_t color;
-
-			if (flags & 0x40) { /* long run length */
-				if (pos >= rle_size)
-					break;
-				run_length = ((flags & 0x3F) << 8) | rle[pos++];
-			} else { /* short run length */
-				run_length = flags & 0x3F;
-			}
-
-			if (flags & 0x80) { /* non-zero color */
-				if (pos >= rle_size)
-					break;
-				color = rle[pos++];
-			} else {
-				color = 0;
-			}
-
-			/* Fill run */
-			int end = std::min(x + run_length, obj.width);
-			while (x < end)
-				line[x++] = color;
+			continue;
 		}
+
+		int run_length = 0;
+		uint8_t color = 0;
+		bool end_of_line = false;
+
+		if (!readRun(rle, rle_size, pos, run_length, color, end_of_line))
+			break;
+
+		if (end_of_line) {
+			x = 0;
+			y++;
+			continue;
+		}
+
+		/* Fill run */
+		int end = std::min(x + run_length, obj.width);
+		while (x < end)
+			line[x++] = color;
+	}
+
+	return true;
+}
+
+bool ePGSSubtitleParser::readRun(const uint8_t* rle, size_t rle_size, size_t& pos, int& run_length, uint8_t& color, bool& end_of_line) {
+	if (pos >= rle_size)
+		return false;
+
+	uint8_t flags = rle[pos++];
+
+	if (flags == 0) {
+		end_of_line = true;
+		return true;
+	}
+
+	if (flags & 0x40) { /* long run length */
+		if (pos >= rle_size)
+			return false;
+		run_length = ((flags & 0x3F) << 8) | rle[pos++];
+	} else { /* short run length */
+		run_length = flags & 0x3F;
+	}
+
+	if (flags & 0x80) { /* non-zero color */
+		if (pos >= rle_size)
+			return false;
+		color = rle[pos++];
 	}
 
 	return true;

--- a/lib/dvb/pgssubtitle.h
+++ b/lib/dvb/pgssubtitle.h
@@ -1,0 +1,78 @@
+#ifndef __lib_dvb_pgssubtitle_h
+#define __lib_dvb_pgssubtitle_h
+
+#include <lib/base/object.h>
+#include <lib/dvb/subtitle.h>
+#include <lib/gdi/gpixmap.h>
+#include <sigc++/sigc++.h>
+#include <vector>
+#include <map>
+
+class ePGSSubtitleParser : public iObject, public sigc::trackable
+{
+	DECLARE_REF(ePGSSubtitleParser);
+public:
+	ePGSSubtitleParser();
+	virtual ~ePGSSubtitleParser() = default;
+
+	/* pts in ms, same unit as eDVBSubtitleParser::processBuffer() */
+	void processBuffer(const uint8_t *data, size_t len, pts_t pts);
+	void reset();
+	void connectNewPage(const sigc::slot<void(const eDVBSubtitlePage&)> &slot, ePtr<eConnection> &connection);
+
+private:
+	/* PGS segment types */
+	enum {
+		PGS_PDS = 0x14,  /* Palette Definition Segment */
+		PGS_ODS = 0x15,  /* Object Definition Segment */
+		PGS_PCS = 0x16,  /* Presentation Composition Segment */
+		PGS_WDS = 0x17,  /* Window Definition Segment */
+		PGS_END = 0x80,  /* End of Display Set */
+	};
+
+	/* a 1920x1080 8bpp object is ~2MB uncompressed; refuse anything beyond that
+	   so a broken stream cannot grow rle_data without bound */
+	static constexpr size_t MAX_OBJECT_RLE = 4 * 1024 * 1024;
+	static constexpr size_t MAX_OBJECTS = 64;
+
+	struct PGSCompositionObject
+	{
+		int object_id;
+		int window_id;
+		int x, y;
+		bool cropped;
+		int crop_x, crop_y, crop_w, crop_h;
+	};
+
+	struct PGSObject
+	{
+		int width = 0;
+		int height = 0;
+		std::vector<uint8_t> rle_data;
+		bool complete = false;
+		bool overflow = false;
+	};
+
+	eSize m_display_size{1920, 1080};
+	gRGB m_palette[256];
+	int m_palette_id = 0;
+	std::map<int, PGSObject> m_objects;
+	std::vector<PGSCompositionObject> m_composition_objects;
+	int m_composition_state = 0;
+	pts_t m_pts = 0;
+
+	sigc::signal<void(const eDVBSubtitlePage&)> m_new_subtitle_page;
+
+	void processSegment(uint8_t segment_type, const uint8_t *data, int len);
+	void processPCS(const uint8_t *data, int len);
+	void processPDS(const uint8_t *data, int len);
+	void processODS(const uint8_t *data, int len);
+	void processEND();
+
+	void clearPalette();
+	void emitPage(std::list<eDVBSubtitleRegion> &&regions);
+	bool decodeRLE(const PGSObject &obj, ePtr<gPixmap> &pixmap) const;
+	static bool isSegmentType(uint8_t type);
+};
+
+#endif

--- a/lib/dvb/pgssubtitle.h
+++ b/lib/dvb/pgssubtitle.h
@@ -5,8 +5,9 @@
 #include <lib/dvb/subtitle.h>
 #include <lib/gdi/gpixmap.h>
 #include <sigc++/sigc++.h>
-#include <vector>
+#include <array>
 #include <map>
+#include <vector>
 
 class ePGSSubtitleParser : public iObject, public sigc::trackable
 {
@@ -37,11 +38,11 @@ private:
 
 	struct PGSCompositionObject
 	{
-		int object_id;
-		int window_id;
-		int x, y;
-		bool cropped;
-		int crop_x, crop_y, crop_w, crop_h;
+		int object_id = 0;
+		int window_id = 0;
+		int x = 0, y = 0;
+		bool cropped = false;
+		int crop_x = 0, crop_y = 0, crop_w = 0, crop_h = 0;
 	};
 
 	struct PGSObject
@@ -54,7 +55,7 @@ private:
 	};
 
 	eSize m_display_size{1920, 1080};
-	gRGB m_palette[256];
+	std::array<gRGB, 256> m_palette;
 	int m_palette_id = 0;
 	std::map<int, PGSObject> m_objects;
 	std::vector<PGSCompositionObject> m_composition_objects;
@@ -70,9 +71,10 @@ private:
 	void processEND();
 
 	void clearPalette();
-	void emitPage(std::list<eDVBSubtitleRegion> &&regions);
+	void emitPage(std::list<eDVBSubtitleRegion> &&regions) const;
 	bool decodeRLE(const PGSObject &obj, ePtr<gPixmap> &pixmap) const;
 	static bool isSegmentType(uint8_t type);
+	static bool readRun(const uint8_t *rle, size_t rle_size, size_t &pos, int &run_length, uint8_t &color, bool &end_of_line);
 };
 
 #endif

--- a/lib/python/Components/Converter/TrackInfo.py
+++ b/lib/python/Components/Converter/TrackInfo.py
@@ -124,8 +124,12 @@ class TrackInfo(Poll, Converter):
 						except Exception:
 							pass
 
+						description = _("unknown")
 						if selectedSubtitle[0] == 0:
 							description = "DVB"
+
+						elif selectedSubtitle[0] == 3:
+							description = "PGS"
 
 						elif selectedSubtitle[0] == 1:
 							description = _("teletext")

--- a/lib/python/Screens/AudioSelection.py
+++ b/lib/python/Screens/AudioSelection.py
@@ -20,6 +20,7 @@ from Screens.Setup import Setup, setupDom
 from Tools.ISO639 import LanguageCodes
 FOCUS_CONFIG, FOCUS_STREAMS = range(2)
 [PAGE_AUDIO, PAGE_SUBTITLES] = ["audio", "subtitles"]
+SUBTITLE_PGS = 3  # iSubtitleOutput track type: 0 DVB, 1 teletext, 2 text, 3 PGS
 
 
 def getConfigMenuItem(configElementName):
@@ -352,10 +353,16 @@ class AudioSelection(ConfigListScreen, Screen):
 						languagetype = x[5].split()
 						if languagetype and len(languagetype) == 2:
 							language = "%s (%s)" % (language, languagetype[1])
+						elif x[5] != language:
+							language = "%s (%s)" % (language, x[5])
 
 					if x[0] == 0:
 						description = "DVB"
 						number = "%x" % (x[1])
+
+					elif x[0] == SUBTITLE_PGS:
+						description = "PGS"
+						number = str(int(number) + 1)
 
 					elif x[0] == 1:
 						description = "teletext"
@@ -688,7 +695,12 @@ class QuickSubtitlesConfigMenu(ConfigListScreen, Screen):
 				getConfigMenuItem("ai_translate_to"),
 				getConfigMenuItem("ai_subtitle_colors")
 			])
-		if sub[0] == 0:  # dvb
+		if sub[0] == SUBTITLE_PGS:  # bitmap, only the position settings reach it
+			menu.extend([
+				getConfigMenuItem("dvb_subtitles_original_position"),
+				getConfigMenuItem("subtitle_position")
+			])
+		elif sub[0] == 0:  # dvb
 			menu.extend([
 				getConfigMenuItem("dvb_subtitles_color"),
 				getConfigMenuItem("dvb_subtitles_backtrans"),

--- a/lib/python/Screens/Information.py
+++ b/lib/python/Screens/Information.py
@@ -1561,6 +1561,8 @@ class InformationService(InformationBase):
 				subtitleLang = subtitle[4]
 				if subtitle[0] == 0:  # DVB PID.
 					info.append(self.formatLine(indent, _("DVB Subtitles PID & Language"), f"{formatHex(subtitle[1])}  -  {subtitleLang}"))
+				elif subtitle[0] == 3:  # PGS.
+					info.append(self.formatLine(indent, _("Other Subtitles & Language"), f"{subtitle[1] + 1}  -  PGS  -  {subtitleLang}"))
 				elif subtitle[0] == 1:  # Teletext.
 					info.append(self.formatLine(indent, _("TXT Subtitles page & Language"), f"0x0{subtitle[3] or 8:X}{subtitle[2]:02X}  -  {subtitleLang}"))
 				elif subtitle[0] == 2:  # File.

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -185,7 +185,7 @@ static GstElement* createDashPlaybackPipeline(const std::string& uri, const std:
 
 /* Handy asyncrone timers for developpers */
 /* It could be used for a hack to set somewhere a timeout which does not interupt or blocks signals */
-static void gst_sleepms(uint32_t msec) {
+[[maybe_unused]] static void gst_sleepms(uint32_t msec) {
 	// does not interfere with signals like sleep and usleep do
 	struct timespec req_ts = {};
 	req_ts.tv_sec = msec / 1000;
@@ -1021,6 +1021,9 @@ eServiceMP3::eServiceMP3(eServiceReference ref)
 	m_dvb_subtitle_parser = new eDVBSubtitleParser();
 	m_dvb_subtitle_parser->connectNewPage(sigc::mem_fun(*this, &eServiceMP3::newDVBSubtitlePage),
 										  m_new_dvb_subtitle_page_connection);
+	m_pgs_subtitle_parser = new ePGSSubtitleParser();
+	m_pgs_subtitle_parser->connectNewPage(sigc::mem_fun(*this, &eServiceMP3::newDVBSubtitlePage),
+										  m_new_pgs_subtitle_page_connection);
 #ifdef PASSTHROUGH_FIX
 	m_passthrough_fix_timer = eTimer::create(eApp);
 #endif
@@ -1028,6 +1031,7 @@ eServiceMP3::eServiceMP3(eServiceReference ref)
 	m_currentAudioStream = -1;
 	m_currentSubtitleStream = -1;
 	m_cachedSubtitleStream = -2; /* report the first subtitle stream to be 'cached'. TODO: use an actual cache. */
+	m_subtitle_generation = 0;
 	m_subtitle_widget = 0;
 	m_currentTrickRatio = 1.0;
 	m_buffer_size = 5LL * 1024LL * 1024LL;
@@ -1475,6 +1479,7 @@ eServiceMP3::~eServiceMP3() {
 	}
 
 	m_new_dvb_subtitle_page_connection = 0;
+	m_new_pgs_subtitle_page_connection = 0;
 }
 
 #ifdef PASSTHROUGH_FIX
@@ -1884,6 +1889,14 @@ RESULT eServiceMP3::seekToImpl(pts_t to) {
 		eDebug("[eServiceMP3] seekTo failed");
 		return -1;
 	}
+	/* The seek flushes, so everything queued arrives again from the new position.
+	   Buffers already handed over are pre-flush, queued pages carry show times for
+	   the old position, and cached PGS objects would be reused by a display set
+	   that does not start a new epoch. */
+	m_subtitle_generation++;
+	m_dvb_subtitle_sync_timer->stop();
+	m_dvb_subtitle_pages.clear();
+	m_pgs_subtitle_parser->reset();
 	if (m_paused || m_to_paused) {
 		m_last_seek_count = 0;
 		m_event((iPlayableService*)this, evUpdatedInfo);
@@ -3883,6 +3896,13 @@ void eServiceMP3::gstPoll(ePtr<GstMessageContainer> const& msg) {
 		case 2: {
 			GstBuffer* buffer = *((GstMessageContainer*)msg);
 			if (buffer) {
+				/* queued before the last stream switch: the buffer still holds data of
+				   the previous track and would be fed to the parser of the new one */
+				if (msg->getGeneration() != m_subtitle_generation) {
+					eDebug("[eServiceMP3] dropping stale subtitle buffer (gen %d, current %d)",
+						   msg->getGeneration(), m_subtitle_generation.load());
+					break;
+				}
 				pullSubtitle(buffer);
 			}
 			break;
@@ -3925,7 +3945,7 @@ void eServiceMP3::gstCBsubtitleAvail(GstElement* subsink, GstBuffer* buffer, gpo
 	 * the GStreamer thread and m_subtitleStreams can be modified by the main
 	 * thread during stream re-enumeration. The bounds check is done in
 	 * pullSubtitle() which runs on the main thread via the pump. */	
-	_this->m_pump.send(new GstMessageContainer(2, NULL, NULL, buffer));
+	_this->m_pump.send(new GstMessageContainer(2, NULL, NULL, buffer, _this->m_subtitle_generation.load()));
 }
 
 /**
@@ -4057,20 +4077,34 @@ void eServiceMP3::pullSubtitle(GstBuffer* buffer) {
 				if (!parsed_subs.empty())
 					m_subtitle_sync_timer->start(250, true);
 			}
+		} else if (subType == stPGS) {
+			GstClockTime buf_pos = GST_BUFFER_PTS(buffer);
+			if (GST_CLOCK_TIME_IS_VALID(buf_pos))
+				m_pgs_subtitle_parser->processBuffer(map.data, map.size, buf_pos / 1000000ULL);
+			else
+				eDebug("[eServiceMP3] PGS buffer without pts, dropped");
 		} else if (subType == stDVB) {
-			uint8_t* data = map.data;
-			int64_t buf_pos = GST_BUFFER_PTS(buffer);
-			m_dvb_subtitle_parser->processBuffer(data, map.size, buf_pos / 1000000ULL);
+			GstClockTime buf_pos = GST_BUFFER_PTS(buffer);
+			if (GST_CLOCK_TIME_IS_VALID(buf_pos))
+				m_dvb_subtitle_parser->processBuffer(map.data, map.size, buf_pos / 1000000ULL);
+			else
+				eDebug("[eServiceMP3] DVB subtitle buffer without pts, dropped");
 		} else if (subType < stVOB) {
-			std::string line(reinterpret_cast<char*>(map.data), map.size);
-			uint32_t start_ms = GST_BUFFER_PTS(buffer) / 1000000ULL;
-			uint32_t duration = GST_BUFFER_DURATION(buffer) / 1000000ULL;
-			uint32_t end_ms = start_ms + duration;
-			// eDebug("[eServiceMP3] got new text subtitle @ start_ms=%d / dur=%d: '%s' ", start_ms, duration,
-			// line.c_str());
+			GstClockTime buf_pos = GST_BUFFER_PTS(buffer);
+			GstClockTime buf_dur = GST_BUFFER_DURATION(buffer);
+			if (!GST_CLOCK_TIME_IS_VALID(buf_pos)) {
+				eDebug("[eServiceMP3] text subtitle buffer without pts, dropped");
+			} else {
+				std::string line(reinterpret_cast<char*>(map.data), map.size);
+				uint32_t start_ms = buf_pos / 1000000ULL;
+				uint32_t duration = GST_CLOCK_TIME_IS_VALID(buf_dur) ? buf_dur / 1000000ULL : 0;
+				uint32_t end_ms = start_ms + duration;
+				// eDebug("[eServiceMP3] got new text subtitle @ start_ms=%d / dur=%d: '%s' ", start_ms, duration,
+				// line.c_str());
 
-			m_subtitle_pages.insert(subtitle_pages_map_pair_t(end_ms, subtitle_page_t(start_ms, end_ms, line)));
-			m_subtitle_sync_timer->start(250, true);
+				m_subtitle_pages.insert(subtitle_pages_map_pair_t(end_ms, subtitle_page_t(start_ms, end_ms, line)));
+				m_subtitle_sync_timer->start(250, true);
+			}
 		}
 		gst_buffer_unmap(buffer, &map);
 	}
@@ -4119,7 +4153,8 @@ void eServiceMP3::pushDVBSubtitles() {
 		if (diff < 20 || decoder_ms == 0) {
 			eTrace("[eServiceMP3] Showing subtitles at %lld. Current decoder time: %lld. Difference: %lld", show_time,
 				   decoder_ms, diff);
-			m_subtitle_widget->setPage(dvb_page);
+			if (m_subtitle_widget)
+				m_subtitle_widget->setPage(dvb_page);
 			m_dvb_subtitle_pages.pop_front();
 		} else {
 			eDebug("[eServiceMP3] Delay early subtitle by %.03fs. Page stack size %zu", diff / 1000.0f,
@@ -4389,48 +4424,29 @@ exit:
  * @return RESULT indicating success or failure.
  */
 RESULT eServiceMP3::enableSubtitles(iSubtitleUser* user, struct SubtitleTrack& track) {
-	bool starting_subtitle = false;
-	if (m_currentSubtitleStream != track.pid || eSubtitleSettings::pango_autoturnon) {
-		// if (m_currentSubtitleStream == -1)
-		//	starting_subtitle = true;
-		g_object_set(m_gst_playbin, "current-text", -1, NULL);
-		// m_cachedSubtitleStream = -1;
-		m_subtitle_sync_timer->stop();
-		m_dvb_subtitle_sync_timer->stop();
-		m_dvb_subtitle_pages.clear();
-		m_subtitle_pages.clear();
-		m_initial_vtt_mpegts = 0;
-		m_vtt_live = false;
-		m_vtt_live_base_time = -1;
-		m_prev_decoder_time = -1;
-		m_decoder_time_valid_state = 0;
-		m_currentSubtitleStream = track.pid;
-		m_cachedSubtitleStream = m_currentSubtitleStream;
-		setCacheEntry(false, track.pid);
-		g_object_set(m_gst_playbin, "current-text", m_currentSubtitleStream, NULL);
+	if (m_currentSubtitleStream == track.pid && !eSubtitleSettings::pango_autoturnon)
+		return 0;
 
-		if (track.type != stDVB) {
-			m_clear_buffers = true;
-			clearBuffers();
-		}
-		m_subtitle_widget = user;
+	m_subtitle_generation++;
+	m_subtitle_sync_timer->stop();
+	m_dvb_subtitle_sync_timer->stop();
+	m_dvb_subtitle_pages.clear();
+	m_subtitle_pages.clear();
+	m_initial_vtt_mpegts = 0;
+	m_vtt_live = false;
+	m_vtt_live_base_time = -1;
+	m_prev_decoder_time = -1;
+	m_decoder_time_valid_state = 0;
+	m_currentSubtitleStream = track.pid;
+	m_cachedSubtitleStream = m_currentSubtitleStream;
+	setCacheEntry(false, track.pid);
+	m_pgs_subtitle_parser->reset();
 
-		eDebug("[eServiceMP3] switched to subtitle stream %i", m_currentSubtitleStream);
+	m_subtitle_widget = user;
+	g_object_set(m_gst_playbin, "current-text", m_currentSubtitleStream, NULL);
 
-#ifdef GSTREAMER_SUBTITLE_SYNC_MODE_BUG
-		/*
-		 * when we're running the subsink in sync=false mode,
-		 * we have to force a seek, before the new subtitle stream will start
-		 */
-		seekRelative(-1, 90000);
-#endif
-
-		// Seek to last position for non-initial subtitle changes
-		if (m_last_seek_pos > 0 && !starting_subtitle) {
-			seekTo(m_last_seek_pos);
-			gst_sleepms(50);
-		}
-	}
+	eDebug("[eServiceMP3] switched to subtitle stream %i (generation %d)", m_currentSubtitleStream,
+		   m_subtitle_generation.load());
 
 	return 0;
 }
@@ -4445,7 +4461,9 @@ RESULT eServiceMP3::enableSubtitles(iSubtitleUser* user, struct SubtitleTrack& t
  */
 RESULT eServiceMP3::disableSubtitles() {
 	eDebug("[eServiceMP3] disableSubtitles");
+	m_subtitle_generation++;
 	m_currentSubtitleStream = -1;
+	m_pgs_subtitle_parser->reset();
 	m_cachedSubtitleStream = m_currentSubtitleStream;
 	setCacheEntry(false, -1);
 	g_object_set(m_gst_playbin, "current-text", m_currentSubtitleStream, NULL);
@@ -4462,6 +4480,18 @@ RESULT eServiceMP3::disableSubtitles() {
 		m_subtitle_widget->destroy();
 	m_subtitle_widget = 0;
 	return 0;
+}
+
+/* iSubtitleOutput track types: 0 DVB, 1 teletext, 2 text/pango, 3 PGS.
+   PGS needs its own value - it renders through the eDVBSubtitlePage widget like
+   DVB, but page_number then carries a composition page id for DVB and a
+   subtype_t for us, so the two are not distinguishable from python. */
+static int subtitleTrackType(subtype_t type) {
+	if (type == stDVB)
+		return 0;
+	if (type == stPGS)
+		return 3;
+	return 2;
 }
 
 /**
@@ -4518,9 +4548,10 @@ RESULT eServiceMP3::getCachedSubtitle(struct SubtitleTrack& track) {
 	}
 
 	if (m_cachedSubtitleStream >= 0 && m_cachedSubtitleStream < (int)m_subtitleStreams.size()) {
-		track.type = m_subtitleStreams[m_cachedSubtitleStream].type == stDVB ? 0 : 2;
+		subtype_t type = m_subtitleStreams[m_cachedSubtitleStream].type;
+		track.type = subtitleTrackType(type);
 		track.pid = m_cachedSubtitleStream;
-		track.page_number = int(m_subtitleStreams[m_cachedSubtitleStream].type);
+		track.page_number = int(type);
 		track.magazine_number = 0;
 		track.language_code = m_subtitleStreams[m_cachedSubtitleStream].language_code;
 		track.title = m_subtitleStreams[m_cachedSubtitleStream].title;
@@ -4546,12 +4577,12 @@ RESULT eServiceMP3::getSubtitleList(std::vector<struct SubtitleTrack>& subtitlel
 		const subtitleStream& stream = m_subtitleStreams[i];
 
 		// Skip unsupported types
-		if (stream.type == stUnknown || stream.type == stVOB || stream.type == stPGS) {
+		if (stream.type == stUnknown || stream.type == stVOB) {
 			continue;
 		}
 
 		struct SubtitleTrack track;
-		track.type = (stream.type == stDVB) ? 0 : 2;
+		track.type = subtitleTrackType(stream.type);
 		track.pid = i;
 		track.page_number = int(stream.type);
 		track.magazine_number = 0;

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -1031,7 +1031,6 @@ eServiceMP3::eServiceMP3(eServiceReference ref)
 	m_currentAudioStream = -1;
 	m_currentSubtitleStream = -1;
 	m_cachedSubtitleStream = -2; /* report the first subtitle stream to be 'cached'. TODO: use an actual cache. */
-	m_subtitle_generation = 0;
 	m_subtitle_widget = 0;
 	m_currentTrickRatio = 1.0;
 	m_buffer_size = 5LL * 1024LL * 1024LL;
@@ -1479,7 +1478,7 @@ eServiceMP3::~eServiceMP3() {
 	}
 
 	m_new_dvb_subtitle_page_connection = 0;
-	m_new_pgs_subtitle_page_connection = 0;
+	m_new_pgs_subtitle_page_connection = nullptr;
 }
 
 #ifdef PASSTHROUGH_FIX
@@ -3945,7 +3944,7 @@ void eServiceMP3::gstCBsubtitleAvail(GstElement* subsink, GstBuffer* buffer, gpo
 	 * the GStreamer thread and m_subtitleStreams can be modified by the main
 	 * thread during stream re-enumeration. The bounds check is done in
 	 * pullSubtitle() which runs on the main thread via the pump. */	
-	_this->m_pump.send(new GstMessageContainer(2, NULL, NULL, buffer, _this->m_subtitle_generation.load()));
+	_this->m_pump.send(new GstMessageContainer(2, nullptr, nullptr, buffer, _this->m_subtitle_generation.load()));
 }
 
 /**

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -100,13 +100,9 @@ class GstMessageContainer : public iObject {
 	int messageGeneration;
 
 public:
-	GstMessageContainer(int type, GstMessage* msg, GstPad* pad, GstBuffer* buffer, int generation = 0) {
-		messagePointer = msg;
-		messagePad = pad;
-		messageBuffer = buffer;
-		messageType = type;
-		messageGeneration = generation;
-	}
+	GstMessageContainer(int type, GstMessage* msg, GstPad* pad, GstBuffer* buffer, int generation = 0)
+		: messagePointer(msg), messagePad(pad), messageBuffer(buffer), messageType(type),
+		  messageGeneration(generation) {}
 	~GstMessageContainer() {
 		if (messagePointer)
 			gst_message_unref(messagePointer);
@@ -118,7 +114,7 @@ public:
 	int getType() {
 		return messageType;
 	}
-	int getGeneration() {
+	int getGeneration() const {
 		return messageGeneration;
 	}
 	operator GstMessage*() {
@@ -349,7 +345,7 @@ private:
 	/* bumped on every subtitle stream switch and on every seek; buffers stamped
 	   with an older generation are still in the pump queue and must not reach a
 	   parser. Written on the main thread, read on the gstreamer thread. */
-	std::atomic<int> m_subtitle_generation;
+	std::atomic<int> m_subtitle_generation{0};
 	int selectAudioStream(int i, bool skipAudioFix = false);
 	std::vector<audioStream> m_audioStreams;
 	std::vector<subtitleStream> m_subtitleStreams;

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -5,11 +5,13 @@
 #include <lib/base/message.h>
 #include <lib/dvb/metaparser.h>
 #include <lib/dvb/pmt.h>
+#include <lib/dvb/pgssubtitle.h>
 #include <lib/dvb/subtitle.h>
 #include <lib/dvb/teletext.h>
 #include <lib/service/iservice.h>
 /* for subtitles */
 #include <lib/gui/esubtitle.h>
+#include <atomic>
 #include <mutex>
 
 class eStaticServiceMP3Info;
@@ -95,13 +97,15 @@ class GstMessageContainer : public iObject {
 	GstPad* messagePad;
 	GstBuffer* messageBuffer;
 	int messageType;
+	int messageGeneration;
 
 public:
-	GstMessageContainer(int type, GstMessage* msg, GstPad* pad, GstBuffer* buffer) {
+	GstMessageContainer(int type, GstMessage* msg, GstPad* pad, GstBuffer* buffer, int generation = 0) {
 		messagePointer = msg;
 		messagePad = pad;
 		messageBuffer = buffer;
 		messageType = type;
+		messageGeneration = generation;
 	}
 	~GstMessageContainer() {
 		if (messagePointer)
@@ -113,6 +117,9 @@ public:
 	}
 	int getType() {
 		return messageType;
+	}
+	int getGeneration() {
+		return messageGeneration;
 	}
 	operator GstMessage*() {
 		return messagePointer;
@@ -339,6 +346,10 @@ private:
 	int m_currentAudioStream;
 	int m_currentSubtitleStream;
 	int m_cachedSubtitleStream;
+	/* bumped on every subtitle stream switch and on every seek; buffers stamped
+	   with an older generation are still in the pump queue and must not reach a
+	   parser. Written on the main thread, read on the gstreamer thread. */
+	std::atomic<int> m_subtitle_generation;
 	int selectAudioStream(int i, bool skipAudioFix = false);
 	std::vector<audioStream> m_audioStreams;
 	std::vector<subtitleStream> m_subtitleStreams;
@@ -427,6 +438,8 @@ private:
 #endif
 	ePtr<eDVBSubtitleParser> m_dvb_subtitle_parser;
 	ePtr<eConnection> m_new_dvb_subtitle_page_connection;
+	ePtr<ePGSSubtitleParser> m_pgs_subtitle_parser;
+	ePtr<eConnection> m_new_pgs_subtitle_page_connection;
 	void newDVBSubtitlePage(const eDVBSubtitlePage& p);
 
 	pts_t m_prev_decoder_time = -1;


### PR DESCRIPTION
Add ePGSSubtitleParser (lib/dvb/pgssubtitle.{cpp,h}) to decode PGS (Blu-ray/ HDMV) display sets into eDVBSubtitlePage, reusing the existing DVB widget path. Handles bare segments and SUP-framed segments, keeps state across processBuffer() calls, and only emits a page on END so a demuxer may deliver a whole display set or one segment per buffer. Palette starts fully transparent (a zeroed gRGB entry is opaque black), is cleared per epoch, and object count / accumulated RLE size are capped against a broken stream.

Hook PGS into servicemp3: streams are no longer skipped in getSubtitleList()/getCachedSubtitle(), reporting a new track type 3 (distinct from DVB's page_number reuse of the composition page id, which made PGS indistinguishable from a DVB track with page id 6). Pages go through m_dvb_subtitle_pages/pushDVBSubtitles() like DVB pages to compensate for the subsink handing buffers over ~2s early. The parser is reset on stream switch, disable and seek.

Rework subtitle stream switching in enableSubtitles(): replace the seekTo()+sleep hack with a generation counter stamped on pump-queued buffers, so buffers still in flight from the previous track are dropped in gstPoll() instead of being fed to the wrong parser. Also drop the dead clearBuffers() call, which compared a SubtitleTrack type against a subtype_t and always ran unconditionally.

Guard all subtitle branches in pullSubtitle() against GST_CLOCK_TIME_NONE: dividing that as unsigned produced a show_time of ~1.8e13 ms, which parked the DVB subtitle queue forever and wrote garbage keys into m_subtitle_pages for text subtitles.

Show PGS tracks in Python: AudioSelection lists them as "PGS" with only the position quick-menu options (DVB colour/background and AI translation don't apply to a bitmap format), TrackInfo/Information gain a PGS branch, and TrackInfo now defaults description instead of raising UnboundLocalError for unknown types.