### PR TITLE
[DAB]

### DIFF
--- a/data/dab.xml
+++ b/data/dab.xml
@@ -1,327 +1,158 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  DAB-over-DVB feed and terrestrial RTL-SDR scan definitions shipped with
-  Enigma2.
 
-  The scanner reads the live DAB ensemble and service information from FIC;
-  therefore this file contains only stable satellite, transponder and transport
-  parameters. The packaged file is installed as /usr/share/enigma2/dab.xml.
-  An optional /etc/enigma2/dab.xml replaces it for local testing or overrides.
+DAB-over-DVB feed and terrestrial RTL-SDR scan definitions shipped with
+Enigma2.
 
-  The native service supports MPE/UDP/EDI (fedi2eti), direct ETI-NA(V.11)
-  framing (tsniv2ni), and E1 ETI-NA with either 12 or 0 payload padding bytes
-  (ts2na12 and ts2na). All paths are normalised to ETI-NI before decoding.
+The scanner reads the live DAB ensemble and service information from FIC;
+therefore this file contains only stable satellite, transponder and transport
+parameters. The packaged file is installed as /usr/share/enigma2/dab.xml.
+An optional /etc/enigma2/dab.xml replaces it for local testing or overrides.
 
-  Source checked 2026-08-29: https://de.kingofsat.tv/dab
+The native service supports MPE/UDP/EDI (fedi2eti), direct ETI-NA(V.11)
+framing (tsniv2ni), and E1 ETI-NA with either 12 or 0 payload padding bytes
+(ts2na12 and ts2na). All paths are normalized to ETI-NI before decoding.
+
+Source checked 2026-08-29: https://de.kingofsat.tv/dab
+
 -->
 <dabFeeds version="2" updated="2026-08-29">
-  <!--
-    Terrestrial Band III blocks are intentionally separate from the satellite
-    feed hierarchy below.  The "all" region selects every channel.  Other
-    regions select channels carrying their id in the regions attribute.
+	<!--
 
-    Europe uses the complete commonly supported Band III table.  Australia's
-    current regional planning uses 8A-8D and 9A-9D (ACMA station book, 2026).
-  -->
-  <terrestrial>
-    <region id="all" name="Worldwide Band III" />
-    <region id="europe" name="Europe (Band III)" />
-    <region id="australia" name="Australia" />
-    <channel id="5A" frequency="174928" regions="europe" />
-    <channel id="5B" frequency="176640" regions="europe" />
-    <channel id="5C" frequency="178352" regions="europe" />
-    <channel id="5D" frequency="180064" regions="europe" />
-    <channel id="6A" frequency="181936" regions="europe" />
-    <channel id="6B" frequency="183648" regions="europe" />
-    <channel id="6C" frequency="185360" regions="europe" />
-    <channel id="6D" frequency="187072" regions="europe" />
-    <channel id="7A" frequency="188928" regions="europe" />
-    <channel id="7B" frequency="190640" regions="europe" />
-    <channel id="7C" frequency="192352" regions="europe" />
-    <channel id="7D" frequency="194064" regions="europe" />
-    <channel id="8A" frequency="195936" regions="europe australia" />
-    <channel id="8B" frequency="197648" regions="europe australia" />
-    <channel id="8C" frequency="199360" regions="europe australia" />
-    <channel id="8D" frequency="201072" regions="europe australia" />
-    <channel id="9A" frequency="202928" regions="europe australia" />
-    <channel id="9B" frequency="204640" regions="europe australia" />
-    <channel id="9C" frequency="206352" regions="europe australia" />
-    <channel id="9D" frequency="208064" regions="europe australia" />
-    <channel id="10A" frequency="209936" regions="europe" />
-    <channel id="10B" frequency="211648" regions="europe" />
-    <channel id="10C" frequency="213360" regions="europe" />
-    <channel id="10D" frequency="215072" regions="europe" />
-    <channel id="11A" frequency="216928" regions="europe" />
-    <channel id="11B" frequency="218640" regions="europe" />
-    <channel id="11C" frequency="220352" regions="europe" />
-    <channel id="11D" frequency="222064" regions="europe" />
-    <channel id="12A" frequency="223936" regions="europe" />
-    <channel id="12B" frequency="225648" regions="europe" />
-    <channel id="12C" frequency="227360" regions="europe" />
-    <channel id="12D" frequency="229072" regions="europe" />
-    <channel id="13A" frequency="230784" regions="europe" />
-    <channel id="13B" frequency="232496" regions="europe" />
-    <channel id="13C" frequency="234208" regions="europe" />
-    <channel id="13D" frequency="235776" regions="europe" />
-    <channel id="13E" frequency="237488" regions="europe" />
-    <channel id="13F" frequency="239200" regions="europe" />
-  </terrestrial>
+	Terrestrial Band III blocks are intentionally separate from the satellite
+	feed hierarchy below. The "all" region selects every channel. Other
+	regions select channels carrying their id in the regions attribute.
 
-  <satellite name="Eutelsat 7C 7.0E" orbitalPosition="70" namespace="460000">
-    <transponder frequency="11513800" polarization="V" system="DVB-S2"
-                 modulation="QPSK" symbolRate="17017000" fec="2/3"
-                 onid="0000" tsid="0000" parentServiceType="0001"
-                 parentSid="0001">
-      <feed id="allgaeu_donau_iller_7e_11513" name="AllgäuDonauIller"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.128.57.20" multicastPort="50020"
-            ensembleId="1133" />
-      <feed id="oberbayern_sued_7e" name="Oberbayern Süd"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.128.58.20" multicastPort="50020"
-            ensembleId="1196" />
-      <feed id="swr_bw_s_7e" name="SWR BW S"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.132.1.50" multicastPort="5004"
-            ensembleId="10EB" />
-      <feed id="swr_bw_n_7e" name="SWR BW N"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.132.1.51" multicastPort="5004"
-            ensembleId="10EA" />
-      <feed id="swr_rlp_7e" name="SWR RLP"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.132.1.52" multicastPort="5004"
-            ensembleId="10D9" />
-      <feed id="oberfranken_7e_11513" name="Oberfranken"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.11" multicastPort="60011"
-            ensembleId="1131" />
-      <feed id="unterfranken_7e_11513" name="Unterfranken"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.13" multicastPort="60013"
-            ensembleId="1134" />
-      <feed id="oberpfalz_7e_11513" name="Oberpfalz"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.14" multicastPort="60014"
-            ensembleId="0000" />
-      <feed id="oberbayern_schwaben_7e" name="Oberbayern/Schwaben"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.15" multicastPort="60015"
-            ensembleId="1162" />
-      <feed id="niederbayern_7e_11513" name="Niederbayern"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.16" multicastPort="60016"
-            ensembleId="0000" />
-      <feed id="bayern_7e" name="Bayern"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.17" multicastPort="60017"
-            ensembleId="10A5" />
-      <feed id="hr_radio_7e_11513" name="hr Radio"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.192.254.200" multicastPort="10000"
-            ensembleId="107A" />
-      <feed id="ndr_sh_ki_7e" name="NDR SH KI"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.229.96.33" multicastPort="50000"
-            ensembleId="10F2" />
-      <feed id="ndr_nds_bs_7e_11513" name="NDR Niedersachsen Braunschweig"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.229.96.42" multicastPort="50000"
-            ensembleId="0000" />
-      <feed id="ndr_mv_sn_7e_11513" name="NDR MV SN"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.229.96.43" multicastPort="50000"
-            ensembleId="1115" />
-    </transponder>
-  </satellite>
+	Europe uses the complete commonly supported Band III table. Australia's
+	current regional planning uses 8A-8D and 9A-9D (ACMA station book, 2026).
 
