### PR TITLE
[SoftCSA] Persist CSA-ALT detection and enforce buffered startup gates

### DIFF
--- a/lib/dvb/csasession.cpp
+++ b/lib/dvb/csasession.cpp
@@ -2,8 +2,14 @@
 #include <lib/dvb/csaengine.h>
 #include <lib/dvb/cahandler.h>
 #include <lib/dvb/cwhandler.h>
+#include <lib/base/eenv.h>
 #include <lib/base/eerror.h>
 #include <lib/base/esimpleconfig.h>
+
+#include <cstdio>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
 
 #ifdef DREAMNEXTGEN
 #include <lib/dvb/alsa.h>
@@ -23,6 +29,89 @@ struct ServiceCsaInfo {
 	bool serviceId_valid; // true if serviceId has been seen
 };
 static std::map<uint64_t, ServiceCsaInfo> s_csa_cache;
+static bool s_persistent_csa_cache_loaded = false;
+static bool s_persistent_csa_cache_dirty = false;
+
+static std::string persistentCsaCachePath()
+{
+	return eEnv::resolve("${sysconfdir}/enigma2/softcsa.cache");
+}
+
+// Keep positive CSA-ALT detections across GUI restarts so known services can
+// select SoftCSA immediately without repeating unnecessary HW decoder setup.
+static void loadPersistentCsaCache()
+{
+	if (s_persistent_csa_cache_loaded)
+		return;
+
+	s_persistent_csa_cache_loaded = true;
+	std::ifstream in(persistentCsaCachePath());
+	if (!in.good())
+		return;
+
+	unsigned int loaded = 0;
+	std::string line;
+	while (std::getline(in, line))
+	{
+		if (line.empty() || line[0] == '#')
+			continue;
+
+		unsigned long long key = 0;
+		unsigned int ecm_mode = 0;
+		unsigned int service_id = 0;
+		std::istringstream fields(line);
+		if (!(fields >> std::hex >> key >> ecm_mode >> service_id) || ecm_mode > 0x0F)
+			continue;
+
+		ServiceCsaInfo &info = s_csa_cache[static_cast<uint64_t>(key)];
+		info.is_csa_alt = true;
+		info.ecm_mode = static_cast<uint8_t>(ecm_mode);
+		info.valid = true;
+		info.serviceId = service_id;
+		info.serviceId_valid = service_id != 0;
+		++loaded;
+	}
+
+	eDebug("[eDVBCSASession] Loaded %u persistent CSA-ALT service(s)", loaded);
+}
+
+static void flushPersistentCsaCache()
+{
+	if (!s_persistent_csa_cache_dirty)
+		return;
+
+	const std::string path = persistentCsaCachePath();
+	const std::string temporary_path = path + ".tmp";
+	std::ofstream out(temporary_path, std::ios::trunc);
+	if (!out.good())
+	{
+		eWarning("[eDVBCSASession] Failed to write persistent cache %s", temporary_path.c_str());
+		return;
+	}
+
+	out << "# Enigma2 SoftCSA CSA-ALT cache v1\n";
+	for (const auto &entry : s_csa_cache)
+	{
+		const ServiceCsaInfo &info = entry.second;
+		if (!info.valid || !info.is_csa_alt)
+			continue;
+
+		out << std::hex << std::setfill('0')
+			<< std::setw(16) << entry.first << ' '
+			<< std::setw(2) << static_cast<unsigned int>(info.ecm_mode) << ' '
+			<< std::setw(8) << (info.serviceId_valid ? info.serviceId : 0) << '\n';
+	}
+	out.close();
+
+	if (!out.good() || std::rename(temporary_path.c_str(), path.c_str()) != 0)
+	{
+		eWarning("[eDVBCSASession] Failed to replace persistent cache %s", path.c_str());
+		std::remove(temporary_path.c_str());
+		return;
+	}
+
+	s_persistent_csa_cache_dirty = false;
+}
 
 // Helper: Check if CAID is VideoGuard
 static bool caid_is_videoguard(uint16_t caid)
