### PR TITLE
Move IPKG feed screens into Screens/Opkg.py as PackageFeedSelection/P…

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -183,7 +183,7 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 					<item key="backup_additional" level="2" text="Select Additional Backup Files" description="Here you can specify additional files that should be added to the backup file." weight="16"><plugin system="SoftwareManager" screen="BackupHelper">6</plugin></item>
 					<item key="backup_excluded" level="2" text="Select Excluded Backup Files" description="Here you can select which files should be excluded from the backup." weight="16"><plugin system="SoftwareManager" screen="BackupHelper">7</plugin></item>
 					<item key="package_manager" level="2" text="Package Manager" description="View, install and remove available or installed packages." weight="16"><screen module="PluginBrowser" screen="PackageAction">4</screen></item>
-					<item key="upgrade_source" level="2" text="Select Upgrade Source" description="Edit the upgrade source address." weight="16"><plugin system="SoftwareManager" screen="IPKGMenu" /></item>
+					<item key="upgrade_source" level="2" text="Select Upgrade Source" description="Edit the upgrade source address." weight="16"><screen module="Opkg" screen="PackageFeedSelection" /></item>
 					<item key="upgrade_settings" level="2" text="Software Manager Settings" description="Here you can select which files should be updated with a online update" weight="16"><setup setupKey="SoftwareManager" /></item>
 				</menu>
 			</menu>

--- a/lib/python/Components/Scanner.py
+++ b/lib/python/Components/Scanner.py
@@ -147,6 +147,19 @@ class ScanFile:
 		return "<ScanFile " + self.path + " (" + str(self.mimetype) + ", " + str(self.size) + " MB)>"
 
 
+def filescan_open(list, session, **kwargs):
+	from Screens.Opkg import IpkgInstaller  # Prevent Cicle imports
+	filelist = [x.path for x in list]
+	session.open(IpkgInstaller, filelist)
+
+
+def filescan(**kwargs):
+	return Scanner(mimetypes=["application/x-debian-package"], paths_to_scan=[
+		ScanPath(path="ipk", with_subdirs=True),
+		ScanPath(path="", with_subdirs=False),
+	], name="Ipkg", description=_("Install extensions."), openfnc=filescan_open)
+
+
 def execute(option):
 	print("[Scanner] execute", option)
 	if option is None:
@@ -157,7 +170,7 @@ def execute(option):
 
 
 def scanDevice(mountpoint):
-	scanner = []
+	scanner = [filescan()]
 
 	for pluginObj in plugins.getPlugins(PluginDescriptor.WHERE_FILESCAN):
 		func = pluginObj()
@@ -214,7 +227,7 @@ def openList(session, files):
 	if not isinstance(files, list):
 		files = [files]
 
-	scanner = []
+	scanner = [filescan()]
 
 	for pluginObj in plugins.getPlugins(PluginDescriptor.WHERE_FILESCAN):
 		func = pluginObj()

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -1,16 +1,12 @@
 from os import F_OK, R_OK, W_OK, access, listdir, makedirs, mkdir, stat  # noqa F401
-from os.path import dirname, exists, isdir, isfile, join as pathjoin
+from os.path import dirname, isdir, isfile, join as pathjoin
 from stat import ST_MTIME
 from pickle import dump, load
 from time import time
 
-from enigma import getDesktop
-
-from Components.ActionMap import HelpableActionMap, HelpableNumberActionMap
+from Components.ActionMap import HelpableActionMap
 from Components.config import config
 from Components.Harddisk import harddiskmanager  # noqa F401
-from Components.Input import Input
-from Components.MenuList import MenuList
 from Components.Opkg import OpkgComponent
 from Components.PluginComponent import plugins  # noqa F401
 from Components.SelectionList import SelectionList
@@ -64,154 +60,6 @@ class ImageWizard(ImageWizard):
 
 class RestoreMenu(RestoreMenu):
 	pass
