### PR TITLE
[Hotplug] * re-register storage devices after a udev re-add

### DIFF
--- a/lib/python/Components/Harddisk.py
+++ b/lib/python/Components/Harddisk.py
@@ -677,17 +677,16 @@ class HarddiskManager:
 		error, blacklisted, removable, is_cdrom, partitions, medium_found = self.getBlockDevInfo(self.splitDeviceName(device)[0])
 		if not blacklisted and medium_found:
 			mountpoint = self.getMountpoint(device)
-			# Optical media changes can be reported by both udev and bdpoll.  Do
-			# not register the same mounted drive twice or show duplicate scans.
-			if is_cdrom:
-				for existing in self.partitions[:]:
-					if existing.device == device:
-						if existing.mountpoint == mountpoint:
-							self.debugPrint(f"Optical device {device} already registered at {mountpoint}")
-							return error, blacklisted, removable, is_cdrom, partitions, medium_found
-						self.partitions.remove(existing)
-						if existing.mountpoint:
-							self.triggerAddRemovePartion("remove", existing)
+			# A device can be reported more than once (udev re-add after a bus
+			# glitch, bdpoll, optical media change).  Do not register it twice.
+			for existing in self.partitions[:]:
+				if existing.device == device:
+					if existing.mountpoint == mountpoint:
+						self.debugPrint(f"Device {device} already registered at {mountpoint}")
+						return error, blacklisted, removable, is_cdrom, partitions, medium_found
+					self.partitions.remove(existing)
+					if existing.mountpoint:
+						self.triggerAddRemovePartion("remove", existing)
 			description = self.getUserfriendlyDeviceName(device, physdev)
 			p = Partition(mountpoint=mountpoint, description=description, force_mounted=True, device=device)
 			self.partitions.append(p)

--- a/lib/python/Plugins/SystemPlugins/Hotplug/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Hotplug/plugin.py
@@ -31,7 +31,6 @@ def autostart(reason, **kwargs):
 
 class HotPlugManager:
 	def __init__(self):
-		self.newCount = 0
 		self.addTimer = eTimer()
 		self.addTimer.callback.append(self.processAddDevice)
 		self.removeTimer = eTimer()
@@ -77,24 +76,23 @@ class HotPlugManager:
 			ID_FS_UUID = eventData.get("ID_FS_UUID")
 			ID_PART_ENTRY_SIZE = int(eventData.get("ID_PART_ENTRY_SIZE", 0))
 			notFound = True
-			mounts = fileReadLines("/proc/mounts")
+			mounts = [(x[0], x[1].replace("\\040", " ")) for x in (line.split() for line in fileReadLines("/proc/mounts", default=[])) if len(x) > 1]
+			mountPoints = [x[1] for x in mounts]
 			mountPoint = "/media/usb"
 			mountPointDevice = DEVNAME.replace("/dev/", "/media/")
-			mountPointHdd = None if [x.split()[1] for x in mounts if "/media/hdd" in x] else "/media/hdd"
+			mountPointHdd = None if "/media/hdd" in mountPoints else "/media/hdd"
 			knownDevices = fileReadLines("/etc/udev/known_devices", default=[])
 			knownDevice = ""
-			if mounts:
-				usbMounts = [x.split()[1] for x in mounts if "/media/usb" in x]
-				nr = 1
-				while mountPoint in usbMounts:
-					nr += 1
-					mountPoint = f"/media/usb{nr}"
+			nr = 1
+			while mountPoint in mountPoints:
+				nr += 1
+				mountPoint = f"/media/usb{nr}"
 
-				for mount in mounts:
-					if DEVNAME in mount and DEVNAME.replace("/dev/", "/media/") not in mount:
-						print(f"[Hotplug] device '{DEVNAME}' found in mounts -> {mount}")
-						notFound = False
-						break
+			for device, point in mounts:
+				if device == DEVNAME and point != mountPointDevice:
+					print(f"[Hotplug] device '{DEVNAME}' found in mounts -> {point}")
+					notFound = False
+					break
 
 			if notFound and knownDevices:
 				for device in knownDevices:
@@ -106,28 +104,26 @@ class HotPlugManager:
 						notFound = knownDevice != "None"  # Ignore this device
 						break
 
