### PR TITLE
Picon: use per-context path (infobar vs. channelselection) for multi-…

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -77,6 +77,7 @@
 				<item key="usage_setup" level="0" text="Customize System Settings" weight="15"><setup setupKey="Usage" /></item>
 				<!--item key="specialfeatures_menu" level="0" text="Special Features Settings" weight="20"><setup setupKey="SpecialFeatures" /></item-->
 				<item key="skin_setup" level="0" text="Skin Settings" weight="25"><screen module="SkinSelection" screen="SkinSelection" /></item>
+				<item key="picon_setup" level="0" text="Picon Settings" weight="26"><screen module="Picon" screen="PiconSettings" /></item>
 				<item key="display_setup" level="0" text="Display Settings" weight="30" requires="DisplaySetup"><setup setupKey="Display" /></item>
 				<item key="led_setup" level="1" text="Configure front panel LEDs" weight="35" requires="LEDColorControl"><setup setupKey="LEDs" /></item>
 				<item key="buttonsetup_setup" level="2" text="Hotkey Settings" weight="45"><screen module="ButtonSetup" screen="ButtonSetup" /></item>

--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -6,7 +6,7 @@ from enigma import eEPGCache, eListbox, eListboxPythonMultiContent, eServiceRefe
 
 from Components.GUIComponent import GUIComponent
 from Components.MultiContent import MultiContentEntryText, MultiContentEntryPixmapAlphaBlend, MultiContentEntryPixmapAlphaTest
-from Components.Renderer.Picon import getPiconName
+from Components.Renderer.Picon import getChannelSelectionPiconName
 from skin import parseColor, parseFont, parameters as skinparameter, getSkinFactor
 from Tools.Alternatives import CompareWithAlternatives
 from Tools.LoadPixmap import LoadPixmap
@@ -932,7 +932,7 @@ class EPGList(GUIComponent):
 		displayPicon = None
 		if self.showPicon:
 			if picon is None:  # go find picon and cache its location
-				picon = getPiconName(service)
+				picon = getChannelSelectionPiconName(service)
 				curIdx = self.l.getCurrentSelectionIndex()
 				self.list[curIdx] = (service, service_name, events, picon, channel)
 			piconWidth = self.picon_size.width()

--- a/lib/python/Components/MovieList.py
+++ b/lib/python/Components/MovieList.py
@@ -14,7 +14,7 @@ from Components.config import config
 from Components.FileList import AUDIO_EXTENSIONS, DVD_EXTENSIONS, IMAGE_EXTENSIONS, MOVIE_EXTENSIONS, KNOWN_EXTENSIONS
 from Components.GUIComponent import GUIComponent
 from Components.MultiContent import MultiContentEntryPixmapAlphaBlend, MultiContentEntryPixmapAlphaTest, MultiContentEntryProgress, MultiContentEntryText
-from Components.Renderer.Picon import getPiconName
+from Components.Renderer.Picon import getChannelSelectionPiconName
 from Screens.LocationBox import defaultInhibitDirs
 from Tools.Directories import SCOPE_GUISKIN, resolveFilename
 from Tools.FuzzyDate import FuzzyTime
@@ -451,7 +451,7 @@ class MovieList(GUIComponent):
 				print(f"[MovieList] Load extended info get failed: '{str(err)}'!")
 			if ext == "2":
 				try:
-					picon = getPiconName(ref)
+					picon = getChannelSelectionPiconName(ref)
 					picon = loadPNG(picon)
 				except Exception as err:
 					print(f"[MovieList] Load picon get failed: '{str(err)}'!")

--- a/lib/python/Components/Renderer/LcdPicon.py
+++ b/lib/python/Components/Renderer/LcdPicon.py
@@ -2,6 +2,7 @@ from os import listdir
 from os.path import exists, getsize, isdir, join
 from re import sub
 from enigma import ePixmap, ePicLoad
+from Components.config import config
 from Components.Harddisk import harddiskmanager
 from Components.Renderer.Renderer import Renderer
 from Components.SystemInfo import BoxInfo
