### PR TITLE
Fix SummaryScreen scaling by using self.desktop in applySkin

### DIFF
--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -1,9 +1,9 @@
 from os.path import isfile
 from types import CodeType
 
-from enigma import eRCInput, eStack, eTimer, eWindow, getDesktop
+from enigma import eRCInput, eStack, eTimer, eWindow
 
-from skin import GUI_SKIN_ID, applyAllAttributes, menus, readSkin, screens, setups
+from skin import applyAllAttributes, menus, readSkin, screens, setups
 from Components.ActionMap import HelpableActionMap
 from Components.config import config
 from Components.GUIComponent import GUIComponent
@@ -289,7 +289,7 @@ class Screen(dict):
 				method()
 
 	def applySkin(self):
-		bounds = (getDesktop(GUI_SKIN_ID).size().width(), getDesktop(GUI_SKIN_ID).size().height())
+		bounds = (self.desktop.size().width(), self.desktop.size().height())
 		resolution = bounds
 		zPosition = 0
 		for (key, value) in self.skinAttributes:


### PR DESCRIPTION
self.desktop is already set correctly via setDesktop() before applySkin() runs (main screens get desktop 0, summary screens get the summary desktop), so applySkin() only needs to read it instead of hardcoding GUI_SKIN_ID. This also avoids a mismatch on dm-* models, where DISPLAY_SKIN_ID is 2 but the summary desktop is always desktop 1.