### PR TITLE
Detect WPA3 and enterprise networks, fix the signal readout

### DIFF
--- a/lib/python/Components/NetworkManager.py
+++ b/lib/python/Components/NetworkManager.py
@@ -52,6 +52,10 @@ class Encryption(StrEnum):
 	WPA2 = "wpa2"
 	WPA_WPA2 = "wpa+wpa2"  # Legacy combined mode stored as wpa2 in wpa_supplicant.
 	WPA3 = "wpa3"
+	WPA2_WPA3 = "wpa2+wpa3"  # WPA3 transition mode, the access point offers PSK and SAE side by side.
+	WPA2_ENTERPRISE = "wpa2-eap"
+	WPA3_ENTERPRISE = "wpa3-eap"
+	WPA2_WPA3_ENTERPRISE = "wpa2+wpa3-eap"  # Same transition idea, 802.1X alongside 802.1X-SHA256.
 
 
 # Deferred via lambda so translation happens at display time, not import time.
@@ -61,7 +65,11 @@ encryptionLabels = {
 	Encryption.WPA: lambda: "WPA",
 	Encryption.WPA2: lambda: "WPA2",
 	Encryption.WPA_WPA2: lambda: "WPA/WPA2",
-	Encryption.WPA3: lambda: "WPA3"
+	Encryption.WPA3: lambda: "WPA3",
+	Encryption.WPA2_WPA3: lambda: "WPA2/WPA3",
+	Encryption.WPA2_ENTERPRISE: lambda: "WPA2 Enterprise",
+	Encryption.WPA3_ENTERPRISE: lambda: "WPA3 Enterprise",
+	Encryption.WPA2_WPA3_ENTERPRISE: lambda: "WPA2/WPA3 Enterprise"
 }
 
 # Driver-API identifiers.
@@ -1221,7 +1229,16 @@ def wpaDictToWiFiConfig(fields: dict[str, str], blockId: int) -> WiFiConfig:
 	if keyMgmt == "NONE":
 		enc = Encryption.NONE if not fields.get("wep_key0") else Encryption.WEP
 	elif "SAE" in keyMgmt:
-		enc = Encryption.WPA3
+		enc = Encryption.WPA2_WPA3 if "WPA-PSK" in keyMgmt else Encryption.WPA3
+	elif "EAP" in keyMgmt:
+		sha256 = "EAP-SHA256" in keyMgmt
+		plain = "EAP" in keyMgmt.replace("EAP-SHA256", "")
+		if sha256 and plain:
+			enc = Encryption.WPA2_WPA3_ENTERPRISE
+		elif sha256:
+			enc = Encryption.WPA3_ENTERPRISE
+		else:
+			enc = Encryption.WPA2_ENTERPRISE
 	elif "WPA" in keyMgmt:
 		enc = Encryption.WPA2 if ("CCMP" in pairwise or "WPA2" in proto or "RSN" in proto) else Encryption.WPA
 	else:
@@ -1268,7 +1285,24 @@ def wifiConfigToWpaBlock(wifi: WiFiConfig) -> list[str]:
 		case Encryption.WPA3:
 			lines.append("\tkey_mgmt=SAE")
 			lines.append("\tproto=RSN")
+			lines.append("\tieee80211w=2")  # WPA3 requires protected management frames.
 			lines.append(f'\tpsk="{wifi.key}"')