@@ -12,6 +13,19 @@ from Tools.Directories import SCOPE_SKINS, SCOPE_GUISKIN, resolveFilename, sanit
 searchPaths = []
 lastLcdPiconPath = None
 BW = BoxInfo.getItem("displaytype") in ("bwlcd255", "bwlcd140") and not BoxInfo.getItem("grautec")
+
+
+def resetLcdPiconPath():
+	global lastLcdPiconPath
+	lastLcdPiconPath = None
+
+
+def getPiconPath():
+	if config.picon.mode.value:
+		path = getattr(config.picon, f"set{config.picon.display.value}").path.value
+		if isdir(path):
+			return path
+	return None
 
 
 def initLcdPiconPaths():
@@ -68,12 +82,17 @@ def onPartitionChange(why, part):
 def findLcdPicon(serviceName):
 	global lastLcdPiconPath
 	if lastLcdPiconPath is not None:
-		pngname = f"{lastLcdPiconPath}{serviceName}.png"
+		pngname = join(lastLcdPiconPath, f"{serviceName}.png")
 		return pngname if exists(pngname) else ""
 	else:
+		path = getPiconPath()
+		if path:
+			lastLcdPiconPath = path
+			pngname = join(lastLcdPiconPath, f"{serviceName}.png")
+			return pngname if exists(pngname) else ""
 		for path in searchPaths:
-			if exists(path) and not path.startswith("/media/net"):
-				pngname = f"{path}{serviceName}.png"
+			if isdir(path) and not path.startswith("/media/net"):
+				pngname = join(path, f"{serviceName}.png")
 				if exists(pngname):
 					lastLcdPiconPath = path
 					return pngname

--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -11,7 +11,23 @@ from Tools.Alternatives import GetWithAlternative
 from Tools.Directories import SCOPE_SKINS, SCOPE_GUISKIN, resolveFilename, sanitizeFilename
 
 searchPaths = []
-lastPiconPath = None
+lastPiconPath = {}
+
+
+def resetPiconPath():
+	global lastPiconPath
+	lastPiconPath = {}
+
+
+def getPiconPath(mode=None):
+	if config.picon.mode.value:
+		if mode not in ("channelselection", "infobar"):
+			mode = "infobar"
+		modeValue = getattr(config.picon, mode).value
+		path = getattr(config.picon, f"set{modeValue}").path.value
+		if isdir(path):
+			return path
+	return None
 
 
 def initPiconPaths():
@@ -56,39 +72,49 @@ def onPartitionChange(why, part):
 		onMountpointRemoved(part.mountpoint)
 
 
-def findPicon(serviceName):
-	global lastPiconPath
-	if lastPiconPath is not None:
-		pngname = f"{lastPiconPath}{serviceName}.png"
+def findPicon(serviceName, mode=None):
+	key = mode if config.picon.mode.value else None
+	cachedPath = lastPiconPath.get(key)
+	if cachedPath is not None:
+		pngname = join(cachedPath, f"{serviceName}.png")
 		return pngname if exists(pngname) else ""
 	else:
+		path = getPiconPath(mode)
+		if path:
+			lastPiconPath[key] = path
+			pngname = join(path, f"{serviceName}.png")
+			return pngname if exists(pngname) else ""
 		for path in searchPaths:
-			if exists(path) and not path.startswith("/media/net"):
-				pngname = f"{path}{serviceName}.png"
+			if isdir(path) and not path.startswith("/media/net"):
+				pngname = join(path, f"{serviceName}.png")
 				if exists(pngname):
-					lastPiconPath = path
+					lastPiconPath[key] = path
 					return pngname
 		return ""
 
 
-def getPiconName(serviceName):
+def getChannelSelectionPiconName(serviceName):
+	return getPiconName(serviceName, mode="channelselection")
+
+
+def getPiconName(serviceName, mode=None):
 	fields = GetWithAlternative(serviceName).split(":", 10)[:10]  # Remove the path and name fields, and replace ":" by "_"
 	if not fields or len(fields) < 10:
 		return ""