-
-
-class IPKGMenu(Screen):
-	skin = """
-		<screen name="IPKGMenu" position="center,center" size="560,400" resolution="1280,720">
-			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
-			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
-			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-			<widget name="filelist" position="5,50" size="550,340" scrollbarMode="showOnDemand" />
-		</screen>"""
-
-	def __init__(self, session):
-		Screen.__init__(self, session)
-		self.setTitle(_("Select Upgrade Source To Edit"))
-		self["key_red"] = StaticText(_("Close"))
-		self["key_green"] = StaticText(_("Edit"))
-		self.sel = []
-		self.val = []
-		self.entry = False
-		self.exe = False
-		self.path = ""
-		self["actions"] = HelpableActionMap(self, ["OkCancelActions"], {
-			"ok": self.KeyOk,
-			"cancel": self.keyCancel
-		}, prio=-1)
-		self["shortcuts"] = HelpableActionMap(self, ["ColorActions"], {
-			"red": self.keyCancel,
-			"green": self.KeyOk,
-		})
-		self["filelist"] = MenuList([])
-		self.fill_list()
-
-	def fill_list(self):
-		flist = []
-		self.path = "/etc/opkg/"
-		if (exists(self.path) is False):
-			self.entry = False
-			return
-		for file in listdir(self.path):
-			if file.endswith(".conf"):
-				if file not in ("arch.conf", "opkg.conf"):
-					flist.append((file))
-					self.entry = True
-		self["filelist"].l.setList(flist)
-
-	def KeyOk(self):
-		if (self.exe is False) and (self.entry is True):
-			self.sel = self["filelist"].getCurrent()
-			self.val = self.path + self.sel
-			self.session.open(IPKGSource, self.val)
-
-	def keyCancel(self):
-		self.close()
-
-	def Exit(self):
-		self.close()
-
-
-class IPKGSource(Screen):
-	skin = """
-		<screen name="IPKGSource" position="center,center" size="560,80" title="Edit upgrade source url." resolution="1280,720">
-			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
-			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
-			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-			<widget name="text" position="5,50" size="550,25" font="Regular;20" backgroundColor="background" foregroundColor="#cccccc" />
-		</screen>"""
-
-	def __init__(self, session, configfile=None):
-		Screen.__init__(self, session)
-		self.setTitle(_("Edit Upgrade Source URL"))
-		self.configfile = configfile
-		text = ""
-		if self.configfile:
-			try:
-				fp = open(configfile)
-				sources = fp.readlines()
-				if sources:
-					text = sources[0]
-				fp.close()
-			except OSError:
-				pass
-		desk = getDesktop(0)
-		x = int(desk.size().width())  # noqa F841
-		y = int(desk.size().height())
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-		if (y >= 720):
-			self["text"] = Input(text, maxSize=False, type=Input.TEXT)
-		else:
-			self["text"] = Input(text, maxSize=False, visible_width=55, type=Input.TEXT)
-		self["actions"] = HelpableNumberActionMap(self, ["WizardActions", "InputActions", "TextEntryActions", "KeyboardInputActions", "ShortcutActions"], {
-			"ok": self.go,
-			"back": self.close,
-			"red": self.close,
-			"green": self.go,
-			"left": self.keyLeft,
-			"right": self.keyRight,
-			"home": self.keyHome,
-			"end": self.keyEnd,
-			"deleteForward": self.keyDeleteForward,
-			"deleteBackward": self.keyDeleteBackward,
-			"1": self.keyNumberGlobal,
-			"2": self.keyNumberGlobal,
-			"3": self.keyNumberGlobal,
-			"4": self.keyNumberGlobal,
-			"5": self.keyNumberGlobal,
-			"6": self.keyNumberGlobal,
-			"7": self.keyNumberGlobal,
-			"8": self.keyNumberGlobal,
-			"9": self.keyNumberGlobal,
-			"0": self.keyNumberGlobal
-		}, prio=-1)
-		self.onLayoutFinish.append(self.layoutFinished)
-
-	def layoutFinished(self):
-		self["text"].right()
-
-	def go(self):
-		text = self["text"].getText()
-		if text:
-			fp = open(self.configfile, "w")
-			fp.write(text)
-			fp.write("\n")
-			fp.close()
-		self.close()
-
-	def keyLeft(self):
-		self["text"].left()
-
-	def keyRight(self):
-		self["text"].right()
-
-	def keyHome(self):
-		self["text"].home()
-
-	def keyEnd(self):
-		self["text"].end()
-
-	def keyDeleteForward(self):
-		self["text"].delete()
-
-	def keyDeleteBackward(self):
-		self["text"].deleteBackward()
-
-	def keyNumberGlobal(self, number):
-		self["text"].number(number)
 
 
 class IpkgInstaller(Screen):

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -8,9 +8,7 @@ from Components.config import config
 from Components.Harddisk import harddiskmanager  # noqa F401
 from Components.PluginComponent import plugins  # noqa F401
 from Components.SystemInfo import BoxInfo