+		case Encryption.WPA2_WPA3:
+			lines.append("\tkey_mgmt=SAE WPA-PSK")  # Prefer SAE, fall back to PSK where the driver cannot do it.
+			lines.append("\tproto=RSN")
+			lines.append("\tieee80211w=1")
+			lines.append(f'\tpsk="{wifi.key}"')
+		case Encryption.WPA2_ENTERPRISE:  # 802.1X needs credentials this profile does not carry yet.
+			lines.append("\tkey_mgmt=WPA-EAP")
+			lines.append("\tproto=RSN")
+		case Encryption.WPA3_ENTERPRISE:
+			lines.append("\tkey_mgmt=WPA-EAP-SHA256")
+			lines.append("\tproto=RSN")
+			lines.append("\tieee80211w=2")
+		case Encryption.WPA2_WPA3_ENTERPRISE:
+			lines.append("\tkey_mgmt=WPA-EAP WPA-EAP-SHA256")
+			lines.append("\tproto=RSN")
+			lines.append("\tieee80211w=1")
 	if wifi.disabled:
 		lines.append("\tdisabled=1")
 	lines.append("}")

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -639,7 +639,11 @@ class NetworkOverview(Screen):
 			Encryption.WEP: "WEP",
 			Encryption.WPA: "WPA",
 			Encryption.WPA2: "WPA2",
-			Encryption.WPA3: "WPA3"
+			Encryption.WPA3: "WPA3",
+			Encryption.WPA2_WPA3: "WPA2/WPA3",
+			Encryption.WPA2_ENTERPRISE: "WPA2 Enterprise",
+			Encryption.WPA3_ENTERPRISE: "WPA3 Enterprise",
+			Encryption.WPA2_WPA3_ENTERPRISE: "WPA2/WPA3 Enterprise"
 		}
 		if conn.isWiFi and conn.wifi and conn.wifi.ssid:
 			result = f"{conn.adapter}  │  {conn.wifi.ssid}  [{encShort.get(conn.wifi.encryption, conn.wifi.encryption)}]"
@@ -893,6 +897,8 @@ class NetworkWiFi(Setup):
 		(Encryption.WEP, "WEP"),
 		(Encryption.WPA, "WPA"),
 		(Encryption.WPA2, "WPA2"),
+		(Encryption.WPA2_WPA3, "WPA2/WPA3"),
+		(Encryption.WPA3, "WPA3"),
 	]
 
 	def __init__(self, session, conn: Connection, adapter: Adapter):
@@ -934,7 +940,10 @@ class NetworkWiFi(Setup):
 		wifi = conn.wifi
 		self.cfgSsid = NoSave(ConfigText(default=wifi.ssid, fixed_size=False))
 		self.cfgHidden = NoSave(ConfigYesNo(default=wifi.hidden))
-		self.cfgEncryption = NoSave(ConfigSelection(choices=self.ENCRYPTION_CHOICES, default=wifi.encryption))
+		encryptionChoices = list(self.ENCRYPTION_CHOICES)  # A hand written config may carry a value this screen does not offer.
+		if wifi.encryption not in [x[0] for x in encryptionChoices]:
+			encryptionChoices.append((wifi.encryption, encryptionLabels.get(wifi.encryption, lambda: str(wifi.encryption))()))
+		self.cfgEncryption = NoSave(ConfigSelection(choices=encryptionChoices, default=wifi.encryption))
 		self.cfgKey = NoSave(ConfigPassword(default=wifi.key, fixed_size=False))
 
 	def keySave(self):
@@ -996,7 +1005,7 @@ class ScanResult:
 	bssid: str = ""
 	frequency: str = ""
 	channel: int = 0
-	signalDbm: int = -100
+	signalDbm: int | None = None  # None when the driver only reports a relative level.
 	signalPct: int = 0
 	encryption: Encryption = Encryption.NONE
 	encDetails: str = ""
@@ -1016,6 +1025,14 @@ class ScanResult:
 		return result
 
 	@property
