### PR TITLE
Move IPK installer screens out of SoftwareManager, make ipk scanning …

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -182,7 +182,7 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 					<item key="backup_additional" level="2" text="Select Additional Backup Files" description="Here you can specify additional files that should be added to the backup file." weight="16"><plugin system="SoftwareManager" screen="BackupHelper">6</plugin></item>
 					<item key="backup_excluded" level="2" text="Select Excluded Backup Files" description="Here you can select which files should be excluded from the backup." weight="16"><plugin system="SoftwareManager" screen="BackupHelper">7</plugin></item>
 					<item key="package_manager" level="2" text="Package Manager" description="View, install and remove available or installed packages." weight="16"><screen module="PluginBrowser" screen="PackageAction">4</screen></item>
-					<item key="upgrade_source" level="2" text="Select Upgrade Source" description="Edit the upgrade source address." weight="16"><plugin system="SoftwareManager" screen="IPKGMenu" /></item>
+					<item key="upgrade_source" level="2" text="Select Upgrade Source" description="Edit the upgrade source address." weight="16"><screen module="IPKGInstaller" screen="IPKGMenu" /></item>
 					<item key="upgrade_settings" level="2" text="Software Manager Settings" description="Here you can select which files should be updated with a online update" weight="16"><setup setupKey="SoftwareManager" /></item>
 				</menu>
 			</menu>

--- a/lib/python/Components/Scanner.py
+++ b/lib/python/Components/Scanner.py
@@ -67,6 +67,7 @@ add_type("video/mpeg", ".pva")
 add_type("video/mpeg", ".wtv")
 
 
+# Guess the mimetype of a file, falling back to a few hardcoded special cases mimetypes doesn't know.
 def getType(file):
 	(type, _) = guess_type(file, strict=False)
 	if type is None:
@@ -89,6 +90,7 @@ def getType(file):
 	return type
 
 
+# Describes one file type handler: which mimetypes/paths it cares about, and what to do when a matching file was found.
 class Scanner:
 	def __init__(self, name, mimetypes=[], paths_to_scan=[], description="", openfnc=None):
 		self.mimetypes = mimetypes
@@ -97,9 +99,11 @@ class Scanner:
 		self.description = description
 		self.openfnc = openfnc
 
+	# Extra filter hook subclasses can override; base implementation accepts every file.
 	def checkFile(self, file):
 		return True
 
+	# Add "file" to the result dict (keyed by this scanner) if its mimetype and checkFile() match.
 	def handleFile(self, res, file):
 		if (self.mimetypes is None or file.mimetype in self.mimetypes) and self.checkFile(file):
 			res.setdefault(self, []).append(file)
@@ -107,11 +111,13 @@ class Scanner:
 	def __repr__(self):
 		return "<Scanner " + self.name + ">"
 
+	# Invoke the configured openfnc (e.g. to open a screen) with the matched files.
 	def open(self, list, *args, **kwargs):
 		if self.openfnc is not None:
 			self.openfnc(list, *args, **kwargs)
 
 
+# A directory to look for files in, and whether to recurse into subdirectories.
 class ScanPath:
 	def __init__(self, path, with_subdirs=False):
 		self.path = path
@@ -134,6 +140,7 @@ class ScanPath:
 		return ((self.with_subdirs, self.path) > (other.with_subdirs, other.path))
 
 
+# A single file found while scanning, with its (auto-detected or explicit) mimetype.
 class ScanFile:
 	def __init__(self, path, mimetype=None, size=None, autodetect=True):
 		self.path = path
@@ -147,6 +154,27 @@ class ScanFile:
 		return "<ScanFile " + self.path + " (" + str(self.mimetype) + ", " + str(self.size) + " MB)>"
 
 
+# openfnc for the built-in Ipkg scanner: open the IPKGInstaller screen with the list of matched .ipk files.
+def filescan_open(list, session, **kwargs):
+	from Screens.IPKGInstaller import IPKGInstaller  # Prevent Cicle imports
+	filelist = [x.path for x in list]
+	session.open(IPKGInstaller, filelist)  # List.
+
+
+# Builds the Scanner that finds .ipk packages, either directly in the scanned root or below an "ipk" subdirectory.
+def filescan(**kwargs):
+	return Scanner(mimetypes=["application/x-debian-package"], paths_to_scan=[
+		ScanPath(path="ipk", with_subdirs=True),
+		ScanPath(path="", with_subdirs=False),
+	], name="Ipkg", description=_("Install extensions."), openfnc=filescan_open)
+
+
+# Scanners that always exist, independent of what filescan plugins happen to be installed.
+def getBuiltinScanners():
+	return [filescan()]
+
+
+# Callback for the ChoiceBox in openList(): re-opens the scanner the user picked with its matched files.
 def execute(option):
 	print("[Scanner] execute", option)
 	if option is None:
@@ -156,8 +184,11 @@ def execute(option):
 	scanner.open(files, session)
 
 
+# Walks a freshly mounted device (e.g. USB stick, DVD) and sorts every file it finds into the scanners that want it.
+# Returns a dict of {scanner: [ScanFile, ...]}.
 def scanDevice(mountpoint):
-	scanner = []
+	# Collect built-in scanners plus every plugin registered for WHERE_FILESCAN.
+	scanner = getBuiltinScanners()
 
 	for pluginObj in plugins.getPlugins(PluginDescriptor.WHERE_FILESCAN):
 		func = pluginObj()
@@ -210,11 +241,14 @@ def scanDevice(mountpoint):
 	return res
 
 
+# Given an explicit list of files (e.g. selected in a file browser), find matching scanners and open one.
+# If several scanners match, let the user pick via a ChoiceBox; returns False if nothing matched at all.
 def openList(session, files):
 	if not isinstance(files, list):
 		files = [files]
 
-	scanner = []
+	# Collect built-in scanners plus every plugin registered for WHERE_FILESCAN.
+	scanner = getBuiltinScanners()
 
 	for pluginObj in plugins.getPlugins(PluginDescriptor.WHERE_FILESCAN):
 		func = pluginObj()
@@ -250,5 +284,6 @@ def openList(session, files):
 	return False
 
 
+# Convenience wrapper around openList() for a single file with a known mimetype.
 def openFile(session, mimetype, file):
 	return openList(session, [ScanFile(file, mimetype)])

--- a/lib/python/Plugins/Extensions/MediaScanner/plugin.py
+++ b/lib/python/Plugins/Extensions/MediaScanner/plugin.py
@@ -3,8 +3,7 @@ from Plugins.Plugin import PluginDescriptor
 from Components.Scanner import scanDevice
 from Components.Harddisk import harddiskmanager
 from Screens.ChoiceBox import ChoiceBox
-from Screens.InfoBar import InfoBar
-from Screens.MessageBox import MessageBox
+from Tools.Notifications import showInfo, notificationCenter
 
 parentScreen = None
 global_session = None
@@ -31,17 +30,16 @@ def mountpoint_choosen(option):
 	(description, mountpoint, session, popup) = option
 	res = scanDevice(mountpoint)
 
-	list = [(r.description, r, res[r], session, popup) for r in res]
+	list = [(r.description, (r.description, r, res[r], session, popup)) for r in res]
 
 	if not list:
-		if popup:
-			if access(mountpoint, F_OK | R_OK):
-				session.open(MessageBox, _("No displayable files on this medium found!"), MessageBox.TYPE_INFO, simple=True, timeout=5)
+		if popup and access(mountpoint, F_OK | R_OK):
+			showInfo(_("No displayable files on this medium found!"))
 		if parentScreen:
 			parentScreen.close()
 		return
 
-	session.openWithCallback(execute, ChoiceBox, title=_("The following files were found..."), list=list)
+	notificationCenter.addModalNotification(_("The following files were found..."), list=list, callback=execute)
 
 
 def scan(session, parent=None):
@@ -57,10 +55,8 @@ def main(session, **kwargs):
 
 
 def partitionListChanged(action, device):
-	if InfoBar.instance:
-		if InfoBar.instance.execing:
-			if action == 'add' and device.is_hotplug:
-				mountpoint_choosen((device.description, device.mountpoint, global_session, False))
+	if action == 'add' and device.is_hotplug:
+		mountpoint_choosen((device.description, device.mountpoint, global_session, False))
 
 
 def sessionstart(reason, session):
@@ -69,12 +65,10 @@ def sessionstart(reason, session):
 
 
 def autostart(reason, **kwargs):
-	global global_session
 	if reason == 0:
 		harddiskmanager.on_partition_list_change.append(partitionListChanged)
 	elif reason == 1:
 		harddiskmanager.on_partition_list_change.remove(partitionListChanged)
