### PR TITLE
servicedvb: use long passthrough delay for DDP

### DIFF
--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2673,9 +2673,11 @@ int eDVBServicePlay::selectAudioStream(int i)
 		std::string pass = CFile::read("/proc/stb/audio/ac3");
 		if(pass.find("passthrough") != std::string::npos)
 		{
-			int shortAudioDelay = eSimpleConfig::getInt("config.av.passthrough_fix_short", 100);
+			int audioDelay = apidtype == eDVBPMTParser::audioStream::atDDP
+				? eSimpleConfig::getInt("config.av.passthrough_fix_long", 1200)
+				: eSimpleConfig::getInt("config.av.passthrough_fix_short", 100);
 			m_passthrough_fix_timer->stop();
-			m_passthrough_fix_timer->start(shortAudioDelay, true);
+			m_passthrough_fix_timer->start(audioDelay, true);
 		}
 	}
 #endif


### PR DESCRIPTION
Fixes #3879

In the live DVB playback path, AC3, AAC and DDP currently all use
`config.av.passthrough_fix_short`.

This change makes DDP use the existing `config.av.passthrough_fix_long`
setting, while AC3/AAC continue to use `passthrough_fix_short`.

This matches the existing OpenATV settings:

- `passthrough_fix_short` — AC3 handling delay
- `passthrough_fix_long` — AC3+ handling delay

Tested on a Vu+ Ultimo 4K with OpenATV 7.6.

Before the patch:

- `short=0`, `long=1800`: E-AC3/DDP could start without audio
- `short=1800`, `long=0`: DDP was reliable, but normal AC3 was unnecessarily delayed

After the patch:

- `short=0`
- `long=1800`

Normal AC3 starts immediately and E-AC3/DDP passthrough initializes reliably
on France 2 UHD, RTL UHD and ProSieben UHD.

Detailed reproduction and analysis: #3879