-  <satellite name="Eutelsat 7B 7.0E" orbitalPosition="70" namespace="460000">
-    <transponder frequency="12567800" polarization="V" system="DVB-S2"
-                 modulation="QPSK" symbolRate="17017000" fec="2/3"
-                 onid="0001" tsid="0016" parentServiceType="0001"
-                 parentSid="0000">
-      <feed id="allgaeu_donau_iller_7e_12567" name="AllgäuDonauIller"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.128.57.20" multicastPort="50020"
-            ensembleId="1133" />
-      <feed id="oberbayern_sued_7e_12567" name="Oberbayern Süd"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.128.58.20" multicastPort="50020"
-            ensembleId="1196" />
-      <feed id="swr_bw_s_7e_12567" name="SWR BW S"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.132.1.50" multicastPort="5004"
-            ensembleId="10EB" />
-      <feed id="swr_bw_n_7e_12567" name="SWR BW N"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.132.1.51" multicastPort="5004"
-            ensembleId="10EA" />
-      <feed id="swr_rlp_7e_12567" name="SWR RLP"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.132.1.52" multicastPort="5004"
-            ensembleId="10D9" />
-      <feed id="oberfranken_7e_12567" name="Oberfranken"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.11" multicastPort="60011"
-            ensembleId="1131" />
-      <feed id="unterfranken_7e" name="Unterfranken"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.13" multicastPort="60013"
-            ensembleId="1134" />
-      <feed id="oberpfalz_7e_12567" name="Oberpfalz"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.14" multicastPort="60014"
-            ensembleId="0000" />
-      <feed id="oberbayern_schwaben_7e_12567" name="Oberbayern/Schwaben"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.15" multicastPort="60015"
-            ensembleId="1162" />
-      <feed id="niederbayern_7e_12567" name="Niederbayern"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.16" multicastPort="60016"
-            ensembleId="0000" />
-      <feed id="bayern_7e_12567" name="Bayern"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.16.242.17" multicastPort="60017"
-            ensembleId="10A5" />
-      <feed id="hr_radio_7e" name="hr Radio"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.192.254.200" multicastPort="10000"
-            ensembleId="107A" />
-      <feed id="ndr_sh_ki_7e_12567" name="NDR SH KI"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.229.96.33" multicastPort="50000"
-            ensembleId="10F2" />
-      <feed id="ndr_nds_bs_7e_12567" name="NDR Niedersachsen Braunschweig"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.229.96.42" multicastPort="50000"
-            ensembleId="0000" />
-      <feed id="ndr_mv_sn_7e" name="NDR MV SN"
-            pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.229.96.43" multicastPort="50000"
-            ensembleId="1115" />
-    </transponder>
-  </satellite>
-
-  <satellite name="Eutelsat 9B 9.0E" orbitalPosition="90" namespace="5A0000">
-    <transponder frequency="11727500" polarization="V" system="DVB-S2"
-                 modulation="8PSK" symbolRate="30000000" fec="3/4"
-                 onid="009E" tsid="C35A" parentServiceType="0001">
-      <feed id="dab_italia_9e" name="DAB Italia"
-            parentSid="035C" pid="1B77" decoder="tsniv2ni"
-            transport="MPE/NI" ensembleId="5009" />
-      <feed id="eurodab_italia_9e" name="EuroDab Italia"
-            parentSid="035D" pid="1BDB" decoder="tsniv2ni"
-            transport="MPE/NI" ensembleId="5003" />
-    </transponder>
-    <transponder frequency="12091900" polarization="H" system="DVB-S2"
-                 modulation="8PSK" symbolRate="27500000" fec="3/4"
-                 onid="009E" tsid="1AF4" parentServiceType="0001">
-      <feed id="d1_national_9e" name="D1 National"
-            parentSid="048D" pid="0426" decoder="ts2na12"
-            transport="TS/NA" ensembleId="C181" />
-      <feed id="sdl_national_9e" name="SDL National"
-            parentSid="0492" pid="0427" decoder="ts2na12"
-            transport="TS/NA" ensembleId="C1CE" />
-      <feed id="d1_scotland_9e" name="D1 Scotland"
-            parentSid="048E" pid="0429" decoder="ts2na12"
-            transport="TS/NA" ensembleId="C181" />
-    </transponder>
-  </satellite>
-
-  <satellite name="Astra 19.2E" orbitalPosition="192" namespace="C00000">
-    <transponder frequency="11603700" polarization="V" system="DVB-S"
-                 modulation="QPSK" symbolRate="2200000" fec="3/4"
-                 onid="0001" tsid="0402" parentServiceType="0002"
-                 parentSid="0BB8" registerParent="true">
-      <feed id="wdr_nrw_19e" name="WDR NRW"
-            pid="0BB8" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="228.10.1.5" multicastPort="10010"
-            ensembleId="10EC" />
-      <feed id="wdr_regional_19e" name="WDR Regional"
-            pid="0BB8" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="228.10.2.5" multicastPort="10010"
-            ensembleId="10FA" />
-    </transponder>
-    <transponder frequency="12460500" polarization="H" system="DVB-S"
-                 modulation="QPSK" symbolRate="27500000" fec="3/4"
-                 onid="0085" tsid="0005" parentServiceType="0002">
-      <feed id="bundesmux1" name="DAB Bundesmux 1"
-            bouquetFile="userbouquet.dab_bundesmux_1.radio"
-            bouquetName="DAB Bundesmux 1 (Radio)"
-            parentSid="1019" pid="1019" decoder="fedi2eti"
-            transport="MPE/UDP/EDI" multicastAddress="239.128.43.43"
-            multicastPort="50043" ensembleId="10BC" />
-      <feed id="bundesmux2" name="DAB Bundesmux 2"
-            bouquetFile="userbouquet.dab_bundesmux_2.radio"
-            bouquetName="DAB Bundesmux 2 (Radio)"
-            parentSid="101A" pid="101A" decoder="fedi2eti"
-            transport="MPE/UDP/EDI" multicastAddress="239.128.72.10"
-            multicastPort="50010" ensembleId="11F7" />
-    </transponder>
-  </satellite>
-
-  <satellite name="Astra 3C 23.5E" orbitalPosition="235" namespace="EB0000">
-    <transponder frequency="12168000" polarization="V" system="DVB-S"
-                 modulation="QPSK" symbolRate="27500000" fec="3/4"
-                 onid="0003" tsid="0C98" parentServiceType="0002">
-      <feed id="bundesmux1_235e" name="DAB Bundesmux 1 (23.5E)"
-            parentSid="1019" pid="1019" decoder="fedi2eti"
-            transport="MPE/UDP/EDI" multicastAddress="239.128.43.43"
-            multicastPort="50043" ensembleId="10BC" />
-      <feed id="bundesmux2_235e" name="DAB Bundesmux 2 (23.5E)"
-            parentSid="101A" pid="101A" decoder="fedi2eti"
-            transport="MPE/UDP/EDI" multicastAddress="239.128.72.10"
-            multicastPort="50010" ensembleId="11F7" />
-    </transponder>
-  </satellite>
-
-  <satellite name="Astra 2E 28.2E" orbitalPosition="282" namespace="11A0000">
-    <transponder frequency="11426500" polarization="H" system="DVB-S"
-                 modulation="QPSK" symbolRate="27500000" fec="2/3"
-                 onid="003B" tsid="090B" parentServiceType="0001">
-      <feed id="bbc_national_282e" name="BBC National"
-            parentSid="2954" pid="0425" decoder="ts2na12"
-            transport="TS/NA" ensembleId="CE15" />
-      <feed id="d1_national_282e" name="D1 National"
-            parentSid="2959" pid="0426" decoder="ts2na12"
-            transport="TS/NA" ensembleId="C181" />
-    </transponder>
-  </satellite>
-
-  <satellite name="Hellas Sat 3 39.0E" orbitalPosition="390" namespace="1860000">
-    <transponder frequency="12241500" polarization="H" system="DVB-S2"
-                 modulation="QPSK" symbolRate="13383000" fec="3/4"
-                 onid="212C" tsid="0001" parentServiceType="0001"
-                 parentSid="0001">
-      <feed id="ert_dab_39e" name="ERT DAB"
-            pid="03F2" decoder="tsniv2ni" transport="MPE/NI"
-            ensembleId="E000" />
-    </transponder>
-  </satellite>
-
-  <satellite name="Eutelsat 5 West B 5.0W" orbitalPosition="3550" namespace="DDE0000">
-    <transponder frequency="11461300" polarization="H" system="DVB-S2"
-                 modulation="QPSK" symbolRate="5780000" fec="3/4"
-                 onid="20FA" tsid="0003" parentServiceType="0001"
-                 parentSid="001E">
-      <feed id="metropolitain1_5w" name="Métropolitain 1"
-            pid="012D" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.0.1.11" multicastPort="5001"
-            ensembleId="F043" />
-      <feed id="metropolitain2_5w" name="Métropolitain 2"
-            pid="012D" decoder="fedi2eti" transport="MPE/UDP/EDI"
-            multicastAddress="239.0.1.12" multicastPort="5002"
-            ensembleId="F044" />
-    </transponder>
-    <transponder frequency="12564000" polarization="V" system="DVB-S2"
-                 modulation="8PSK" symbolRate="35294000" fec="2/3"
-                 onid="217C" tsid="00B7" parentServiceType="0001"
-                 parentSid="0001" inputStreamId="12" plsMode="Gold"
-                 plsCode="131070">
-      <feed id="rai_dab_test_5w" name="DAB+ RAI Test"
-            pid="03E9" decoder="ts2na" transport="TS/NA"
-            ensembleId="5DAB" />
-    </transponder>
-  </satellite>
+	-->
+	<terrestrial>
+		<region id="all" name="Worldwide Band III" />
+		<region id="europe" name="Europe (Band III)" />
+		<region id="australia" name="Australia" />
+		<channel id="5A" frequency="174928" regions="europe" />
+		<channel id="5B" frequency="176640" regions="europe" />
+		<channel id="5C" frequency="178352" regions="europe" />
+		<channel id="5D" frequency="180064" regions="europe" />
+		<channel id="6A" frequency="181936" regions="europe" />
+		<channel id="6B" frequency="183648" regions="europe" />
+		<channel id="6C" frequency="185360" regions="europe" />
+		<channel id="6D" frequency="187072" regions="europe" />
+		<channel id="7A" frequency="188928" regions="europe" />
+		<channel id="7B" frequency="190640" regions="europe" />
+		<channel id="7C" frequency="192352" regions="europe" />
+		<channel id="7D" frequency="194064" regions="europe" />
+		<channel id="8A" frequency="195936" regions="australia europe" />
+		<channel id="8B" frequency="197648" regions="australia europe" />
+		<channel id="8C" frequency="199360" regions="australia europe" />
+		<channel id="8D" frequency="201072" regions="australia europe" />
+		<channel id="9A" frequency="202928" regions="australia europe" />
+		<channel id="9B" frequency="204640" regions="australia europe" />
+		<channel id="9C" frequency="206352" regions="australia europe" />
+		<channel id="9D" frequency="208064" regions="australia europe" />
+		<channel id="10A" frequency="209936" regions="europe" />
+		<channel id="10B" frequency="211648" regions="europe" />
+		<channel id="10C" frequency="213360" regions="europe" />
+		<channel id="10D" frequency="215072" regions="europe" />
+		<channel id="11A" frequency="216928" regions="europe" />
+		<channel id="11B" frequency="218640" regions="europe" />
+		<channel id="11C" frequency="220352" regions="europe" />
+		<channel id="11D" frequency="222064" regions="europe" />
+		<channel id="12A" frequency="223936" regions="europe" />
+		<channel id="12B" frequency="225648" regions="europe" />
+		<channel id="12C" frequency="227360" regions="europe" />
+		<channel id="12D" frequency="229072" regions="europe" />
+		<channel id="13A" frequency="230784" regions="europe" />
+		<channel id="13B" frequency="232496" regions="europe" />
+		<channel id="13C" frequency="234208" regions="europe" />
+		<channel id="13D" frequency="235776" regions="europe" />
+		<channel id="13E" frequency="237488" regions="europe" />
+		<channel id="13F" frequency="239200" regions="europe" />
+	</terrestrial>
+	<satellite name="Eutelsat 7C 7.0E" orbitalPosition="70" namespace="460000">
+		<transponder frequency="11513800" polarization="V" system="DVB-S2" modulation="QPSK" symbolRate="17017000" fec="2/3" onid="0000" tsid="0000" parentServiceType="0001" parentSid="0001">
+			<feed id="allgaeu_donau_iller_7e_11513" name="AllgäuDonauIller" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.128.57.20" multicastPort="50020" ensembleId="1133" />
+			<feed id="oberbayern_sued_7e" name="Oberbayern Süd" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.128.58.20" multicastPort="50020" ensembleId="1196" />
+			<feed id="swr_bw_s_7e" name="SWR BW S" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.132.1.50" multicastPort="5004" ensembleId="10EB" />
+			<feed id="swr_bw_n_7e" name="SWR BW N" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.132.1.51" multicastPort="5004" ensembleId="10EA" />
+			<feed id="swr_rlp_7e" name="SWR RLP" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.132.1.52" multicastPort="5004" ensembleId="10D9" />
+			<feed id="oberfranken_7e_11513" name="Oberfranken" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.11" multicastPort="60011" ensembleId="1131" />
+			<feed id="unterfranken_7e_11513" name="Unterfranken" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.13" multicastPort="60013" ensembleId="1134" />
+			<feed id="oberpfalz_7e_11513" name="Oberpfalz" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.14" multicastPort="60014" ensembleId="0000" />
+			<feed id="oberbayern_schwaben_7e" name="Oberbayern/Schwaben" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.15" multicastPort="60015" ensembleId="1162" />
+			<feed id="niederbayern_7e_11513" name="Niederbayern" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.16" multicastPort="60016" ensembleId="0000" />
+			<feed id="bayern_7e" name="Bayern" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.17" multicastPort="60017" ensembleId="10A5" />
+			<feed id="hr_radio_7e_11513" name="hr Radio" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.192.254.200" multicastPort="10000" ensembleId="107A" />
+			<feed id="ndr_sh_ki_7e" name="NDR SH KI" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.229.96.33" multicastPort="50000" ensembleId="10F2" />
+			<feed id="ndr_nds_bs_7e_11513" name="NDR Niedersachsen Braunschweig" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.229.96.42" multicastPort="50000" ensembleId="0000" />
+			<feed id="ndr_mv_sn_7e_11513" name="NDR MV SN" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.229.96.43" multicastPort="50000" ensembleId="1115" />
+		</transponder>
+	</satellite>
+	<satellite name="Eutelsat 7B 7.0E" orbitalPosition="70" namespace="460000">
+		<transponder frequency="12567800" polarization="V" system="DVB-S2" modulation="QPSK" symbolRate="17017000" fec="2/3" onid="0001" tsid="0016" parentServiceType="0001" parentSid="0000">
+			<feed id="allgaeu_donau_iller_7e_12567" name="AllgäuDonauIller" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.128.57.20" multicastPort="50020" ensembleId="1133" />
+			<feed id="oberbayern_sued_7e_12567" name="Oberbayern Süd" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.128.58.20" multicastPort="50020" ensembleId="1196" />
+			<feed id="swr_bw_s_7e_12567" name="SWR BW S" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.132.1.50" multicastPort="5004" ensembleId="10EB" />
+			<feed id="swr_bw_n_7e_12567" name="SWR BW N" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.132.1.51" multicastPort="5004" ensembleId="10EA" />
+			<feed id="swr_rlp_7e_12567" name="SWR RLP" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.132.1.52" multicastPort="5004" ensembleId="10D9" />
+			<feed id="oberfranken_7e_12567" name="Oberfranken" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.11" multicastPort="60011" ensembleId="1131" />
+			<feed id="unterfranken_7e" name="Unterfranken" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.13" multicastPort="60013" ensembleId="1134" />
+			<feed id="oberpfalz_7e_12567" name="Oberpfalz" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.14" multicastPort="60014" ensembleId="0000" />
+			<feed id="oberbayern_schwaben_7e_12567" name="Oberbayern/Schwaben" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.15" multicastPort="60015" ensembleId="1162" />
+			<feed id="niederbayern_7e_12567" name="Niederbayern" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.16" multicastPort="60016" ensembleId="0000" />
+			<feed id="bayern_7e_12567" name="Bayern" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.16.242.17" multicastPort="60017" ensembleId="10A5" />
+			<feed id="hr_radio_7e" name="hr Radio" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.192.254.200" multicastPort="10000" ensembleId="107A" />
+			<feed id="ndr_sh_ki_7e_12567" name="NDR SH KI" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.229.96.33" multicastPort="50000" ensembleId="10F2" />
+			<feed id="ndr_nds_bs_7e_12567" name="NDR Niedersachsen Braunschweig" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.229.96.42" multicastPort="50000" ensembleId="0000" />
+			<feed id="ndr_mv_sn_7e" name="NDR MV SN" pid="0065" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.229.96.43" multicastPort="50000" ensembleId="1115" />
+		</transponder>
+	</satellite>
+	<satellite name="Eutelsat 9B 9.0E" orbitalPosition="90" namespace="5A0000">
+		<transponder frequency="11727500" polarization="V" system="DVB-S2" modulation="8PSK" symbolRate="30000000" fec="3/4" onid="009E" tsid="C35A" parentServiceType="0001">
+			<feed id="dab_italia_9e" name="DAB Italia" parentSid="035C" pid="1B77" decoder="tsniv2ni" transport="MPE/NI" ensembleId="5009" />
+			<feed id="eurodab_italia_9e" name="EuroDab Italia" parentSid="035D" pid="1BDB" decoder="tsniv2ni" transport="MPE/NI" ensembleId="5003" />
+		</transponder>
+		<transponder frequency="12091900" polarization="H" system="DVB-S2" modulation="8PSK" symbolRate="27500000" fec="3/4" onid="009E" tsid="1AF4" parentServiceType="0001">
+			<feed id="d1_national_9e" name="D1 National" parentSid="048D" pid="0426" decoder="ts2na12" transport="TS/NA" ensembleId="C181" />
+			<feed id="sdl_national_9e" name="SDL National" parentSid="0492" pid="0427" decoder="ts2na12" transport="TS/NA" ensembleId="C1CE" />
+			<feed id="d1_scotland_9e" name="D1 Scotland" parentSid="048E" pid="0429" decoder="ts2na12" transport="TS/NA" ensembleId="C181" />
+		</transponder>
+	</satellite>
+	<satellite name="Astra 19.2E" orbitalPosition="192" namespace="C00000">
+		<transponder frequency="11603700" polarization="V" system="DVB-S" modulation="QPSK" symbolRate="2200000" fec="3/4" onid="0001" tsid="0402" parentServiceType="0002" parentSid="0BB8" registerParent="true">
+			<feed id="wdr_nrw_19e" name="WDR NRW" pid="0BB8" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="228.10.1.5" multicastPort="10010" ensembleId="10EC" />
+			<feed id="wdr_regional_19e" name="WDR Regional" pid="0BB8" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="228.10.2.5" multicastPort="10010" ensembleId="10FA" />
+		</transponder>
+		<transponder frequency="12460500" polarization="H" system="DVB-S" modulation="QPSK" symbolRate="27500000" fec="3/4" onid="0085" tsid="0005" parentServiceType="0002">
+			<feed id="bundesmux1" name="DAB Bundesmux 1" bouquetFile="userbouquet.dab_bundesmux_1.radio" bouquetName="DAB Bundesmux 1 (Radio)" parentSid="1019" pid="1019" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.128.43.43" multicastPort="50043" ensembleId="10BC" />
+			<feed id="bundesmux2" name="DAB Bundesmux 2" bouquetFile="userbouquet.dab_bundesmux_2.radio" bouquetName="DAB Bundesmux 2 (Radio)" parentSid="101A" pid="101A" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.128.72.10" multicastPort="50010" ensembleId="11F7" />
+		</transponder>
+	</satellite>
+	<satellite name="Astra 3C 23.5E" orbitalPosition="235" namespace="EB0000">
+		<transponder frequency="12168000" polarization="V" system="DVB-S" modulation="QPSK" symbolRate="27500000" fec="3/4" onid="0003" tsid="0C98" parentServiceType="0002">
+			<feed id="bundesmux1_235e" name="DAB Bundesmux 1 (23.5E)" parentSid="1019" pid="1019" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.128.43.43" multicastPort="50043" ensembleId="10BC" />
+			<feed id="bundesmux2_235e" name="DAB Bundesmux 2 (23.5E)" parentSid="101A" pid="101A" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.128.72.10" multicastPort="50010" ensembleId="11F7" />
+		</transponder>
+	</satellite>
+	<satellite name="Astra 2E 28.2E" orbitalPosition="282" namespace="11A0000">
+		<transponder frequency="11426500" polarization="H" system="DVB-S" modulation="QPSK" symbolRate="27500000" fec="2/3" onid="003B" tsid="090B" parentServiceType="0001">
+			<feed id="bbc_national_282e" name="BBC National" parentSid="2954" pid="0425" decoder="ts2na12" transport="TS/NA" ensembleId="CE15" />
+			<feed id="d1_national_282e" name="D1 National" parentSid="2959" pid="0426" decoder="ts2na12" transport="TS/NA" ensembleId="C181" />
+		</transponder>
+	</satellite>
+	<satellite name="Hellas Sat 3 39.0E" orbitalPosition="390" namespace="1860000">
+		<transponder frequency="12241500" polarization="H" system="DVB-S2" modulation="QPSK" symbolRate="13383000" fec="3/4" onid="212C" tsid="0001" parentServiceType="0001" parentSid="0001">
+			<feed id="ert_dab_39e" name="ERT DAB" pid="03F2" decoder="tsniv2ni" transport="MPE/NI" ensembleId="E000" />
+		</transponder>
+	</satellite>
+	<satellite name="Eutelsat 5 West B 5.0W" orbitalPosition="3550" namespace="DDE0000">
+		<transponder frequency="11461300" polarization="H" system="DVB-S2" modulation="QPSK" symbolRate="5780000" fec="3/4" onid="20FA" tsid="0003" parentServiceType="0001" parentSid="001E">
+			<feed id="metropolitain1_5w" name="Métropolitain 1" pid="012D" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.0.1.11" multicastPort="5001" ensembleId="F043" />
+			<feed id="metropolitain2_5w" name="Métropolitain 2" pid="012D" decoder="fedi2eti" transport="MPE/UDP/EDI" multicastAddress="239.0.1.12" multicastPort="5002" ensembleId="F044" />
+		</transponder>
+		<transponder frequency="12564000" polarization="V" system="DVB-S2" modulation="8PSK" symbolRate="35294000" fec="2/3" onid="217C" tsid="00B7" parentServiceType="0001" parentSid="0001" inputStreamId="12" plsMode="Gold" plsCode="131070">
+			<feed id="rai_dab_test_5w" name="DAB+ RAI Test" pid="03E9" decoder="ts2na" transport="TS/NA" ensembleId="5DAB" />
+		</transponder>
+	</satellite>
 </dabFeeds>

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -148,8 +148,8 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 				<item key="tuner_basic_settings" level="1" text="Tuner Settings" weight="1"><setup setupKey="Tuner" /></item>
 				<item key="auto_scan" level="0" text="Automatic Scan" weight="5"><screen module="ScanSetup" screen="ScanSimple" /></item>
 				<item key="manual_scan" level="0" text="Manual Scan" weight="10"><screen module="ScanSetup" /></item>
