### PR TITLE
[DAB+] follow-ups from the code review and a scan that did not reproduce its result

### DIFF
--- a/lib/python/Screens/DABScan.py
+++ b/lib/python/Screens/DABScan.py
@@ -301,14 +301,20 @@ class DABScan(ServiceScan):
 		elapsed = int((monotonic() - self.feedStarted) * 1000)
 		self.updateProgress(min(elapsed, self.FEED_TIMEOUT))
 		raw = ""
+		revision = 0
 		service = self.session.nav.getCurrentService()
 		if service:
 			info = service.info()
 			if info:
 				raw = info.getInfoString(iServiceInformation.sDABServiceList) or ""
+				revision = info.getInfo(iServiceInformation.sDABServiceRevision)
 		services = self.parseServiceList(raw)
 		if services:
-			signature = tuple((item["sid"], item["bitrate"], item["dabplus"], item["label"]) for item in services)
+			# The revision rises on every FIC change, including one that only adds
+			# a label. A service still missing its FIG 0/1 or FIG 1 is filtered
+			# out of the list, so without the revision the signature looks
+			# settled while the ensemble is still being assembled.
+			signature = (revision, tuple((item["sid"], item["bitrate"], item["dabplus"], item["label"]) for item in services))
 			if signature == self.lastSignature:
 				self.stablePolls += 1
 			else:

--- a/lib/service/dabdecoder.cpp
+++ b/lib/service/dabdecoder.cpp
@@ -327,6 +327,7 @@ size_t eDABDecoder::processPF(const uint8_t *data, size_t length)
 		collector.addressed = addressed;
 		collector.source = source;
 		collector.destination = destination;
+		collector.arrival = ++m_pf_arrival;
 		collector.fragments.resize(count);
 	}
 	if (collector.fragments[index].empty())
