### PR TITLE
[DAB+] * fix decoder, TS adapter and audio path defects

### DIFF
--- a/lib/python/Screens/DABScan.py
+++ b/lib/python/Screens/DABScan.py
@@ -49,7 +49,7 @@ class DABScan(ServiceScan):
 
 	def runScan(self):
 		if not self.loadFeeds():
-			message = _("No supported DAB+ feeds are available for the satellite positions configured on this box.") if self.knownFeeds else _("No valid DAB+ feeds configured. Check /etc/enigma2/dab.xml.")
+			message = _("No supported DAB+ feeds are available for the satellite positions configured on this box.") if self.knownFeeds and not self.feedErrors else _("No valid DAB+ feeds configured. Check /etc/enigma2/dab.xml.")
 			self.finishWithError(message)
 			return
 		if self.session.nav.RecordTimer.isRecording():
@@ -71,7 +71,7 @@ class DABScan(ServiceScan):
 		try:
 			root = parse(xmlPath).getroot()
 			if root.tag != "dabFeeds":
-				raise ValueError(_("Invalid DAB feed file root element"))
+				raise ValueError("invalid root element")
 			definitions = [(node, None, None) for node in root.findall("feed")]
 			for satellite in root.findall("satellite"):
 				for transponder in satellite.findall("transponder"):
@@ -91,14 +91,14 @@ class DABScan(ServiceScan):
 						continue
 					self.feeds.append(feed)
 				except (TypeError, ValueError) as err:
-					feedName = node.get("name") or node.get("id") or _("Unknown feed")
+					feedName = node.get("name") or node.get("id") or "unknown feed"
 					self.feedErrors.append(f"{feedName}: {err}")
 		except (OSError, ParseError, ValueError) as err:
 			self.feedErrors.append(f"{xmlPath}: {err}")
 		if self.knownFeeds:
 			print("[DABScan] Feed definitions: %d known, %d selected, %d unavailable, %d unsupported, %d disabled." % (self.knownFeeds, len(self.feeds), self.skippedUnavailableFeeds, self.skippedUnsupportedFeeds, self.skippedDisabledFeeds))
-		if not self.feeds and not self.feedErrors:
-			self.feedErrors.append(_("%d feeds are on unavailable satellites, %d use unsupported transports and %d are disabled") % (self.skippedUnavailableFeeds, self.skippedUnsupportedFeeds, self.skippedDisabledFeeds))
+		for error in self.feedErrors:
+			print(f"[DABScan] {error}")
 		return bool(self.feeds)
 
 	def feedAttribute(self, node, transponder, satellite, attribute, default=None):
@@ -113,18 +113,18 @@ class DABScan(ServiceScan):
 		feedId = attribute("id", "feed")
 		orbitalPosition = int(attribute("orbitalPosition", "-1"), 10)
 		if orbitalPosition < 0 or orbitalPosition > 3599:
-			raise ValueError(_("Invalid orbital position"))
+			raise ValueError("invalid orbital position")
 		decoder = attribute("decoder", "fedi2eti").lower()
 		generatedName = "userbouquet.dab_%s.radio" % sub("[^a-z0-9_]+", "_", feedId.lower()).strip("_")
 		bouquetFile = attribute("bouquetFile", generatedName)
 		if basename(bouquetFile) != bouquetFile or not fullmatch(r"userbouquet\.[A-Za-z0-9_.-]+\.radio", bouquetFile):
-			raise ValueError(_("Invalid bouquet file name '%s'") % bouquetFile)
+			raise ValueError(f"invalid bouquet file name '{bouquetFile}'")
 		address = attribute("multicastAddress", "")
 		if decoder == "fedi2eti" and not address:
-			raise ValueError(_("Missing multicast address"))
+			raise ValueError("missing multicast address")
 		port = int(attribute("multicastPort", "0"), 10)
 		if decoder == "fedi2eti" and (port < 1 or port > 65535):