-				<item key="dab_scan" level="0" text="DAB+ Scan" weight="15" conditional="nimmanager.getEnabledNimListOfType('DVB-S') or canScanRTLSDR()"><screen module="DABScan" screen="DABScan" /></item>
-				<item key="dab_usb_setup" level="0" text="DAB+ USB receiver" weight="16" conditional="hasRTLSDRDevice()"><screen module="RTLSDRSetup" screen="RTLSDRSetup" /></item>
+				<item key="dab_scan" level="0" text="DAB+ Scan" weight="15" requires="CanScanDAB"><screen module="DABScan" screen="DABScan" /></item>
+				<item key="dab_usb_setup" level="0" text="DAB+ USB receiver" weight="16" requires="HasRTLSDR"><screen module="RTLSDRSetup" screen="RTLSDRSetup" /></item>
 				<item key="fallbacktuner_settings" text="Fallback Remote Receiver Settings"><screen module="SetupFallbacktuner"/></item>
 			</menu>
 			<!-- Menu / Setup / Common interface -->

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -149,7 +149,7 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 				<item key="auto_scan" level="0" text="Automatic Scan" weight="5"><screen module="ScanSetup" screen="ScanSimple" /></item>
 				<item key="manual_scan" level="0" text="Manual Scan" weight="10"><screen module="ScanSetup" /></item>
 				<item key="dab_scan" level="0" text="DAB+ Scan" weight="15" requires="CanScanDAB"><screen module="DABScan" screen="DABScan" /></item>
-				<item key="dab_usb_setup" level="0" text="DAB+ USB receiver" weight="16" requires="HasRTLSDR"><screen module="RTLSDRSetup" screen="RTLSDRSetup" /></item>
+				<item key="dab_usb_setup" level="0" text="DAB+ USB Tuner Settings" weight="16" requires="HasRTLSDR"><screen module="RTLSDRSetup" screen="RTLSDRSetup" /></item>
 				<item key="fallbacktuner_settings" text="Fallback Remote Receiver Settings"><screen module="SetupFallbacktuner"/></item>
 			</menu>
 			<!-- Menu / Setup / Common interface -->

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -1042,16 +1042,16 @@
 		<item level="1" text="Channel">config.rfmod.channel</item>
 		<item level="1" text="Fine-tune">config.rfmod.finetune</item>
 	</setup>
-	<setup key="RTLSDRSetup" title="DAB+ USB receiver">
-		<item level="0" text="Enable DAB+ USB receiver" description="Use the RTL-SDR device exclusively for DAB+ reception.">config.dab.rtlsdr.enabled</item>
-		<item level="0" text="Receiver" description="Select the RTL-SDR device. Generic devices are identified by their physical USB port.">config.dab.rtlsdr.device</item>
+	<setup key="RTLSDRSetup" title="DAB+ USB Tuner Settings">
+		<item level="0" text="Enable DAB+ mode" description="Use a selected RTL-SDR USB tuner device exclusively for DAB+ reception. This tuner will not be available for TV service reception.">config.dab.rtlsdr.enabled</item>
 		<if requires="config.dab.rtlsdr.enabled">
-			<item level="0" text="Scan region" description="Limit a DAB+ USB scan to the frequency blocks defined for this region in dab.xml.">config.dab.rtlsdr.region</item>
-			<item level="0" text="Reception sources to scan" description="Scan the USB receiver, available DAB+ satellite feeds, or both." conditional="self.hasAvailableSatelliteDAB()">config.dab.rtlsdr.scanSource</item>
-			<item level="0" text="Show DAB slideshow" description="Replace the static radio background with pictures transmitted by the current DAB+ station.">config.dab.rtlsdr.slideshow</item>
+			<item level="0" text="Select tuner" description="Select the RTL-SDR USB tuner to be used for DAB+ reception.">config.dab.rtlsdr.device</item>
+			<item level="0" text="Scan region" description="Limit a DAB+ USB scan to the frequency blocks defined for this region in the 'dab.xml' file.">config.dab.rtlsdr.region</item>
+			<item level="0" text="Reception sources to scan" description="Scan the USB tuner, available DAB+ satellite feeds, or both." conditional="self.hasAvailableSatelliteDAB()">config.dab.rtlsdr.scanSource</item>
+			<item level="0" text="Show DAB+ slideshow" description="Replace the static radio background with pictures transmitted by the current DAB+ station.">config.dab.rtlsdr.slideshow</item>
 			<item level="0" text="Automatic gain" description="Let the tuner select its RF gain automatically.">config.dab.rtlsdr.automaticGain</item>
-			<item level="0" text="RF gain" description="Position in the tuner's supported gain range. The backend selects the closest gain step." conditional="not config.dab.rtlsdr.automaticGain.value">config.dab.rtlsdr.gain</item>
-			<item level="0" text="Frequency correction" description="Correct the tuner oscillator in parts per million.">config.dab.rtlsdr.ppm</item>
+			<item level="0" text="RF gain" description="Position in the tuner's supported gain range. The back end selects the closest gain step." conditional="not config.dab.rtlsdr.automaticGain.value">config.dab.rtlsdr.gain</item>
+			<item level="0" text="Frequency correction offset" description="Adjust the tuner oscillator offset to refine the DAB+ signal reception.">config.dab.rtlsdr.ppm</item>
 		</if>
 	</setup>
 	<setup key="Satellite" title="Satellite Dish Settings">

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -1049,7 +1049,7 @@
 			<item level="0" text="Select tuner" description="Select the RTL-SDR USB tuner to be used for DAB+ reception." indent="1">config.dab.rtlsdr.device</item>
 			<item level="0" text="Scan region" description="Limit a DAB+ USB scan to the frequency blocks defined for this region in the 'dab.xml' file." indent="1">config.dab.rtlsdr.region</item>
 			<item level="0" text="Reception sources to scan" description="Scan the USB tuner, available DAB+ satellite feeds, or both." conditional="self.hasAvailableSatelliteDAB()" indent="1">config.dab.rtlsdr.scanSource</item>
-			<item level="0" text="Show DAB+ slideshow" description="Replace the static radio background with pictures transmitted by the current DAB+ station.">config.dab.rtlsdr.slideshow</item>
+			<item level="0" text="Show DAB+ slideshow" description="Replace the static radio background with pictures transmitted by the current DAB+ station." indent="1">config.dab.rtlsdr.slideshow</item>
 			<item level="0" text="Automatic gain" description="Let the tuner select its RF gain automatically." indent="1">config.dab.rtlsdr.automaticGain</item>
 			<item level="0" text="RF gain" description="Position in the tuner's supported gain range. The back end selects the closest gain step." conditional="not config.dab.rtlsdr.automaticGain.value" indent="1">config.dab.rtlsdr.gain</item>
 			<item level="0" text="Frequency correction offset" description="Adjust the tuner oscillator offset to refine the DAB+ signal reception." indent="1">config.dab.rtlsdr.ppm</item>

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -1042,6 +1042,18 @@
 		<item level="1" text="Channel">config.rfmod.channel</item>
 		<item level="1" text="Fine-tune">config.rfmod.finetune</item>
 	</setup>
+	<setup key="RTLSDRSetup" title="DAB+ USB receiver">
+		<item level="0" text="Enable DAB+ USB receiver" description="Use the RTL-SDR device exclusively for DAB+ reception.">config.dab.rtlsdr.enabled</item>
+		<item level="0" text="Receiver" description="Select the RTL-SDR device. Generic devices are identified by their physical USB port.">config.dab.rtlsdr.device</item>
+		<if requires="config.dab.rtlsdr.enabled">
+			<item level="0" text="Scan region" description="Limit a DAB+ USB scan to the frequency blocks defined for this region in dab.xml.">config.dab.rtlsdr.region</item>
+			<item level="0" text="Reception sources to scan" description="Scan the USB receiver, available DAB+ satellite feeds, or both." conditional="self.hasAvailableSatelliteDAB()">config.dab.rtlsdr.scanSource</item>
+			<item level="0" text="Show DAB slideshow" description="Replace the static radio background with pictures transmitted by the current DAB+ station.">config.dab.rtlsdr.slideshow</item>
+			<item level="0" text="Automatic gain" description="Let the tuner select its RF gain automatically.">config.dab.rtlsdr.automaticGain</item>
+			<item level="0" text="RF gain" description="Position in the tuner's supported gain range. The backend selects the closest gain step." conditional="not config.dab.rtlsdr.automaticGain.value">config.dab.rtlsdr.gain</item>
+			<item level="0" text="Frequency correction" description="Correct the tuner oscillator in parts per million.">config.dab.rtlsdr.ppm</item>
+		</if>
+	</setup>
 	<setup key="Satellite" title="Satellite Dish Settings">
 		<item text="Tuner slot" description="Choose which tuner to configure.">config.sat.tunerslot</item>
 		<item text="Configuration mode" description="Configure the tuner mode.">config.sat.configmode</item>

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -1043,15 +1043,16 @@
 		<item level="1" text="Fine-tune">config.rfmod.finetune</item>
 	</setup>
 	<setup key="RTLSDRSetup" title="DAB+ USB Tuner Settings">
-		<item level="0" text="Enable DAB+ mode" description="Use a selected RTL-SDR USB tuner device exclusively for DAB+ reception. This tuner will not be available for TV service reception.">config.dab.rtlsdr.enabled</item>
+		<item level="0" text="Common Settings" />
+		<item level="0" text="Enable DAB+ mode" description="Use a selected RTL-SDR USB tuner device exclusively for DAB+ reception. This tuner will not be available for TV service reception." indent="1">config.dab.rtlsdr.enabled</item>
 		<if requires="config.dab.rtlsdr.enabled">
-			<item level="0" text="Select tuner" description="Select the RTL-SDR USB tuner to be used for DAB+ reception.">config.dab.rtlsdr.device</item>
-			<item level="0" text="Scan region" description="Limit a DAB+ USB scan to the frequency blocks defined for this region in the 'dab.xml' file.">config.dab.rtlsdr.region</item>
-			<item level="0" text="Reception sources to scan" description="Scan the USB tuner, available DAB+ satellite feeds, or both." conditional="self.hasAvailableSatelliteDAB()">config.dab.rtlsdr.scanSource</item>
+			<item level="0" text="Select tuner" description="Select the RTL-SDR USB tuner to be used for DAB+ reception." indent="1">config.dab.rtlsdr.device</item>
+			<item level="0" text="Scan region" description="Limit a DAB+ USB scan to the frequency blocks defined for this region in the 'dab.xml' file." indent="1">config.dab.rtlsdr.region</item>
+			<item level="0" text="Reception sources to scan" description="Scan the USB tuner, available DAB+ satellite feeds, or both." conditional="self.hasAvailableSatelliteDAB()" indent="1">config.dab.rtlsdr.scanSource</item>
 			<item level="0" text="Show DAB+ slideshow" description="Replace the static radio background with pictures transmitted by the current DAB+ station.">config.dab.rtlsdr.slideshow</item>