-from Plugins.Plugin import PluginDescriptor
 from Screens.MessageBox import MessageBox
-from Screens.Opkg import IpkgInstaller
 from Screens.Screen import Screen
 
 from .BackupRestore import InitConfig as BackupRestore_InitConfig, BackupSelection, BackupScreen, RestoreScreen, getBackupPath, getOldBackupPath, getBackupFilename, RestoreMenu
@@ -56,19 +54,6 @@ class ImageWizard(ImageWizard):
 
 class RestoreMenu(RestoreMenu):
 	pass
-
-
-def filescan_open(list, session, **kwargs):
-	filelist = [x.path for x in list]
-	session.open(IpkgInstaller, filelist)  # List.
-
-
-def filescan(**kwargs):
-	from Components.Scanner import Scanner, ScanPath
-	return Scanner(mimetypes=["application/x-debian-package"], paths_to_scan=[
-		ScanPath(path="ipk", with_subdirs=True),
-		ScanPath(path="", with_subdirs=False),
-	], name="Ipkg", description=_("Install extensions."), openfnc=filescan_open)
 
 
 class BackupHelper(Screen):
@@ -126,4 +111,4 @@ class BackupHelper(Screen):
 
 
 def Plugins(path, **kwargs):
-	return [PluginDescriptor(name=_("Ipkg"), where=PluginDescriptor.WHERE_FILESCAN, needsRestart=False, fnc=filescan)]
+	return []

--- a/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SoftwareManager/plugin.py
@@ -4,17 +4,13 @@ from stat import ST_MTIME
 from pickle import dump, load
 from time import time
 
-from Components.ActionMap import HelpableActionMap
 from Components.config import config
 from Components.Harddisk import harddiskmanager  # noqa F401
-from Components.Opkg import OpkgComponent
 from Components.PluginComponent import plugins  # noqa F401
-from Components.SelectionList import SelectionList
 from Components.SystemInfo import BoxInfo
-from Components.Sources.StaticText import StaticText
 from Plugins.Plugin import PluginDescriptor
 from Screens.MessageBox import MessageBox
-from Screens.Opkg import Opkg
+from Screens.Opkg import IpkgInstaller
 from Screens.Screen import Screen
 
 from .BackupRestore import InitConfig as BackupRestore_InitConfig, BackupSelection, BackupScreen, RestoreScreen, getBackupPath, getOldBackupPath, getBackupFilename, RestoreMenu
@@ -60,55 +56,6 @@ class ImageWizard(ImageWizard):
 
 class RestoreMenu(RestoreMenu):
 	pass