-		global_session = None
 
 
 def Plugins(**kwargs):

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -1,24 +1,12 @@
-from os import F_OK, R_OK, W_OK, access, listdir, makedirs, mkdir, stat  # noqa F401
-from os.path import dirname, exists, isdir, isfile, join as pathjoin
+from os import F_OK, R_OK, W_OK, access, makedirs, mkdir, stat  # noqa F401
+from os.path import dirname, isdir, isfile, join as pathjoin
 from stat import ST_MTIME
 from pickle import dump, load
 from time import time
 
-from enigma import getDesktop
-
-from Components.ActionMap import HelpableActionMap, HelpableNumberActionMap
 from Components.config import config
-from Components.Harddisk import harddiskmanager  # noqa F401
-from Components.Input import Input
-from Components.MenuList import MenuList
-from Components.Opkg import OpkgComponent
-from Components.PluginComponent import plugins  # noqa F401
-from Components.SelectionList import SelectionList
 from Components.SystemInfo import BoxInfo
-from Components.Sources.StaticText import StaticText
-from Plugins.Plugin import PluginDescriptor
 from Screens.MessageBox import MessageBox
-from Screens.Opkg import Opkg
 from Screens.Screen import Screen
 
 from .BackupRestore import InitConfig as BackupRestore_InitConfig, BackupSelection, BackupScreen, RestoreScreen, getBackupPath, getOldBackupPath, getBackupFilename, RestoreMenu
@@ -64,216 +52,6 @@ class ImageWizard(ImageWizard):
 
 class RestoreMenu(RestoreMenu):
 	pass