@@ -386,8 +387,18 @@ bool eDABDecoder::reconstructPF(uint16_t, PFCollection &collector, std::vector<u
 
 void eDABDecoder::trimPFCollectors()
 {
+	// Drop by age. begin() is the lowest sequence number, which is the newest
+	// collector right after the 16 bit sequence wraps.
 	while (m_pf_collectors.size() > 8)
-		m_pf_collectors.erase(m_pf_collectors.begin());
+	{
+		auto oldest = m_pf_collectors.begin();
+		for (auto entry = m_pf_collectors.begin(); entry != m_pf_collectors.end(); ++entry)
+		{
+			if (entry->second.arrival < oldest->second.arrival)
+				oldest = entry;
+		}
+		m_pf_collectors.erase(oldest);
+	}
 }
 
 void eDABDecoder::processTags(const uint8_t *data, size_t length)
@@ -444,6 +455,11 @@ void eDABDecoder::parseFIC(const uint8_t *data, size_t length)
 	++m_fic_frames;
 	for (size_t fib = 0; fib + 32 <= length; fib += 32)
 	{
+		if (!checkInvertedCRC(data + fib, 32))  // The last two bytes carry the FIB CRC.
+		{
+			++m_crc_errors;
+			continue;
+		}
 		size_t position = 0;
 		while (position < 30 && data[fib + position] != 0xff)
 		{

--- a/lib/service/dabdecoder.h
+++ b/lib/service/dabdecoder.h
@@ -88,6 +88,7 @@ private:
 		uint16_t destination;
 		std::vector<std::vector<uint8_t> > fragments;
 		size_t received;
+		uint64_t arrival = 0;
 		PFCollection();
 	};
 
@@ -122,6 +123,7 @@ private:
 	ImageCallback m_image_callback;
 	DABlinPAD::PADDecoder m_pad_decoder;
 	std::map<uint16_t, PFCollection> m_pf_collectors;
+	uint64_t m_pf_arrival = 0;
 	std::map<int, Subchannel> m_subchannels;
 	std::map<uint32_t, Service> m_services;
 	std::string m_service_label;

--- a/lib/service/dabmotmanager.cpp
+++ b/lib/service/dabmotmanager.cpp
@@ -138,7 +138,7 @@ bool MOTObject::ParseCheckHeader(MOT_FILE& target_file) {
 			break;
 		}
 
-		if(offset + data_len - 1 >= data.size())
+		if(data_len > data.size() - offset)	// data_len may be zero, so do not add to it
 			return false;
 
 		// process parameter

--- a/lib/service/dabpadtools.cpp
+++ b/lib/service/dabpadtools.cpp
@@ -112,6 +112,23 @@ std::string CharsetTools::ConvertCharEBUToUTF8(const uint8_t value) {
 std::string CharsetTools::ConvertTextToUTF8(const uint8_t *data, size_t len, int charset,
 	bool mot, std::string *charset_name)
 {
+	/* UCS-2 is two bytes per character, so the control characters have to be
+	 * dropped as code points. Removing single bytes would shift everything
+	 * that follows. */
+	if (charset == 6 && !mot)
+	{
+		if (charset_name)
+			*charset_name = "UCS-2BE";
+		std::string result;
+		for (size_t i = 0; i + 1 < len; i += 2)
+		{
+			const unsigned value = (static_cast<unsigned>(data[i]) << 8) | data[i + 1];
+			if (value == 0x00 || value == 0x0a || value == 0x0b || value == 0x1f)
+				continue;
+			result += CodepointToUTF8(value);
+		}
+		return result;
+	}
 	std::vector<uint8_t> cleaned;
 	for (size_t i = 0; i < len; ++i)
 	{
@@ -142,15 +159,6 @@ std::string CharsetTools::ConvertTextToUTF8(const uint8_t *data, size_t len, int
 		std::string result;
 		for (std::vector<uint8_t>::const_iterator it = cleaned.begin(); it != cleaned.end(); ++it)
 			result += CodepointToUTF8(*it);
-		return result;
-	}
-	if (charset == 6 && !mot)
-	{
-		if (charset_name)
-			*charset_name = "UCS-2BE";
-		std::string result;
-		for (size_t i = 0; i + 1 < cleaned.size(); i += 2)
-			result += CodepointToUTF8((static_cast<unsigned>(cleaned[i]) << 8) | cleaned[i + 1]);
 		return result;
 	}
 	if (charset == 15)

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -430,7 +430,8 @@ public:
 		sIsSoftCSA,			/* 1 if current service uses software descrambling */
 
 		sUser = 0x100,
-		sDABServiceList = sUser + 1 /* tab-separated SID, bitrate, DAB+ flag and label */
+		sDABServiceList = sUser + 1, /* tab-separated SID, bitrate, DAB+ flag and label */
+		sDABServiceRevision = sUser + 2 /* rises while the FIC still changes */
 	};
 	enum {
 		resNA = -1,

--- a/lib/service/servicedab.cpp
+++ b/lib/service/servicedab.cpp
@@ -184,11 +184,6 @@ void eDABWorker::processInput(const uint8_t *data, size_t length)
 	}
 	if (offset)
 		m_input.erase(m_input.begin(), m_input.begin() + offset);
-	if (m_input.size() > TS_PACKET_SIZE * 4)
-	{
-		m_stats.syncErrors += m_input.size();
-		m_input.clear();
-	}
 }
 
 void eDABWorker::processTSPacket(const uint8_t *packet)
@@ -203,12 +198,17 @@ void eDABWorker::processTSPacket(const uint8_t *packet)
 	const bool payloadPresent = packet[3] & 0x10;
 	const bool adaptationPresent = packet[3] & 0x20;
 	const int cc = packet[3] & 0x0f;
-	if (payloadPresent && m_last_cc >= 0 && ((m_last_cc + 1) & 0x0f) != cc)
+	if (payloadPresent && m_last_cc >= 0)
 	{
-		++m_stats.continuityErrors;
-		clearSection();
-		if (m_ts_adapter)
-			m_ts_adapter->reset();
+		if (cc == m_last_cc)
+			return;  // A packet may be sent twice, feeding it again would corrupt the section.
+		if (((m_last_cc + 1) & 0x0f) != cc)
+		{
+			++m_stats.continuityErrors;
+			clearSection();
+			if (m_ts_adapter)
+				m_ts_adapter->reset();
+		}
 	}
 	if (payloadPresent)
 		m_last_cc = cc;
@@ -680,7 +680,7 @@ RESULT eServiceDABRecord::start(bool simulate)
 		return m_error;
 	}
 	m_state = stateRecording;
-	eDebug("[eServiceDABRecord] recording DAB+ ADTS to '%s'", m_filename.c_str());
+	eDebug("[eServiceDABRecord] recording DAB+ LOAS to '%s'", m_filename.c_str());
 	if (m_tuned && !startTap())
 	{
 		::close(m_file_fd);

--- a/lib/service/servicedab.cpp
+++ b/lib/service/servicedab.cpp
@@ -376,6 +376,7 @@ void eDABWorker::updateDecoderStats()
 	m_stats.dynamicLabel[sizeof(m_stats.dynamicLabel) - 1] = 0;
 	if (m_stats.serviceRevision != m_decoder->serviceRevision())
 	{
+		m_publish_pending = true;  // A scan waits for this to stop changing.
 		const std::vector<eDABDecoder::ServiceInfo> services = m_decoder->serviceList();
 		m_stats.serviceRevision = m_decoder->serviceRevision();
 		m_stats.ensembleId = m_decoder->ensembleId();
@@ -400,8 +401,9 @@ void eDABWorker::clearSection()
 void eDABWorker::publish(bool force)
 {
 	const uint64_t now = monotonicMilliseconds();
-	if (!force && now - m_last_publish_ms < 1000)
+	if (!force && !m_publish_pending && now - m_last_publish_ms < 1000)
 		return;
+	m_publish_pending = false;
 	m_last_publish_ms = now;
 	m_pump.send(m_stats);
 }
@@ -1606,6 +1608,8 @@ int eServiceDAB::getInfo(int w)
 		return m_reference.getUnsignedData(4);
 	case sDVBState:
 		return m_parent_state;
+	case sDABServiceRevision:
+		return static_cast<int>(m_stats.serviceRevision);
 	case sTransferBPS:
 		return static_cast<int>(std::min<uint64_t>(m_transfer_bps, std::numeric_limits<int>::max()));
 	case sProvider:

--- a/lib/service/servicedab.h
+++ b/lib/service/servicedab.h
@@ -120,6 +120,7 @@ private:
 	bool m_started;
 	int m_last_cc;
 	uint64_t m_last_publish_ms;
+	bool m_publish_pending = false;
 	eDABWorkerStats m_stats;
 	std::vector<uint8_t> m_input;
 	std::vector<uint8_t> m_section;


### PR DESCRIPTION
Two commits. The first collects the findings from reading through the DAB+ code that were left out of #3868 and #3870, the second fixes a scan that does not reproduce its own result.

None of the first commit's findings were reported by a user.

### Correctness

**FIB CRC unchecked** — `parseFIC` walked the payload without looking at the two CRC bytes at the end of each 32 byte FIB, so a corrupted FIG 0/1 or 0/2 entered `m_subchannels` and `m_services` and stayed there. The ETI and AF checks cover the frame, not the individual FIB.

**PF collector eviction picked the newest** — the cap dropped `m_pf_collectors.begin()`, which is the smallest sequence number. Right after the 16 bit sequence wraps that is the newest collector, so the fragments still being assembled were the ones thrown away. Evicting by arrival instead needs a timestamp, hence the extra member.

**MOT header parameter underflow** — a parameter with PLI `0b00` carries no data field, which the spec allows. `offset + data_len - 1` then underflowed to `SIZE_MAX`, the bound rejected it and the whole header parse was abandoned, losing `ContentName` and with it the slide.

**UCS-2 text lost its alignment** — the control character filter ran over the raw bytes before the pairs were decoded. U+0041 is `00 41`, so the `00` was dropped and everything after it was assembled from the wrong pair. Since FIG 1 gained charset handling this also affects ensemble and service labels, not just DLS.

**Repeated continuity counter treated as an error** — a repeated CC marks a packet the multiplexer sent twice, which EN 300 468 allows. It was counted as an error, which discarded the partial section, reset the TS adapter and then fed the same payload a second time on top of what had already been accepted.

### Cleanups

The guard for more than four packets left in the input buffer can never be true, the loop above consumes until fewer than one packet remains; it also inflated `syncErrors` by the buffer size. The recording log said ADTS where `emitLOAS` writes an AudioSyncStream.

### Scan result was not reproducible

Reported for 19.2E: 51 services on one receiver, 48 and 44 on another. The scan committed a feed once the service signature had been identical for three polls, one second. A service whose FIG 0/1 or FIG 1 has not arrived yet is filtered out of `sDABServiceList`, so it is absent from the signature rather than changing it, and the list looks settled while the ensemble is still being assembled.

Measured on 19.2E, decoder side constant at 51:

| ensemble | decoder | run 1 | run 2 |
|---|---|---|---|
| WDR NRW | 13 | 10 | 10 |
| WDR Regional | 9 | 9 | 5 |
| DR Deutschland | 13 | 13 | 13 |
| Antenne DE | 16 | 16 | 16 |
| | 51 | 48 | 44 |

Both writes for the WDR ensembles landed exactly one second after the feed started, with the ensemble label still empty. The two Bundesmux feeds are smaller and were complete by then, which is why only the WDR entries move.

`m_service_revision` already counts every FIC change, including one that only adds a label, so it is exposed as `sDABServiceRevision` and folded into the signature. That alone still gave 47: `eDABWorker` throttles its statistics to one message per second, so two polls half a second apart see the same value whether or not the ensemble changed, and the scan was measuring the publish rate rather than the FIC. Sending immediately when the revision moves makes three unchanged polls mean what they say.

Three consecutive scans then gave 51 with identical per ensemble counts, 11.1 s for four feeds against 4 s before. The new enumerator is appended, so no existing `sUser` value shifts.