-
-
-class IpkgInstaller(Screen):
-	skin = """
-		<screen name="IpkgInstaller" position="center,center" size="550,450" title="Install extensions" resolution="1280,720">
-			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/yellow.png" position="280,0" size="140,40" alphatest="on" />
-			<ePixmap pixmap="skin_default/buttons/blue.png" position="420,0" size="140,40" alphatest="on" />
-			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
-			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
-			<widget source="key_yellow" render="Label" position="280,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#a08500" transparent="1" />
-			<widget source="key_blue" render="Label" position="420,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#18188b" transparent="1" />
-			<widget name="list" position="5,50" size="540,360" />
-			<ePixmap pixmap="skin_default/div-h.png" position="0,410" zPosition="10" size="560,2" transparent="1" alphatest="on" />
-			<widget source="introduction" render="Label" position="5,420" zPosition="10" size="550,30" halign="center" valign="center" font="Regular;22" transparent="1" shadowColor="black" shadowOffset="-1,-1" />
-		</screen>"""
-
-	def __init__(self, session, list):
-		Screen.__init__(self, session)
-		self.selectionList = SelectionList()
-		self["list"] = self.selectionList
-		p = 0
-		if len(list):
-			p = list[0].rfind("/")
-			title = list[0][:p]
-			self.title = ("%s %s %s") % (_("Install extensions"), _("from"), title)
-		for listindex in range(len(list)):
-			self.selectionList.addSelection(list[listindex][p + 1:], list[listindex], listindex, False)
-		self.selectionList.sort()
-		self["key_red"] = StaticText(_("Close"))
-		self["key_green"] = StaticText(_("Install"))
-		self["key_yellow"] = StaticText()
-		self["key_blue"] = StaticText(_("Invert"))
-		self["introduction"] = StaticText(_("Press OK to toggle the selection."))
-		self["actions"] = HelpableActionMap(self, ["OkCancelActions", "ColorActions"], {
-			"ok": self.selectionList.toggleSelection,
-			"cancel": self.close,
-			"red": self.close,
-			"green": self.install,
-			"blue": self.selectionList.toggleAllSelection
-		}, prio=-1)
-
-	def install(self):
-		packages = self.selectionList.getSelectionsList()
-		cmdList = [(OpkgComponent.CMD_UPDATE, None)]
-		for item in packages:
-			cmdList.append((OpkgComponent.CMD_INSTALL, {"package": item[1]}))
-		self.session.open(Opkg, cmdList=cmdList)
 
 
 def filescan_open(list, session, **kwargs):

--- a/lib/python/Screens/Opkg.py
+++ b/lib/python/Screens/Opkg.py
@@ -1,13 +1,21 @@
+from os import listdir
+from os.path import isdir, join
+
 from enigma import eTimer
 
 from Components.ActionMap import HelpableActionMap
 from Components.Label import Label
+from Components.MenuList import MenuList
 from Components.Opkg import OpkgComponent
 from Components.ScrollLabel import ScrollLabel
 from Components.Slider import Slider
 from Components.Sources.StaticText import StaticText
 from Screens.MessageBox import MessageBox
 from Screens.Screen import Screen
+from Screens.VirtualKeyBoard import VirtualKeyboard
+from Tools.Directories import fileReadLines, fileWriteLines
+
+MODULE_NAME = __name__.split(".")[-1]
 
 
 class Opkg(Screen):
@@ -175,3 +183,59 @@ class Opkg(Screen):
 			self["slider"].show()
 			self["activityslider"].show()
 			self["status"].show()
