### PR TITLE
[NetworkMounts] * fix mount handling and clean up the share browser

### DIFF
--- a/lib/python/Components/NetworkManager.py
+++ b/lib/python/Components/NetworkManager.py
@@ -1940,6 +1940,7 @@ class AvahiProvider:
 		self.browser = None
 		self.started = False
 		self.onObservation: list[Callable] = []
+		self.onSnapshot: list[Callable] = []
 
 	def start(self):
 		if not self.started:
@@ -1958,8 +1959,12 @@ class AvahiProvider:
 			self.started = False
 
 	def changed(self):
+		addresses = set()
 		for entry in self.browser.getServices():
 			self.dispatch(entry)
+			addresses.update(entry["addresses"] or [])
+		for callback in self.onSnapshot:
+			callback(addresses)
 
 	def dispatch(self, entry: dict):
 		networkManager.log(f"AvahiProvider: found {entry["name"]} / {entry["hostname"]}")
@@ -2071,6 +2076,7 @@ class DiscoveryManager:
 		self.avahi = AvahiProvider()
 		self.netscan = NetscanProvider()
 		self.avahi.onObservation.append(self.onAvahiObservation)
+		self.avahi.onSnapshot.append(self.onAvahiSnapshot)
 		self.netscan.onObservation.append(self.onNetscanObservation)
 		self.stopTimer = eTimer()
 		self.stopTimer.callback.append(self.stop)
@@ -2152,6 +2158,13 @@ class DiscoveryManager:
 						host["avahiShares"][name] = share
 						changed = True
 		if changed:
+			self.notify()
+
+	def onAvahiSnapshot(self, addresses):
+		stale = [address for address, host in self.hosts.items() if host["source"] == "avahi" and address not in addresses]
+		for address in stale:
+			del self.hosts[address]
+		if stale:
 			self.notify()
 
 	def onNetscanObservation(self, observation):

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -521,7 +521,8 @@ class NetworkShares(Screen):
 	# the user leaves instead of scanning the network in the background.
 	def startDiscovery(self):
 		self.configuredShares = {(mount.get("server"), (mount.get("remotePath") or "").lstrip("/")): self.repository.mountPointFor(mount) for mount in self.repository.load()}
-		discoveryManager.onChanged.append(self.onHostsChanged)
+		if self.onHostsChanged not in discoveryManager.onChanged:
+			discoveryManager.onChanged.append(self.onHostsChanged)
 		discoveryManager.start(runMs=None)
 		self["description"].setText(_("Scanning..."))
 		self.buildList()

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -102,6 +102,7 @@ class NetworkMountsOverview(Screen):
 		self.onChangedEntry = []
 		self.buildList()
 		self.onShown.append(self.selectionChanged)
+		self.savedMount = None
 		self.onClose.append(self.console.killAll)
 
 	def selectionChanged(self):
@@ -149,14 +150,18 @@ class NetworkMountsOverview(Screen):
 	def keyEdit(self):
 		current = self["mountList"].getCurrent()
 		if current:
-			dlg = self.session.openWithCallback(lambda *args: self.keySetupClosed(dlg, *args), NetworkMountSetup, mount=current[self.LIST_DATA])
+			self.session.openWithCallback(self.keySetupClosed, NetworkMountSetup, mount=current[self.LIST_DATA], onSaved=self.mountSaved)
 
-	def keySetupClosed(self, dlg, *args):
-		if args and isinstance(args[0], bool) and args[0]:  # Special case for close recursive.
+	def mountSaved(self, mount):
+		self.savedMount = mount
+
+	def keySetupClosed(self, *args):
+		saved, self.savedMount = self.savedMount, None
+		if args and args[0] is True:
 			self.close(True)
 			return
 		self.buildList()
-		self.applyMountChange(getattr(dlg, "savedMount", None))
+		self.applyMountChange(saved)
 
 	def applyMountChange(self, mount):
 		def autofsRestarted(exitCode):
@@ -238,7 +243,7 @@ class NetworkMountsOverview(Screen):
 		def keyMenuCallback(choice=None):
 			if choice:
 				if choice[1] == "manual":
-					dlg = self.session.openWithCallback(lambda *args: self.keySetupClosed(dlg, *args), NetworkMountSetup, mount=None)
+					self.session.openWithCallback(self.keySetupClosed, NetworkMountSetup, mount=None, onSaved=self.mountSaved)
 				elif choice[1] == "delete":
 					deleteMount()
 				elif choice[1] == "edit_credentials":
