### PR TITLE
[YTDLPWrapper] * play streams that have no muxed format

### DIFF
--- a/lib/python/Plugins/Extensions/YTDLPWrapper/plugin.py
+++ b/lib/python/Plugins/Extensions/YTDLPWrapper/plugin.py
@@ -20,13 +20,20 @@ def playService(service, **kwargs):
 				url = url.replace(SCHEMA, "")
 				url = url.replace("%3a", ":")
 				try:
-					ydl = YoutubeDL({"format": "b", "no_color": True, "usenetrc": True})
+					ydl = YoutubeDL({"format": "b/bv*+ba/bv*", "no_color": True, "usenetrc": True})
 					result = ydl.extract_info(url, download=False)
 					result = ydl.sanitize_info(result)
-					if result and result.get("url"):
-						url = result["url"]
-						print(f"[{WRAPPER}] playService result url '{url}'")
-						return (url, errormsg)
+					stream = result.get("url") if result else None
+					if not stream and result:
+						# Video and audio come as separate streams, which the player cannot
+						# merge. Hand it the master playlist holding both instead.
+						for fmt in (result.get("requested_formats") or []) + (result.get("formats") or []):
+							stream = fmt.get("manifest_url")
+							if stream:
+								break
+					if stream:
+						print(f"[{WRAPPER}] playService result url '{stream}'")
+						return (stream, errormsg)
 					else:
 						errormsg = "No Link found!"
 						print(f"[{WRAPPER}] playService no streams")


### PR DESCRIPTION
None of yt-dlp's default player clients offer muxed formats any more, so the "b" selector cannot be satisfied and playService returns without a URL. Nothing starts, neither for live streams nor for ordinary videos.

Select "b/bv*+ba/bv*" so separate video and audio streams are accepted, and pass the shared HLS master playlist to the player in that case. It holds every rendition including audio, which the player resolves itself.

yt-dlp dropped android_vr from its default player clients on 2026-08-18 (dae52d838), after YouTube started answering that client with HTTP 403. It was the last default client still serving the muxed HLS itags 91-96.

https://github.com/yt-dlp/yt-dlp/commit/dae52d8386557f4c19ab58a9ae56062b8d52b3af