-			raise ValueError(_("Invalid multicast port"))
+			raise ValueError("invalid multicast port")
 		return {
 			"id": feedId,
 			"name": attribute("name", feedId),
@@ -148,7 +148,7 @@ class DABScan(ServiceScan):
 	def parseHex(self, node, transponder, satellite, attribute):
 		value = self.feedAttribute(node, transponder, satellite, attribute)
 		if value is None:
-			raise ValueError(_("Missing attribute '%s'") % attribute)
+			raise ValueError(f"missing attribute '{attribute}'")
 		return int(value, 16)
 
 	def startFeed(self):
@@ -343,7 +343,7 @@ class DABScan(ServiceScan):
 		self.restoreService()
 		self["pass"].setText("")
 		self["network"].setText(_("DAB+ Scan"))
-		self["transponder"].setText("; ".join(self.feedErrors))
+		self["transponder"].setText("")
 		self.setScanState(message)
 		self["key_red"].setText(_("Close"))
 

--- a/lib/service/dabdecoder.cpp
+++ b/lib/service/dabdecoder.cpp
@@ -264,10 +264,11 @@ void eDABDecoder::processAF(const uint8_t *data, size_t length)
 	const bool hasCRC = data[8] & 0x80;
 	if (((data[8] >> 4) & 7) != 1 || (data[8] & 0x0f) != 0 || data[9] != 'T')
 		return;
-	const size_t packetLength = 10 + tagLength + (hasCRC ? 2 : 0);
-	if (packetLength > length)
+	// LEN is 32 bit, adding to it wraps a 32-bit size_t.
+	const size_t overhead = hasCRC ? 12 : 10;
+	if (tagLength > length - overhead)
 		return;
-	if (hasCRC && !checkInvertedCRC(data, packetLength))
+	if (hasCRC && !checkInvertedCRC(data, overhead + tagLength))
 	{
 		++m_crc_errors;
 		return;

--- a/lib/service/dabdecoder.cpp
+++ b/lib/service/dabdecoder.cpp
@@ -242,9 +242,9 @@ void eDABDecoder::feedETI(const uint8_t *data, size_t length)
 		streams.push_back(stream);
 		position += streamLength;
 	}
-	/* FL covers FC, STC, EOH, FIC and MSC in 32-bit words. It provides a
-	 * second independent bound for malformed direct ETI input. */
-	const size_t expectedMSTEnd = 8 + frameLengthWords * 4;
+	/* FL covers FC, STC, EOH, FIC and MSC in 32-bit words, so the MST ends at
+	 * 4 + FL * 4. It provides a second independent bound for malformed input. */
+	const size_t expectedMSTEnd = 4 + frameLengthWords * 4;
 	if (position != expectedMSTEnd || position + 2 > length ||
 		!checkInvertedCRC(data + mstStart, position + 2 - mstStart))
 	{

--- a/lib/service/dabdecoder.cpp
+++ b/lib/service/dabdecoder.cpp
@@ -633,7 +633,7 @@ void eDABDecoder::feedMSC(const std::vector<Stream> &streams)
 		return;
 	for (size_t i = 0; i < streams.size(); ++i)
 	{
-		if (streams[i].subchannel != m_selected_subchannel && streams[i].startAddress != m_selected_start_address)
+		if (streams[i].subchannel != m_selected_subchannel)
 			continue;
 		++m_msc_frames;
 		if (m_selected_dabplus)

--- a/lib/service/dabdecoder.cpp
+++ b/lib/service/dabdecoder.cpp
@@ -39,18 +39,20 @@ const EEPProfile eepProfiles[8] = {
 class LATMBitWriter
 {
 public:
-	LATMBitWriter() : m_byte_bits(0) { }
+	LATMBitWriter() = default;
 
 	void addBits(uint32_t value, size_t count)
 	{
 		while (count)
 		{
-			if (!m_byte_bits)
+			const size_t usedBits = m_byte_bits & 7;  // Keeps the range provable, m_byte_bits is unsigned.
+			if (!usedBits)
 				m_data.push_back(0);
-			const size_t copyBits = std::min(count, static_cast<size_t>(8 - m_byte_bits));
+			const size_t freeBits = 8 - usedBits;
+			const size_t copyBits = std::min(count, freeBits);
 			const uint8_t copyData = static_cast<uint8_t>((value >> (count - copyBits)) & (0xff >> (8 - copyBits)));
-			m_data.back() |= static_cast<uint8_t>(copyData << (8 - m_byte_bits - copyBits));
-			m_byte_bits = (m_byte_bits + copyBits) % 8;
+			m_data.back() |= static_cast<uint8_t>(copyData << (freeBits - copyBits));
+			m_byte_bits = (usedBits + copyBits) % 8;
 			count -= copyBits;
 		}
 	}
@@ -73,7 +75,7 @@ public:
 
 private:
 	std::vector<uint8_t> m_data;
-	size_t m_byte_bits;
+	size_t m_byte_bits = 0;
 };
 }
 

--- a/lib/service/dabtsadapter.cpp
+++ b/lib/service/dabtsadapter.cpp
@@ -134,7 +134,7 @@ uint8_t eDABTSAdapter::getAlignedByte(size_t bitPosition) const
 		(m_na_input[bytePosition + 1] >> (8 - shift)));
 }
 
-bool eDABTSAdapter::findE1Sync(size_t &bitPosition, bool &inverted) const
+bool eDABTSAdapter::findE1Sync(size_t startBit, size_t &bitPosition, bool &inverted) const
 {
 	const size_t spacing = E1_FRAME_SIZE * 2 * 8;
 	const size_t samples = 8;
@@ -142,7 +142,8 @@ bool eDABTSAdapter::findE1Sync(size_t &bitPosition, bool &inverted) const
 	const size_t availableBits = m_na_input.size() * 8;
 	if (availableBits < requiredBits)
 		return false;
-	for (size_t start = 0; start + requiredBits <= availableBits; ++start)
+	// Skip candidates the caller already rejected, otherwise they are found again.
+	for (size_t start = startBit; start + requiredBits <= availableBits; ++start)
 	{
 		const uint8_t first = getAlignedByte(start) & E1_SYNC_MASK;
 		if (first != E1_SYNC && first != (E1_SYNC ^ E1_SYNC_MASK))
@@ -328,7 +329,7 @@ void eDABTSAdapter::processTSNA()
 		{
 			size_t syncPosition = 0;
 			bool inverted = false;
-			if (!findE1Sync(syncPosition, inverted))
+			if (!findE1Sync(m_na_bit_position, syncPosition, inverted))
 				return;
 			m_na_bit_position = syncPosition;
 			m_na_inverted = inverted;

--- a/lib/service/dabtsadapter.h
+++ b/lib/service/dabtsadapter.h
@@ -33,7 +33,7 @@ private:
 	void finishTSNI();
 	void feedTSNA(const uint8_t *payload, size_t length);
 	void processTSNA();
-	bool findE1Sync(size_t &bitPosition, bool &inverted) const;
+	bool findE1Sync(size_t startBit, size_t &bitPosition, bool &inverted) const;
 	uint8_t getAlignedByte(size_t bitPosition) const;
 	bool extractE1Frames(size_t bitPosition, size_t count, std::vector<uint8_t> &frames) const;
 	int findBlockPhase(const std::vector<uint8_t> &frames) const;

--- a/lib/service/servicedab.cpp
+++ b/lib/service/servicedab.cpp
@@ -27,6 +27,15 @@ namespace
 {
 constexpr size_t TS_PACKET_SIZE = 188;
 constexpr size_t PSI_MAX_SIZE = 0x0fff;
+constexpr uint64_t LOAS_PROBE_MS = 8000;
+constexpr uint64_t LOAS_PROBE_OVERRUNS = 3;
+
+/* Latched when a sink advertises LOAS but does not consume it. */
+bool &loasSinkRejected()
+{
+	static bool rejected = false;
+	return rejected;
+}
 
 uint64_t monotonicMilliseconds()
 {
@@ -1032,7 +1041,10 @@ bool eServiceDAB::startTap()
 			uint64_t durationNs, uint8_t config) {
 			if (m_audio_capture)
 				fwrite(framed, 1, framedLength, m_audio_capture);
-			pushAudio(data, length, durationNs, config);
+			if (m_audio_loas)
+				pushAudio(framed, framedLength, durationNs, config);
+			else
+				pushAudio(data, length, durationNs, config);
 		},
 		[this](const uint8_t *data, size_t length, int format) { storeSlide(data, length, format); },
 		m_worker_pump));
@@ -1049,6 +1061,7 @@ bool eServiceDAB::startTap()
 		return false;
 	}
 	m_tap_running = true;
+	m_audio_probe_deadline = m_audio_loas ? monotonicMilliseconds() + LOAS_PROBE_MS : 0;
 	eDebug("[eServiceDAB] native PID tap started pid=%04x dabSid=%04x eid=%04x target=%s",
 		pid, m_reference.getUnsignedData(6) & 0xffff, m_reference.getUnsignedData(7) & 0xffff,
 		m_reference.path.c_str());
@@ -1112,6 +1125,19 @@ void eServiceDAB::workerMessage(const eDABWorkerStats &stats)
 	m_stats = stats;
 	pollAudioBus();
 	const uint64_t queueOverruns = m_audio_queue_overruns.load();
+	/* The sink advertised LOAS but leaves the queue to overflow, so it does not
+	 * consume what it claimed to take. Re-tap with the software decoder. */
+	if (queueOverruns >= LOAS_PROBE_OVERRUNS && m_audio_probe_deadline && monotonicMilliseconds() < m_audio_probe_deadline)
+	{
+		loasSinkRejected() = true;
+		m_audio_probe_deadline = 0;
+		eWarning("[eServiceDAB] sink does not consume LOAS after %llu overruns, falling back to the software decoder",
+			static_cast<unsigned long long>(queueOverruns));
+		stopTap();
+		if (!startTap())
+			eWarning("[eServiceDAB] unable to restart the tap with the software decoder");
+		return;
+	}
 	if (queueOverruns != m_reported_audio_queue_overruns)
 	{
 		guint levelBuffers = 0;
@@ -1172,6 +1198,58 @@ void eServiceDAB::workerMessage(const eDABWorkerStats &stats)
 		eWarning("[eServiceDAB] worker stopped with error %d", stats.error);
 }
 
+static bool structureOffersLOAS(const GstStructure *structure)
+{
+	const GValue *value = gst_structure_get_value(structure, "stream-format");
+	if (!value)
+		return false;
+	if (G_VALUE_HOLDS_STRING(value))
+		return g_strcmp0(g_value_get_string(value), "loas") == 0;
+	if (GST_VALUE_HOLDS_LIST(value))
+	{
+		for (guint index = 0; index < gst_value_list_get_size(value); ++index)
+		{
+			const GValue *item = gst_value_list_get_value(value, index);
+			if (G_VALUE_HOLDS_STRING(item) && g_strcmp0(g_value_get_string(item), "loas") == 0)
+				return true;
+		}
+	}
+	return false;
+}
+
+bool eServiceDAB::sinkAcceptsLOAS(const char *factoryName)
+{
+	GstElementFactory *factory = gst_element_factory_find(factoryName);
+	if (!factory)
+		return false;
+	/* Require stream-format to name loas. A caps query would also match a sink
+	 * that leaves the field open, and such a sink decodes the access units as
+	 * plain AAC instead of LATM. */
+	bool accepted = false;
+	for (const GList *entry = gst_element_factory_get_static_pad_templates(factory); entry; entry = entry->next)
+	{
+		GstStaticPadTemplate *padTemplate = static_cast<GstStaticPadTemplate *>(entry->data);
+		if (padTemplate->direction != GST_PAD_SINK)
+			continue;
+		GstCaps *caps = gst_static_pad_template_get_caps(padTemplate);
+		if (!caps)
+			continue;
+		for (guint index = 0; index < gst_caps_get_size(caps); ++index)
+		{
+			if (structureOffersLOAS(gst_caps_get_structure(caps, index)))
+			{
+				accepted = true;
+				break;
+			}
+		}
+		gst_caps_unref(caps);
+		if (accepted)
+			break;
+	}
+	gst_object_unref(factory);
+	return accepted;
+}
+
 bool eServiceDAB::startAudioPipeline()
 {
 	if (m_audio_pipeline)
@@ -1181,10 +1259,15 @@ bool eServiceDAB::startAudioPipeline()
 #else
 	const char *sink = "dvbaudiosink";
 #endif
+	/* A sink that takes LOAS decodes in hardware. Fall back to the software
+	 * decoder only when it does not, dvbaudiosink advertises raw audio but
+	 * never consumes it. */
+	m_audio_loas = !loasSinkRejected() && sinkAcceptsLOAS(sink);
 	std::string description =
 		"appsrc name=dabsource is-live=true format=time do-timestamp=false block=false "
-		"! queue name=dabqueue max-size-buffers=64 max-size-bytes=524288 max-size-time=2000000000 leaky=downstream "
-		"! faad ! audioconvert ! audioresample ! ";
+		"! queue name=dabqueue max-size-buffers=64 max-size-bytes=524288 max-size-time=2000000000 leaky=downstream ! ";
+	if (!m_audio_loas)
+		description += "faad ! audioconvert ! audioresample ! ";
 	description += sink;
 	description += " name=dabaudiosink";
 	GError *error = nullptr;
@@ -1281,6 +1364,26 @@ void eServiceDAB::setAudioCaps(uint8_t config)
 	const unsigned formatIndex = (dacRate ? 2 : 0) | (sbr ? 1 : 0);
 	const unsigned coreSampleIndex = coreSampleIndexTable[formatIndex];
 	const unsigned coreChannels = stereo ? 2 : 1;
+	if (m_audio_loas)
+	{
+		// The StreamMuxConfig carries the AudioSpecificConfig, no codec_data needed.
+		const unsigned rate = sbr ? coreSampleRateTable[formatIndex] * 2 : coreSampleRateTable[formatIndex];
+		GstCaps *loasCaps = gst_caps_new_simple("audio/mpeg",
+			"mpegversion", G_TYPE_INT, 4,
+			"rate", G_TYPE_INT, static_cast<int>(rate),
+			"channels", G_TYPE_INT, static_cast<int>(coreChannels),
+			"stream-format", G_TYPE_STRING, "loas",
+			"framed", G_TYPE_BOOLEAN, TRUE, nullptr);
+		if (!loasCaps)
+			return;
+		g_object_set(m_audio_source, "caps", loasCaps, nullptr);
+		gst_caps_unref(loasCaps);
+		m_audio_format = config;
+		m_audio_caps_set = true;
+		eDebug("[eServiceDAB] AAC hardware decode configured: LOAS %u Hz channels=%u sbr=%d ps=%d",
+			rate, coreChannels, sbr, ps);
+		return;
+	}
 	uint8_t asc[7] = {
 		static_cast<uint8_t>((2 << 3) | (coreSampleIndex >> 1)),
 		static_cast<uint8_t>(((coreSampleIndex & 1) << 7) | (coreChannels << 3) | 0b100)

--- a/lib/service/servicedab.h
+++ b/lib/service/servicedab.h
@@ -208,6 +208,7 @@ private:
 	void stopTap();
 	void parentEvent(iPlayableService *service, int event);
 	void workerMessage(const eDABWorkerStats &stats);
+	static bool sinkAcceptsLOAS(const char *factoryName);
 	bool startAudioPipeline();
 	void stopAudioPipeline();
 	void pushAudio(const uint8_t *data, size_t length, uint64_t durationNs, uint8_t config);
@@ -240,6 +241,8 @@ private:
 	uint64_t m_audio_next_pts;
 	uint8_t m_audio_format;
 	bool m_audio_caps_set;
+	bool m_audio_loas = false;
+	uint64_t m_audio_probe_deadline = 0;
 	std::atomic<uint64_t> m_audio_queue_overruns;
 	uint64_t m_reported_audio_queue_overruns;
 	std::string m_slide_jpeg_path;


### PR DESCRIPTION
Started as a Quality Gate fix and grew into a review of the DAB+ code, then into a no audio report on a pulse4kmini. Seven changes.

### Audio output

**`[eServiceDAB]` feed LOAS to sinks that advertise it**

On a pulse4kmini DAB+ produced no sound at all, with or without the other commits in this PR, so this is not a regression from them. The scan, FIC, MSC, PAD, DLS and SLS all worked, the audio queue simply overran once a second and leaked. Measured standalone with enigma2 stopped, so nothing else held the decoder:

| pipeline | material | result |
|---|---|---|
| LOAS → dvbaudiosink | 120 KB ≈ 9.2 s | plays, ends after 9.8 s, real time |
| PCM → dvbaudiosink | 819 KB ≈ 4.3 s | no buffer consumed within 30 s |
| PCM → fakesink | same buffers | done in 4 ms |

`dvbaudiosink` advertises `audio/x-raw` and does not consume it, and the DAB pipeline ended in `faad ! audioconvert ! audioresample ! dvbaudiosink`. `emitLOAS` already built a LOAS stream and only used it for the diagnostic capture; `aacparse` reads that capture back as `audio/mpeg mpegversion=4 rate=48000 channels=2 stream-format=loas`, so it is well formed. The 9.8 s also match the 960 sample transform, at 1024 the same data would have taken 10.5 s, so the hardware decoder handles DAB+ correctly here.

The path is chosen from the sink template naming `loas` in `stream-format`, not from a caps query: `dreamaudiosink` leaves `stream-format` open, which matches any value, and then maps `mpegversion=4` to `AV_CODEC_ID_AAC` without looking at the format, so a query would have switched it too and it would decode LATM as plain AAC. Since a template is a claim and not a guarantee, three queue overruns within eight seconds re-tap with the software decoder and the rejection is remembered for the session.

Note for reviewers with other hardware: this covers a sink that consumes nothing. A decoder that takes the buffers and renders them wrong, for instance by treating the 960 sample transform as 1024, would sound 6 to 7 % too low and too slow and can only be caught by listening.

### Correctness

**`[dabtsadapter]` endless loop when ETI multiframe alignment fails**
`processTSNA` advances the bit position and clears the sync flag when the block phase or the multiframe cannot be validated, but `findE1Sync` always searched from bit 0 and overwrote the position with the same result, so the same candidate failed again forever. One corrupted management byte is enough, `validMultiframe` requires all 24 block and superframe numbers to be consecutive. The worker thread then spins at 100% and never checks `m_stop` again, which also blocks the join when the service is stopped. Affects `dab://ts2na12` and `dab://ts2na`.

**`[dabdecoder]` AF packet length overflowed `size_t`**
`processAF` read the 32-bit LEN field and added the header and CRC overhead before comparing against the available length. On a 32-bit target that addition wraps, so a LEN close to `0xffffffff` produced a small `packetLength`, passed the bound and handed the unmodified LEN to `processTags`, which then walked far past the buffer. The data comes from the transport stream, so it is not trusted input.

**`[dabdecoder]` expected MST end derived from FL was one word too high**
EN 300 799 counts FL in 32-bit words from the FC field, excluding SYNC, EOF and TIST, so the MST ends at `4 + FL * 4`. `feedETI` expected `8 + FL * 4`. With the offsets `feedETI` uses itself, `position` ends at `12 + 4 * NST + MST`, which equals `4 + FL * 4` for a conformant frame, so the old constant could never match and every direct ETI frame was counted as a CRC error and dropped. This affects the three TS transports, which reach the decoder through `feedETI`; the MPE/EDI path goes through `feedEDI` and is unaffected.

**`[dabdecoder]` MSC stream selected by start address**
`feedMSC` skipped a stream only when the sub-channel id and the start address both differed, so a stream of a different sub-channel was accepted whenever its start address happened to match the selected one. SubChId identifies the sub-channel and the start address comes from the same FIG 0/1 record, so matching on the id alone is both sufficient and safe across a reconfiguration.

### Static analysis

**`[dabdecoder]` LATM bit ranges made provable**
SonarCloud fails the Quality Gate on New Code with `cpp:S3949` in `LATMBitWriter::addBits`: it cannot prove that `m_byte_bits` stays in [0,7], so it assumes `8 - m_byte_bits` underflows, `copyBits` becomes `count` and `0xff >> (8 - copyBits)` shifts by `(size_t)-3`. At runtime this cannot happen, the modulo keeps the member in range, so it is a false positive. Masking the member makes the range local and provable without changing the generated bitstream. Also clears `cpp:S1905` and `cpp:S3230` in the same class.

### Translations

**`[DABScan]` dab.xml parser diagnostics out of the GUI**
The parser raised a separate translated message for every way a feed definition can be wrong and joined them into the transponder line. Those texts only help someone writing a `dab.xml`, the shipped file is valid. They are now plain untranslated text in the debug log. Eight translatable strings less, none added. This also corrects the message shown when the file is readable but its feed entries are invalid, which claimed the satellite positions were unsuitable.

### Verification

- LATM: old and new `addBits` compared over the full parameter space of `buildAudioSyncStream` plus 200000 randomised bit sequences, byte identical output, clean under `-fsanitize=undefined`
- TS adapter: a harness feeding a buffer that carries the E1 sync pattern but no valid block sequence does not return before the fix and returns after it
- ETI: a frame built to EN 300 799 with both CRCs is rejected as a CRC error before the fix and accepted after it
- Audio: on air on Astra 19.2E, DAB Bundesmux 1 and 2, several services across three bit rates and sub-channels. Queue overruns went from 402 to 0, the software decode disappeared from the pipeline, the fallback never triggered, no GStreamer errors
- Built for an armv7 target (pulse4kmini, openatv 8.0) with no new compiler warnings