+
+
+class PackageFeedSelection(Screen):
+	PACKAGE_PATH = "/etc/opkg/"
+	skin = """
+	<screen name="PackageFeedSelection" title="Package Feed Selection" position="center,center" size="700,400" resolution="1280,720">
+		<widget name="feeds" position="10,10" size="e-20,e-70" font="Regular;20" itemHeight="25" />
+		<widget source="key_red" render="Label" position="10,e-50" size="180,40" backgroundColor="key_red" font="Regular;20" foregroundColor="key_text" horizontalAlignment="center" wrap="off" verticalAlignment="center">
+			<convert type="ConditionalShowHide" />
+		</widget>
+		<widget source="key_green" render="Label" position="200,e-50" size="180,40" backgroundColor="key_green" font="Regular;20" foregroundColor="key_text" horizontalAlignment="center" wrap="off" verticalAlignment="center">
+			<convert type="ConditionalShowHide" />
+		</widget>
+		<widget source="key_help" render="Label" position="e-100,e-50" size="90,40" backgroundColor="key_back" font="Regular;20" foregroundColor="key_text" horizontalAlignment="center" wrap="off" verticalAlignment="center">
+			<convert type="ConditionalShowHide" />
+		</widget>
+	</screen>"""
+
+	def __init__(self, session):
+		Screen.__init__(self, session, enableHelp=True, mandatoryWidgets=["feeds"])
+		self.setTitle(_("Select Upgrade Source To Edit"))
+		feedList = []
+		if isdir(self.PACKAGE_PATH):
+			for file in sorted(listdir(self.PACKAGE_PATH)):
+				if file.endswith(".conf") and file not in ("arch.conf", "opkg.conf"):
+					feedList.append(file)
+		self["feeds"] = MenuList(feedList)
+		self["key_red"] = StaticText(_("Close"))
+		self["key_green"] = StaticText(_("Edit") if feedList else "")
+		self["actions"] = HelpableActionMap(self, ["OkCancelActions", "ColorActions"], {
+			"ok": (self.keyOk, _("Edit the currently highlighted feed")),
+			"cancel": (self.close, _("Close the screen")),
+			"red": (self.close, _("Close the screen")),
+			"green": (self.keyOk, _("Edit the currently highlighted feed"))
+		}, prio=0, description=_("Package Feed Editor Actions"))
+		self["actions"].setEnabledAction("ok", feedList != [])
+		self["actions"].setEnabledAction("green", feedList != [])
+
+	def keyOk(self):
+		self.session.open(PackageFeedEditor, join(self.PACKAGE_PATH, self["feeds"].getCurrent()))
+
+
+class PackageFeedEditor(VirtualKeyboard):
+	def __init__(self, session, configFile=None):
+		self.configFile = configFile
+		self.lines = fileReadLines(configFile, default=[], source=MODULE_NAME) if configFile else []
+		VirtualKeyboard.__init__(self, session, title=_("Edit the feed URL:"), text=self.lines[0] if self.lines else "", style=VirtualKeyboard.VKB_SAVE_ICON, windowTitle=_("Package Feed Editor"))
+
+	def save(self):  # This is a redefinition of the method in VirtualKeyboard.
+		self.smsGotChar()  # Commit any pending SMS character before the text is read.
+		text = self["text"].getText().replace(self.TAB_GLYPH, "\t")
+		if text and self.configFile:
+			if fileWriteLines(self.configFile, [text] + self.lines[1:], source=MODULE_NAME) == 0:  # Only the first line is edited, keep the others.
+				self.session.open(MessageBox, _("Error: There was a problem writing '%s'!") % self.configFile, MessageBox.TYPE_ERROR, windowTitle=self.getTitle())
+				return  # Keep the screen open so the edit is not lost.
+		VirtualKeyboard.save(self)

--- a/lib/python/Screens/Opkg.py
+++ b/lib/python/Screens/Opkg.py
@@ -8,6 +8,7 @@ from Components.Label import Label
 from Components.MenuList import MenuList
 from Components.Opkg import OpkgComponent
 from Components.ScrollLabel import ScrollLabel
+from Components.SelectionList import SelectionList
 from Components.Slider import Slider
 from Components.Sources.StaticText import StaticText
 from Screens.MessageBox import MessageBox