+	def signalDbmText(self) -> str:
+		return f"{self.signalDbm} dBm" if self.signalDbm is not None else "—"  # Em dash, matching the adapter overview.
+
+	@property
+	def signalText(self) -> str:
+		return f"{self.signalPct}%  ({self.signalDbmText})" if self.signalDbm is not None else f"{self.signalPct}%"
+
+	@property
 	def encLabel(self) -> str:
 		return {
 			Encryption.NONE: _("None"),
@@ -1023,6 +1040,10 @@ class ScanResult:
 			Encryption.WPA: "WPA",
 			Encryption.WPA2: "WPA2",
 			Encryption.WPA3: "WPA3",
+			Encryption.WPA2_WPA3: "WPA2/WPA3",
+			Encryption.WPA2_ENTERPRISE: "WPA2 Enterprise",
+			Encryption.WPA3_ENTERPRISE: "WPA3 Enterprise",
+			Encryption.WPA2_WPA3_ENTERPRISE: "WPA2/WPA3 Enterprise",
 		}.get(self.encryption, self.encryption.upper())
 
 
@@ -1030,7 +1051,7 @@ class NetworkWiFiScan(Screen):
 	"""Runs iwlist scan and shows results sorted by signal strength."""
 
 	skin = """
-	<screen name="NetworkWiFiScan" title="Wi-Fi Scan" position="center,center" size="940,455" resolution="1280,720">
+	<screen name="NetworkWiFiScan" title="Wi-Fi Scan" position="center,center" size="1060,455" resolution="1280,720">
 		<widget source="list" render="Listbox" position="10,10" size="e-20,e-105">
 			<template name="Default" fonts="Regular;22,Regular;20,enigma2icons;20" itemHeight="35">
 				<mode name="default">
@@ -1039,7 +1060,7 @@ class NetworkWiFiScan(Screen):
 						<text index="Glyph" position="left" size="30,35" font="2" horizontalAlignment="center" padding="5,0" verticalAlignment="center" />
 						<text index="Percentage" position="left" size="60,35" font="1" horizontalAlignment="right" padding="5,0" verticalAlignment="center" />
 						<text index="dBm" position="left" size="90,35" font="1" horizontalAlignment="right" padding="5,0" verticalAlignment="center" />
-						<text index="Encryption" position="left" size="100,35" font="1" horizontalAlignment="center" padding="5,0" verticalAlignment="center" />
+						<text index="Encryption" position="left" size="220,35" font="1" horizontalAlignment="center" padding="5,0" verticalAlignment="center" />
 						<text index="Channel" position="left" size="80,35" font="1" horizontalAlignment="center" padding="5,0" verticalAlignment="center" />
 						<text index="Frequency" position="right" size="110,35" font="1" horizontalAlignment="right" padding="5,0" verticalAlignment="center" />
 					</panel>
@@ -1102,7 +1123,11 @@ class NetworkWiFiScan(Screen):
 	def keySelect(self):
 		current = self["list"].getCurrent()
 		if current:
-			self.close(current[-1])
+			accessPoint = current[-1]
+			if accessPoint.encryption in self.ENTERPRISE_ENCRYPTIONS:
+				self.session.open(MessageBox, _("'%s' uses enterprise authentication (802.1X). Networks like this cannot be set up here, they have to be configured manually in wpa_supplicant.conf.") % accessPoint.ssid, type=MessageBox.TYPE_INFO)
+				return
+			self.close(accessPoint)
 
 	def keyClose(self):
 		if self.console:
@@ -1129,9 +1154,9 @@ class NetworkWiFiScan(Screen):
 						accessPoint.ssid,                                            # SSID.
 						accessPoint.bssid,                                           # BSSID.
 						self.STRENGTH_GLYPHS[min(accessPoint.signalBars, 4)],        # Glyph.
-						f"{accessPoint.signalPct}%  ({accessPoint.signalDbm} dBm)",  # Strength.
+						accessPoint.signalText,                                      # Strength.
 						f"{accessPoint.signalPct}%",                                 # Percent.
-						f"{accessPoint.signalDbm} dBm",                              # dBM.
+						accessPoint.signalDbmText,                                   # dBM.
 						accessPoint.encLabel,                                        # Encryption.
 						f"Ch-{accessPoint.channel}  ({accessPoint.frequency})",      # ChannelFrequency.
 						f"Ch-{accessPoint.channel}",                                 # Channel.
@@ -1175,13 +1200,63 @@ class NetworkWiFiScan(Screen):
 			else:
 				self.console.ePopen(("/sbin/ifconfig", "/sbin/ifconfig", self.adapter, "up"), callback=ifUpCallback)
 
+	# AKM suite types under the 00-0F-AC organisation identifier (IEEE 802.11).
+	AKM_PSK_TYPES = {2, 4, 6, 19, 20}  # PSK, FT-PSK, PSK-SHA256, FT-PSK-SHA384, PSK-SHA384.
+	AKM_SAE_TYPES = {8, 9, 24, 25}  # SAE, FT-SAE, SAE-EXT-KEY, FT-SAE-EXT-KEY - all of them are WPA3-Personal.
+	AKM_EAP_TYPES = {1, 3}  # 802.1X, FT-802.1X - WPA2-Enterprise.
+	AKM_EAP_SHA256_TYPES = {5, 11, 12, 13}  # 802.1X-SHA256, Suite-B, Suite-B-192, FT-802.1X-SHA384 - WPA3-Enterprise.
+	# Verdicts that carry more detail than a bare RSN element, never overwritten by the generic branches.
+	ENTERPRISE_ENCRYPTIONS = (Encryption.WPA2_ENTERPRISE, Encryption.WPA3_ENTERPRISE, Encryption.WPA2_WPA3_ENTERPRISE)
+	RSN_DETERMINED = (Encryption.WPA3, Encryption.WPA2_WPA3, Encryption.WPA2_ENTERPRISE, Encryption.WPA3_ENTERPRISE, Encryption.WPA2_WPA3_ENTERPRISE)
+
+	@classmethod
+	def enterpriseFrom(cls, suites: set[int]) -> Encryption:
+		"""WPA2- or WPA3-Enterprise, or the transition mode offering both."""
+		sha256 = bool(suites & cls.AKM_EAP_SHA256_TYPES)
+		plain = bool(suites & cls.AKM_EAP_TYPES)
+		if sha256 and plain:
+			return Encryption.WPA2_WPA3_ENTERPRISE
+		return Encryption.WPA3_ENTERPRISE if sha256 else Encryption.WPA2_ENTERPRISE
+
+	@classmethod
+	def akmSuitesFromRsnIe(cls, hexIe: str) -> set[int]:
+		"""Suite types of the AKM list in an RSN information element, empty when it cannot be read.
+
+		iwlist renders SAE as "unknown (8)" because wireless-tools predates WPA3, so the raw
+		element it prints alongside is the only dependable source.
+		"""
+		try:
+			data = bytes.fromhex(hexIe)
+		except ValueError:
+			return set()
+		if data[:1] == b"\x30":  # Strip element id and length when the whole element is reported.
+			data = data[2:]
+		pos = 2 + 4  # Version and group cipher suite.
+		if len(data) < pos + 2:
+			return set()
+		pos += 2 + 4 * int.from_bytes(data[pos:pos + 2], "little")  # Skip the pairwise cipher list.
+		if len(data) < pos + 2:
+			return set()
+		count = int.from_bytes(data[pos:pos + 2], "little")
+		pos += 2
+		suites = set()
+		for index in range(count):
+			suite = data[pos + 4 * index:pos + 4 * (index + 1)]
+			if len(suite) == 4 and suite[:3] == b"\x00\x0f\xac":
+				suites.add(suite[3])
+		return suites
+
 	def parseIwlist(self, raw: str) -> list[ScanResult]:
 		results: list[ScanResult] = []
 		current: ScanResult | None = None
 		reCell = compile(r"Cell \d+ - Address:\s*([0-9A-Fa-f:]{17})")
 		reSsid = compile(r"ESSID:\"(.*?)\"")
 		reFreq = compile(r"Frequency:([\d.]+ \w+Hz).*?Channel:?\s*(\d+)?")
-		reQuality = compile(r"Quality=(\d+)/(\d+)\s+Signal level=(-?\d+) dBm")
+		reQuality = compile(r"Quality[=:]\s*(\d+)(?:/(\d+))?")
+		reSignalDbm = compile(r"Signal level[=:]\s*(-\d+)\s*dBm")
+		reSignalRel = compile(r"Signal level[=:]\s*(\d+)/(\d+)")
+		reRsnIe = compile(r"rsn_ie=([0-9A-Fa-f]+)")
+		reAuthSuites = compile(r"Authentication Suites \(\d+\)\s*:\s*(.+)")
 		reEncOn = compile(r"Encryption key:on")
 		reEncOff = compile(r"Encryption key:off")
 		reIeWpa1 = compile(r"IE:.*WPA Version 1", IGNORECASE)
@@ -1205,12 +1280,42 @@ class NetworkWiFiScan(Screen):
 					current.channel = int(match.group(2))
 			match = reQuality.search(line)
 			if match:
-				qVal, qMax = int(match.group(1)), int(match.group(2))
-				current.signalPct = int(qVal * 100 / qMax) if qMax else 0
-				current.signalDbm = int(match.group(3))
+				qVal = int(match.group(1))
+				qMax = int(match.group(2)) if match.group(2) else 100
+				current.signalPct = max(0, min(100, int(qVal * 100 / qMax))) if qMax else 0
+			match = reSignalDbm.search(line)
+			if match:
+				current.signalDbm = int(match.group(1))
+			else:
+				match = reSignalRel.search(line)
+				if match:  # "Signal level=23/100" carries the real level, the quality above it is often a constant.
+					level, maximum = int(match.group(1)), int(match.group(2))
+					if maximum == 100:  # WEXT drivers without dBm scale the RSSI so that 0 means -100 dBm.
+						current.signalDbm = level - 100
+						current.signalPct = max(0, min(100, 2 * (current.signalDbm + 100)))
+					else:
+						current.signalPct = max(0, min(100, int(level * 100 / maximum))) if maximum else 0
+			match = reRsnIe.search(line)
+			if match:
+				suites = self.akmSuitesFromRsnIe(match.group(1))
+				if suites:
+					if suites & self.AKM_SAE_TYPES:
+						current.encryption = Encryption.WPA2_WPA3 if suites & self.AKM_PSK_TYPES else Encryption.WPA3
+					elif suites & (self.AKM_EAP_TYPES | self.AKM_EAP_SHA256_TYPES):
+						current.encryption = self.enterpriseFrom(suites)
+					else:
+						current.encryption = Encryption.WPA2
+					current.encDetails = line
+			match = reAuthSuites.search(line)
+			if match and current.encryption not in self.RSN_DETERMINED:
+				suiteText = match.group(1).upper()  # Fallback for drivers that print no raw element.
+				if "SAE" in suiteText or any(f"UNKNOWN ({x})" in suiteText for x in self.AKM_SAE_TYPES):
+					current.encryption = Encryption.WPA2_WPA3 if "PSK" in suiteText else Encryption.WPA3
+					current.encDetails = line
 			if reIeWpa2.search(line):
-				current.encryption = Encryption.WPA2
-				current.encDetails = line
+				if current.encryption not in self.RSN_DETERMINED:  # Never downgrade a WPA3 verdict.
+					current.encryption = Encryption.WPA2
+					current.encDetails = line
 			elif reIeWpa1.search(line):
 				if current.encryption == Encryption.NONE:
 					current.encryption = Encryption.WPA
@@ -1247,7 +1352,18 @@ class NetworkWiFiScan(Screen):
 				signalDbm = int(signalStr)
 			except ValueError:
 				continue
-			if "WPA2" in flags or "RSN" in flags:
+			if "SAE" in flags:  # "[WPA2-PSK+SAE-CCMP]" is transition mode, "[WPA2-SAE-CCMP]" is WPA3 only.
+				encryption = Encryption.WPA2_WPA3 if "PSK" in flags else Encryption.WPA3
+			elif "EAP" in flags:  # "[WPA2-EAP+EAP-SHA256-CCMP]" is the enterprise transition mode.
+				sha256 = "EAP-SHA256" in flags
+				plain = "EAP" in flags.replace("EAP-SHA256", "")
+				if sha256 and plain:
+					encryption = Encryption.WPA2_WPA3_ENTERPRISE
+				elif sha256:
+					encryption = Encryption.WPA3_ENTERPRISE
+				else:
+					encryption = Encryption.WPA2_ENTERPRISE
+			elif "WPA2" in flags or "RSN" in flags:
 				encryption = Encryption.WPA2
 			elif "WPA" in flags:
 				encryption = Encryption.WPA


### PR DESCRIPTION

### What is wrong today

The Wi-Fi scan maps every RSN network to WPA2. An access point running WPA3 is
therefore shown as WPA2 **and connected to as WPA2**, because the detected
encryption is what `scanResultToConnection()` writes into `key_mgmt`. Almost every
router that offers WPA3 does so in transition mode, side by side with PSK, so the
downgrade is silent — the connection works, it is simply not WPA3.

Signal strength is read only from `Signal level=-63 dBm`. Drivers that cannot
report dBm write `Signal level=23/100` instead, which never matched, so every
network showed `0 %` and `-100 dBm` with no signal bars at all.

### What this changes

**Detection now comes from the AKM suites**, not from a text match. Both scan
paths were adapted: the raw `rsn_ie` element that `iwlist` prints next to its own
output, and the flags field of `wpa_cli scan_results`.

The raw element is the only dependable source on the `iwlist` path — wireless-tools
predates WPA3 and renders SAE as `unknown (8)`.

Recognised suites under `00-0F-AC` (IEEE 802.11-2020, table 9-151):

| Type | Suite | Shown as |
|---|---|---|
| 2, 4, 6, 19, 20 | PSK and its variants | WPA2 |
| 8, 9, 24, 25 | SAE, FT-SAE, SAE-EXT-KEY, FT-SAE-EXT-KEY | WPA3 |
| 1, 3 | 802.1X, FT-802.1X | WPA2 Enterprise |
| 5, 11, 12, 13 | 802.1X-SHA256, Suite-B, Suite-B-192, FT-802.1X-SHA384 | WPA3 Enterprise |

An access point offering PSK and SAE together is transition mode and is written as
`key_mgmt=SAE WPA-PSK` with `ieee80211w=1`. SAE is used where the driver supports
it and PSK everywhere else, so boxes whose driver or kernel cannot do SAE keep the
connection they have today.

Plain WPA3 gains `ieee80211w=2`. This was missing before, and SAE without protected
management frames is refused by every WPA3 access point — the existing WPA3 support
in the config writer could not have worked.

**Enterprise networks are shown but not offered for setup.** This screen has no
fields for a user name, an EAP method or a certificate. Selecting such a network
explains that instead of opening a dialog that cannot be filled in. A configuration
that already carries such a value stays safe to open: the encryption choice list
gains the current value when it is not among the offered ones, which
`ConfigSelection` would otherwise fail on with a `KeyError`.

**Signal strength** now understands both forms. `Signal level=x/100` is the RSSI on
a scale whose zero is `-100 dBm` and is converted accordingly; a relative scale with
any other maximum stays a percentage and reports no dBm at all rather than an
invented one.

<img width="1280" height="720" alt="shot1" src="https://github.com/user-attachments/assets/08861183-332f-4a7b-b64d-63277a6b50d0" />

<img width="1280" height="720" alt="shot2" src="https://github.com/user-attachments/assets/9bec4893-8a5d-4bed-83dc-28d374bdde49" />

### Companion change

The label column in MetrixHD is 110 pixels wide and cuts the longer values off.
See openatv/MetrixHD#689. The two are independent —
neither breaks without the other, they only look right together.