-			if notFound:
-				fstab = fileReadLines("/etc/fstab")
-				fstabDevice = [x.split()[1] for x in fstab if ID_FS_UUID in x and EXPANDER_MOUNT not in x]
-				if fstabDevice and fstabDevice[0] not in mounts:  # Check if device is already in fstab and if the mountpoint not used
+			if notFound and ID_FS_UUID:
+				fstabEntries = [x for x in (line.split() for line in fileReadLines("/etc/fstab", default=[])) if len(x) > 1]
+				fstabDevice = [x[1] for x in fstabEntries if x[0] == f"UUID={ID_FS_UUID}" and EXPANDER_MOUNT not in x[1]]
+				if fstabDevice and fstabDevice[0] not in mountPoints:  # Check if device is already in fstab and if the mountpoint not used
 					if not exists(fstabDevice[0]):
 						mkdir(fstabDevice[0], 0o755)
 					self.callMount = True
 					notFound = False
-					self.newCount += 1
 
-			if notFound and mountPointHdd:  # If device is the first and /media/hdd not mounted
+			if notFound and mountPointHdd and ID_FS_UUID:  # If device is the first and /media/hdd not mounted
 				knownDevices.append(f"{ID_FS_UUID}:{mountPointHdd}")
 				fileWriteLines("/etc/udev/known_devices", knownDevices)
-				fstab = fileReadLines("/etc/fstab")
+				fstab = fileReadLines("/etc/fstab", default=[])
 				newFstab = [x for x in fstab if f"UUID={ID_FS_UUID}" not in x]
 				newFstab.append(f"UUID={ID_FS_UUID} {mountPointHdd} {ID_FS_TYPE} defaults 0 0")
 				fileWriteLines("/etc/fstab", newFstab)
 				if not exists(mountPointHdd):
-					mkdir(mountPoint, 0o755)
+					mkdir(mountPointHdd, 0o755)
 				self.callMount = True
 				notFound = False
-				self.newCount += 1
 
 			if notFound:
 				description = ""
@@ -140,9 +136,7 @@ class HotPlugManager:
 				def newDeviceCallback(answer):
 					if answer:
 						knownDevice = None
-						if answer in (2, 3, 4, 5):
-							self.newCount += 1
-						fstab = fileReadLines("/etc/fstab")
+						fstab = fileReadLines("/etc/fstab", default=[])
 						if answer in (2, 3) and not exists(mountPoint):
 							mkdir(mountPoint, 0o755)
 						if answer == 4 and not exists(mountPointHdd):
@@ -196,14 +190,14 @@ class HotPlugManager:
 			else:
 				self.addedDevice.append((DEVNAME, DEVPATH, ID_MODEL))
 				self.addTimer.start(1000)
-		else:
-			if self.newCount:
-				if self.callMount:
-					self.callMount = False
-					Console().ePopen("/bin/mount -a")
-				self.newCount = 0
-				for device, physicalDevicePath, model in self.addedDevice:
-					harddiskmanager.addHotplugPartition(device, physicalDevicePath, model=model)
+		elif self.addedDevice:
+			if self.callMount:
+				self.callMount = False
+				Console().ePopen("/bin/mount -a")  # Without a callback this blocks, so the mount point is ready below.
+			addedDevice = self.addedDevice
+			self.addedDevice = []
+			for device, physicalDevicePath, model in addedDevice:
+				harddiskmanager.addHotplugPartition(device, physicalDevicePath, model=model)
 
 	def processRemoveDevice(self):
 		self.removeTimer.stop()


### PR DESCRIPTION
A udev remove/add cycle (bus glitch, USB reset) dropped the partition from the harddisk manager, but the kernel mount survived. On the following add event the device was found in /proc/mounts, so the registration was skipped and the mount point stayed invisible to enigma2 until a reboot.

* drop the newCount gate, drive the registration from addedDevice and clear that list afterwards
* dedupe in addHotplugPartition for every device, not only optical ones
* fix mkdir of the /media/hdd mount point creating /media/usb instead
* compare the fstab mount point against real mount points instead of whole /proc/mounts lines, and anchor the UUID match so short NTFS and exFAT ids cannot match as a substring
* do not write UUID=None to fstab when udev reports no filesystem uuid