### PR TITLE
servicedvb: use long passthrough delay for DDP

### DIFF
--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2739,9 +2739,11 @@ int eDVBServicePlay::selectAudioStream(int i)
 		std::string pass = CFile::read("/proc/stb/audio/ac3");
 		if(pass.find("passthrough") != std::string::npos)
 		{
-			int shortAudioDelay = eSimpleConfig::getInt("config.av.passthrough_fix_short", 100);
+			int audioDelay = apidtype == eDVBPMTParser::audioStream::atDDP
+				? eSimpleConfig::getInt("config.av.passthrough_fix_long", 1200)
+				: eSimpleConfig::getInt("config.av.passthrough_fix_short", 100);
 			m_passthrough_fix_timer->stop();
-			m_passthrough_fix_timer->start(shortAudioDelay, true);
+			m_passthrough_fix_timer->start(audioDelay, true);
 		}
 	}
 #endif


### PR DESCRIPTION
Related to #3879

The same DDP passthrough issue also exists in the OpenATV 8.0 branch.

In the live DVB playback path, AC3, AAC and DDP currently all use
`config.av.passthrough_fix_short`.

This change makes DDP use the existing `config.av.passthrough_fix_long`
setting, while AC3/AAC continue to use `passthrough_fix_short`.

This matches the existing OpenATV settings:

- `passthrough_fix_short` — AC3 handling delay
- `passthrough_fix_long` — AC3+ handling delay

The identical change was tested successfully on a Vu+ Ultimo 4K with OpenATV 7.6.

See #3879 for detailed reproduction, analysis and hardware verification.