@@ -126,16 +215,14 @@ bool eDVBCSASession::init()
 
 void eDVBCSASession::startECMMonitor(iDVBDemux *demux, uint16_t ecm_pid, uint16_t caid)
 {
-	if (!demux || ecm_pid == 0 || ecm_pid == 0xFFFF)
+	if (!demux)
 		return;
 
-	stopECMMonitor();
-
-	m_ecm_pid = ecm_pid;
 	m_caid = caid;
+	loadPersistentCsaCache();
 
-	// Cache-driven early activation: skip ECM section reader if CSA-ALT for
-	// this service is already known. Disabled in Aggressive mode (audio race on dm900).
+	// Cache-driven early activation when CSA-ALT for this service is already
+	// known. Disabled in Aggressive mode (audio race on dm900).
 	const bool cache_early_activate_disabled =
 		(eSimpleConfig::getInt("config.softcsa.decoderRelease", 0) == 2);
 
@@ -152,10 +239,10 @@ void eDVBCSASession::startECMMonitor(iDVBDemux *demux, uint16_t ecm_pid, uint16_
 			m_ecm_mode = info.ecm_mode;
 			m_ecm_mode_detected = true;
 
-			m_ecm_analyzed = true;
-			m_csa_alt = info.is_csa_alt;
+			const bool use_cached_alt = info.is_csa_alt && caid_is_videoguard(caid);
+			m_csa_alt = use_cached_alt;
 
-			if (info.is_csa_alt && !m_active)
+			if (use_cached_alt && !m_active)
 			{
 				if (shouldSuppressActivation && shouldSuppressActivation())
 				{
@@ -168,9 +255,31 @@ void eDVBCSASession::startECMMonitor(iDVBDemux *demux, uint16_t ecm_pid, uint16_
 				}
 			}
 
-			return;
+			if (!info.is_csa_alt)
+			{
+				m_ecm_analyzed = true;
+				return;
+			}
+
+			// A positive cache entry starts SoftCSA immediately, but keep the ECM
+			// monitor running once to validate it.  This automatically removes a
+			// stale entry if the provider changes the CA system or scrambling mode.
+			eDebug("[eDVBCSASession] ECM Monitor: Validating cached CSA-ALT info");
 		}
 	}
+
+	// The first program-info event can contain the CAID while its ECM PID is
+	// still the 0xFFFF placeholder.  Cache activation above must happen on that
+	// event so updateDecoder() never starts the hardware decoder.  A later event
+	// supplies the real ECM PID and starts validation normally.
+	if (ecm_pid == 0 || ecm_pid == 0xFFFF)
+	{
+		eDebug("[eDVBCSASession] ECM Monitor: Waiting for valid ECM PID after cache lookup");
+		return;
+	}
+
+	stopECMMonitor();
+	m_ecm_pid = ecm_pid;
 
 	// Create section reader
 	ePtr<iDVBSectionReader> reader;
@@ -247,12 +356,20 @@ void eDVBCSASession::ecmDataReceived(const uint8_t *data)
 		eDebug("[eDVBCSASession] ECM received (PMT): caid=0x%04X, ecm[2]=0x%02X, ecm[4]=0x%02X, ecm_mode=0x%02X, CSA-ALT=%d",
 			m_caid, data[2], data[4], new_ecm_mode, is_csa_alt);
 
-		// Update unified cache (preserve serviceId if already known)
+		// Update unified cache (preserve serviceId if already known). Only
+		// rewrite the persistent positive-only view when that view changes.
 		uint64_t svc_key = makeServiceKey(m_service_ref);
 		auto& cached = s_csa_cache[svc_key];
+		const bool persistent_cache_changed = cached.valid
+			? cached.is_csa_alt != is_csa_alt
+				|| (is_csa_alt && cached.ecm_mode != new_ecm_mode)
+			: is_csa_alt;
 		cached.is_csa_alt = is_csa_alt;
 		cached.ecm_mode = new_ecm_mode;
 		cached.valid = true;
+		if (persistent_cache_changed)
+			s_persistent_csa_cache_dirty = true;
+		flushPersistentCsaCache();
 
 		m_ecm_analyzed = true;
 		m_csa_alt = is_csa_alt;
@@ -275,6 +392,17 @@ void eDVBCSASession::ecmDataReceived(const uint8_t *data)
 		else
 		{
 			eDebug("[eDVBCSASession] ECM analyzed: Not CSA-ALT, hardware descrambling will be used");
+			if (m_active)
+			{
+				eWarning("[eDVBCSASession] Cached CSA-ALT info is stale, returning to hardware descrambling");
+				setActive(false);
+				// setActive(false) resets the analysis state; retain the result of
+				// this validation so eventNewProgramInfo does not start another reader.
+				m_ecm_mode = new_ecm_mode;
+				m_ecm_mode_detected = true;
+				m_ecm_analyzed = true;
+				m_csa_alt = false;
+			}
 		}
 
 		stopECMMonitor();
@@ -425,8 +553,16 @@ void eDVBCSASession::onCwReceived(eServiceReferenceDVB ref, int parity, const ch
 
 		// Cache serviceId for future sessions (enables pre-registration on PiP swap)
 		auto& cached = s_csa_cache[svc_key];
-		cached.serviceId = serviceId;
-		cached.serviceId_valid = true;
+		const bool service_id_changed = serviceId != 0
+			&& (!cached.serviceId_valid || cached.serviceId != serviceId);
+		if (serviceId != 0)
+		{
+			cached.serviceId = serviceId;
+			cached.serviceId_valid = true;
+		}
+		if (cached.valid && cached.is_csa_alt && service_id_changed)
+			s_persistent_csa_cache_dirty = true;
+		flushPersistentCsaCache();
 	}
 	else if (serviceId != 0 && serviceId != m_cw_service_id &&
 		serviceId != m_cw_alt_service_id &&

--- a/lib/dvb/csasession.cpp
+++ b/lib/dvb/csasession.cpp
@@ -148,6 +148,57 @@ static bool dvbTripletMatch(const eServiceReferenceDVB& ref1, const eServiceRefe
 	       ref1.getOriginalNetworkID() == ref2.getOriginalNetworkID();
 }
 
+static bool extractTsPesPts(const unsigned char *packet, uint64_t &pts)
+{
+	if (!packet || packet[0] != 0x47 || !(packet[1] & 0x40))
+		return false;
+
+	const unsigned int adaptation_control = (packet[3] >> 4) & 0x03;
+	if (adaptation_control == 0 || adaptation_control == 2)
+		return false;
+
+	unsigned int payload_offset = 4;
+	if (adaptation_control == 3)
+	{
+		payload_offset += 1 + packet[4];
+		if (payload_offset >= 188)
+			return false;
+	}
+
+	const unsigned char *pes = packet + payload_offset;
+	const unsigned int available = 188 - payload_offset;
+	if (available < 14 || pes[0] != 0x00 || pes[1] != 0x00 || pes[2] != 0x01)
+		return false;
+	if (!(pes[7] & 0x80) || pes[8] < 5)
+		return false;
+	if (!(pes[9] & 0x01) || !(pes[11] & 0x01) || !(pes[13] & 0x01))
+		return false;
+
+	pts = (static_cast<uint64_t>(pes[9] & 0x0E) << 29)
+		| (static_cast<uint64_t>(pes[10]) << 22)
+		| (static_cast<uint64_t>(pes[11] & 0xFE) << 14)
+		| (static_cast<uint64_t>(pes[12]) << 7)
+		| (static_cast<uint64_t>(pes[13] & 0xFE) >> 1);
+	return true;
+}
+
+static unsigned int ptsSpanMs(uint64_t first, uint64_t last)
+{
+	static const uint64_t PTS_WRAP = 1ULL << 33;
+	const uint64_t span = last >= first ? last - first : PTS_WRAP - first + last;
+	return static_cast<unsigned int>(span / 90);
+}
+
+static unsigned int ptsBufferedMs(uint64_t first, uint64_t last, uint64_t last_step)
+{
+	// A PTS marks the beginning of a PES block, so last-first omits the media
+	// carried by the final block.  Include one observed interval (bounded to
+	// 500ms) to avoid systematically underestimating coarse audio PES chunks.
+	static const uint64_t MAX_TRAILING_STEP = 500ULL * 90;
+	const uint64_t trailing = last_step < MAX_TRAILING_STEP ? last_step : MAX_TRAILING_STEP;
+	return ptsSpanMs(first, last) + static_cast<unsigned int>(trailing / 90);
+}
+
 eDVBCSASession::eDVBCSASession(const eServiceReferenceDVB& ref)
 	: m_service_ref(ref)
 	, m_active(false)
@@ -163,8 +214,114 @@ eDVBCSASession::eDVBCSASession(const eServiceReferenceDVB& ref)
 	, m_cw_handler_registered(false)
 	, m_first_cw_signaled(false)
 	, m_pending_cw{}
+	, m_buffer_readiness_enabled(false)
+	, m_buffer_video_pid(-1)
+	, m_buffer_audio_pid(-1)
+	, m_buffer_video{}
+	, m_buffer_audio{}
 {
 	eDebug("[eDVBCSASession] Created for service %s", ref.toString().c_str());
+}
+
+void eDVBCSASession::configureBufferReadiness(int video_pid, int audio_pid)
+{
+	m_buffer_readiness_enabled.store(false, std::memory_order_release);
+	std::lock_guard<std::mutex> lock(m_buffer_readiness_mutex);
+	m_buffer_video_pid = video_pid;
+	m_buffer_audio_pid = audio_pid;
+	m_buffer_video = {};
+	m_buffer_audio = {};
+	const bool enabled = video_pid >= 0 || audio_pid >= 0;
+	m_buffer_readiness_enabled.store(enabled, std::memory_order_release);
+	if (enabled)
+		eDebug("[eDVBCSASession] Buffer readiness reset: vpid=%04x apid=%04x",
+			video_pid, audio_pid);
+	else
+		eDebug("[eDVBCSASession] Buffer readiness disabled");
+}
+
+eDVBCSASession::BufferReadiness eDVBCSASession::getBufferReadiness() const
+{
+	std::lock_guard<std::mutex> lock(m_buffer_readiness_mutex);
+	BufferReadiness readiness = {};
+	readiness.video_pid = m_buffer_video_pid;
+	readiness.audio_pid = m_buffer_audio_pid;
+	readiness.video_packets = m_buffer_video.packets;
+	readiness.audio_packets = m_buffer_audio.packets;
+	readiness.video_pts_valid = m_buffer_video.valid;
+	readiness.audio_pts_valid = m_buffer_audio.valid;
+	readiness.video_ms = m_buffer_video.valid
+		? ptsBufferedMs(m_buffer_video.first, m_buffer_video.last, m_buffer_video.last_step) : 0;
+	readiness.audio_ms = m_buffer_audio.valid
+		? ptsBufferedMs(m_buffer_audio.first, m_buffer_audio.last, m_buffer_audio.last_step) : 0;
+	return readiness;
+}
+
+void eDVBCSASession::updateBufferReadiness(const unsigned char *packets, int len)
+{
+	if (!packets || len < 188 || !m_buffer_readiness_enabled.load(std::memory_order_acquire))
+		return;
+
+	std::lock_guard<std::mutex> lock(m_buffer_readiness_mutex);
+	if (!m_buffer_readiness_enabled.load(std::memory_order_acquire)
+		|| (m_buffer_video_pid < 0 && m_buffer_audio_pid < 0))
+		return;
+
+	static const uint64_t MAX_PTS_STEP = 10ULL * 90000;
+	static const uint64_t MAX_PTS_REORDER = 2ULL * 90000;
+	static const uint64_t PTS_WRAP = 1ULL << 33;
+
+	for (int offset = 0; offset + 188 <= len; offset += 188)
+	{
+		const unsigned char *packet = packets + offset;
+		if (packet[0] != 0x47 || (packet[3] >> 6) != 0)
+			continue;
+
+		const int pid = ((packet[1] & 0x1F) << 8) | packet[2];
+		PtsReadiness *state = nullptr;
+		if (pid == m_buffer_video_pid)
+			state = &m_buffer_video;
+		else if (pid == m_buffer_audio_pid)
+			state = &m_buffer_audio;
+		if (!state)
+			continue;
+
+		++state->packets;
+		uint64_t pts = 0;
+		if (!extractTsPesPts(packet, pts))
+			continue;
+
+		if (!state->valid)
+		{
+			state->first = state->last = pts;
+			state->last_step = 0;
+			state->valid = true;
+			continue;
+		}
+
+		const uint64_t forward = pts >= state->last
+			? pts - state->last : PTS_WRAP - state->last + pts;
+		if (forward <= MAX_PTS_STEP)
+		{
+			if (forward)
+				state->last_step = forward;
+			state->last = pts;
+			continue;
+		}
+
+		const uint64_t backward = state->last >= pts
+			? state->last - pts : PTS_WRAP - pts + state->last;
+		if (backward <= MAX_PTS_REORDER)
+		{
+			// Presentation order can briefly move backwards for B-frames.
+			// Keep the furthest buffered timestamp instead of resetting.
+			continue;
+		}
+
+		// A discontinuity or stale data must not make the gate look ready.
+		state->first = state->last = pts;
+		state->last_step = 0;
+	}
 }
 
 eDVBCSASession::~eDVBCSASession()
@@ -623,4 +780,9 @@ void eDVBCSASession::descramble(unsigned char* packets, int len)
 
 	// CW available - descramble via engine (in-place)
 	m_engine->descramble(packets, len);
+
+	// The engine turns packets without the matching parity key into null
+	// packets.  Scanning after descrambling therefore counts only clear A/V
+	// packets that are safe to queue for decoder startup.
+	updateBufferReadiness(packets, len);
 }

--- a/lib/dvb/csasession.h
+++ b/lib/dvb/csasession.h
@@ -5,7 +5,9 @@
 #include <lib/dvb/idvb.h>
 #include <lib/base/ebase.h>
 #include <sigc++/sigc++.h>
+#include <atomic>
 #include <functional>
+#include <mutex>
 
 class eDVBCSAEngine;
 class eDVBCAHandler;
@@ -31,6 +33,18 @@ class eDVBCSASession : public iServiceScrambled, public sigc::trackable
 	DECLARE_REF(eDVBCSASession);
 
 public:
+	struct BufferReadiness
+	{
+		int video_pid;
+		int audio_pid;
+		unsigned int video_packets;
+		unsigned int audio_packets;
+		unsigned int video_ms;
+		unsigned int audio_ms;
+		bool video_pts_valid;
+		bool audio_pts_valid;
+	};
+
 	/**
 	 * Constructor
 	 * @param ref Service reference for CW filtering
@@ -71,6 +85,11 @@ public:
 	bool isEcmModeDetected() const { return m_ecm_mode_detected; }
 	bool isEcmAnalyzed() const { return m_ecm_analyzed; }  // true once ECM was analyzed
 	bool isCsaAlt() const { return m_csa_alt; }            // true if CSA-ALT was detected
+
+	// Track clear A/V data after software descrambling.  The live SoftDecoder
+	// uses this to start from actual buffered media instead of a blind timer.
+	void configureBufferReadiness(int video_pid, int audio_pid);
+	BufferReadiness getBufferReadiness() const;
 
 	/**
 	 * Force activation for recording sessions
@@ -140,6 +159,22 @@ private:
 		bool valid;
 	};
 	PendingCw m_pending_cw;
+
+	struct PtsReadiness
+	{
+		uint64_t first;
+		uint64_t last;
+		uint64_t last_step;
+		unsigned int packets;
+		bool valid;
+	};
+	std::atomic<bool> m_buffer_readiness_enabled;
+	mutable std::mutex m_buffer_readiness_mutex;
+	int m_buffer_video_pid;
+	int m_buffer_audio_pid;
+	PtsReadiness m_buffer_video;
+	PtsReadiness m_buffer_audio;
+	void updateBufferReadiness(const unsigned char *packets, int len);
 };
 
 #endif // __dvbcsasession_h

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -9,6 +9,13 @@
 
 DEFINE_REF(eDVBSoftDecoder);
 
+static int64_t softDecoderMonotonicMs()
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return static_cast<int64_t>(ts.tv_sec) * 1000 + ts.tv_nsec / 1000000;
+}
+
 eDVBSoftDecoder::eDVBSoftDecoder(eDVBServicePMTHandler& source_handler,
                                  ePtr<eDVBService> dvb_service,
                                  int decoder_index)
@@ -16,10 +23,16 @@ eDVBSoftDecoder::eDVBSoftDecoder(eDVBServicePMTHandler& source_handler,
 	, m_dvb_service(dvb_service)
 	, m_decoder_index(decoder_index)
 	, m_dvr_fd(-1)
+	, m_buffer_video_pid(-2)
+	, m_buffer_audio_pid(-2)
 	, m_running(false)
 	, m_stopping(false)
 	, m_noaudio(false)
 	, m_decoder_started(false)
+	, m_buffer_wait_started(0)
+	, m_buffer_target_ms(0)
+	, m_buffer_deadline_ms(0)
+	, m_buffer_last_log(0)
 	, m_last_pts(0)
 	, m_stall_count(0)
 	, m_recovery_attempts(0)
@@ -116,8 +129,16 @@ void eDVBSoftDecoder::startDecoderOrBuffer()
 {
 	if (int bufferTime = eSimpleConfig::getInt("config.softcsa.bufferTime", 0); bufferTime > 0)
 	{
-		eDebug("[eDVBSoftDecoder] Pre-buffering %dms before decoder start", bufferTime);
-		m_buffer_timer->start(bufferTime, true);
+		if (m_buffer_wait_started)
+			return;
+
+		m_buffer_target_ms = bufferTime;
+		m_buffer_deadline_ms = bufferTime + 500;
+		m_buffer_wait_started = softDecoderMonotonicMs();
+		m_buffer_last_log = 0;
+		eDebug("[eDVBSoftDecoder] Adaptive pre-buffer: target=%dms deadline=%dms",
+			m_buffer_target_ms, m_buffer_deadline_ms);
+		m_buffer_timer->start(25, false);
 		return;
 	}
 	startDecoder();
@@ -125,18 +146,74 @@ void eDVBSoftDecoder::startDecoderOrBuffer()
 
 void eDVBSoftDecoder::onBufferTimerExpired()
 {
-	eDebug("[eDVBSoftDecoder] Pre-buffer complete - starting decoder");
-	startDecoder();
+	if (m_decoder_started || !m_buffer_wait_started)
+		return;
+
+	const int64_t now = softDecoderMonotonicMs();
+	const int elapsed = static_cast<int>(now - m_buffer_wait_started);
+	if (!m_session)
+	{
+		eWarning("[eDVBSoftDecoder] Adaptive pre-buffer has no CSA session - starting decoder");
+		startDecoder();
+		return;
+	}
+
+	const eDVBCSASession::BufferReadiness readiness = m_session->getBufferReadiness();
+	// PES timestamps are quantized by the broadcaster and the timer itself is
+	// sampled every 25ms.  Treat a stream within 50ms of the configured target
+	// as ready so a nominal one-second buffer cannot miss by one timestamp step
+	// and overflow the idle DVR queue while waiting for the next PES header.
+	const unsigned int readiness_target_ms = m_buffer_target_ms > 50
+		? static_cast<unsigned int>(m_buffer_target_ms - 50)
+		: static_cast<unsigned int>(m_buffer_target_ms);
+	const bool video_ready = readiness.video_pid < 0
+		|| (readiness.video_pts_valid && readiness.video_ms >= readiness_target_ms);
+	const bool audio_ready = readiness.audio_pid < 0
+		|| (readiness.audio_pts_valid && readiness.audio_ms >= readiness_target_ms);
+
+	if (video_ready && audio_ready)
+	{
+		eDebug("[eDVBSoftDecoder] Adaptive pre-buffer ready after %dms "
+			"(video=%ums/%u packets, audio=%ums/%u packets)",
+			elapsed, readiness.video_ms, readiness.video_packets,
+			readiness.audio_ms, readiness.audio_packets);
+		startDecoder();
+		return;
+	}
+
+	if (elapsed >= m_buffer_deadline_ms)
+	{
+		eWarning("[eDVBSoftDecoder] Adaptive pre-buffer deadline after %dms "
+			"(video=%ums/%u packets, audio=%ums/%u packets) - starting decoder",
+			elapsed, readiness.video_ms, readiness.video_packets,
+			readiness.audio_ms, readiness.audio_packets);
+		startDecoder();
+		return;
+	}
+
+	if (!m_buffer_last_log || now - m_buffer_last_log >= 250)
+	{
+		eDebug("[eDVBSoftDecoder] Adaptive pre-buffer waiting: elapsed=%dms "
+			"video=%ums/%u audio=%ums/%u",
+			elapsed, readiness.video_ms, readiness.video_packets,
+			readiness.audio_ms, readiness.audio_packets);
+		m_buffer_last_log = now;
+	}
 }
 
 void eDVBSoftDecoder::startDecoder()
 {
 	if (m_decoder_started)
 		return;
+	if (m_buffer_timer)
+		m_buffer_timer->stop();
+	m_buffer_wait_started = 0;
 
 	// Start decoder
 	eDebug("[eDVBSoftDecoder] Starting decoder");
 	updatePids(true);
+	if (m_session)
+		m_session->configureBufferReadiness(-1, -1);
 	m_decoder_started = true;
 
 	if (!m_health_timer)
@@ -195,6 +272,12 @@ void eDVBSoftDecoder::stop()
 		m_health_timer->stop();
 		m_health_timer = nullptr;
 	}
+	if (m_buffer_timer)
+		m_buffer_timer->stop();
+	m_buffer_wait_started = 0;
+	m_buffer_target_ms = 0;
+	m_buffer_deadline_ms = 0;
+	m_buffer_last_log = 0;
 	if (m_first_cw_conn.connected())
 		m_first_cw_conn.disconnect();
 
@@ -244,6 +327,8 @@ void eDVBSoftDecoder::stop()
 	}
 
 	m_pids_active.clear();
+	m_buffer_video_pid = -2;
+	m_buffer_audio_pid = -2;
 	m_running = false;
 	m_decoder_started = false;
 	m_last_pts = 0;
@@ -619,8 +704,68 @@ void eDVBSoftDecoder::updatePids(bool withDecoder)
 	if (timing_pid != -1)
 		m_record->setTimingPID(timing_pid, timing_pid_type, timing_stream_type);
 
+	int readiness_apid = -1;
+	if (!m_noaudio && !program.audioStreams.empty())
+	{
+		int readiness_atype = -1;
+		unsigned int readiness_index = 0;
+		selectAudioStream(program, readiness_apid, readiness_atype, readiness_index, false);
+	}
+	if (m_session && !m_decoder_started
+		&& (vpid != m_buffer_video_pid || readiness_apid != m_buffer_audio_pid))
+	{
+		m_session->configureBufferReadiness(vpid, readiness_apid);
+		m_buffer_video_pid = vpid;
+		m_buffer_audio_pid = readiness_apid;
+	}
+
 	if (withDecoder)
 		updateDecoder(vpid, vpidtype, pcrpid);
+}
+
+bool eDVBSoftDecoder::selectAudioStream(const eDVBServicePMTHandler::program& program,
+	int& apid, int& atype, unsigned int& audio_index, bool log_selection)
+{
+	apid = -1;
+	atype = -1;
+	audio_index = 0;
+	if (program.audioStreams.empty())
+		return false;
+
+	// Use the service cache first so the readiness gate observes exactly the
+	// audio stream that updateDecoder() will select later.
+	if (m_dvb_service)
+	{
+		for (int m = 0; m < eDVBService::nAudioCacheTags; ++m)
+		{
+			const int cached_apid = m_dvb_service->getCacheEntry(eDVBService::audioCacheTags[m]);
+			if (cached_apid == -1)
+				continue;
+
+			for (unsigned int s = 0; s < program.audioStreams.size(); ++s)
+			{
+				if (program.audioStreams[s].pid != cached_apid)
+					continue;
+				apid = cached_apid;
+				atype = program.audioStreams[s].type;
+				audio_index = s;
+				if (log_selection)
+					eDebug("[eDVBSoftDecoder] Using cached audio: apid=%04x atype=%d (stream %u)",
+						apid, atype, audio_index);
+				return true;
+			}
+		}
+	}
+
+	audio_index = program.defaultAudioStream;
+	if (audio_index >= program.audioStreams.size())
+		audio_index = 0;
+	apid = program.audioStreams[audio_index].pid;
+	atype = program.audioStreams[audio_index].type;
+	if (log_selection)
+		eDebug("[eDVBSoftDecoder] Using default audio: apid=%04x atype=%d (stream %u of %zu)",
+			apid, atype, audio_index, program.audioStreams.size());
+	return true;
 }
 
 void eDVBSoftDecoder::updateDecoder(int vpid, int vpidtype, int pcrpid)
@@ -667,45 +812,7 @@ void eDVBSoftDecoder::updateDecoder(int vpid, int vpidtype, int pcrpid)
 			int atype = -1;
 			unsigned int audio_index = 0;
 
-			// First, try to get cached audio PID from service database
-			// This preserves user's previous audio selection for this channel
-			if (m_dvb_service)
-			{
-				for(int m = 0; m < eDVBService::nAudioCacheTags; m++)
-				{
-					int cached_apid = m_dvb_service->getCacheEntry(eDVBService::audioCacheTags[m]);
-					if (cached_apid != -1)
-					{
-						// Find matching stream index for this cached PID
-						for(unsigned int s = 0; s < program.audioStreams.size(); s++)
-						{
-							if (program.audioStreams[s].pid == cached_apid)
-							{
-								apid = cached_apid;
-								atype = program.audioStreams[s].type;
-								audio_index = s;
-								eDebug("[eDVBSoftDecoder] Using cached audio: apid=%04x atype=%d (stream %u)", apid, atype, audio_index);
-								break;
-							}
-						}
-						if (apid != -1)
-							break;
-					}
-				}
-			}
-
-			// If no cached audio, use language preferences (defaultAudioStream)
-			if (apid == -1)
-			{
-				audio_index = program.defaultAudioStream;
-				if (audio_index >= program.audioStreams.size())
-					audio_index = 0;  // Fallback to first stream
-
-				apid = program.audioStreams[audio_index].pid;
-				atype = program.audioStreams[audio_index].type;
-				eDebug("[eDVBSoftDecoder] Using default audio: apid=%04x atype=%d (stream %u of %zu)",
-				       apid, atype, audio_index, program.audioStreams.size());
-			}
+			selectAudioStream(program, apid, atype, audio_index, true);
 
 			if (!m_noaudio)
 			{
@@ -801,7 +908,13 @@ void eDVBSoftDecoder::setNoAudio(bool noaudio, int preferred_pid)
 {
 	if (!m_decoder || !m_decoder_started)
 	{
+		const bool changed = m_noaudio != noaudio;
 		m_noaudio = noaudio;
+		if (changed && m_running && m_record)
+		{
+			m_buffer_audio_pid = -2;
+			updatePids(false);
+		}
 		return;
 	}
 

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -493,7 +493,10 @@ void eDVBSoftDecoder::serviceEventSource(int event)
 	case eDVBServicePMTHandler::eventNewProgramInfo:
 		eDebug("[eDVBSoftDecoder] Source: eventNewProgramInfo");
 		if (m_running)
-			updatePids(true);  // Decoder already running, update it
+			// Keep recorder PIDs current while waiting for the first CW and the
+			// configured pre-buffer.  m_running only means that the recorder is
+			// active; creating the decoder here would bypass both start gates.
+			updatePids(m_decoder_started);
 		break;
 	default:
 		break;

--- a/lib/service/servicedvbsoftdecoder.h
+++ b/lib/service/servicedvbsoftdecoder.h
@@ -110,6 +110,8 @@ private:
 
 	int m_decoder_index;
 	int m_dvr_fd;
+	int m_buffer_video_pid;
+	int m_buffer_audio_pid;
 	bool m_running;
 	bool m_stopping;
 	bool m_noaudio;  // When true, suppress audio (PIP mode)
@@ -122,6 +124,10 @@ private:
 
 	// Pre-buffer: delay decoder start to let DVR data accumulate
 	ePtr<eTimer> m_buffer_timer;
+	int64_t m_buffer_wait_started;
+	int m_buffer_target_ms;
+	int m_buffer_deadline_ms;
+	int64_t m_buffer_last_log;
 	void onBufferTimerExpired();
 
 	ePtr<eTimer> m_health_timer;
@@ -147,6 +153,8 @@ private:
 	int setupRecorder();
 	void updatePids(bool withDecoder = true);
 	void updateDecoder(int vpid, int vpidtype, int pcrpid);
+	bool selectAudioStream(const eDVBServicePMTHandler::program& program,
+		int& apid, int& atype, unsigned int& audio_index, bool log_selection);
 
 	// Video Event Signal
 	sigc::signal<void(struct iTSMPEGDecoder::videoEvent)> m_video_event;


### PR DESCRIPTION
## Problem

SoftCSA startup had several ordering and persistence issues:

- Positive CSA-ALT detection was cached only for the lifetime of the Enigma2 process. After a GUI restart, an already known service had to be classified again.
- `eventNewProgramInfo` could call `updatePids(true)` while only the recorder was active. This created the decoder before the first-CW and pre-buffer gates had completed.
- The configured pre-buffer was a blind wall-clock delay. Depending on CW timing, PES cadence, and DVR queue pressure, the decoder could start with too little clear audio/video data or wait until the idle queue filled.

## Changes

- Persist positive CSA-ALT detections by DVB triplet in `${sysconfdir}/enigma2/softcsa.cache`.
- Load the cache before rejecting the initial `0xFFFF` ECM PID placeholder, allowing known services to select SoftCSA without waiting for a second classification.
- Continue monitoring the first valid ECM to validate cached entries. Stale entries are removed automatically and playback returns to hardware descrambling.
- Write the persistent cache only when its serialized positive classification or nonzero service ID changes. Failed writes remain dirty and are retried at the next save opportunity.
- Preserve the first-CW and pre-buffer gates on PMT updates by passing `m_decoder_started`, rather than `m_running`, to `updatePids()`.
- Track clear packets for the selected video and audio PIDs after software descrambling, extract PES PTS values, and derive actual buffered media duration.
- Start the decoder when both selected streams have reached the configured `bufferTime`. The last observed PES interval is included because a PTS marks the beginning of a block; a bounded 50 ms tolerance covers timestamp/timer quantization.
- Retain a `bufferTime + 500 ms` safety deadline for missing or unusable timestamps.
- Disable readiness tracking as soon as the decoder starts, leaving no steady-state packet-scanning or locking overhead.

Only positive detections are persisted. Writes use a temporary file plus `rename()`. FTA, process-local negative detections, and other CA systems retain their existing hardware path. CI activation suppression, timeout fallback, and the existing Aggressive-mode cache bypass remain in place.

The PR deliberately retains the existing hardware-decoder startup order for unknown services. Instrumented control runs did not demonstrate a visible hardware-to-software dropout, so waiting for local ECM classification did not justify an additional hardware-start gate.

## Test

- Rebased on current `master` (`414e49e707`) and completed a clean ARMv7 `vuuno4k` Docker build.
- Deployed the binary and matching generated Python wrapper to an openATV 8.0 `vuuno4k`.
- On an anonymized encrypted CSA-ALT test service with `bufferTime=1000`, clear A/V readiness completed after 965 ms. SoftDecoder PLAY followed, and confirmed video and audio PTS were present 121 ms after the decoder start request.
- Left the SoftCSA service running continuously for five minutes. Twenty video-only grabs taken at 15-second intervals were all different; ECM data kept updating and the Enigma2 process remained unchanged.
- The five-minute log contained no traceback, fatal error, TS write error, recorder error, buffer overrun/underrun, decoder-start failure, or softcam-proxy disconnect.
- Repeated startup and tune cycles for an anonymized non-CSA-ALT encrypted service. Its hardware decoder retained the normal immediate startup order and produced changing video output in both complete control runs.
- Starting without a cache recreated the positive classification. After a subsequent GUI restart, cached validation, ECM handling, and first-CW delivery left the cache inode, modification time, size, and content unchanged.
- Tuning an unrelated negative VideoGuard service also left the positive-only cache unchanged.
- Cached positive classifications select SoftCSA directly. Negative classifications remain process-local and retain their immediate hardware-decoder path.

This complements the pre-buffer work merged in #3720 by ensuring PMT updates cannot bypass the gate and by basing decoder startup on clear media readiness instead of elapsed time alone.