-
-
-class IPKGMenu(Screen):
-	skin = """
-		<screen name="IPKGMenu" position="center,center" size="560,400" resolution="1280,720">
-			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
-			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
-			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-			<widget name="filelist" position="5,50" size="550,340" scrollbarMode="showOnDemand" />
-		</screen>"""
-
-	def __init__(self, session):
-		Screen.__init__(self, session)
-		self.setTitle(_("Select Upgrade Source To Edit"))
-		self["key_red"] = StaticText(_("Close"))
-		self["key_green"] = StaticText(_("Edit"))
-		self.sel = []
-		self.val = []
-		self.entry = False
-		self.exe = False
-		self.path = ""
-		self["actions"] = HelpableActionMap(self, ["OkCancelActions"], {
-			"ok": self.KeyOk,
-			"cancel": self.keyCancel
-		}, prio=-1)
-		self["shortcuts"] = HelpableActionMap(self, ["ColorActions"], {
-			"red": self.keyCancel,
-			"green": self.KeyOk,
-		})
-		self["filelist"] = MenuList([])
-		self.fill_list()
-
-	def fill_list(self):
-		flist = []
-		self.path = "/etc/opkg/"
-		if (exists(self.path) is False):
-			self.entry = False
-			return
-		for file in listdir(self.path):
-			if file.endswith(".conf"):
-				if file not in ("arch.conf", "opkg.conf"):
-					flist.append((file))
-					self.entry = True
-		self["filelist"].l.setList(flist)
-
-	def KeyOk(self):
-		if (self.exe is False) and (self.entry is True):
-			self.sel = self["filelist"].getCurrent()
-			self.val = self.path + self.sel
-			self.session.open(IPKGSource, self.val)
-
-	def keyCancel(self):
-		self.close()
-
-	def Exit(self):
-		self.close()
-
-
-class IPKGSource(Screen):
-	skin = """
-		<screen name="IPKGSource" position="center,center" size="560,80" title="Edit upgrade source url." resolution="1280,720">
-			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
-			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
-			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-			<widget name="text" position="5,50" size="550,25" font="Regular;20" backgroundColor="background" foregroundColor="#cccccc" />
-		</screen>"""
-
-	def __init__(self, session, configfile=None):
-		Screen.__init__(self, session)
-		self.setTitle(_("Edit Upgrade Source URL"))
-		self.configfile = configfile
-		text = ""
-		if self.configfile:
-			try:
-				fp = open(configfile)
-				sources = fp.readlines()
-				if sources:
-					text = sources[0]
-				fp.close()
-			except OSError:
-				pass
-		desk = getDesktop(0)
-		x = int(desk.size().width())  # noqa F841
-		y = int(desk.size().height())
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-		if (y >= 720):
-			self["text"] = Input(text, maxSize=False, type=Input.TEXT)
-		else:
-			self["text"] = Input(text, maxSize=False, visible_width=55, type=Input.TEXT)
-		self["actions"] = HelpableNumberActionMap(self, ["WizardActions", "InputActions", "TextEntryActions", "KeyboardInputActions", "ShortcutActions"], {
-			"ok": self.go,
-			"back": self.close,
-			"red": self.close,
-			"green": self.go,
-			"left": self.keyLeft,
-			"right": self.keyRight,
-			"home": self.keyHome,
-			"end": self.keyEnd,
-			"deleteForward": self.keyDeleteForward,
-			"deleteBackward": self.keyDeleteBackward,
-			"1": self.keyNumberGlobal,
-			"2": self.keyNumberGlobal,
-			"3": self.keyNumberGlobal,
-			"4": self.keyNumberGlobal,
-			"5": self.keyNumberGlobal,
-			"6": self.keyNumberGlobal,
-			"7": self.keyNumberGlobal,
-			"8": self.keyNumberGlobal,
-			"9": self.keyNumberGlobal,
-			"0": self.keyNumberGlobal
-		}, prio=-1)
-		self.onLayoutFinish.append(self.layoutFinished)
-
-	def layoutFinished(self):
-		self["text"].right()
-
-	def go(self):
-		text = self["text"].getText()
-		if text:
-			fp = open(self.configfile, "w")
-			fp.write(text)
-			fp.write("\n")
-			fp.close()
-		self.close()
-
-	def keyLeft(self):
-		self["text"].left()
-
-	def keyRight(self):
-		self["text"].right()
-
-	def keyHome(self):
-		self["text"].home()
-
-	def keyEnd(self):
-		self["text"].end()
-
-	def keyDeleteForward(self):
-		self["text"].delete()
-
-	def keyDeleteBackward(self):
-		self["text"].deleteBackward()
-
-	def keyNumberGlobal(self, number):
-		self["text"].number(number)
-
-
-class IpkgInstaller(Screen):
-	skin = """
-		<screen name="IpkgInstaller" position="center,center" size="550,450" title="Install extensions" resolution="1280,720">
-			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/yellow.png" position="280,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/blue.png" position="420,0" size="140,40" alphatest="on" />
-			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
-			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-			<widget source="key_yellow" render="Label" position="280,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#a08500" transparent="1" />
-			<widget source="key_blue" render="Label" position="420,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#18188b" transparent="1" />
-			<widget name="list" position="5,50" size="540,360" />
-			<ePixmap pixmap="skin_default/div-h.png" position="0,410" zPosition="10" size="560,2" transparent="1" alphatest="on" />
-			<widget source="introduction" render="Label" position="5,420" zPosition="10" size="550,30" halign="center" valign="center" font="Regular;22" transparent="1" shadowColor="black" shadowOffset="-1,-1" />
-		</screen>"""
-
-	def __init__(self, session, list):
-		Screen.__init__(self, session)
-		self.selectionList = SelectionList()
-		self["list"] = self.selectionList
-		p = 0
-		if len(list):
-			p = list[0].rfind("/")
-			title = list[0][:p]
-			self.title = ("%s %s %s") % (_("Install extensions"), _("from"), title)
-		for listindex in range(len(list)):
-			self.selectionList.addSelection(list[listindex][p + 1:], list[listindex], listindex, False)
-		self.selectionList.sort()
-		self["key_red"] = StaticText(_("Close"))
-		self["key_green"] = StaticText(_("Install"))
-		self["key_yellow"] = StaticText()
-		self["key_blue"] = StaticText(_("Invert"))
-		self["introduction"] = StaticText(_("Press OK to toggle the selection."))
-		self["actions"] = HelpableActionMap(self, ["OkCancelActions", "ColorActions"], {
-			"ok": self.selectionList.toggleSelection,
-			"cancel": self.close,
-			"red": self.close,
-			"green": self.install,
-			"blue": self.selectionList.toggleAllSelection
-		}, prio=-1)
-
-	def install(self):
-		packages = self.selectionList.getSelectionsList()
-		cmdList = [(OpkgComponent.CMD_UPDATE, None)]
-		for item in packages:
-			cmdList.append((OpkgComponent.CMD_INSTALL, {"package": item[1]}))
-		self.session.open(Opkg, cmdList=cmdList)
-
-
-def filescan_open(list, session, **kwargs):
-	filelist = [x.path for x in list]
-	session.open(IpkgInstaller, filelist)  # List.
-
-
-def filescan(**kwargs):
-	from Components.Scanner import Scanner, ScanPath
-	return Scanner(mimetypes=["application/x-debian-package"], paths_to_scan=[
-		ScanPath(path="ipk", with_subdirs=True),
-		ScanPath(path="", with_subdirs=False),
-	], name="Ipkg", description=_("Install extensions."), openfnc=filescan_open)
 
 
 class BackupHelper(Screen):