@@ -278,7 +283,7 @@ class NetworkMountsOverview(Screen):
 					mount["shareName"] = picked["shareName"]
 				if picked.get("smbVersion"):
 					mount["smbVersion"] = picked["smbVersion"]
-				dlg = self.session.openWithCallback(lambda *args: self.keySetupClosed(dlg, *args), NetworkMountSetup, mount=mount)
+				self.session.openWithCallback(self.keySetupClosed, NetworkMountSetup, mount=mount, onSaved=self.mountSaved)
 
 		self.session.openWithCallback(keyGreenCallback, NetworkShares)
 
@@ -311,10 +316,11 @@ class NetworkMountsSummary(ScreenSummary):
 
 
 class NetworkMountSetup(Setup):
-	def __init__(self, session, mount=None):
+	def __init__(self, session, mount=None, onSaved=None):
 		def default(key, default=""):
 			return mount.get(key, default) if mount else default
 
+		self.onSaved = onSaved
 		self.repository = NetworkMountRepository()
 		self.mountId = mount.get("id") if mount else None
 		self.enabled = NoSave(ConfigYesNo(default=default("enabled", True)))
@@ -402,7 +408,8 @@ class NetworkMountSetup(Setup):
 		self.repository.save(mounts)
 		if self.enabled.value and self.mode.value == "fstab":
 			self.repository.ensureMountPoint(mount)
-		self.savedMount = mount
+		if self.onSaved:
+			self.onSaved(mount)
 		Setup.keySave(self)
 
 

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -829,7 +829,14 @@ class NetworkShares(Screen):
 			def sortKeyByName(host):
 				return (not host["protocols"], (host["hostname"] or host["address"]).lower())
 
-			for host in sorted(discoveryManager.hosts.values(), key=sortKeyByIP if config.network.browserSortByIP.value else sortKeyByName):
+			hosts = {}
+			for host in discoveryManager.hosts.values():
+				key = (host["hostname"] or host["address"], ":" in host["address"])
+				known = hosts.get(key)
+				if known is None or host["address"] < known["address"]:
+					hosts[key] = host
+
+			for host in sorted(hosts.values(), key=sortKeyByIP if config.network.browserSortByIP.value else sortKeyByName):
 				address = host["address"]
 				name = host["hostname"] or address
 				username = self.repository.credentialsGet(self.hostnameFor(address)).get("username", "")

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -661,6 +661,10 @@ class NetworkShares(Screen):
 	def pickShare(self, share):
 		host = discoveryManager.hosts.get(share["address"]) or {}
 		hostname = host.get("hostname") or ""