@@ -16,6 +17,55 @@ from Screens.VirtualKeyBoard import VirtualKeyboard
 from Tools.Directories import fileReadLines, fileWriteLines
 
 MODULE_NAME = __name__.split(".")[-1]
+
+
+class IpkgInstaller(Screen):
+	skin = """
+		<screen name="IpkgInstaller" position="center,center" size="550,450" title="Install extensions" resolution="1280,720">
+			<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/yellow.png" position="280,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/blue.png" position="420,0" size="140,40" alphatest="on" />
+			<widget source="key_red" render="Label" position="0,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" transparent="1" />
+			<widget source="key_green" render="Label" position="140,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" transparent="1" />
+			<widget source="key_yellow" render="Label" position="280,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#a08500" transparent="1" />
+			<widget source="key_blue" render="Label" position="420,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#18188b" transparent="1" />
+			<widget name="list" position="5,50" size="540,360" />
+			<ePixmap pixmap="skin_default/div-h.png" position="0,410" zPosition="10" size="560,2" transparent="1" alphatest="on" />
+			<widget source="introduction" render="Label" position="5,420" zPosition="10" size="550,30" halign="center" valign="center" font="Regular;22" transparent="1" shadowColor="black" shadowOffset="-1,-1" />
+		</screen>"""
+
+	def __init__(self, session, list):
+		Screen.__init__(self, session)
+		self.selectionList = SelectionList()
+		self["list"] = self.selectionList
+		p = 0
+		if len(list):
+			p = list[0].rfind("/")
+			title = list[0][:p]
+			self.title = ("%s %s %s") % (_("Install extensions"), _("from"), title)
+		for listindex in range(len(list)):
+			self.selectionList.addSelection(list[listindex][p + 1:], list[listindex], listindex, False)
+		self.selectionList.sort()
+		self["key_red"] = StaticText(_("Close"))
+		self["key_green"] = StaticText(_("Install"))
+		self["key_yellow"] = StaticText()
+		self["key_blue"] = StaticText(_("Invert"))
+		self["introduction"] = StaticText(_("Press OK to toggle the selection."))
+		self["actions"] = HelpableActionMap(self, ["OkCancelActions", "ColorActions"], {
+			"ok": self.selectionList.toggleSelection,
+			"cancel": self.close,
+			"red": self.close,
+			"green": self.install,
+			"blue": self.selectionList.toggleAllSelection
+		}, prio=-1)
+
+	def install(self):
+		packages = self.selectionList.getSelectionsList()
+		cmdList = [(OpkgComponent.CMD_UPDATE, None)]
+		for item in packages:
+			cmdList.append((OpkgComponent.CMD_INSTALL, {"package": item[1]}))
+		self.session.open(Opkg, cmdList=cmdList)
 
 
 class Opkg(Screen):


### PR DESCRIPTION
…ackageFeedEditor

Replace the old IPKGMenu/IPKGSource screens in the SoftwareManager plugin with PackageFeedSelection and PackageFeedEditor in Screens/Opkg.py, so they're shared screens rather than plugin-local.

- PackageFeedSelection: new skin (help/red/green with ConditionalShowHide), uses MenuList + HelpableActionMap with per-action help texts and enableHelp/mandatoryWidgets instead of the old plain ActionMap/skin.
- PackageFeedEditor: replaces the raw Input-widget screen with a VirtualKeyboard (VKB_SAVE_ICON), so it gets the standard on-screen keyboard skin instead of the old single-line Input skin. Reads/writes the feed file via Tools.Directories fileReadLines/fileWriteLine and shows a MessageBox on write failure instead of silently failing.
- menu.xml: "Select Upgrade Source" now opens PackageFeedSelection directly via <screen module="Opkg" .../> instead of routing through the SoftwareManager plugin's system="SoftwareManager" lookup.
- plugin.py: drop the now-unused IPKGMenu/IPKGSource classes and their imports (getDesktop, Input, MenuList, HelpableNumberActionMap, exists).