-			<item level="0" text="Automatic gain" description="Let the tuner select its RF gain automatically.">config.dab.rtlsdr.automaticGain</item>
-			<item level="0" text="RF gain" description="Position in the tuner's supported gain range. The back end selects the closest gain step." conditional="not config.dab.rtlsdr.automaticGain.value">config.dab.rtlsdr.gain</item>
-			<item level="0" text="Frequency correction offset" description="Adjust the tuner oscillator offset to refine the DAB+ signal reception.">config.dab.rtlsdr.ppm</item>
+			<item level="0" text="Automatic gain" description="Let the tuner select its RF gain automatically." indent="1">config.dab.rtlsdr.automaticGain</item>
+			<item level="0" text="RF gain" description="Position in the tuner's supported gain range. The back end selects the closest gain step." conditional="not config.dab.rtlsdr.automaticGain.value" indent="1">config.dab.rtlsdr.gain</item>
+			<item level="0" text="Frequency correction offset" description="Adjust the tuner oscillator offset to refine the DAB+ signal reception." indent="1">config.dab.rtlsdr.ppm</item>
 		</if>
 	</setup>
 	<setup key="Satellite" title="Satellite Dish Settings">

--- a/hotplug/hotplug.c
+++ b/hotplug/hotplug.c
@@ -153,7 +153,7 @@ int main(int argc, char* argv[]) {
 				const char* env_bus = getenv("ID_BUS");
 				const char* env_model = getenv("ID_MODEL");
 				const char* env_name = getenv("ID_NAME");
-				if (strcmp(action, "dab-sdr-add") == 0) {
+				if (strcmp(action, "dab-sdr-add") == 0 || strcmp(action, "dab-sdr-remove") == 0) {
 					int len = snprintf(data, datalen, "ACTION=%s\nDEVPATH=%s\nID_TYPE=dab-sdr\nDEVTYPE=usb_device\nID_BUS=usb\nID_MODEL=%s", action,
 						devpath, env_model ? env_model : (env_name ? env_name : "RTL2832U"));
 					send_to_socket(sd, mode, debug, data, len, datalen);

--- a/lib/python/Components/RTLSDR.py
+++ b/lib/python/Components/RTLSDR.py
@@ -4,7 +4,7 @@ from os.path import basename, exists, join
 from re import fullmatch, split
 from xml.etree.ElementTree import ParseError, parse
 
-from enigma import eTimer, iServiceInformation
+from enigma import eTimer
 
 from Components.config import ConfigInteger, ConfigSelection, ConfigSelectionNumber, ConfigSubsection, ConfigText, ConfigYesNo, config, configfile
 from Components.Opkg import OpkgComponent
@@ -343,20 +343,6 @@ def isRTLSDRInUse(device=None):
 		return False
 
 
-def getActiveRTLSDRTuner():
-	try:
-		from NavigationInstance import instance
-		reference = instance.getCurrentlyPlayingServiceReference() if instance else None
-		if not reference or not reference.getPath().startswith("dab://rtlsdr/"):
-			return ""
-		service = instance.getCurrentService()
-		info = service and service.info()
-		field = getattr(iServiceInformation, "sDABReceiverName", None)
-		return info.getInfoString(field).strip() if info and field is not None else ""
-	except (AttributeError, TypeError, ValueError):
-		return ""
-
-
 def cacheRTLSDRTuner(device, tuner):
 	if not device or not tuner:
 		return False
@@ -429,7 +415,7 @@ class DABUSBInstaller:
 			Toast.instance.showToast(
 				_("An RTL-SDR receiver was detected. The optional DAB+ USB runtime is being installed from the feed."),
 				Toast.TYPE_INFO, timeout=6)
-		self.opkg.runCommand(self.opkg.CMD_REFRESH_INSTALL, {"arguments": ["enigma2-plugin-systemplugins-dabusb"], "lineMode": True})
+		self.opkg.runCommand(self.opkg.CMD_REFRESH_INSTALL, {"arguments": ["enigma2-plugin-systemplugins-dabusb"]})
 
 	def opkgCallback(self, event, parameter):
 		if event == self.opkg.EVENT_ERROR:
@@ -451,20 +437,20 @@ class DABUSBInstaller:
 
 
 dabUSBInstaller = None
+dabHotplugNotifier = []
 
 
 def dabUSBHotplug(device, action):
-	if action == "dab-sdr-add" and dabUSBInstaller:
+	if action in ("dab-sdr-add", "dab-sdr-remove") and dabUSBInstaller:
 		dabUSBInstaller.requestInstall()
 
 
 def initRTLSDR(session):
-	from Plugins.SystemPlugins.Hotplug.plugin import hotplugNotifier
 	global dabUSBInstaller
 	dabUSBInstaller = DABUSBInstaller()
 	dabUSBInstaller.session = session
-	if dabUSBHotplug not in hotplugNotifier:
-		hotplugNotifier.append(dabUSBHotplug)
+	if dabUSBHotplug not in dabHotplugNotifier:
+		dabHotplugNotifier.append(dabUSBHotplug)
 	# A receiver can already be present before Enigma2 opens the hotplug socket.
 	bootProbe = eTimer()
 	bootProbe.callback.append(dabUSBInstaller.requestInstall)

--- a/lib/python/Components/RTLSDR.py
+++ b/lib/python/Components/RTLSDR.py
@@ -4,7 +4,12 @@ from os.path import basename, exists, join
 from re import fullmatch, split
 from xml.etree.ElementTree import ParseError, parse
 
-from Components.config import ConfigInteger, ConfigSelection, ConfigSelectionNumber, ConfigSubsection, ConfigText, ConfigYesNo, config
+from enigma import eTimer, iServiceInformation
+
+from Components.config import ConfigInteger, ConfigSelection, ConfigSelectionNumber, ConfigSubsection, ConfigText, ConfigYesNo, config, configfile
+from Components.Opkg import OpkgComponent
+from Components.SystemInfo import BoxInfo
+from Screens.Toast import Toast
 from Tools.Directories import SCOPE_CONFIG, SCOPE_SKINS, resolveFilename
 
 
@@ -84,7 +89,7 @@ def _dabXMLRoot(terrestrial=False):
 			if root.tag == "dabFeeds" and (not terrestrial or root.find("terrestrial") is not None):
 				return root
 		except (OSError, ParseError, ValueError) as err:
-			print("[RTLSDR] Unable to read DAB configuration '%s': %s" % (path, err))
+			print(f"[RTLSDR] Unable to read DAB configuration '{path}': {err}")
 	return None
 
 
@@ -164,14 +169,6 @@ def hasAvailableSatelliteDAB():
 	return False
 
 
-def _decode(value):
-	if not value:
-		return ""
-	if isinstance(value, bytes):
-		return value.decode("utf-8", "replace").strip()
-	return str(value).strip()
-
-
 def _read(path):
 	try:
 		with open(path, "r", encoding="utf-8", errors="replace") as fd:
@@ -180,7 +177,7 @@ def _read(path):
 		return ""
 
 
-def _usbDevices():
+def usbDevices():
 	devices = []
 	for path in sorted(glob("/sys/bus/usb/devices/*")):
 		vendor = _read(join(path, "idVendor"))
@@ -225,22 +222,29 @@ class RTLSDRLibrary:
 		return int(self.lib.rtlsdr_get_device_count())
 
 	def device(self, index, probe=False):
+		def decode(value):
+			if not value:
+				return ""
+			if isinstance(value, bytes):
+				return value.decode("utf-8", "replace").strip()
+			return str(value).strip()
+
 		manufacturer = create_string_buffer(256)
 		product = create_string_buffer(256)
 		serial = create_string_buffer(256)
 		result = self.lib.rtlsdr_get_device_usb_strings(index, manufacturer, product, serial)
 		info = {
 			"index": index,
-			"name": _decode(self.lib.rtlsdr_get_device_name(index)),
-			"manufacturer": _decode(manufacturer.value),
-			"product": _decode(product.value),
-			"serial": _decode(serial.value),
+			"name": decode(self.lib.rtlsdr_get_device_name(index)),
+			"manufacturer": decode(manufacturer.value),
+			"product": decode(product.value),
+			"serial": decode(serial.value),
 			"tunerType": 0,
 			"tuner": RTLSDR_TUNERS[0],
 			"gains": [],
 			"available": result == 0,
 			"errorCode": result,
-			"error": "" if result == 0 else "USB string query failed (%d)" % result
+			"error": "" if result == 0 else f"USB string query failed ({result})"
 		}
 		if probe and info["available"]:
 			device = c_void_p()
@@ -249,7 +253,7 @@ class RTLSDRLibrary:
 				try:
 					tunerType = int(self.lib.rtlsdr_get_tuner_type(device))
 					info["tunerType"] = tunerType
-					info["tuner"] = RTLSDR_TUNERS.get(tunerType, "Unknown (%d)" % tunerType)
+					info["tuner"] = RTLSDR_TUNERS.get(tunerType, f"Unknown ({tunerType})")
 					count = self.lib.rtlsdr_get_tuner_gains(device, None)
 					if count > 0:
 						values = (c_int * count)()
@@ -260,12 +264,12 @@ class RTLSDRLibrary:
 			else:
 				info["available"] = False
 				info["errorCode"] = result
-				info["error"] = "Unable to open device (%d)" % result
+				info["error"] = f"Unable to open device ({result})"
 		return info
 
 
-def _matchSysfs(devices):
-	sysfsDevices = _usbDevices()
+def matchSysfs(devices):
+	sysfsDevices = usbDevices()
 	used = set()
 	for device in devices:
 		matches = []
@@ -290,9 +294,9 @@ def enumerateRTLSDRDevices(probe=False):
 		library = RTLSDRLibrary()
 		devices = [library.device(index, probe=probe) for index in range(library.count())]
 	except (AttributeError, OSError, ValueError) as err:
-		print("[RTLSDR] Device enumeration failed: %s" % err)
+		print(f"[RTLSDR] Device enumeration failed: {err}")
 		return []
-	_matchSysfs(devices)
+	matchSysfs(devices)
 	serialCounts = {}
 	for device in devices:
 		serial = device.get("serial", "")
@@ -301,11 +305,11 @@ def enumerateRTLSDRDevices(probe=False):
 		serial = device.get("serial", "")
 		port = device.get("port", "")
 		if serial not in GENERIC_SERIALS and serialCounts.get(serial) == 1:
-			key = "serial:%s" % serial
+			key = f"serial:{serial}"
 		elif port:
-			key = "port:%s" % port
+			key = f"port:{port}"
 		else:
-			key = "index:%d" % device["index"]
+			key = f"index:{device['index']}"
 		device["key"] = key
 		if probe and device.get("available") and device.get("tunerType"):
 			config.dab.rtlsdr.cachedDevice.value = key
@@ -327,10 +331,6 @@ def hasRTLSDRDevice():
 	return bool(enumerateRTLSDRDevices(probe=False))
 
 
-def hasRTLSDRUSBHardware():
-	return any((device.get("vendorId"), device.get("productId")) in RTLSDR_USB_DEVICES for device in _usbDevices())
-
-
 def isRTLSDRInUse(device=None):
 	try:
 		from NavigationInstance import instance
@@ -345,7 +345,6 @@ def isRTLSDRInUse(device=None):
 
 def getActiveRTLSDRTuner():
 	try:
-		from enigma import iServiceInformation
 		from NavigationInstance import instance
 		reference = instance.getCurrentlyPlayingServiceReference() if instance else None
 		if not reference or not reference.getPath().startswith("dab://rtlsdr/"):
@@ -382,7 +381,6 @@ def cacheRTLSDRTuner(device, tuner):
 	device["tuner"] = canonical
 	device["probeCached"] = True
 	if changed:
-		from Components.config import configfile
 		config.dab.rtlsdr.cachedDevice.save()
 		config.dab.rtlsdr.cachedTunerType.save()
 		config.dab.rtlsdr.cachedTuner.save()
@@ -398,12 +396,80 @@ def hasRTLSDRBackend():
 	return exists("/usr/bin/dab-rtlsdr-welle-e2")
 
 
-def hasRTLSDRRuntime():
-	return hasRTLSDRBackend() and any(exists(path) for path in RTLSDR_LIBRARY_PATHS)
-
-
 def canScanRTLSDR():
 	return isRTLSDREnabled() and hasRTLSDRBackend()
+
+
+def updateDABBoxInfo(configElement=None):
+	from Components.NimManager import nimmanager
+	BoxInfo.setMutableItem("HasRTLSDR", hasRTLSDRDevice())
+	BoxInfo.setMutableItem("CanScanDAB", canScanRTLSDR() or bool(nimmanager.getEnabledNimListOfType("DVB-S")))
+
+
+class DABUSBInstaller:
+	def __init__(self):
+		self.session = None
+		self.opkg = None
+		self.running = False
+
+	def hasRTLSDRRuntime(self):
+		return hasRTLSDRBackend() and any(exists(path) for path in RTLSDR_LIBRARY_PATHS)
+
+	def requestInstall(self):
+		def hasRTLSDRUSBHardware():
+			return any((device.get("vendorId"), device.get("productId")) in RTLSDR_USB_DEVICES for device in usbDevices())
+
+		updateDABBoxInfo()
+		if self.running or self.hasRTLSDRRuntime() or not hasRTLSDRUSBHardware() or self.session is None:
+			return
+		self.running = True
+		self.opkg = OpkgComponent()
+		self.opkg.addCallback(self.opkgCallback)
+		if Toast.instance:
+			Toast.instance.showToast(
+				_("An RTL-SDR receiver was detected. The optional DAB+ USB runtime is being installed from the feed."),
+				Toast.TYPE_INFO, timeout=6)
+		self.opkg.runCommand(self.opkg.CMD_REFRESH_INSTALL, {"arguments": ["enigma2-plugin-systemplugins-dabusb"], "lineMode": True})
+
+	def opkgCallback(self, event, parameter):
+		if event == self.opkg.EVENT_ERROR:
+			self.finish(False)
+		elif event == self.opkg.EVENT_DONE:
+			self.finish(self.hasRTLSDRRuntime())
+
+	def finish(self, success):
+		if not self.running:
+			return
+		self.running = False
+		if self.opkg:
+			self.opkg.removeCallback(self.opkgCallback)
+			self.opkg = None
+		if self.session and Toast.instance:
+			Toast.instance.showToast(
+				_("DAB+ USB support was installed. You can now enable the receiver in Reception settings.") if success else _("DAB+ USB support could not be installed from the feed."),
+				Toast.TYPE_INFO if success else Toast.TYPE_ERROR, timeout=10)
+
+
+dabUSBInstaller = None
+
+
+def dabUSBHotplug(device, action):
+	if action == "dab-sdr-add" and dabUSBInstaller:
+		dabUSBInstaller.requestInstall()
+
+
+def initRTLSDR(session):
+	from Plugins.SystemPlugins.Hotplug.plugin import hotplugNotifier
+	global dabUSBInstaller
+	dabUSBInstaller = DABUSBInstaller()
+	dabUSBInstaller.session = session
+	if dabUSBHotplug not in hotplugNotifier:
+		hotplugNotifier.append(dabUSBHotplug)
+	# A receiver can already be present before Enigma2 opens the hotplug socket.
+	bootProbe = eTimer()
+	bootProbe.callback.append(dabUSBInstaller.requestInstall)
+	bootProbe.start(2000, True)
+	dabUSBInstaller.bootProbe = bootProbe
 
 
 if not hasattr(config, "dab"):
@@ -429,3 +495,5 @@ if not hasattr(config.dab, "rtlsdr"):
 	# is a percentage, not a physical dB value.
 	config.dab.rtlsdr.gain = ConfigSelectionNumber(min=0, max=100, stepwidth=1, default=35, units="%")
 	config.dab.rtlsdr.ppm = ConfigInteger(default=0, limits=(-200, 200))
+
+config.dab.rtlsdr.enabled.addNotifier(updateDABBoxInfo)

--- a/lib/python/Components/RTLSDR.py
+++ b/lib/python/Components/RTLSDR.py
@@ -1,7 +1,8 @@
-from ctypes import CDLL, POINTER, byref, c_char, c_char_p, c_int, c_uint32, c_void_p, create_string_buffer
+from ctypes import ArgumentError, CDLL, POINTER, byref, c_char, c_char_p, c_int, c_uint32, c_void_p, create_string_buffer
 from glob import glob
 from os.path import basename, exists, join
 from re import fullmatch, split
+from threading import Thread
 from xml.etree.ElementTree import ParseError, parse
 
 from enigma import eTimer
@@ -289,12 +290,24 @@ def matchSysfs(devices):
 	return devices
 
 
-def enumerateRTLSDRDevices(probe=False):
+RTLSDR_PROBE_TIMEOUT = 3  # Seconds. A stuck USB transfer inside librtlsdr can block indefinitely otherwise.
+
+
+def _probeRTLSDRDevices(probe, result):
 	try:
 		library = RTLSDRLibrary()
-		devices = [library.device(index, probe=probe) for index in range(library.count())]
-	except (AttributeError, OSError, ValueError) as err:
+		result.extend(library.device(index, probe=probe) for index in range(library.count()))
+	except (ArgumentError, AttributeError, OSError, ValueError) as err:
 		print(f"[RTLSDR] Device enumeration failed: {err}")
+
+
+def enumerateRTLSDRDevices(probe=False):
+	devices = []
+	worker = Thread(target=_probeRTLSDRDevices, args=(probe, devices), daemon=True)
+	worker.start()
+	worker.join(RTLSDR_PROBE_TIMEOUT)
+	if worker.is_alive():
+		print(f"[RTLSDR] Device enumeration did not respond within {RTLSDR_PROBE_TIMEOUT}s; a USB transfer may be stuck.")
 		return []
 	matchSysfs(devices)
 	serialCounts = {}

--- a/lib/python/Plugins/Extensions/MediaScanner/plugin.py
+++ b/lib/python/Plugins/Extensions/MediaScanner/plugin.py
@@ -1,61 +1,13 @@
 from os import access, F_OK, R_OK
-from enigma import eTimer
 from Plugins.Plugin import PluginDescriptor
-from Components.Opkg import OpkgComponent
 from Components.Scanner import scanDevice
 from Components.Harddisk import harddiskmanager
 from Screens.ChoiceBox import ChoiceBox
 from Screens.InfoBar import InfoBar
 from Screens.MessageBox import MessageBox
-from Screens.Toast import Toast
 
 parentScreen = None
 global_session = None
-DAB_USB_PACKAGE = "enigma2-plugin-systemplugins-dabusb"
-dabUSBInstaller = None
-
-
-class DABUSBInstaller:
-	def __init__(self):
-		self.opkg = None
-		self.running = False
-
-	def requestInstall(self):
-		from Components.RTLSDR import hasRTLSDRRuntime, hasRTLSDRUSBHardware
-		if self.running or hasRTLSDRRuntime() or not hasRTLSDRUSBHardware() or global_session is None:
-			return
-		self.running = True
-		self.opkg = OpkgComponent()
-		self.opkg.addCallback(self.opkgCallback)
-		if Toast.instance:
-			Toast.instance.showToast(
-				_("An RTL-SDR receiver was detected. The optional DAB+ USB runtime is being installed from the feed."),
-				Toast.TYPE_INFO, timeout=6)
-		self.opkg.runCommand(self.opkg.CMD_REFRESH_INSTALL, {"arguments": [DAB_USB_PACKAGE], "lineMode": True})
-
-	def opkgCallback(self, event, parameter):
-		if event == self.opkg.EVENT_ERROR:
-			self.finish(False)
-		elif event == self.opkg.EVENT_DONE:
-			from Components.RTLSDR import hasRTLSDRRuntime
-			self.finish(hasRTLSDRRuntime())
-
-	def finish(self, success):
-		if not self.running:
-			return
-		self.running = False
-		if self.opkg:
-			self.opkg.removeCallback(self.opkgCallback)
-			self.opkg = None
-		if global_session and Toast.instance:
-			Toast.instance.showToast(
-				_("DAB+ USB support was installed. You can now enable the receiver in Reception settings.") if success else _("DAB+ USB support could not be installed from the feed."),
-				Toast.TYPE_INFO if success else Toast.TYPE_ERROR, timeout=10)
-
-
-def dabUSBHotplug(device, action):
-	if action == "dab-sdr-add" and dabUSBInstaller:
-		dabUSBInstaller.requestInstall()
 
 
 def execute(option):
@@ -112,30 +64,17 @@ def partitionListChanged(action, device):
 
 
 def sessionstart(reason, session):
-	global global_session, dabUSBInstaller
+	global global_session
 	global_session = session
-	if dabUSBInstaller is None:
-		dabUSBInstaller = DABUSBInstaller()
-	# A receiver can already be present before Enigma2 opens the hotplug socket.
-	bootProbe = eTimer()
-	bootProbe.callback.append(dabUSBInstaller.requestInstall)
-	bootProbe.start(2000, True)
-	dabUSBInstaller.bootProbe = bootProbe
 
 
 def autostart(reason, **kwargs):
-	global global_session, dabUSBInstaller
-	from Plugins.SystemPlugins.Hotplug.plugin import hotplugNotifier
+	global global_session
 	if reason == 0:
 		harddiskmanager.on_partition_list_change.append(partitionListChanged)
-		if dabUSBHotplug not in hotplugNotifier:
-			hotplugNotifier.append(dabUSBHotplug)
 	elif reason == 1:
 		harddiskmanager.on_partition_list_change.remove(partitionListChanged)
-		if dabUSBHotplug in hotplugNotifier:
-			hotplugNotifier.remove(dabUSBHotplug)
 		global_session = None
-		dabUSBInstaller = None
 
 
 def Plugins(**kwargs):

--- a/lib/python/Plugins/SystemPlugins/Hotplug/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Hotplug/plugin.py
@@ -6,6 +6,7 @@ from enigma import eHotplugSocket, getDeviceDB, eTimer
 from Components.config import config
 from Components.Console import Console
 from Components.Harddisk import harddiskmanager
+from Components.RTLSDR import dabHotplugNotifier
 from Components.Storage import EXPANDER_MOUNT, cleanMediaDirs
 from Plugins.Plugin import PluginDescriptor
 from Screens.MessageBox import ModalMessageBox
@@ -214,13 +215,13 @@ class HotPlugManager:
 			print("[Hotplug] DEBUG: ", eventData)
 		action = eventData.get("ACTION")
 		if mode == 1 and eventData.get("MODE", "") != "CD":
-			if action == "dab-sdr-add":
+			if action in ("dab-sdr-add", "dab-sdr-remove"):
 				device = eventData.get("DEVPATH", "").split("/")[-1]
-				for callback in hotplugNotifier[:]:
+				for callback in dabHotplugNotifier[:]:
 					try:
 						callback(device, action)
 					except AttributeError:
-						hotplugNotifier.remove(callback)
+						dabHotplugNotifier.remove(callback)
 			elif action == "add":
 				self.addTimer.stop()
 				ID_TYPE = eventData.get("ID_TYPE")

--- a/lib/python/Screens/DABScan.py
+++ b/lib/python/Screens/DABScan.py
@@ -22,6 +22,7 @@ class DABScan(ServiceScan):
 	FEED_TIMEOUT = DVB_FEED_TIMEOUT
 	STABLE_POLLS = 3
 	SUPPORTED_DECODERS = ("fedi2eti", "tsniv2ni", "ts2na12", "ts2na")
+
 	def __init__(self, session, source=None):
 		if source is None:
 			from Components.RTLSDR import canScanRTLSDR, hasAvailableSatelliteDAB
@@ -140,7 +141,7 @@ class DABScan(ServiceScan):
 			self.feeds.append({
 				"id": "rtlsdr_%s" % channel.lower(),
 				"name": _("DAB+ channel %s") % channel,
-				"satellite": _("RTL-SDR receiver"),
+				"satellite": _("RTL-SDR tuner"),
 				"orbitalPosition": 0,
 				"decoder": "rtlsdr",
 				"transport": channel,

--- a/lib/python/Screens/Information.py
+++ b/lib/python/Screens/Information.py
@@ -21,6 +21,7 @@ from Components.Label import Label
 from Components.NetworkManager import encryptionLabels, networkManager
 from Components.NimManager import nimmanager
 from Components.Pixmap import Pixmap
+from Components.RTLSDR import getRTLSDRChannelFrequency
 from Components.ScrollLabel import ScrollLabel
 from Components.ServiceEventTracker import ServiceEventTracker
 from Components.Sources.StaticText import StaticText
@@ -1507,6 +1508,10 @@ class InformationService(InformationBase):
 		self.service = None
 
 	def showServiceInformation(self):
+		def addIfAvailable(info, label, value):
+			if value not in (None, "", -1, _("N/A")):
+				info.append(self.formatLine("P1", label, value))
+
 		def formatHex(value):
 			return f"0x{value:04X}  ({value})" if value and isinstance(value, int) else ""
 
@@ -1567,117 +1572,105 @@ class InformationService(InformationBase):
 					subtitleDesc = subtitleTypes.get(subtitle[2], f"{_("Unknown")}: {subtitle[2]}")
 					info.append(self.formatLine(indent, _("Other Subtitles & Language"), f"{subtitle[1] + 1}  -  {subtitleDesc}  -  {subtitleLang}"))
 
-		if self.serviceReferenceType == eServiceReference.idServiceDAB and self.serviceInfo:
-			return self.showDABServiceInformation(getServiceInfoValue, formatHex)
-
 		info = []
-		info.append(self.formatLine("H", _("Service and PID information for '%s'") % self.serviceName))
-		info.append("")
-		if self.serviceInfo:
-			from Components.Converter.PliExtraInfo import codec_data  # This should be in SystemInfo maybe as a BoxInfo variable.
-			videoData = []
-			videoData.append(codec_data.get(self.serviceInfo.getInfo(iServiceInformation.sVideoType), _("N/A")))
-			width = self.serviceInfo.getInfo(iServiceInformation.sVideoWidth)
-			height = self.serviceInfo.getInfo(iServiceInformation.sVideoHeight)
-			if width > 0 and height > 0:
-				videoData.append(f"{width}x{height}")
-				videoData.append(f"{(self.serviceInfo.getInfo(iServiceInformation.sFrameRate) + 500) // 1000}{("i", "p", "")[self.serviceInfo.getInfo(iServiceInformation.sProgressive)]}")
-				videoData.append(f"[{"4:3" if getServiceInfoValue(iServiceInformation.sAspect) in (1, 2, 5, 6, 9, 0xA, 0xD, 0xE) else "16:9"}]")  # This should be in SystemInfo maybe as a BoxInfo variable.
-			gamma = ("SDR", "HDR", "HDR10", "HLG", "")[self.serviceInfo.getInfo(iServiceInformation.sGamma)]  # This should be in SystemInfo maybe as a BoxInfo variable.
-			if gamma:
-				videoData.append(gamma)
-			videoData = "  -  ".join(videoData)
+		if self.serviceReferenceType == eServiceReference.idServiceDAB and self.serviceInfo:
+			info.append(self.formatLine("H", _("DAB+ service information for '%s'") % self.serviceName))
+			info.append("")
+			addIfAvailable(info, _("Station"), self.serviceName)
+			addIfAvailable(info, _("Reception source"), getServiceInfoValue(iServiceInformation.sProvider))
+			addIfAvailable(info, _("Ensemble"), getServiceInfoValue(iServiceInformation.sDABEnsembleLabel))
+			ensembleId = getServiceInfoValue(iServiceInformation.sDABEnsembleId)
+			addIfAvailable(info, _("Ensemble ID (EID)"), formatHex(ensembleId))
+			addIfAvailable(info, _("Service ID (SID)"), formatHex(getServiceInfoValue(iServiceInformation.sSID)))
+			channel = getServiceInfoValue(iServiceInformation.sDABChannel)
+			serviceRef = self.session.nav.getCurrentlyPlayingServiceReference()
+			if channel:
+				frequency = getRTLSDRChannelFrequency(channel)
+				channelText = _("Block %s") % channel
+				if frequency:
+					channelText = _("Block %s - %.3f MHz") % (channel, frequency / 1000.0)
+				addIfAvailable(info, _("DAB+ channel"), channelText)
+			elif serviceRef:
+				addIfAvailable(info, _("DVB payload PID"), formatHex(serviceRef.getUnsignedData(5) & 0x1FFF))
+			addIfAvailable(info, _("Program type"), getServiceInfoValue(iServiceInformation.sTagGenre))
+			addIfAvailable(info, _("Language"), getServiceInfoValue(iServiceInformation.sTagLanguageCode))
+			addIfAvailable(info, _("Codec"), getServiceInfoValue(iServiceInformation.sTagCodec))
+			addIfAvailable(info, _("Audio bit rate"), getServiceInfoValue(iServiceInformation.sTagBitrate))
+			addIfAvailable(info, _("Protection"), getServiceInfoValue(iServiceInformation.sDABProtection))
+			addIfAvailable(info, _("Dynamic label"), getServiceInfoValue(iServiceInformation.sDABDynamicLabel))
+			addIfAvailable(info, _("RTL-SDR tuner"), getServiceInfoValue(iServiceInformation.sDABReceiverName))
+			frontendInfo = self.service and self.service.frontendInfo()
+			if frontendInfo and channel:
+				locked = frontendInfo.getFrontendInfo(iFrontendInformation.lockState)
+				info.append("")
+				addIfAvailable(info, _("Receiver lock"), _("Locked") if locked else _("Tuning"))
+				snr = frontendInfo.getFrontendInfo(iFrontendInformation.signalQualitydB)
+				if snr >= 0:
+					addIfAvailable(info, _("RF SNR"), "%.2f dB" % (snr / 100.0))
+				ficQuality = getServiceInfoValue(iServiceInformation.sDABFICQuality)
+				mscQuality = getServiceInfoValue(iServiceInformation.sDABMSCQuality)
+				if isinstance(ficQuality, int) and ficQuality >= 0:
+					addIfAvailable(info, _("FIC quality"), "%d %%" % ficQuality)
+				if isinstance(mscQuality, int) and mscQuality >= 0:
+					addIfAvailable(info, _("MSC audio frame quality"), "%d %%" % mscQuality)
 		else:
-			videoData = _("Unknown")
-		if "%3a//" in self.serviceReference and self.serviceReferenceType not in (1, 257, 4098, 4114):  # IPTV 4097 5001, no PIDs shown.
-			info.append(self.formatLine("P1", _("Video Codec, Size & Format"), videoData))
-			info.append(self.formatLine("P1", _("Service reference"), ":".join(self.serviceReference.split(":")[:9])))
-			info.append(self.formatLine("P1", _("URL"), self.serviceReference.split(":")[10].replace("%3a", ":")))
-			getSubtitleList()  # IanSav: This wasn't activated to be used!
-		else:
-			if ":/" in self.serviceReference:  # mp4 videos, DVB-S-T recording.
+			info.append(self.formatLine("H", _("Service and PID information for '%s'") % self.serviceName))
+			info.append("")
+			if self.serviceInfo:
+				from Components.Converter.PliExtraInfo import codec_data  # This should be in SystemInfo maybe as a BoxInfo variable.
+				videoData = []
+				videoData.append(codec_data.get(self.serviceInfo.getInfo(iServiceInformation.sVideoType), _("N/A")))
+				width = self.serviceInfo.getInfo(iServiceInformation.sVideoWidth)
+				height = self.serviceInfo.getInfo(iServiceInformation.sVideoHeight)
+				if width > 0 and height > 0:
+					videoData.append(f"{width}x{height}")
+					videoData.append(f"{(self.serviceInfo.getInfo(iServiceInformation.sFrameRate) + 500) // 1000}{("i", "p", "")[self.serviceInfo.getInfo(iServiceInformation.sProgressive)]}")
+					videoData.append(f"[{"4:3" if getServiceInfoValue(iServiceInformation.sAspect) in (1, 2, 5, 6, 9, 0xA, 0xD, 0xE) else "16:9"}]")  # This should be in SystemInfo maybe as a BoxInfo variable.
+				gamma = ("SDR", "HDR", "HDR10", "HLG", "")[self.serviceInfo.getInfo(iServiceInformation.sGamma)]  # This should be in SystemInfo maybe as a BoxInfo variable.
+				if gamma:
+					videoData.append(gamma)
+				videoData = "  -  ".join(videoData)
+			else:
+				videoData = _("Unknown")
+			if "%3a//" in self.serviceReference and self.serviceReferenceType not in (1, 257, 4098, 4114):  # IPTV 4097 5001, no PIDs shown.
 				info.append(self.formatLine("P1", _("Video Codec, Size & Format"), videoData))
 				info.append(self.formatLine("P1", _("Service reference"), ":".join(self.serviceReference.split(":")[:9])))
-				info.append(self.formatLine("P1", _("Filename"), self.serviceReference.split(":")[10]))
-			else:  # fallback, movistartv, live DVB-S-T.
-				info.append(self.formatLine("P1", _("Provider"), getServiceInfoValue(iServiceInformation.sProvider)))
-				info.append(self.formatLine("P1", _("Video Codec, Size & Format"), videoData))
-				if "%3a//" in self.serviceReference:  # fallback, movistartv.
-					info.append(self.formatLine("P1", _("Service reference"), ":".join(self.serviceReference.split(":")[:9])))
-					info.append(self.formatLine("P1", _("URL"), self.serviceReference.split(":")[10].replace("%3a", ":")))
-				else:  # Live DVB-S-T
-					info.append(self.formatLine("P1", _("Service reference"), self.serviceReference))
-			info.append(self.formatLine("P1", _("Namespace & Orbital position"), getNamespace(getServiceInfoValue(iServiceInformation.sNamespace))))
-			info.append(self.formatLine("P1", _("Service ID (SID)"), formatHex(getServiceInfoValue(iServiceInformation.sSID))))
-			info.append(self.formatLine("P1", _("Transport Stream ID (TSID)"), formatHex(getServiceInfoValue(iServiceInformation.sTSID))))
-			info.append(self.formatLine("P1", _("Original Network ID (ONID)"), formatHex(getServiceInfoValue(iServiceInformation.sONID))))
-			info.append(self.formatLine("P1", _("Video PID"), formatHex(getServiceInfoValue(iServiceInformation.sVideoPID))))
-			audio = self.service and self.service.audioTracks()
-			numberOfTracks = audio and audio.getNumberOfTracks()
-			if numberOfTracks:
-				for index in range(numberOfTracks):
-					audioPID = audio.getTrackInfo(index).getPID()
-					audioDesc = audio.getTrackInfo(index).getDescription()
-					audioLang = audio.getTrackInfo(index).getLanguage() or _("Undefined")
-					audioPIDValue = _("N/A") if getServiceInfoValue(iServiceInformation.sAudioPID) == "N/A" else formatHex(audioPID)
-					indent = "P1F0" if numberOfTracks > 1 and audio.getCurrentTrack() == index else "P1"
-					info.append(self.formatLine(indent, _("Audio PID%s, Codec & Language") % (f" {index + 1}" if numberOfTracks > 1 else ""), f"{audioPIDValue}  -  {audioDesc}  -  {audioLang}"))
+				info.append(self.formatLine("P1", _("URL"), self.serviceReference.split(":")[10].replace("%3a", ":")))
+				getSubtitleList()  # IanSav: This wasn't activated to be used!
 			else:
-				info.append(self.formatLine("P1", _("Audio PID"), _("N/A")))
-			info.append(self.formatLine("P1", _("PCR PID"), formatHex(getServiceInfoValue(iServiceInformation.sPCRPID))))
-			info.append(self.formatLine("P1", _("PMT PID"), formatHex(getServiceInfoValue(iServiceInformation.sPMTPID))))
-			info.append(self.formatLine("P1", _("TXT PID"), formatHex(getServiceInfoValue(iServiceInformation.sTXTPID))))
-			getSubtitleList()
-		return info
-
-	def showDABServiceInformation(self, getServiceInfoValue, formatHex):
-		def addIfAvailable(info, label, value):
-			if value not in (None, "", -1, _("N/A")):
-				info.append(self.formatLine("P1", label, value))
-
-		serviceRef = self.session.nav.getCurrentlyPlayingServiceReference()
-		info = [self.formatLine("H", _("DAB service information for '%s'") % self.serviceName)]
-		info.append("")
-		addIfAvailable(info, _("Station"), self.serviceName)
-		addIfAvailable(info, _("Reception source"), getServiceInfoValue(iServiceInformation.sProvider))
-		addIfAvailable(info, _("Ensemble"), getServiceInfoValue(iServiceInformation.sDABEnsembleLabel))
-		ensembleId = getServiceInfoValue(iServiceInformation.sDABEnsembleId)
-		addIfAvailable(info, _("Ensemble ID (EID)"), formatHex(ensembleId))
-		addIfAvailable(info, _("Service ID (SID)"), formatHex(getServiceInfoValue(iServiceInformation.sSID)))
-
-		channel = getServiceInfoValue(iServiceInformation.sDABChannel)
-		if channel:
-			from Components.RTLSDR import getRTLSDRChannelFrequency
-			frequency = getRTLSDRChannelFrequency(channel)
-			channelText = _("Block %s") % channel
-			if frequency:
-				channelText = _("Block %s - %.3f MHz") % (channel, frequency / 1000.0)
-			addIfAvailable(info, _("DAB channel"), channelText)
-		elif serviceRef:
-			addIfAvailable(info, _("DVB payload PID"), formatHex(serviceRef.getUnsignedData(5) & 0x1FFF))
-
-		addIfAvailable(info, _("Programme type"), getServiceInfoValue(iServiceInformation.sTagGenre))
-		addIfAvailable(info, _("Language"), getServiceInfoValue(iServiceInformation.sTagLanguageCode))
-		addIfAvailable(info, _("Codec"), getServiceInfoValue(iServiceInformation.sTagCodec))
-		addIfAvailable(info, _("Audio bitrate"), getServiceInfoValue(iServiceInformation.sTagBitrate))
-		addIfAvailable(info, _("Protection"), getServiceInfoValue(iServiceInformation.sDABProtection))
-		addIfAvailable(info, _("Dynamic label"), getServiceInfoValue(iServiceInformation.sDABDynamicLabel))
-		addIfAvailable(info, _("RTL-SDR tuner"), getServiceInfoValue(iServiceInformation.sDABReceiverName))
-
-		frontendInfo = self.service and self.service.frontendInfo()
-		if frontendInfo and channel:
-			locked = frontendInfo.getFrontendInfo(iFrontendInformation.lockState)
-			info.append("")
-			addIfAvailable(info, _("Receiver lock"), _("Locked") if locked else _("Tuning"))
-			snr = frontendInfo.getFrontendInfo(iFrontendInformation.signalQualitydB)
-			if snr >= 0:
-				addIfAvailable(info, _("RF SNR"), "%.2f dB" % (snr / 100.0))
-			ficQuality = getServiceInfoValue(iServiceInformation.sDABFICQuality)
-			mscQuality = getServiceInfoValue(iServiceInformation.sDABMSCQuality)
-			if isinstance(ficQuality, int) and ficQuality >= 0:
-				addIfAvailable(info, _("FIC quality"), "%d %%" % ficQuality)
-			if isinstance(mscQuality, int) and mscQuality >= 0:
-				addIfAvailable(info, _("MSC audio frame quality"), "%d %%" % mscQuality)
+				if ":/" in self.serviceReference:  # mp4 videos, DVB-S-T recording.
+					info.append(self.formatLine("P1", _("Video Codec, Size & Format"), videoData))
+					info.append(self.formatLine("P1", _("Service reference"), ":".join(self.serviceReference.split(":")[:9])))
+					info.append(self.formatLine("P1", _("Filename"), self.serviceReference.split(":")[10]))
+				else:  # fallback, movistartv, live DVB-S-T.
+					info.append(self.formatLine("P1", _("Provider"), getServiceInfoValue(iServiceInformation.sProvider)))
+					info.append(self.formatLine("P1", _("Video Codec, Size & Format"), videoData))
+					if "%3a//" in self.serviceReference:  # fallback, movistartv.
+						info.append(self.formatLine("P1", _("Service reference"), ":".join(self.serviceReference.split(":")[:9])))
+						info.append(self.formatLine("P1", _("URL"), self.serviceReference.split(":")[10].replace("%3a", ":")))
+					else:  # Live DVB-S-T
+						info.append(self.formatLine("P1", _("Service reference"), self.serviceReference))
+				info.append(self.formatLine("P1", _("Namespace & Orbital position"), getNamespace(getServiceInfoValue(iServiceInformation.sNamespace))))
+				info.append(self.formatLine("P1", _("Service ID (SID)"), formatHex(getServiceInfoValue(iServiceInformation.sSID))))
+				info.append(self.formatLine("P1", _("Transport Stream ID (TSID)"), formatHex(getServiceInfoValue(iServiceInformation.sTSID))))
+				info.append(self.formatLine("P1", _("Original Network ID (ONID)"), formatHex(getServiceInfoValue(iServiceInformation.sONID))))
+				info.append(self.formatLine("P1", _("Video PID"), formatHex(getServiceInfoValue(iServiceInformation.sVideoPID))))
+				audio = self.service and self.service.audioTracks()
+				numberOfTracks = audio and audio.getNumberOfTracks()
+				if numberOfTracks:
+					for index in range(numberOfTracks):
+						audioPID = audio.getTrackInfo(index).getPID()
+						audioDesc = audio.getTrackInfo(index).getDescription()
+						audioLang = audio.getTrackInfo(index).getLanguage() or _("Undefined")
+						audioPIDValue = _("N/A") if getServiceInfoValue(iServiceInformation.sAudioPID) == "N/A" else formatHex(audioPID)
+						indent = "P1F0" if numberOfTracks > 1 and audio.getCurrentTrack() == index else "P1"
+						info.append(self.formatLine(indent, _("Audio PID%s, Codec & Language") % (f" {index + 1}" if numberOfTracks > 1 else ""), f"{audioPIDValue}  -  {audioDesc}  -  {audioLang}"))
+				else:
+					info.append(self.formatLine("P1", _("Audio PID"), _("N/A")))
+				info.append(self.formatLine("P1", _("PCR PID"), formatHex(getServiceInfoValue(iServiceInformation.sPCRPID))))
+				info.append(self.formatLine("P1", _("PMT PID"), formatHex(getServiceInfoValue(iServiceInformation.sPMTPID))))
+				info.append(self.formatLine("P1", _("TXT PID"), formatHex(getServiceInfoValue(iServiceInformation.sTXTPID))))
+				getSubtitleList()
 		return info
 
 	def showTransponderInformation(self):

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -8,10 +8,8 @@ from Components.ActionMap import HelpableNumberActionMap, HelpableActionMap
 from Components.AVSwitch import avSwitch
 from Components.config import ConfigDictionarySet, NoSave, config, configfile
 from Components.Label import Label
-from Components.NimManager import nimmanager  # noqa F401 needed in menu.xml
 from Components.Pixmap import Pixmap
 from Components.PluginComponent import plugins
-from Components.RTLSDR import canScanRTLSDR, hasRTLSDRDevice  # noqa F401 needed in menu.xml
 from Components.Sources.List import List
 from Components.Sources.StaticText import StaticText
 from Components.SystemInfo import BoxInfo, getBoxDisplayName

--- a/lib/python/Screens/RTLSDRSetup.py
+++ b/lib/python/Screens/RTLSDRSetup.py
@@ -1,6 +1,8 @@
+from enigma import iServiceInformation
+
 from Components.ActionMap import HelpableActionMap
 from Components.config import ConfigNothing, ConfigText, NoSave, ReadOnly, config
-from Components.RTLSDR import cacheRTLSDRTuner, enumerateRTLSDRDevices, getActiveRTLSDRTuner, hasAvailableSatelliteDAB, hasRTLSDRBackend, isRTLSDRInUse, updateDABBoxInfo
+from Components.RTLSDR import cacheRTLSDRTuner, enumerateRTLSDRDevices, hasAvailableSatelliteDAB, hasRTLSDRBackend, isRTLSDRInUse, updateDABBoxInfo
 from Components.Sources.StaticText import StaticText
 from Screens.Setup import Setup
 
@@ -50,7 +52,7 @@ class RTLSDRSetup(Setup):
 		else:
 			inUse = isRTLSDRInUse(device)
 			if inUse:
-				cacheRTLSDRTuner(device, getActiveRTLSDRTuner())
+				cacheRTLSDRTuner(device, self.getActiveRTLSDRTuner())
 			status = _("In use by DAB+") if inUse else (_("Ready") if device.get("available") and hasRTLSDRBackend() else (
 				_("DAB+ decoder back end not installed") if device.get("available") else _("Unable to open tuner (%d)") % device.get("errorCode", -1)))
 			tuner = device.get("tuner")
@@ -83,3 +85,15 @@ class RTLSDRSetup(Setup):
 		else:
 			device = self.deviceByKey.get(key)
 		return device
+
+	def getActiveRTLSDRTuner(self):
+		try:
+			reference = self.session.nav.getCurrentlyPlayingServiceReference()
+			if reference and reference.getPath().startswith("dab://rtlsdr/"):
+				service = self.session.nav.getCurrentService()
+				info = service and service.info()
+				field = getattr(iServiceInformation, "sDABReceiverName", None)
+				return info.getInfoString(field).strip() if info and field is not None else ""
+		except (AttributeError, TypeError, ValueError):
+			pass
+		return ""

--- a/lib/python/Screens/RTLSDRSetup.py
+++ b/lib/python/Screens/RTLSDRSetup.py
@@ -53,8 +53,12 @@ class RTLSDRSetup(Setup):
 			inUse = isRTLSDRInUse(device)
 			if inUse:
 				cacheRTLSDRTuner(device, self.getActiveRTLSDRTuner())
-			status = _("In use by DAB+") if inUse else (_("Ready") if device.get("available") and hasRTLSDRBackend() else (
-				_("DAB+ decoder back end not installed") if device.get("available") else _("Unable to open tuner (%d)") % device.get("errorCode", -1)))
+			if inUse:
+				status = _("In use by DAB+")
+			elif device.get("available"):
+				status = _("Ready") if hasRTLSDRBackend() else _("DAB+ decoder back end not installed")
+			else:
+				status = _("Unable to open tuner (%d)") % device.get("errorCode", -1)
 			tuner = device.get("tuner")
 			if device.get("probeCached") and tuner:
 				tuner = _("%s (cached)") % tuner

--- a/lib/python/Screens/RTLSDRSetup.py
+++ b/lib/python/Screens/RTLSDRSetup.py
@@ -1,42 +1,22 @@
 from Components.ActionMap import NumberActionMap
-from Components.ConfigList import ConfigListScreen
-from Components.Label import Label
 from Components.RTLSDR import cacheRTLSDRTuner, enumerateRTLSDRDevices, getActiveRTLSDRTuner, hasAvailableSatelliteDAB, hasRTLSDRBackend, isRTLSDRInUse, updateDABBoxInfo
 from Components.Sources.StaticText import StaticText
-from Components.config import ConfigNothing, ConfigText, NoSave, ReadOnly, config, configfile, getConfigListEntry
-from Screens.Screen import Screen
+from Components.config import ConfigNothing, ConfigText, NoSave, ReadOnly, config
+from Screens.Setup import Setup
 
 
-def _readOnly(value):
-	value = str(value) if value not in (None, "") else _("Not available")
-	return ReadOnly(NoSave(ConfigText(default=value, fixed_size=False)))
-
-
-class RTLSDRSetup(Screen, ConfigListScreen):
+class RTLSDRSetup(Setup):
 	def __init__(self, session):
-		Screen.__init__(self, session, mandatoryWidgets=["config", "footnote", "description"], enableHelp=True)
-		self.setImage("RTLSDRSetup", "setup")
-		self.skinName = ["RTLSDRSetup", "Setup"]
-		self.setTitle(_("DAB+ USB receiver"))
 		self.devices = []
 		self.deviceByKey = {}
-		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=session, fullUI=True)
-		self["footnote"] = Label()
-		self["footnote"].hide()
-		self["description"] = Label()
+		self.hasAvailableSatelliteDAB = hasAvailableSatelliteDAB  # exposed for the "conditional" eval in setup.xml
+		Setup.__init__(self, session, "RTLSDRSetup")
 		self["key_yellow"] = StaticText("")
 		self["key_blue"] = StaticText(_("Refresh"))
 		self["refreshActions"] = NumberActionMap(["ColorActions"], {
 			"blue": self.refreshDevices
 		}, -2)
-		self["config"].onSelectionChanged.append(self.selectionChanged)
 		self.refreshDevices()
-		self.selectionChanged()
-
-	def selectionChanged(self):
-		current = self["config"].getCurrent()
-		self["description"].setText(current[2] if current and len(current) > 2 else "")
 
 	def refreshDevices(self):
 		self.devices = enumerateRTLSDRDevices(probe=True)
@@ -47,8 +27,8 @@ class RTLSDRSetup(Screen, ConfigListScreen):
 			label = device.get("name") or device.get("knownModel") or device.get("product") or _("RTL-SDR device")
 			serial = device.get("serial")
 			port = device.get("port")
-			details = [value for value in (serial, "USB %s" % port if port else "") if value]
-			choices.append((device["key"], "%s (%s)" % (label, ", ".join(details)) if details else label))
+			details = [value for value in (serial, f"USB {port}" if port else "") if value]
+			choices.append((device["key"], f"{label} ({', '.join(details)})" if details else label))
 		selected = config.dab.rtlsdr.device.value
 		keys = [choice[0] for choice in choices]
 		if selected not in keys:
@@ -63,72 +43,43 @@ class RTLSDRSetup(Screen, ConfigListScreen):
 			return self.devices[0] if self.devices else None
 		return self.deviceByKey.get(key)
 
-	def createSetup(self):
-		settings = [
-			getConfigListEntry(_("Enable DAB+ USB receiver"), config.dab.rtlsdr.enabled,
-				_("Use the RTL-SDR device exclusively for DAB+ reception.")),
-			getConfigListEntry(_("Receiver"), config.dab.rtlsdr.device,
-				_("Select the RTL-SDR device. Generic devices are identified by their physical USB port."))
-		]
-		if config.dab.rtlsdr.enabled.value:
-			settings.append(getConfigListEntry(_("Scan region"), config.dab.rtlsdr.region,
-				_("Limit a DAB+ USB scan to the frequency blocks defined for this region in dab.xml.")))
-			if hasAvailableSatelliteDAB():
-				settings.append(getConfigListEntry(_("Reception sources to scan"), config.dab.rtlsdr.scanSource,
-					_("Scan the USB receiver, available DAB+ satellite feeds, or both.")))
-			settings.append(getConfigListEntry(_("Show DAB slideshow"), config.dab.rtlsdr.slideshow,
-				_("Replace the static radio background with pictures transmitted by the current DAB+ station.")))
-			settings.append(getConfigListEntry(_("Automatic gain"), config.dab.rtlsdr.automaticGain,
-				_("Let the tuner select its RF gain automatically.")))
-			if not config.dab.rtlsdr.automaticGain.value:
-				settings.append(getConfigListEntry(_("RF gain"), config.dab.rtlsdr.gain,
-					_("Position in the tuner's supported gain range. The backend selects the closest gain step.")))
-			settings.append(getConfigListEntry(_("Frequency correction"), config.dab.rtlsdr.ppm,
-				_("Correct the tuner oscillator in parts per million.")))
-		settings.append(getConfigListEntry(_("Detected hardware"), NoSave(ConfigNothing())))
+	def createSetup(self, appendItems=None, prependItems=None):
+		Setup.createSetup(self, appendItems=self.buildDiagnosticsItems())
+
+	def buildDiagnosticsItems(self):
+		def readOnly(value):
+			value = str(value) if value not in (None, "") else _("Not available")
+			return ReadOnly(NoSave(ConfigText(default=value, fixed_size=False)))
+
+		items = [(_("Detected hardware"), NoSave(ConfigNothing()))]
 		device = self.selectedDevice()
 		if device is None:
-			settings.append(getConfigListEntry(_("Status"), _readOnly(_("No compatible RTL-SDR device detected"))))
-		else:
-			inUse = isRTLSDRInUse(device)
-			if inUse:
-				cacheRTLSDRTuner(device, getActiveRTLSDRTuner())
-			status = _("In use by DAB+") if inUse else (_("Ready") if device.get("available") and hasRTLSDRBackend() else (
-				_("DAB+ decoder backend is not installed") if device.get("available") else _("Unable to open receiver (%d)") % device.get("errorCode", -1)))
-			tuner = device.get("tuner")
-			if device.get("probeCached") and tuner:
-				tuner = _("%s (cached)") % tuner
-			settings.extend([
-				getConfigListEntry(_("Status"), _readOnly(status)),
-				getConfigListEntry(_("Model"), _readOnly(device.get("name") or device.get("knownModel") or device.get("product"))),
-				getConfigListEntry(_("Manufacturer"), _readOnly(device.get("manufacturer"))),
-				getConfigListEntry(_("Product"), _readOnly(device.get("product"))),
-				getConfigListEntry(_("Serial number"), _readOnly(device.get("serial"))),
-				getConfigListEntry(_("USB ID"), _readOnly("%s:%s" % (device.get("vendorId", ""), device.get("productId", "")))),
-				getConfigListEntry(_("USB port"), _readOnly(device.get("port"))),
-				getConfigListEntry(_("USB speed"), _readOnly("%s Mbit/s" % device.get("speed") if device.get("speed") else "")),
-				getConfigListEntry(_("Tuner"), _readOnly(tuner)),
-				getConfigListEntry(_("Gain steps"), _readOnly(len(device.get("gains", []))))
-			])
-		self.list = settings
-		self["config"].setList(settings)
-
-	def keyLeft(self):
-		ConfigListScreen.keyLeft(self)
-		self.createSetup()
-
-	def keyRight(self):
-		ConfigListScreen.keyRight(self)
-		self.createSetup()
-
-	def keyCancel(self):
-		for entry in self["config"].list:
-			entry[1].cancel()
-		self.close()
+			items.append((_("Status"), readOnly(_("No compatible RTL-SDR device detected"))))
+			return items
+		inUse = isRTLSDRInUse(device)
+		if inUse:
+			cacheRTLSDRTuner(device, getActiveRTLSDRTuner())
+		status = _("In use by DAB+") if inUse else (_("Ready") if device.get("available") and hasRTLSDRBackend() else (
+			_("DAB+ decoder backend is not installed") if device.get("available") else _("Unable to open receiver (%d)") % device.get("errorCode", -1)))
+		tuner = device.get("tuner")
+		if device.get("probeCached") and tuner:
+			tuner = _("%s (cached)") % tuner
+		items.extend([
+			(_("Status"), readOnly(status)),
+			(_("Model"), readOnly(device.get("name") or device.get("knownModel") or device.get("product"))),
+			(_("Manufacturer"), readOnly(device.get("manufacturer"))),
+			(_("Product"), readOnly(device.get("product"))),
+			(_("Serial number"), readOnly(device.get("serial"))),
+			(_("USB ID"), readOnly(f"{device.get('vendorId', '')}:{device.get('productId', '')}")),
+			(_("USB port"), readOnly(device.get("port"))),
+			(_("USB speed"), readOnly(f"{device.get('speed')} Mbit/s" if device.get("speed") else "")),
+			(_("Tuner"), readOnly(tuner)),
+			(_("Gain steps"), readOnly(len(device.get("gains", []))))
+		])
+		return items
 
 	def keySave(self):
 		device = self.selectedDevice()
 		config.dab.rtlsdr.deviceIndex.value = device.get("index", 0) if device else 0
-		config.dab.rtlsdr.save()
-		configfile.save()
-		self.close()
+		config.dab.rtlsdr.deviceIndex.save()  # Not part of the visible list, so Setup.keySave wouldn't persist it.
+		Setup.keySave(self)

--- a/lib/python/Screens/RTLSDRSetup.py
+++ b/lib/python/Screens/RTLSDRSetup.py
@@ -1,7 +1,7 @@
-from Components.ActionMap import NumberActionMap
+from Components.ActionMap import HelpableActionMap
+from Components.config import ConfigNothing, ConfigText, NoSave, ReadOnly, config
 from Components.RTLSDR import cacheRTLSDRTuner, enumerateRTLSDRDevices, getActiveRTLSDRTuner, hasAvailableSatelliteDAB, hasRTLSDRBackend, isRTLSDRInUse, updateDABBoxInfo
 from Components.Sources.StaticText import StaticText
-from Components.config import ConfigNothing, ConfigText, NoSave, ReadOnly, config
 from Screens.Setup import Setup
 
 
@@ -9,39 +9,31 @@ class RTLSDRSetup(Setup):
 	def __init__(self, session):
 		self.devices = []
 		self.deviceByKey = {}
-		self.hasAvailableSatelliteDAB = hasAvailableSatelliteDAB  # exposed for the "conditional" eval in setup.xml
+		self.hasAvailableSatelliteDAB = hasAvailableSatelliteDAB  # Exposed for the "conditional" eval in 'setup.xml'.
 		Setup.__init__(self, session, "RTLSDRSetup")
-		self["key_yellow"] = StaticText("")
 		self["key_blue"] = StaticText(_("Refresh"))
-		self["refreshActions"] = NumberActionMap(["ColorActions"], {
-			"blue": self.refreshDevices
-		}, -2)
-		self.refreshDevices()
+		self["refreshActions"] = HelpableActionMap(self, ["ColorActions"], {
+			"blue": (self.keyRefreshDevices, _("Refresh list of RTL-SDR USB tuners"))
+		}, prio=0, description=_("DAB+ USB Tuner Settings Actions"))
+		self.keyRefreshDevices()
 
-	def refreshDevices(self):
+	def keyRefreshDevices(self):
 		self.devices = enumerateRTLSDRDevices(probe=True)
 		updateDABBoxInfo()
 		self.deviceByKey = {device["key"]: device for device in self.devices}
 		choices = [("auto", _("Automatic"))]
 		for device in self.devices:
-			label = device.get("name") or device.get("knownModel") or device.get("product") or _("RTL-SDR device")
+			label = device.get("name") or device.get("knownModel") or device.get("product") or _("RTL-SDR USB tuner")
 			serial = device.get("serial")
 			port = device.get("port")
 			details = [value for value in (serial, f"USB {port}" if port else "") if value]
-			choices.append((device["key"], f"{label} ({', '.join(details)})" if details else label))
+			choices.append((device["key"], f"{label} ({", ".join(details)})" if details else label))
 		selected = config.dab.rtlsdr.device.value
-		keys = [choice[0] for choice in choices]
-		if selected not in keys:
+		if selected not in [choice[0] for choice in choices]:
 			selected = "auto"
-		config.dab.rtlsdr.device.setChoices(choices, default=selected)
+		config.dab.rtlsdr.device.setChoices(default=selected, choices=choices)
 		config.dab.rtlsdr.device.value = selected
 		self.createSetup()
-
-	def selectedDevice(self):
-		key = config.dab.rtlsdr.device.value
-		if key == "auto":
-			return self.devices[0] if self.devices else None
-		return self.deviceByKey.get(key)
 
 	def createSetup(self, appendItems=None, prependItems=None):
 		Setup.createSetup(self, appendItems=self.buildDiagnosticsItems())
@@ -54,32 +46,40 @@ class RTLSDRSetup(Setup):
 		items = [(_("Detected hardware"), NoSave(ConfigNothing()))]
 		device = self.selectedDevice()
 		if device is None:
-			items.append((_("Status"), readOnly(_("No compatible RTL-SDR device detected"))))
-			return items
-		inUse = isRTLSDRInUse(device)
-		if inUse:
-			cacheRTLSDRTuner(device, getActiveRTLSDRTuner())
-		status = _("In use by DAB+") if inUse else (_("Ready") if device.get("available") and hasRTLSDRBackend() else (
-			_("DAB+ decoder backend is not installed") if device.get("available") else _("Unable to open receiver (%d)") % device.get("errorCode", -1)))
-		tuner = device.get("tuner")
-		if device.get("probeCached") and tuner:
-			tuner = _("%s (cached)") % tuner
-		items.extend([
-			(_("Status"), readOnly(status)),
-			(_("Model"), readOnly(device.get("name") or device.get("knownModel") or device.get("product"))),
-			(_("Manufacturer"), readOnly(device.get("manufacturer"))),
-			(_("Product"), readOnly(device.get("product"))),
-			(_("Serial number"), readOnly(device.get("serial"))),
-			(_("USB ID"), readOnly(f"{device.get('vendorId', '')}:{device.get('productId', '')}")),
-			(_("USB port"), readOnly(device.get("port"))),
-			(_("USB speed"), readOnly(f"{device.get('speed')} Mbit/s" if device.get("speed") else "")),
-			(_("Tuner"), readOnly(tuner)),
-			(_("Gain steps"), readOnly(len(device.get("gains", []))))
-		])
+			items.append((_("Status"), readOnly(_("No compatible RTL-SDR USB tuner detected"))))
+		else:
+			inUse = isRTLSDRInUse(device)
+			if inUse:
+				cacheRTLSDRTuner(device, getActiveRTLSDRTuner())
+			status = _("In use by DAB+") if inUse else (_("Ready") if device.get("available") and hasRTLSDRBackend() else (
+				_("DAB+ decoder back end not installed") if device.get("available") else _("Unable to open tuner (%d)") % device.get("errorCode", -1)))
+			tuner = device.get("tuner")
+			if device.get("probeCached") and tuner:
+				tuner = _("%s (cached)") % tuner
+			items.extend([
+				(_("Status"), readOnly(status)),
+				(_("Model"), readOnly(device.get("name") or device.get("knownModel") or device.get("product"))),
+				(_("Manufacturer"), readOnly(device.get("manufacturer"))),
+				(_("Product"), readOnly(device.get("product"))),
+				(_("Serial number"), readOnly(device.get("serial"))),
+				(_("USB ID"), readOnly(f"{device.get("vendorId", "")}:{device.get("productId", "")}")),
+				(_("USB port"), readOnly(device.get("port"))),
+				(_("USB speed"), readOnly(f"{device.get("speed")} Mbps" if device.get("speed") else "")),
+				(_("Tuner"), readOnly(tuner)),
+				(_("Gain steps"), readOnly(len(device.get("gains", []))))
+			])
 		return items
 
-	def keySave(self):
+	def keySave(self):  # This modified the keySave() method in 'ConfigList.py'.
 		device = self.selectedDevice()
 		config.dab.rtlsdr.deviceIndex.value = device.get("index", 0) if device else 0
-		config.dab.rtlsdr.deviceIndex.save()  # Not part of the visible list, so Setup.keySave wouldn't persist it.
+		config.dab.rtlsdr.deviceIndex.save()  # Not part of the visible list, so Setup.keySave wouldn't save it.
 		Setup.keySave(self)
+
+	def selectedDevice(self):
+		key = config.dab.rtlsdr.device.value
+		if key == "auto":
+			device = self.devices[0] if self.devices else None
+		else:
+			device = self.deviceByKey.get(key)
+		return device

--- a/lib/python/Screens/RTLSDRSetup.py
+++ b/lib/python/Screens/RTLSDRSetup.py
@@ -1,7 +1,7 @@
 from enigma import iServiceInformation
 
 from Components.ActionMap import HelpableActionMap
-from Components.config import ConfigNothing, ConfigText, NoSave, ReadOnly, config
+from Components.config import ConfigText, NoSave, ReadOnly, config
 from Components.RTLSDR import cacheRTLSDRTuner, enumerateRTLSDRDevices, hasAvailableSatelliteDAB, hasRTLSDRBackend, isRTLSDRInUse, updateDABBoxInfo
 from Components.Sources.StaticText import StaticText
 from Screens.Setup import Setup
@@ -45,10 +45,10 @@ class RTLSDRSetup(Setup):
 			value = str(value) if value not in (None, "") else _("Not available")
 			return ReadOnly(NoSave(ConfigText(default=value, fixed_size=False)))
 
-		items = [(_("Detected hardware"), NoSave(ConfigNothing()))]
+		items = [(_("Detected hardware"),)]
 		device = self.selectedDevice()
 		if device is None:
-			items.append((_("Status"), readOnly(_("No compatible RTL-SDR USB tuner detected"))))
+			items.append(((_("Status"), 1), readOnly(_("No compatible RTL-SDR USB tuner detected"))))
 		else:
 			inUse = isRTLSDRInUse(device)
 			if inUse:
@@ -59,16 +59,16 @@ class RTLSDRSetup(Setup):
 			if device.get("probeCached") and tuner:
 				tuner = _("%s (cached)") % tuner
 			items.extend([
-				(_("Status"), readOnly(status)),
-				(_("Model"), readOnly(device.get("name") or device.get("knownModel") or device.get("product"))),
-				(_("Manufacturer"), readOnly(device.get("manufacturer"))),
-				(_("Product"), readOnly(device.get("product"))),
-				(_("Serial number"), readOnly(device.get("serial"))),
-				(_("USB ID"), readOnly(f"{device.get("vendorId", "")}:{device.get("productId", "")}")),
-				(_("USB port"), readOnly(device.get("port"))),
-				(_("USB speed"), readOnly(f"{device.get("speed")} Mbps" if device.get("speed") else "")),
-				(_("Tuner"), readOnly(tuner)),
-				(_("Gain steps"), readOnly(len(device.get("gains", []))))
+				((_("Status"), 1), readOnly(status)),
+				((_("Model"), 1), readOnly(device.get("name") or device.get("knownModel") or device.get("product"))),
+				((_("Manufacturer"), 1), readOnly(device.get("manufacturer"))),
+				((_("Product"), 1), readOnly(device.get("product"))),
+				((_("Serial number"), 1), readOnly(device.get("serial"))),
+				((_("USB ID"), 1), readOnly(f"{device.get("vendorId", "")}:{device.get("productId", "")}")),
+				((_("USB port"), 1), readOnly(device.get("port"))),
+				((_("USB speed"), 1), readOnly(f"{device.get("speed")} Mbps" if device.get("speed") else "")),
+				((_("Tuner"), 1), readOnly(tuner)),
+				((_("Gain steps"), 1), readOnly(len(device.get("gains", []))))
 			])
 		return items
 

--- a/lib/python/Screens/RTLSDRSetup.py
+++ b/lib/python/Screens/RTLSDRSetup.py
@@ -1,7 +1,7 @@
 from Components.ActionMap import NumberActionMap
 from Components.ConfigList import ConfigListScreen
 from Components.Label import Label
-from Components.RTLSDR import cacheRTLSDRTuner, enumerateRTLSDRDevices, getActiveRTLSDRTuner, hasAvailableSatelliteDAB, hasRTLSDRBackend, isRTLSDRInUse
+from Components.RTLSDR import cacheRTLSDRTuner, enumerateRTLSDRDevices, getActiveRTLSDRTuner, hasAvailableSatelliteDAB, hasRTLSDRBackend, isRTLSDRInUse, updateDABBoxInfo
 from Components.Sources.StaticText import StaticText
 from Components.config import ConfigNothing, ConfigText, NoSave, ReadOnly, config, configfile, getConfigListEntry
 from Screens.Screen import Screen
@@ -40,6 +40,7 @@ class RTLSDRSetup(Screen, ConfigListScreen):
 
 	def refreshDevices(self):
 		self.devices = enumerateRTLSDRDevices(probe=True)
+		updateDABBoxInfo()
 		self.deviceByKey = {device["key"]: device for device in self.devices}
 		choices = [("auto", _("Automatic"))]
 		for device in self.devices:

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -416,6 +416,8 @@ def runScreenTest():
 	nav = Navigation(config.misc.nextWakeup.value)
 	session = Session(desktop=enigma.getDesktop(0), summaryDesktop=enigma.getDesktop(1), navigation=nav)
 	CiHandler.setSession(session)
+	from Components.RTLSDR import initRTLSDR
+	initRTLSDR(session)
 	from Screens.SwapManager import SwapAutostart
 	SwapAutostart()
 	enigma.eProfileWrite("Processing Screen")


### PR DESCRIPTION
* Move DAB+/RTL-SDR device gating and USB-runtime install into Components/RTLSDR
* Resolve the DAB+ menu conditionals via BoxInfo
* DABUSBInstaller (feed install of the optional DAB+ USB runtime) moves from Plugins/Extensions/MediaScanner into Components/RTLSDR, since it has nothing to do with media scanning.It's now started once from StartEnigma.py via initRTLSDR(session).
* Convert % string formatting in RTLSDR.py to f-strings.