### PR TITLE
[dabdecoder] * stop rejecting ETI frames on the FL field

### DIFF
--- a/lib/service/dabdecoder.cpp
+++ b/lib/service/dabdecoder.cpp
@@ -242,11 +242,10 @@ void eDABDecoder::feedETI(const uint8_t *data, size_t length)
 		streams.push_back(stream);
 		position += streamLength;
 	}
-	/* FL covers FC, STC, EOH, FIC and MSC in 32-bit words, so the MST ends at
-	 * 4 + FL * 4. It provides a second independent bound for malformed input. */
-	const size_t expectedMSTEnd = 4 + frameLengthWords * 4;
-	if (position != expectedMSTEnd || position + 2 > length ||
-		!checkInvertedCRC(data + mstStart, position + 2 - mstStart))
+	/* The MST CRC decides. FL is not compared against the parsed end, the frame
+	 * can come from eDABTSAdapter, whose reconstruction need not place the
+	 * fields where a broadcast ETI-NI frame does. */
+	if (position + 2 > length || !checkInvertedCRC(data + mstStart, position + 2 - mstStart))
 	{
 		++m_crc_errors;
 		return;


### PR DESCRIPTION
Fixes a regression from #3868 reported on a Vu+ Zero 4K on Astra 28.2°E, where the DAB+ scan no longer finds any service.

That PR changed the expected MST end in `feedETI` from `8 + FL * 4` to `4 + FL * 4`, derived from EN 300 799. The verification behind that change was circular: the test frame was built to the same reading of the standard the code was changed to, so it could only agree. It was never checked against a frame that `eDABTSAdapter` produces.

Both 28.2°E feeds use `ts2na12`, so their frames reach `feedETI` from the adapter, which rebuilds an ETI-NI frame from E1 rather than passing a broadcast frame through. Its field offsets need not match, and the old constant evidently matched them. With no accepted frame there is no FIC, hence no service is found, and no MSC, hence the previously working bouquets fall silent as well.

Rather than restoring a constant that neither value can be justified for, the comparison is dropped. The frame is validated by the MST CRC, a 16 bit check over the whole main stream. The bounds that keep parsing inside the buffer are unaffected: `position + streamLength > length` per stream and `position + 2 > length` before the CRC. A secondary plausibility test that rejects valid frames is worse than none.