+		existing = self.configuredMount(share["address"], hostname, share["path"])
+		if existing:
+			self.session.openWithCallback(self.mountSetupClosed, NetworkMountSetup, mount=existing, onSaved=self.mountSaved)
+			return
 		server = hostname if (hostname and not config.network.browserUsingIP.value) else share["address"]
 		mount = {
 			"server": server,

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -425,10 +425,10 @@ class NetworkShares(Screen):
 				</rowtemplate>
 				<rowtemplate>
 					<text index="Glyph" position="50,9" size="42,32" font="2" foregroundColor="+GlyphColor" horizontalAlignment="center" padding="5,0" verticalAlignment="center" />
-					<text index="Type" position="102,0" size="50,50" font="3" foregroundColor="gray" padding="5,0" verticalAlignment="center" />
-					<text index="Name" position="152,0" size="200,50" font="3" padding="5,0" verticalAlignment="center" />
-					<text index="Description" position="352,0" size="500,25" font="3" padding="5,0" verticalAlignment="center" />
-					<text index="LocalPath" position="372,25" size="480,25" font="3" foregroundColor="gray" padding="5,0" verticalAlignment="center" />
+					<text index="Type" position="102,0" size="70,50" font="3" foregroundColor="gray" padding="5,0" verticalAlignment="center" />
+					<text index="Name" position="172,0" size="200,50" font="3" padding="5,0" verticalAlignment="center" />
+					<text index="Description" position="372,0" size="480,25" font="3" padding="5,0" verticalAlignment="center" />
+					<text index="LocalPath" position="392,25" size="460,25" font="3" foregroundColor="gray" padding="5,0" verticalAlignment="center" />
 				</rowtemplate>
 			</template>
 		</widget>
@@ -814,9 +814,6 @@ class NetworkShares(Screen):
 			for host in sorted(discoveryManager.hosts.values(), key=sortKeyByIP if config.network.browserSortByIP.value else sortKeyByName):
 				address = host["address"]
 				name = host["hostname"] or address
-				version = self.smbVersions.get(address)
-				if version:
-					name = f"{name} (SMB{version.split('.')[0]})"
 				entries.append((self.TEMPLATE_HOST, self.GLYPH_HOST, 0, address, "", name, "", "", {"kind": "host", "address": address}))
 				if address not in self.expanded:
 					continue
@@ -828,6 +825,10 @@ class NetworkShares(Screen):
 
 				for share in self.shares.get(address, []):
 					typeLabel = protocolLabels.get(share["protocol"], share["protocol"])
+					if share["protocol"] == "smb":
+						version = self.smbVersions.get(address)
+						if version:
+							typeLabel = f"SMB{version.split('.')[0]}"
 					existing = self.configuredMount(address, host["hostname"], share["path"])
 					localPath = self.repository.mountPointFor(existing) if existing else None
 					glyph = self.GLYPH_MOUNTED if localPath else self.GLYPH_NOT_MOUNTED

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -266,24 +266,13 @@ class NetworkMountsOverview(Screen):
 		self.session.openWithCallback(keyMenuCallback, ChoiceBox, title=_("Mount Context Menu"), list=choices)
 
 	def keyGreen(self):
-		def keyGreenCallback(picked=None):
-			if isinstance(picked, bool) and picked:  # Special case for close recursive.
+		def keyGreenCallback(saved=None):
+			if isinstance(saved, bool) and saved:
 				self.close(True)
 				return
-			mount = None
-			if picked:
-				mount = {
-					"server": picked.get("address") or ""
-				}
-				if picked.get("protocol"):
-					mount["protocol"] = picked["protocol"]
-				if picked.get("remotePath"):
-					mount["remotePath"] = picked["remotePath"]
-				if picked.get("shareName"):
-					mount["shareName"] = picked["shareName"]
-				if picked.get("smbVersion"):
-					mount["smbVersion"] = picked["smbVersion"]
-				self.session.openWithCallback(self.keySetupClosed, NetworkMountSetup, mount=mount, onSaved=self.mountSaved)
+			self.buildList()
+			if saved:
+				self.applyMountChange(saved)
 
 		self.session.openWithCallback(keyGreenCallback, NetworkShares)
 
@@ -507,6 +496,7 @@ class NetworkShares(Screen):
 		self.pendingProtocols = {}  # address -> {"nfs", "smb"} remaining
 		self.smbVersions = {}    # address -> negotiated dialect as a mount "vers=" value
 		self.smbGuestCallback = {}  # address -> one-shot callback run once the guest SMB probe below finishes
+		self.savedMount = None
 		self.configuredMounts = {}  # (server, remotePath) -> mount, for shares that are already configured
 		self.repository = NetworkMountRepository()
 		self.menuAddress = None
@@ -671,11 +661,9 @@ class NetworkShares(Screen):
 	def pickShare(self, share):
 		host = discoveryManager.hosts.get(share["address"]) or {}
 		hostname = host.get("hostname") or ""
-		address = hostname if (hostname and not config.network.browserUsingIP.value) else share["address"]
-
-		picked = {
-			"address": address,
-			"hostname": hostname,
+		server = hostname if (hostname and not config.network.browserUsingIP.value) else share["address"]
+		mount = {
+			"server": server,
 			"protocol": {
 				"smb": "cifs",
 				"nfs": "nfs"
@@ -684,8 +672,21 @@ class NetworkShares(Screen):
 			"shareName": share["name"],
 		}
 		if share["protocol"] == "smb":
-			picked["smbVersion"] = self.smbVersions.get(share["address"], self.SMB_FALLBACK_VERSION)
-		self.close(picked)
+			mount["smbVersion"] = self.smbVersions.get(share["address"], self.SMB_FALLBACK_VERSION)
+		self.session.openWithCallback(self.mountSetupClosed, NetworkMountSetup, mount=mount, onSaved=self.mountSaved)
+
+	def mountSaved(self, mount):
+		self.savedMount = mount
+
+	def mountSetupClosed(self, *args):
+		saved, self.savedMount = self.savedMount, None
+		if args and args[0] is True:
+			self.close(True)
+			return
+		if saved:
+			self.close(saved)
+		else:
+			self.buildList()
 
 	def startShareEnumeration(self, address):
 		if self.shareState.get(address) == "loading":

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -68,7 +68,7 @@ class NetworkMountsOverview(Screen):
 	MOUNT = "/bin/mount"
 	UMOUNT = "/bin/umount"
 
-	def __init__(self, session):
+	def __init__(self, session, openBrowser=False):
 		Screen.__init__(self, session, enableHelp=True)
 		self.setTitle(_("Network Mounts Overview"))
 		indexNames = {
@@ -103,6 +103,9 @@ class NetworkMountsOverview(Screen):
 		self.buildList()
 		self.onShown.append(self.selectionChanged)
 		self.savedMount = None
+		self.transient = openBrowser
+		if openBrowser:
+			self.onFirstExecBegin.append(self.keyGreen)
 		self.onClose.append(self.console.killAll)
 
 	def selectionChanged(self):
@@ -270,9 +273,14 @@ class NetworkMountsOverview(Screen):
 			if isinstance(saved, bool) and saved:
 				self.close(True)
 				return
-			self.buildList()
 			if saved:
+				self.transient = False
+				self.buildList()
 				self.applyMountChange(saved)
+			elif self.transient:
+				self.close()
+			else:
+				self.buildList()
 
 		self.session.openWithCallback(keyGreenCallback, NetworkShares)
 

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -673,6 +673,11 @@ class NetworkShares(Screen):
 		}
 		if share["protocol"] == "smb":
 			mount["smbVersion"] = self.smbVersions.get(share["address"], self.SMB_FALLBACK_VERSION)
+			credentials = self.repository.credentialsGet(self.hostnameFor(share["address"]))
+			username = credentials.get("username", "")
+			if username and username != NetworkCredentials.GUEST_USERNAME:
+				mount["username"] = username
+				mount["password"] = credentials.get("password", "")
 		self.session.openWithCallback(self.mountSetupClosed, NetworkMountSetup, mount=mount, onSaved=self.mountSaved)
 
 	def mountSaved(self, mount):

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -814,6 +814,9 @@ class NetworkShares(Screen):
 			for host in sorted(discoveryManager.hosts.values(), key=sortKeyByIP if config.network.browserSortByIP.value else sortKeyByName):
 				address = host["address"]
 				name = host["hostname"] or address
+				username = self.repository.credentialsGet(self.hostnameFor(address)).get("username", "")
+				if username:
+					name = f"{name} ({_('guest') if username == NetworkCredentials.GUEST_USERNAME else username})"
 				entries.append((self.TEMPLATE_HOST, self.GLYPH_HOST, 0, address, "", name, "", "", {"kind": "host", "address": address}))
 				if address not in self.expanded:
 					continue

--- a/lib/python/Screens/NetworkMounts.py
+++ b/lib/python/Screens/NetworkMounts.py
@@ -507,7 +507,7 @@ class NetworkShares(Screen):
 		self.pendingProtocols = {}  # address -> {"nfs", "smb"} remaining
 		self.smbVersions = {}    # address -> negotiated dialect as a mount "vers=" value
 		self.smbGuestCallback = {}  # address -> one-shot callback run once the guest SMB probe below finishes
-		self.configuredShares = {}  # (server, remotePath) -> local mount path, for already-configured shares
+		self.configuredMounts = {}  # (server, remotePath) -> mount, for shares that are already configured
 		self.repository = NetworkMountRepository()
 		self.menuAddress = None
 		self.menuHostname = None
@@ -520,7 +520,7 @@ class NetworkShares(Screen):
 	# Discovery only runs while this screen is open, so it stops as soon as
 	# the user leaves instead of scanning the network in the background.
 	def startDiscovery(self):
-		self.configuredShares = {(mount.get("server"), (mount.get("remotePath") or "").lstrip("/")): self.repository.mountPointFor(mount) for mount in self.repository.load()}
+		self.configuredMounts = {(mount.get("server"), (mount.get("remotePath") or "").lstrip("/")): mount for mount in self.repository.load()}
 		if self.onHostsChanged not in discoveryManager.onChanged:
 			discoveryManager.onChanged.append(self.onHostsChanged)
 		discoveryManager.start(runMs=None)
@@ -663,6 +663,10 @@ class NetworkShares(Screen):
 		if any(share["protocol"] == "smb" for share in self.shares.get(address, [])):
 			return
 		self.session.openWithCallback(lambda *args: self.startShareEnumeration(address), NetworkCredentials, hostname, self.repository)
+
+	def configuredMount(self, address, hostname, remotePath):
+		path = remotePath.lstrip("/")
+		return self.configuredMounts.get((address, path)) or (self.configuredMounts.get((hostname, path)) if hostname else None)
 
 	def pickShare(self, share):
 		host = discoveryManager.hosts.get(share["address"]) or {}
@@ -824,7 +828,8 @@ class NetworkShares(Screen):
 
 				for share in self.shares.get(address, []):
 					typeLabel = protocolLabels.get(share["protocol"], share["protocol"])
-					localPath = self.configuredShares.get((address, share["path"].lstrip("/")))
+					existing = self.configuredMount(address, host["hostname"], share["path"])
+					localPath = self.repository.mountPointFor(existing) if existing else None
 					glyph = self.GLYPH_MOUNTED if localPath else self.GLYPH_NOT_MOUNTED
 					glyphColor = self.COLOR_MOUNTED if localPath else self.COLOR_NOT_MOUNTED
 					entries.append((self.TEMPLATE_SHARE, glyph, glyphColor, "", typeLabel, share["name"], localPath or "", share.get("description") or "", dict(share, kind="share")))

--- a/lib/python/Screens/QuickMenu.py
+++ b/lib/python/Screens/QuickMenu.py
@@ -330,7 +330,7 @@ class QuickMenu(Screen, ProtectedScreen):
 	def subMenuMount(self):  # Mount Settings Menu.
 		self.subList = []
 		self.subList.append(self.quickSubMenuEntryComponent(_("Network Mounts Overview"), _("Manage network mounts"), _("Setup your network mounts"), screen="NetworkMounts", screenName="NetworkMountsOverview"))
-		self.subList.append(self.quickSubMenuEntryComponent(_("Network Browser"), _("Search for network shares"), _("Search for network shares"), screen="NetworkMounts", screenName="NetworkShares"))
+		self.subList.append(self.quickSubMenuEntryComponent(_("Network Browser"), _("Search for network shares"), _("Search for network shares"), callback=self.openNetworkShares))
 		self.setSubList()
 
 	def subMenuNetwork(self):  # Network Menu.
@@ -454,6 +454,10 @@ class QuickMenu(Screen, ProtectedScreen):
 			self.openScreen(screen, screenName=screenName)
 		elif callback and callable(callback):
 			callback()
+
+	def openNetworkShares(self):
+		from Screens.NetworkMounts import NetworkMountsOverview
+		self.session.open(NetworkMountsOverview, openBrowser=True)
 
 	def openSetup(self, key):
 		self.session.open(Setup, key)


### PR DESCRIPTION
A pass over the network share browser and the mount handling behind it. The
individual commits carry the details, in short:

**Fixes**

* `applyMountChange()` never ran, so neither `mount -a` nor the autofs restart
  was triggered after adding or editing a mount. The saved mount is now handed
  over through a callback while the setup screen is still alive.
* Picking a share always built a fresh mount without an id, so editing an
  already configured share wrote it into fstab / auto.network a second time
  instead of replacing it.
* The discovery callback was registered on every `onShow`, rebuilding the list
  once per registration.
* Mounts stored with a host name (as written while "Using DNS" is active) were
  never recognised as configured; they are now looked up by name and address.
* The `QuickMenu` entry opened the browser directly with no callback, so a
  picked share went nowhere and the entry could browse but never mount.
* Avahi hosts were only ever added, never removed, so hosts that went offline
  or changed address stayed in the list until enigma2 restarted.

**Behaviour**

* One row per host and address family. A host announcing a link local, a SLAAC
  and a DHCPv6 address no longer appears four times.
* The mount setup opens on top of the browser and prefills the credentials that
  were just used to list the shares. Cancelling returns to the share list with
  its state intact instead of dropping into the overview.
* The negotiated SMB dialect moved from the host name into the protocol column
  of the share row, where it describes the share it belongs to and matches the
  `vers=` the mount ends up with. The type column grows by 20 pixels for it.
* The stored user name is shown behind the host name, `guest` for anonymous
  access, nothing when no credentials are stored. The password is not shown.