-	pngname = findPicon("_".join(fields))
+	pngname = findPicon("_".join(fields), mode)
 	if not pngname and not fields[6].endswith("0000"):
 		fields[6] = fields[6][:-4] + "0000"  # Remove "sub-network" from namespace
-		pngname = findPicon("_".join(fields))
+		pngname = findPicon("_".join(fields), mode)
 	if not pngname and fields[0] != "1":
 		fields[0] = "1"  # Fallback to 1 for other reftypes
-		pngname = findPicon("_".join(fields))
+		pngname = findPicon("_".join(fields), mode)
 	if not pngname and fields[2] != "1":
 		fields[2] = "1"  # Fallback to 1 for services with different service types
-		pngname = findPicon("_".join(fields))
+		pngname = findPicon("_".join(fields), mode)
 	if not pngname:
 		if (sName := ServiceReference(serviceName).getServiceName().replace('\x80', '').replace('\x86', '').replace('\x87', '')) and "SID 0x" not in sName and (utf8Name := sanitizeFilename(sName).lower()) and utf8Name != "__":  # avoid lookups on zero length service names
 			legacyName = sub("[^a-z0-9]", "", utf8Name.replace("&", "and").replace("+", "plus").replace("*", "star"))  # legacy ascii service name picons
-			pngname = findPicon(utf8Name) or legacyName and findPicon(legacyName) or findPicon(sub(r"(fhd|uhd|hd|sd|4k)$", "", utf8Name).strip()) or legacyName and findPicon(sub(r"(fhd|uhd|hd|sd|4k)$", "", legacyName).strip())
+			pngname = findPicon(utf8Name, mode) or legacyName and findPicon(legacyName, mode) or findPicon(sub(r"(fhd|uhd|hd|sd|4k)$", "", utf8Name).strip(), mode) or legacyName and findPicon(sub(r"(fhd|uhd|hd|sd|4k)$", "", legacyName).strip(), mode)
 	return pngname
 
 
@@ -115,6 +141,10 @@ class Picon(Renderer):
 		self.piconsize = (0, 0)
 		self.pngname = ""
 		self.lastPath = None
+		self.mode = None
+		self.setDefaultPicon()
+
+	def setDefaultPicon(self, mode=None):
 		defaultName = "picon_default"
 		pngname = findPicon(defaultName)
 		self.defaultpngname = None
@@ -142,6 +172,11 @@ class Picon(Renderer):
 			if attrib == "path":
 				self.addPath(value)
 				attribs.remove((attrib, value))
+			elif attrib == "mode":
+				if value in ("infobar", "channelselection"):
+					self.mode = value
+					self.setDefaultPicon(value)
+				attribs.remove((attrib, value))
 			elif attrib == "size":
 				self.piconsize = value
 		self.skinAttributes = attribs
@@ -160,7 +195,7 @@ class Picon(Renderer):
 		if self.instance:
 			pngname = ""
 			if what[0] == 1 or what[0] == 3:
-				pngname = getDABImage(self.source.text) or getPiconName(self.source.text)
+				pngname = getDABImage(self.source.text) or getPiconName(self.source.text, self.mode)
 				if not exists(pngname):  # No picon for service found
 					pngname = self.defaultpngname
 				if not config.usage.showpicon.value:

--- a/lib/python/Components/ServiceList.py
+++ b/lib/python/Components/ServiceList.py
@@ -13,7 +13,7 @@ from enigma import eLabel, eRect, eSize, eServiceReference, gFont, eListbox, eSe
 from Components.GUIComponent import GUIComponent
 from Components.config import config
 from Components.MultiContent import MultiContentEntryProgress, MultiContentEntryText, MultiContentEntryRectangle, MultiContentEntryLinearGradient, MultiContentEntryLinearGradientAlphaBlend
-from Components.Renderer.Picon import getPiconName
+from Components.Renderer.Picon import getChannelSelectionPiconName
 import NavigationInstance
 from ServiceReference import ServiceReference, isRadioServiceReference
 from skin import componentTemplates, getcomponentTemplate, parseColor, parseFont, parseListOrientation, reloadSkinTemplates, SizeTuple, SkinContext, SkinContextStack, TemplateParser