@@ -331,4 +109,4 @@ class BackupHelper(Screen):
 
 
 def Plugins(path, **kwargs):
-	return [PluginDescriptor(name=_("Ipkg"), where=PluginDescriptor.WHERE_FILESCAN, needsRestart=False, fnc=filescan)]
+	return []

--- a/lib/python/Screens/IPKGInstaller.py
+++ b/lib/python/Screens/IPKGInstaller.py
@@ -1,0 +1,211 @@
+from os import listdir
+from os.path import exists
+
+from enigma import getDesktop
+
+from Components.ActionMap import HelpableActionMap, HelpableNumberActionMap
+from Components.Input import Input
+from Components.MenuList import MenuList
+from Components.Opkg import OpkgComponent
+from Components.SelectionList import SelectionList
+from Components.Sources.StaticText import StaticText
+from Screens.Opkg import Opkg
+from Screens.Screen import Screen
+
+
+class IPKGMenu(Screen):
+	skin = """
+		<screen name="IPKGMenu" position="center,center" size="560,400" resolution="1280,720">
+			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
+			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
+			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
+			<widget name="filelist" position="5,50" size="550,340" scrollbarMode="showOnDemand" />
+		</screen>"""
+
+	def __init__(self, session):
+		Screen.__init__(self, session)
+		self.setTitle(_("Select Upgrade Source To Edit"))
+		self["key_red"] = StaticText(_("Close"))
+		self["key_green"] = StaticText(_("Edit"))
+		self.sel = []
+		self.val = []
+		self.entry = False
+		self.exe = False
+		self.path = ""
+		self["actions"] = HelpableActionMap(self, ["OkCancelActions"], {
+			"ok": self.KeyOk,
+			"cancel": self.keyCancel
+		}, prio=-1)
+		self["shortcuts"] = HelpableActionMap(self, ["ColorActions"], {
+			"red": self.keyCancel,
+			"green": self.KeyOk,
+		})
+		self["filelist"] = MenuList([])
+		self.fill_list()
+
+	def fill_list(self):
+		flist = []
+		self.path = "/etc/opkg/"
+		if (exists(self.path) is False):
+			self.entry = False
+			return
+		for file in listdir(self.path):
+			if file.endswith(".conf"):
+				if file not in ("arch.conf", "opkg.conf"):
+					flist.append((file))
+					self.entry = True
+		self["filelist"].l.setList(flist)
+
+	def KeyOk(self):
+		if (self.exe is False) and (self.entry is True):
+			self.sel = self["filelist"].getCurrent()
+			self.val = self.path + self.sel
+			self.session.open(IPKGSource, self.val)
+
+	def keyCancel(self):
+		self.close()
+
+	def Exit(self):
+		self.close()
+
+
+class IPKGSource(Screen):
+	skin = """
+		<screen name="IPKGSource" position="center,center" size="560,80" title="Edit upgrade source url." resolution="1280,720">
+			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
+			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
+			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
+			<widget name="text" position="5,50" size="550,25" font="Regular;20" backgroundColor="background" foregroundColor="#cccccc" />
+		</screen>"""
+
+	def __init__(self, session, configfile=None):
+		Screen.__init__(self, session)
+		self.setTitle(_("Edit Upgrade Source URL"))
+		self.configfile = configfile
+		text = ""
+		if self.configfile:
+			try:
+				fp = open(configfile)
+				sources = fp.readlines()
+				if sources:
+					text = sources[0]
+				fp.close()
+			except OSError:
+				pass
+		desk = getDesktop(0)
+		x = int(desk.size().width())  # noqa F841
+		y = int(desk.size().height())
+		self["key_red"] = StaticText(_("Cancel"))
+		self["key_green"] = StaticText(_("Save"))
+		if (y >= 720):
+			self["text"] = Input(text, maxSize=False, type=Input.TEXT)
+		else:
+			self["text"] = Input(text, maxSize=False, visible_width=55, type=Input.TEXT)
+		self["actions"] = HelpableNumberActionMap(self, ["WizardActions", "InputActions", "TextEntryActions", "KeyboardInputActions", "ShortcutActions"], {
+			"ok": self.go,
+			"back": self.close,
+			"red": self.close,
+			"green": self.go,
+			"left": self.keyLeft,
+			"right": self.keyRight,
+			"home": self.keyHome,
+			"end": self.keyEnd,
+			"deleteForward": self.keyDeleteForward,
+			"deleteBackward": self.keyDeleteBackward,
+			"1": self.keyNumberGlobal,
+			"2": self.keyNumberGlobal,
+			"3": self.keyNumberGlobal,
+			"4": self.keyNumberGlobal,
+			"5": self.keyNumberGlobal,
+			"6": self.keyNumberGlobal,
+			"7": self.keyNumberGlobal,
+			"8": self.keyNumberGlobal,
+			"9": self.keyNumberGlobal,
+			"0": self.keyNumberGlobal
+		}, prio=-1)
+		self.onLayoutFinish.append(self.layoutFinished)
+
+	def layoutFinished(self):
+		self["text"].right()
+
+	def go(self):
+		text = self["text"].getText()
+		if text:
+			fp = open(self.configfile, "w")
+			fp.write(text)
+			fp.write("\n")
+			fp.close()
+		self.close()
+
+	def keyLeft(self):
+		self["text"].left()
+
+	def keyRight(self):
+		self["text"].right()
+
+	def keyHome(self):
+		self["text"].home()
+
+	def keyEnd(self):
+		self["text"].end()
+
+	def keyDeleteForward(self):
+		self["text"].delete()
+
+	def keyDeleteBackward(self):
+		self["text"].deleteBackward()
+
+	def keyNumberGlobal(self, number):
+		self["text"].number(number)
+
+
+class IPKGInstaller(Screen):
+	skin = """
+		<screen name="IPKGInstaller" position="center,center" size="550,450" title="Install extensions" resolution="1280,720">
+			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/yellow.png" position="280,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/blue.png" position="420,0" size="140,40" alphatest="on" />
+			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
+			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
+			<widget source="key_yellow" render="Label" position="280,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#a08500" transparent="1" />
+			<widget source="key_blue" render="Label" position="420,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#18188b" transparent="1" />
+			<widget name="list" position="5,50" size="540,360" />
+			<ePixmap pixmap="skin_default/div-h.png" position="0,410" zPosition="10" size="560,2" transparent="1" alphatest="on" />
+			<widget source="introduction" render="Label" position="5,420" zPosition="10" size="550,30" halign="center" valign="center" font="Regular;22" transparent="1" shadowColor="black" shadowOffset="-1,-1" />
+		</screen>"""
+
+	def __init__(self, session, list):
+		Screen.__init__(self, session)
+		self.skinName = ["IpkgInstaller", self.skinName]
+		self.selectionList = SelectionList()
+		self["list"] = self.selectionList
+		p = 0
+		if len(list):
+			p = list[0].rfind("/")
+			title = list[0][:p]
+			self.title = ("%s %s %s") % (_("Install extensions"), _("from"), title)
+		for listindex in range(len(list)):
+			self.selectionList.addSelection(list[listindex][p + 1:], list[listindex], listindex, False)
+		self.selectionList.sort()
+		self["key_red"] = StaticText(_("Close"))
+		self["key_green"] = StaticText(_("Install"))
+		self["key_yellow"] = StaticText()
+		self["key_blue"] = StaticText(_("Invert"))
+		self["introduction"] = StaticText(_("Press OK to toggle the selection."))
+		self["actions"] = HelpableActionMap(self, ["OkCancelActions", "ColorActions"], {
+			"ok": self.selectionList.toggleSelection,
+			"cancel": self.close,
+			"red": self.close,
+			"green": self.install,
+			"blue": self.selectionList.toggleAllSelection
+		}, prio=-1)
+
+	def install(self):
+		packages = self.selectionList.getSelectionsList()
+		cmdList = [(OpkgComponent.CMD_UPDATE, None)]
+		for item in packages:
+			cmdList.append((OpkgComponent.CMD_INSTALL, {"package": item[1]}))
+		self.session.open(Opkg, cmdList=cmdList)


### PR DESCRIPTION
…built-in

Split IPKGMenu, IPKGSource and IpkgInstaller (renamed IPKGInstaller) out of SoftwareManager/plugin.py into their own Screens/IPKGInstaller.py, and register the ipk file scanner as a built-in in Components/Scanner.py instead of via a WHERE_FILESCAN plugin descriptor, decoupling ipk handling from the SoftwareManager plugin being installed.

MediaScanner/plugin.py now uses Tools.Notifications (showInfo, addModalNotification) instead of ChoiceBox/MessageBox directly, and drops the InfoBar.execing guard in partitionListChanged. Since MessageBox only returns the second element of a selected list entry (unlike ChoiceBox, which returns the whole entry), the scan-result list is now built as (description, (description, scanner, files, session, popup)) pairs so execute() still receives the full tuple it expects.