### PR TITLE
dvb: ensure disabled tuners (configMode=nothing) never participate in tuner selection

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -359,7 +359,12 @@ class SecConfigure:
 							continue
 						eDVBResourceManager.getInstance().setFrontendType(slot.frontend_id, FeType, True)
 				else:
-					eDVBResourceManager.getInstance().setFrontendType(slot.frontend_id, slot.getType())
+					# For single-type tuners, respect configMode=nothing: disabled tuners (A-H with
+					# dvbc.configMode=nothing) must not advertise a delivery system, otherwise
+					# they could still be considered for tuning despite m_enabled=False.
+					slot_type = slot.getType()
+					if slot_type not in ("DVB-C", "DVB-C2") or config.Nims[slot.slot].dvbc.configMode.value != "nothing":
+						eDVBResourceManager.getInstance().setFrontendType(slot.frontend_id, "dummy", False)
 		print("[NimManager] sec config completed")
 
 	def updateAdvanced(self, sec, slotid):
@@ -2481,6 +2486,8 @@ def InitNimManager(nimmgr, update_slots=None):
 	empty_slots = 0
 	for slot in nimmgr.nim_slots:
 		slot_id = slot.slot
+		if slot_id >= len(config.Nims):
+			continue
 		nim = config.Nims[slot_id]
 		nim.force_legacy_signal_stats = ConfigYesNo(default=False)
 		if slot.canBeCompatible("DVB-S"):
@@ -2596,6 +2603,8 @@ def InitNimManager(nimmgr, update_slots=None):
 	empty_slots = 0
 	for slot in nimmgr.nim_slots:
 		slot_id = slot.slot
+		if slot_id >= len(config.Nims):
+			continue
 		nim = config.Nims[slot_id]
 		addMultiType = False
 		try:


### PR DESCRIPTION


* NimManager: clear delivery-system whitelist for disabled single-type tuners (configMode=nothing)

Tuners A-H are DVB-C BCM3158 with dvbc.configMode=nothing and must not advertise DVB-C. Previously SecConfigure only cleared the whitelist for multi-type slots (continue), while single-type did setFrontendType( slot.getType()) unconditionally, so a disabled BCM3158 still reported SYS_DVBC_ANNEX_A via m_delsys and could be scored 2 before the m_enabled check. Now single-type checks configMode and calls setFrontendType( 'dummy', False) for nothing, so supportsDeliverySystem() fails and isCompatibleWith() returns 0. Tuner J (SAT>IP VTUNER slot 9, DVB-C) remains the sole DVB-C candidate; A-H never participate in allocateFrontend.

Tested on vuuno4kse (8x BCM3158 + 2x SAT>IP VTUNER, frontend_priority=9, A-H nothing, J enabled).

* NimManager: guard IndexError when VTUNER/minisatip creates extra NIM slots beyond config.Nims

On vuuno4kse with local minisatip -a 0:0:8, NIM sockets 10/11 (SAT>IP VTUNER frontend 10/11) appear while config.Nims only has 0-9. InitNimManager accessed config.Nims[slot_id] without bounds check at two loops (2501, 2616), raising IndexError: list index out of range and aborting StartEnigma (release cached channel timer). Add if slot_id >= len(config.Nims): continue.

---------