@@ -821,7 +821,7 @@ class ServiceListLegacy(ServiceListBase):
 		self.l.setShowTwoLines(twoLines)
 
 		if config.usage.service_icon_enable.value:
-			self.l.setGetPiconNameFunc(getPiconName)
+			self.l.setGetPiconNameFunc(getChannelSelectionPiconName)
 		else:
 			self.l.setGetPiconNameFunc(None)
 
@@ -1087,7 +1087,7 @@ class ServiceList(ServiceListBase, ServiceListTemplateParser):
 			service_str = first_in_alternative.toString() if first_in_alternative else service.toString()
 		else:
 			service_str = service.toString()
-		picon = getPiconName(service_str)
+		picon = getChannelSelectionPiconName(service_str)
 		if exists(picon):
 			return loadPNG(picon)
 		return None

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -19,7 +19,7 @@ from Components.ServiceEventTracker import ServiceEventTracker, InfoBarBase
 from Components.ServiceList import ServiceList, ServiceListLegacy, refreshServiceList
 from Components.SystemInfo import BoxInfo, getBoxDisplayName
 from Components.UsageConfig import preferredTimerPath
-from Components.Renderer.Picon import getPiconName
+from Components.Renderer.Picon import getChannelSelectionPiconName
 from Components.Sources.Event import Event
 from Components.Sources.List import List
 from Components.Sources.RdsDecoder import RdsDecoder
@@ -83,6 +83,7 @@ def unregisterServicelistInfoKeyHandler(key):
 
 def getServicelistInfoKeyHandler(key):
 	return SERVICELIST_INFOKEY_HANDLERS.get(key)
+
 
 # Values for csel.bouquet_mark_edit:
 OFF = 0
@@ -3478,7 +3479,7 @@ class HistoryZapSelector(Screen):
 						localBegin = localtime(begin)
 						localEnd = localtime(end)
 						eventDuration = f"{strftime(config.usage.time.short.value, localBegin)}  -  {strftime(config.usage.time.short.value, localEnd)}    ({prefix}{ngettext('%d Min', '%d Mins', remaining) % remaining})"
-				servicePicon = getPiconName(str(ServiceReference(serviceReference)))
+				servicePicon = getChannelSelectionPiconName(str(ServiceReference(serviceReference)))
 				servicePicon = loadPNG(servicePicon) if servicePicon else ""
 				historyList.append(("", index == markedItem and "\u00BB" or "", serviceName, eventName, eventDescription, eventDuration, servicePicon, serviceReference))
 		if config.usage.zapHistorySort.value == 0:

--- a/lib/python/Screens/Picon.py
+++ b/lib/python/Screens/Picon.py
@@ -2,6 +2,8 @@ from os.path import isdir
 
 from Components.ActionMap import HelpableActionMap
 from Components.config import config
+from Components.Renderer.LcdPicon import resetLcdPiconPath
+from Components.Renderer.Picon import resetPiconPath
 from Components.Sources.StaticText import StaticText
 from Screens.LocationBox import LocationBox, DEFAULT_INHIBIT_DIRECTORIES
 from Screens.Setup import Setup
@@ -50,7 +52,11 @@ class PiconSettings(Setup):
 			if path and not isdir(path):
 				self.setFootnote(_("Directory '%s' does not exist!") % path)
 				return
+		pathChanged = any(getattr(config.picon, f"set{index}").path.isChanged() for index in range(4)) or any(cfg.isChanged() for cfg in (config.picon.mode, config.picon.infobar, config.picon.channelselection, config.picon.display))
 		Setup.keySave(self)
+		if pathChanged:
+			resetPiconPath()
+			resetLcdPiconPath()
 
 	def updateButtons(self):
 		yellowText = "" if config.picon.mode.value == 0 or config.picon.set3.path.value else _("Add Path")


### PR DESCRIPTION
…path mode

Pass a "mode" through getPiconName()/findPicon() so the channel selection, EPG and movie lists resolve picons from the channelselection-configured path, while the infobar picon renderer keeps its own path. LcdPicon now also honors the configured display path when multi-path mode is enabled.